### PR TITLE
Fixed InferenceRequest::ReportStatisticsWithDuration

### DIFF
--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -1177,6 +1177,11 @@ EnsembleScheduler::Create(
 Status
 EnsembleScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
 {
+  // Queue timer starts at the beginning of the queueing and
+  // scheduling process
+  INFER_TRACE_ACTIVITY(
+      request->Trace(), TRITONSERVER_TRACE_QUEUE_START,
+      request->CaptureQueueStartNs());
   std::shared_ptr<EnsembleContext> context(new EnsembleContext(
       metric_reporter_.get(), stats_aggregator_, is_, info_.get(), request,
       stream_));

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -718,13 +718,13 @@ InferenceRequest::ReportStatisticsWithDuration(
   INFER_STATS_DECL_TIMESTAMP(request_end_ns);
 
   if (success) {
-    backend_raw_->MutableStatsAggregator()->UpdateSuccess(
+    backend_raw_->MutableStatsAggregator()->UpdateSuccessWithDuration(
         metric_reporter, std::max(1U, batch_size_), request_start_ns_,
         queue_start_ns_, compute_start_ns, request_end_ns,
         compute_input_duration_ns, compute_infer_duration_ns,
         compute_output_duration_ns);
     if (secondary_stats_aggregator_ != nullptr) {
-      secondary_stats_aggregator_->UpdateSuccess(
+      secondary_stats_aggregator_->UpdateSuccessWithDuration(
           nullptr /* metric_reporter */, std::max(1U, batch_size_),
           request_start_ns_, queue_start_ns_, compute_start_ns, request_end_ns,
           compute_input_duration_ns, compute_infer_duration_ns,


### PR DESCRIPTION
This bug seems to affects`ensemble_scheduler` to report underflow-ish(?) value.