### PR TITLE
clients:CMake:Hide symbols that are not TRTIS API

### DIFF
--- a/src/clients/c++/CMakeLists.txt
+++ b/src/clients/c++/CMakeLists.txt
@@ -31,6 +31,8 @@ cmake_minimum_required (VERSION 3.5)
 #
 find_package(CURL REQUIRED)
 
+configure_file(librequest.ldscript librequest.ldscript COPYONLY)
+
 add_library(
   request SHARED
   request.cc request.h
@@ -40,7 +42,15 @@ add_library(
   $<TARGET_OBJECTS:proto-library>
   $<TARGET_OBJECTS:grpc-library>
 )
-set_target_properties(request PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/EXPORT_SYMBOLS")
+set_target_properties(
+  request
+  PROPERTIES LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/librequest.ldscript
+)
+set_target_properties(
+  request
+  PROPERTIES LINK_FLAGS "-Wl,--version-script=librequest.ldscript"
+)
+
 target_link_libraries(
   request
   PRIVATE gRPC::grpc++

--- a/src/clients/c++/EXPORT_SYMBOLS
+++ b/src/clients/c++/EXPORT_SYMBOLS
@@ -1,7 +1,0 @@
-{
-  global:
-    extern "C++" {
-      nvidia::inferenceserver*
-    };
-  local: *;
-};

--- a/src/clients/c++/librequest.ldscript
+++ b/src/clients/c++/librequest.ldscript
@@ -1,0 +1,32 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+{
+  global:
+    extern "C++" {
+      nvidia::inferenceserver*
+    };
+  local: *;
+};


### PR DESCRIPTION
gRPC symbols were visible and caused crash on
client application which is using different
version of gRPC

Signed-off-by: Wenjia Zhou <wenjiaz@nvidia.com>