### PR TITLE
Install dependencies for generating nightly summary pdf

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -312,7 +312,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                               valgrind \
                               xfonts-75dpi && \
     rm -rf /var/lib/apt/lists/* && \
-    wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb && \    dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb && \
+    wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb && \
+    dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb && \
     rm -rf wkhtmltox_0.12.6-1.bionic_amd64.deb
 
 # CI/QA expects "python" executable (not python3).

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -295,7 +295,7 @@ RUN if [ $(cat /etc/os-release | grep 'VERSION_ID="16.04"' | wc -l) -ne 0 ]; the
     fi
 
 # go client requires golang and CI/QA for memcheck requires valgrind
-# wkhtmltox, xfonts-75dpi are dependencies of pdfkit
+# wkhtmltox, xfonts-75dpi, xfonts-base are dependencies of pdfkit
 RUN apt-get update && apt-get install -y --no-install-recommends \
                               curl \
                               libopencv-dev \
@@ -310,7 +310,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                               nginx \
                               protobuf-compiler \
                               valgrind \
-                              xfonts-75dpi && \
+                              xfonts-75dpi \
+                              xfonts-base && \
     rm -rf /var/lib/apt/lists/* && \
     wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb && \
     dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb && \

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -295,6 +295,7 @@ RUN if [ $(cat /etc/os-release | grep 'VERSION_ID="16.04"' | wc -l) -ne 0 ]; the
     fi
 
 # go client requires golang and CI/QA for memcheck requires valgrind
+# wkhtmltox, xfonts-75dpi are dependencies of pdfkit
 RUN apt-get update && apt-get install -y --no-install-recommends \
                               curl \
                               libopencv-dev \
@@ -308,8 +309,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                               golang-go \
                               nginx \
                               protobuf-compiler \
-                              valgrind && \
-    rm -rf /var/lib/apt/lists/*
+                              valgrind \
+                              xfonts-75dpi && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.bionic_amd64.deb && \    dpkg -i wkhtmltox_0.12.6-1.bionic_amd64.deb && \
+    rm -rf wkhtmltox_0.12.6-1.bionic_amd64.deb
 
 # CI/QA expects "python" executable (not python3).
 RUN rm -f /usr/bin/python && \


### PR DESCRIPTION
Side note: A few tests install awslocal-cli elasticsearch and some other packages in the test scripts (gitlab) 
I will have a follow up PR to move those installs into the Dockerfile.QA