### PR TITLE
Add CUDA graph specification in model config

### DIFF
--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -600,7 +600,8 @@ message ModelOptimizationPolicy
       //@@
       //@@         Specification of tensor dimension.
       //@@
-      message Shape {
+      message Shape
+      {
         //@@        .. cpp:var:: int64 dim (repeated)
         //@@
         //@@           The dimension.

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -600,7 +600,7 @@ message ModelOptimizationPolicy
       //@@
       //@@         Specification of tensor dimension.
       //@@
-      message Dims {
+      message Shape {
         //@@        .. cpp:var:: int64 dim (repeated)
         //@@
         //@@           The dimension.
@@ -610,15 +610,18 @@ message ModelOptimizationPolicy
 
       //@@      .. cpp:var:: int32 batch_size
       //@@
-      //@@         The batch size of the CUDA graph.
+      //@@         The batch size of the CUDA graph. If 'max_batch_size' is 0,
+      //@@         'batch_size' must be set to 0. Otherwise, 'batch_size' must
+      //@@         be set to value between 1 and 'max_batch_size'.
       //@@
       int32 batch_size = 1;
 
-      //@@      .. cpp:var:: map<string, Dims> input
+      //@@      .. cpp:var:: map<string, Shape> input
       //@@
-      //@@         The specification of the inputs.
+      //@@         The specification of the inputs. 'Shape' is the shape of the
+      //@@         input without batching dimension.
       //@@
-      map<string, Dims> input = 2;
+      map<string, Shape> input = 2;
     }
 
     //@@    .. cpp:var:: bool graphs

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -590,6 +590,37 @@ message ModelOptimizationPolicy
   //@@
   message Cuda
   {
+    //@@    .. cpp:var:: message GraphSpec
+    //@@
+    //@@       Specification of the CUDA graph to be captured.
+    //@@
+    message GraphSpec
+    {
+      //@@      .. cpp:var:: message Dims
+      //@@
+      //@@         Specification of tensor dimension.
+      //@@
+      message Dims {
+        //@@        .. cpp:var:: int64 dim (repeated)
+        //@@
+        //@@           The dimension.
+        //@@
+        repeated int64 dim = 1;
+      }
+
+      //@@      .. cpp:var:: int32 batch_size
+      //@@
+      //@@         The batch size of the CUDA graph.
+      //@@
+      int32 batch_size = 1;
+
+      //@@      .. cpp:var:: map<string, Dims> input
+      //@@
+      //@@         The specification of the inputs.
+      //@@
+      map<string, Dims> input = 2;
+    }
+
     //@@    .. cpp:var:: bool graphs
     //@@
     //@@       Use CUDA graphs API to capture model operations and execute
@@ -606,6 +637,15 @@ message ModelOptimizationPolicy
     //@@       Currently only recognized by TensorRT backend.
     //@@
     bool busy_wait_events = 2;
+
+    //@@    .. cpp:var:: GraphSpec graph_spec (repeated)
+    //@@
+    //@@       Specification of the CUDA graph to be captured. If not specified
+    //@@       and 'graphs' is true, the default CUDA graphs will be captured
+    //@@       based on model settings.
+    //@@       Currently only recognized by TensorRT backend.
+    //@@
+    repeated GraphSpec graph_spec = 3;
   }
 
   //@@

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -1449,7 +1449,8 @@ ValidateModelConfigInt64()
       "ModelConfig::sequence_batching::oldest::max_queue_delay_microseconds",
       "ModelConfig::sequence_batching::max_sequence_idle_microseconds",
       "ModelConfig::ensemble_scheduling::step::model_version",
-      "ModelConfig::model_warmup::inputs::value::dims"};
+      "ModelConfig::model_warmup::inputs::value::dims",
+      "ModelConfig::optimization::cuda::graph_spec::input::value::dim"};
 
   if (int64_fields != expected) {
     return Status(


### PR DESCRIPTION
@deadeyegoodwin Given the limitation of CUDA graph, this is the new config option to increase the usefulness of CUDA graph in the case of dynamic shape. User needs to specify the combinations explicitly so that the users can control what the graphs to be captured for different models and Triton doesn't need to populate the combinations.