### PR TITLE
Fixes HTTPAPIServer leak

### DIFF
--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -982,9 +982,9 @@ class HTTPAPIServer : public HTTPServerImpl {
       evbuffer* evbuffer_;
     };
 
-    ~AllocPayload() 
+    ~AllocPayload()
     {
-      for(auto it: output_map_) {
+      for (auto it : output_map_) {
         delete it.second;
       }
     }

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -982,6 +982,13 @@ class HTTPAPIServer : public HTTPServerImpl {
       evbuffer* evbuffer_;
     };
 
+    ~AllocPayload() 
+    {
+      for(auto it: output_map_) {
+        delete it.second;
+      }
+    }
+
     AllocPayload() : default_output_kind_(OutputInfo::Kind::JSON){};
     std::unordered_map<std::string, OutputInfo*> output_map_;
     AllocPayload::OutputInfo::Kind default_output_kind_;


### PR DESCRIPTION
In HandleInfer, when TRITONSERVER_ServerInferAsync returns an error, the infer_req unique pointer goes out of scope without being released. However, since no release callback is called, the InferRequestClass still has an AllocPayload::OutputInfo object in the output_map_. 