### PR TITLE
Fixed leak in TensorRT PlanBackend

### DIFF
--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -353,7 +353,7 @@ function check_valgrind_log () {
 
     leak_records=$(grep "are definitely lost" -A 8 $valgrind_log | awk \
     'BEGIN{RS="--";acc=0} !(/cnmem/||/tensorflow::NewSession/||/dl-init/|| \
-    /dlerror/||/LoadPlan/||/libtorch/) \
+    /dlerror/||/libtorch/) \
     {print;acc+=1} END{print acc}')
 
     num_leaks=$(echo -e "$leak_records" | tail -n1)

--- a/src/backends/tensorrt/loader.cc
+++ b/src/backends/tensorrt/loader.cc
@@ -47,13 +47,6 @@ LoadPlan(
     }
   }
 
-  *engine = nullptr;
-
-  *runtime = nvinfer1::createInferRuntime(tensorrt_logger);
-  if (*runtime == nullptr) {
-    return Status(Status::Code::INTERNAL, "unable to create TensorRT runtime");
-  }
-
   *engine =
       (*runtime)->deserializeCudaEngine(&model_data[0], model_data.size());
   if (*engine == nullptr) {


### PR DESCRIPTION
There seemed to be duplicated calling of createInferRuntime using the same pointer, resulting in the leak of the first runtime.