### PR TITLE
[DO NOT MERGE] Support TensorRT reformat-free I/O

### DIFF
--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -417,8 +417,8 @@ PlanBackend::Context::InitOptimizationProfiles(
           return Status(
               Status::Code::INTERNAL, "unable to create TensorRT context");
         }
-        if (!res.first->second.context_->setOptimizationProfile(
-                profile_index)) {
+        if (!res.first->second.context_->setOptimizationProfileAsync(
+                profile_index, stream_)) {
           return Status(
               Status::Code::INVALID_ARG,
               "Can not set the specified optimization profile " + profile_name +
@@ -928,7 +928,8 @@ PlanBackend::Context::InitializeExecuteInputBinding(
     nvinfer1::Dims engine_dims = engine_->getBindingDimensions(binding_index);
     int vector_size = MemoryFormat_VectorSize(fmt);
     if (vector_size > 1) {
-      int dim_idx = engine_dims.nbDims - 3;
+      int vector_dim = MemoryFormat_VectorDim(fmt);
+      int dim_idx = engine_dims.nbDims - vector_dim;
       int64_t padding_offset =
           vector_size - (engine_dims.d[dim_idx] % vector_size);
       padding_info_[binding_index] = std::make_pair(dim_idx, padding_offset);
@@ -1355,7 +1356,8 @@ PlanBackend::Context::InitializeConfigExecuteOutputBindings(
       nvinfer1::Dims engine_dims = engine_->getBindingDimensions(binding_index);
       int vector_size = MemoryFormat_VectorSize(fmt);
       if (vector_size > 1) {
-        int dim_idx = engine_dims.nbDims - 3;
+        int vector_dim = MemoryFormat_VectorDim(fmt);
+        int dim_idx = engine_dims.nbDims - vector_dim;
         int64_t padding_offset =
             vector_size - (engine_dims.d[dim_idx] % vector_size);
         padding_info_[binding_index] = std::make_pair(dim_idx, padding_offset);

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -363,6 +363,10 @@ class PlanBackend : public InferenceBackend {
 
     // The request details of the ongoing model execution
     std::unique_ptr<Payload> payload_;
+
+    // map from binding_index to pair of index of full dims to
+    // be padded and the padding offset.
+    std::unordered_map<int, std::pair<int, int64_t>> padding_info_;
   };
 
   // CUDA engine shared across all model instances on the same device.

--- a/src/backends/tensorrt/plan_utils.cc
+++ b/src/backends/tensorrt/plan_utils.cc
@@ -63,6 +63,12 @@ ConvertTrtFmtToFmt(nvinfer1::TensorFormat trt_fmt)
       return MemoryFormat::CHW16;
     case nvinfer1::TensorFormat::kCHW32:
       return MemoryFormat::CHW32;
+    case nvinfer1::TensorFormat::kDHWC8:
+      return MemoryFormat::DHWC8;
+    case nvinfer1::TensorFormat::kCDHW32:
+      return MemoryFormat::CDHW32;
+    default:
+      return MemoryFormat::INVALID; 
   }
 
   return MemoryFormat::INVALID;
@@ -84,6 +90,10 @@ MemoryFormat_Name(MemoryFormat fmt)
       return "CHW16";
     case MemoryFormat::CHW32:
       return "CHW32";
+    case MemoryFormat::DHWC8:
+      return "DHWC8";
+    case MemoryFormat::CDHW32:
+      return "CDHW32";
     case MemoryFormat::INVALID:
       return "INVALID";
   }
@@ -106,12 +116,14 @@ MemoryFormat_VectorSize(MemoryFormat fmt)
       vector_size = 4;
       break;
     case MemoryFormat::HWC8:
+    case MemoryFormat::DHWC8:
       vector_size = 8;
       break;
     case MemoryFormat::CHW16:
       vector_size = 16;
       break;
     case MemoryFormat::CHW32:
+    case MemoryFormat::CDHW32:
       vector_size = 32;
       break;
     default:
@@ -119,6 +131,32 @@ MemoryFormat_VectorSize(MemoryFormat fmt)
       break;
   }
   return vector_size;
+}
+
+int
+MemoryFormat_VectorDim(MemoryFormat fmt)
+{
+  int vector_dim = -1;
+  switch(fmt) {
+    case MemoryFormat::LINEAR:
+      vector_dim = -1;
+      break;
+    case MemoryFormat::CHW2:
+    case MemoryFormat::CHW4:
+    case MemoryFormat::HWC8:
+    case MemoryFormat::CHW16:
+    case MemoryFormat::CHW32:
+      vector_dim = 3;
+      break;
+    case MemoryFormat::DHWC8:
+    case MemoryFormat::CDHW32:
+      vector_dim = 4;
+      break;
+    default:
+      vector_dim = -1; // In the default case, assume LINEAR
+      break;
+  }
+  return vector_dim;
 }
 
 std::pair<bool, nvinfer1::DataType>

--- a/src/backends/tensorrt/plan_utils.h
+++ b/src/backends/tensorrt/plan_utils.h
@@ -46,6 +46,10 @@ enum class MemoryFormat {
   CHW16,
   // Thirty-two wide channel vectorized row major format.
   CHW32,
+  // Eight channel format where C is padded to a multiple of 8 with 3 spatial dims.
+  DHWC8,
+  // Thirty-two wide channel vectorized row major format with 3 spatial dims.
+  CDHW32,
   // Invalid Memory format
   INVALID
 };
@@ -54,6 +58,7 @@ MemoryFormat ConvertTrtFmtToFmt(nvinfer1::TensorFormat trt_fmt);
 
 const std::string MemoryFormat_Name(MemoryFormat fmt);
 int MemoryFormat_VectorSize(MemoryFormat fmt);
+int MemoryFormat_VectorDim(MemoryFormat fmt);
 
 inference::DataType ConvertTrtTypeToDataType(nvinfer1::DataType trt_type);
 


### PR DESCRIPTION
This PR is merely for collecting reviews as we don't have plan on supporting reformat-free I/O yet. This change is not tested thoroughly, so it only guarantees reformat-free I/O is handled for a particular use case.

@tanmayv25 @deadeyegoodwin I think this change is somewhat close to how we are going to handle reformat-free I/O? Please provide some feedbacks.