### PR TITLE
Formalize reformat-free input. Minor plan_backend clean up

### DIFF
--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -820,10 +820,18 @@ PlanBackend::Context::InitializeShapeInputBinding(
     }
 
     if (engine_->isExecutionBinding(binding_index)) {
-      std::vector<int64_t> dim_vec;
-      DimsToDimVec(
-          context.context_->getBindingDimensions(binding_index), &dim_vec);
-      int64_t byte_size = GetByteSize(dt, dim_vec);
+      int64_t byte_size = 0;
+      if (is_linear_format_[io_index]) {
+        std::vector<int64_t> dim_vec;
+        DimsToDimVec(
+            context.context_->getBindingDimensions(binding_index), &dim_vec);
+        byte_size = GetByteSize(dt, dim_vec);
+      } else {
+        auto component_count =
+            GetElementCount(context.context_->getStrides(binding_index));
+        component_count *= engine_->getBindingComponentsPerElement(binding_index);
+        byte_size = component_count * engine_->getBindingBytesPerComponent(binding_index);
+      }
       max_byte_size = std::max(max_byte_size, byte_size);
     }
   }

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -417,8 +417,8 @@ PlanBackend::Context::InitOptimizationProfiles(
           return Status(
               Status::Code::INTERNAL, "unable to create TensorRT context");
         }
-        if (!res.first->second.context_->setOptimizationProfile(
-                profile_index)) {
+        if (!res.first->second.context_->setOptimizationProfileAsync(
+                profile_index, stream_)) {
           return Status(
               Status::Code::INVALID_ARG,
               "Can not set the specified optimization profile " + profile_name +
@@ -2177,7 +2177,7 @@ PlanBackend::Context::Run(
         FAIL_ALL_AND_RETURN_IF_ERROR(
             payload_->requests_, payload_->responses_, metric_reporter_.get(),
             SetBindingDimensions(
-                name, ragged_shape, citr->second, bindex, io_index),
+                name, ragged_shape, citr->second, bindex, io_index, &input_dims),
             "error setting the binding dimension");
 
         size_t total_byte_size = 0;

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -550,7 +550,8 @@ PlanBackend::CreateExecutionContext(
   // Initialize the inputs and outputs. Make sure the model matches
   // what is in the configuration. Allocate memory for the maximum
   // possible batch size: min(engine maximum, config maximum)
-  context->io_binding_infos_ = std::vector<Context::IOBindingInfo>(context->num_expected_bindings_);
+  context->io_binding_infos_ =
+      std::vector<Context::IOBindingInfo>(context->num_expected_bindings_);
   context->buffer_bindings_ =
       std::vector<void*>(context->total_bindings_, nullptr);
 
@@ -792,8 +793,8 @@ PlanBackend::Context::InitializeShapeInputBinding(
          nvinfer1::TensorFormat::kLINEAR);
     if (!io_binding_info.is_linear_format_) {
       io_binding_info.format_element_size_ =
-              engine_->getBindingComponentsPerElement(binding_index) *
-              engine_->getBindingBytesPerComponent(binding_index);
+          engine_->getBindingComponentsPerElement(binding_index) *
+          engine_->getBindingBytesPerComponent(binding_index);
     }
 
     nvinfer1::Dims engine_dims = engine_->getBindingDimensions(binding_index);
@@ -931,8 +932,8 @@ PlanBackend::Context::InitializeExecuteInputBinding(
          nvinfer1::TensorFormat::kLINEAR);
     if (!io_binding_info.is_linear_format_) {
       io_binding_info.format_element_size_ =
-              engine_->getBindingComponentsPerElement(binding_index) *
-              engine_->getBindingBytesPerComponent(binding_index);
+          engine_->getBindingComponentsPerElement(binding_index) *
+          engine_->getBindingBytesPerComponent(binding_index);
     }
 
     // Detect whether dynamic or not
@@ -1255,10 +1256,10 @@ PlanBackend::Context::InitializeConfigShapeOutputBindings(
           (engine_->getBindingFormat(binding_index) ==
            nvinfer1::TensorFormat::kLINEAR);
       if (!io_binding_info.is_linear_format_) {
-      io_binding_info.format_element_size_ =
-              engine_->getBindingComponentsPerElement(binding_index) *
-              engine_->getBindingBytesPerComponent(binding_index);
-    }
+        io_binding_info.format_element_size_ =
+            engine_->getBindingComponentsPerElement(binding_index) *
+            engine_->getBindingBytesPerComponent(binding_index);
+      }
 
       const DimsList& model_config_dims =
           (io.has_reshape()) ? io.reshape().shape() : io.dims();
@@ -1362,10 +1363,10 @@ PlanBackend::Context::InitializeConfigExecuteOutputBindings(
           (engine_->getBindingFormat(binding_index) ==
            nvinfer1::TensorFormat::kLINEAR);
       if (!io_binding_info.is_linear_format_) {
-      io_binding_info.format_element_size_ =
-              engine_->getBindingComponentsPerElement(binding_index) *
-              engine_->getBindingBytesPerComponent(binding_index);
-    }
+        io_binding_info.format_element_size_ =
+            engine_->getBindingComponentsPerElement(binding_index) *
+            engine_->getBindingBytesPerComponent(binding_index);
+      }
 
       const DimsList& model_config_dims =
           (io.has_reshape()) ? io.reshape().shape() : io.dims();
@@ -1724,7 +1725,8 @@ PlanBackend::Context::SetCudaGraphShape(
         return Status(
             Status::Code::INTERNAL,
             "trt failed to set binding dimension to " + DimsDebugString(shape) +
-                " for binding " + std::to_string(binding_index) + " for " + name_);
+                " for binding " + std::to_string(binding_index) + " for " +
+                name_);
       }
       std::vector<int64_t> dims;
       DimsToDimVec(shape, &dims);
@@ -1746,7 +1748,8 @@ PlanBackend::Context::SetCudaGraphShape(
         shape.insert(shape.end(), it->second.begin(), it->second.end());
         nvinfer1::Dims trt_shape;
         DimVecToDims(shape, &trt_shape);
-        if (!trt_context->context_->setBindingDimensions(binding_index, trt_shape)) {
+        if (!trt_context->context_->setBindingDimensions(
+                binding_index, trt_shape)) {
           return Status(
               Status::Code::INTERNAL,
               "trt failed to set binding dimension to " +
@@ -2166,8 +2169,8 @@ PlanBackend::Context::Run(
       if (it != request_shape_values.end()) {
         status = ValidateShapeValues(
             it->second, citr->second.min_shapes_[binding_index],
-            citr->second.max_shapes_[binding_index], citr->second.nb_shape_values_,
-            support_batching_);
+            citr->second.max_shapes_[binding_index],
+            citr->second.nb_shape_values_, support_batching_);
       } else {
         status = Status(
             Status::Code::INTERNAL,
@@ -2178,7 +2181,8 @@ PlanBackend::Context::Run(
             status, "missing shape values for the shape tensor");
       }
       if (status.IsOk()) {
-        citr->second.context_->setInputShapeBinding(binding_index, &(it->second[0]));
+        citr->second.context_->setInputShapeBinding(
+            binding_index, &(it->second[0]));
       } else {
         FAIL_ALL_AND_RETURN_IF_ERROR(
             payload_->requests_, payload_->responses_, metric_reporter_.get(),
@@ -2221,9 +2225,10 @@ PlanBackend::Context::Run(
           total_byte_size = GetByteSize(datatype, ragged_shape);
         } else {
           // FIXME case where vectorized dim is first dimension
-          total_byte_size = io_binding_info.format_element_size_ *
-                            citr->second.context_->getStrides(binding_index).d[0] *
-                            ragged_shape[0];
+          total_byte_size =
+              io_binding_info.format_element_size_ *
+              citr->second.context_->getStrides(binding_index).d[0] *
+              ragged_shape[0];
         }
 
         FAIL_ALL_AND_RETURN_IF_ERROR(
@@ -2240,8 +2245,8 @@ PlanBackend::Context::Run(
               payload_->requests_, payload_->responses_, metric_reporter_.get(),
               CopyBuffer(
                   name, mem_type, mem_type_id, TRITONSERVER_MEMORY_GPU,
-                  gpu_device_, total_byte_size, input_buffer, io_binding_info.buffer_,
-                  input_copy_stream_, &cuda_used),
+                  gpu_device_, total_byte_size, input_buffer,
+                  io_binding_info.buffer_, input_copy_stream_, &cuda_used),
               "error copying the batch input buffer");
           if (cuda_used) {
             cudaEventRecord(
@@ -2274,9 +2279,10 @@ PlanBackend::Context::Run(
           total_byte_size = GetByteSize(datatype, ragged_shape);
         } else {
           // FIXME case where vectorized dim is first dimension
-          total_byte_size = io_binding_info.format_element_size_ *
-                            citr->second.context_->getStrides(binding_index).d[0] *
-                            ragged_shape[0];
+          total_byte_size =
+              io_binding_info.format_element_size_ *
+              citr->second.context_->getStrides(binding_index).d[0] *
+              ragged_shape[0];
         }
 
         collector.ProcessTensor(
@@ -2306,7 +2312,8 @@ PlanBackend::Context::Run(
       const inference::DataType datatype = repr_input->DType();
 
       // Set the binding dimension so that output dimensions can be obtained
-      if (UseTensorRTv2API(engine_) && !engine_->isShapeBinding(binding_index)) {
+      if (UseTensorRTv2API(engine_) &&
+          !engine_->isShapeBinding(binding_index)) {
         FAIL_ALL_AND_RETURN_IF_ERROR(
             payload_->requests_, payload_->responses_, metric_reporter_.get(),
             SetBindingDimensions(
@@ -2320,9 +2327,10 @@ PlanBackend::Context::Run(
         total_byte_size = GetByteSize(datatype, batchn_shape);
       } else {
         // FIXME case where vectorized dim is first dimension
-        total_byte_size = io_binding_info.format_element_size_ *
-                          citr->second.context_->getStrides(binding_index).d[0] *
-                          batchn_shape[0];
+        total_byte_size =
+            io_binding_info.format_element_size_ *
+            citr->second.context_->getStrides(binding_index).d[0] *
+            batchn_shape[0];
       }
 
       if ((engine_->isShapeBinding(binding_index)) && (support_batching_)) {
@@ -2341,7 +2349,8 @@ PlanBackend::Context::Run(
         // Copy rest of the shape values to the buffer.
         status = CopyBuffer(
             name, TRITONSERVER_MEMORY_CPU, 0, TRITONSERVER_MEMORY_GPU,
-            gpu_device_, total_byte_size, (void*)&request_shape_values[io_index],
+            gpu_device_, total_byte_size,
+            (void*)&request_shape_values[io_index],
             (static_cast<char*>(io_binding_info.buffer_) + sizeof(int32_t)),
             input_copy_stream_, &cuda_used);
         FAIL_ALL_AND_RETURN_IF_ERROR(
@@ -2589,13 +2598,13 @@ PlanBackend::Context::Run(
       }
     } else if (io_binding_info.buffer_is_ragged_) {
       // FIXME add correctness checking like below
-      inference::DataType dt = ConvertTrtTypeToDataType(
-          engine_->getBindingDataType(binding_index));
+      inference::DataType dt =
+          ConvertTrtTypeToDataType(engine_->getBindingDataType(binding_index));
       payload_->responder_->ProcessTensor(
           name, io_binding_info.io_shape_mapping_.first, dt,
           io_binding_info.io_shape_mapping_.second,
-          static_cast<const char*>(io_binding_info.buffer_), TRITONSERVER_MEMORY_GPU,
-          gpu_device_);
+          static_cast<const char*>(io_binding_info.buffer_),
+          TRITONSERVER_MEMORY_GPU, gpu_device_);
     } else {
       std::vector<int64_t> batchn_shape;
 
@@ -2607,8 +2616,8 @@ PlanBackend::Context::Run(
         batchn_shape.push_back(dims.d[i]);
       }
 
-      inference::DataType dt = ConvertTrtTypeToDataType(
-          engine_->getBindingDataType(binding_index));
+      inference::DataType dt =
+          ConvertTrtTypeToDataType(engine_->getBindingDataType(binding_index));
 
       // FIXME process reformat-free output, need to update output process
       // code to accept batch1_byte_size and request batch size to break down
@@ -2625,14 +2634,16 @@ PlanBackend::Context::Run(
             Status(
                 Status::Code::INTERNAL,
                 "unexpected size for output '" + name + "', byte-size " +
-                    std::to_string(io_binding_info.byte_size_) + " is less than " +
+                    std::to_string(io_binding_info.byte_size_) +
+                    " is less than " +
                     std::to_string(payload_->total_batch_size_) + " * " +
                     std::to_string(batch1_byte_size)),
             "failed to run TRT response");
       }
 
       payload_->responder_->ProcessTensor(
-          name, dt, batchn_shape, static_cast<const char*>(io_binding_info.buffer_),
+          name, dt, batchn_shape,
+          static_cast<const char*>(io_binding_info.buffer_),
           TRITONSERVER_MEMORY_GPU, gpu_device_);
     }
   }

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -357,19 +357,22 @@ class PlanBackend : public InferenceBackend {
     using BatchInputData =
         std::pair<inference::BatchInput, std::unique_ptr<AllocatedMemory>>;
     struct IOBindingInfo {
-        IOBindingInfo() : byte_size_(0), buffer_(nullptr), buffer_is_ragged_(false),
-        is_linear_format_(false), format_element_size_(0) {}
-    uint64_t byte_size_;
-    void* buffer_;
-    bool buffer_is_ragged_;
-    bool is_linear_format_;
-    size_t format_element_size_;
-    // Instructions on constructing the batch input and the CPU buffer for
-    // storing mutable data
-    std::shared_ptr<BatchInputData> batch_input_;
-    // Store the pair of input name to look up and output shape
-    // for output scattering
-    std::pair<std::string, std::vector<int64_t>> io_shape_mapping_;
+      IOBindingInfo()
+          : byte_size_(0), buffer_(nullptr), buffer_is_ragged_(false),
+            is_linear_format_(false), format_element_size_(0)
+      {
+      }
+      uint64_t byte_size_;
+      void* buffer_;
+      bool buffer_is_ragged_;
+      bool is_linear_format_;
+      size_t format_element_size_;
+      // Instructions on constructing the batch input and the CPU buffer for
+      // storing mutable data
+      std::shared_ptr<BatchInputData> batch_input_;
+      // Store the pair of input name to look up and output shape
+      // for output scattering
+      std::pair<std::string, std::vector<int64_t>> io_shape_mapping_;
     };
 
     // The array sizes are equal to Context::num_expected_bindings_

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -357,6 +357,7 @@ class PlanBackend : public InferenceBackend {
     std::vector<uint64_t> byte_sizes_;
     std::vector<void*> buffers_;
     std::vector<bool> buffer_is_ragged_;
+    std::vector<bool> is_linear_format_;
     // Instructions on constructing the batch input and the CPU buffer for
     // storing mutable data
     using BatchInputData =

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -359,7 +359,7 @@ class PlanBackend : public InferenceBackend {
     struct IOBindingInfo {
       IOBindingInfo()
           : byte_size_(0), buffer_(nullptr), buffer_is_ragged_(false),
-            is_linear_format_(false), format_element_size_(0)
+            is_linear_format_(true), format_element_size_(0)
       {
       }
       uint64_t byte_size_;

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -266,8 +266,8 @@ class PlanBackend : public InferenceBackend {
 
     Status SetBindingDimensions(
         const std::string& input_name, const std::vector<int64_t>& shape,
-        const TensorRTContext& trt_context, const size_t binding_idx,
-        const size_t io_idx, std::vector<int64_t>* input_dims);
+        const TensorRTContext& trt_context, const size_t io_index,
+        const size_t binding_index, std::vector<int64_t>* input_dims);
     Status SetCudaGraphShape(
         TensorRTContext* trt_context, const GraphSpec& graph_spec,
         std::vector<int64_t>* cuda_graph_key,
@@ -353,19 +353,27 @@ class PlanBackend : public InferenceBackend {
 
     // The maximum possible size of the TensorRT tensor and the corresponding
     // allocated GPU buffer across all optimization
-    // profile. The array sizes are equal to Context::num_expected_bindings_
-    std::vector<uint64_t> byte_sizes_;
-    std::vector<void*> buffers_;
-    std::vector<bool> buffer_is_ragged_;
-    std::vector<bool> is_linear_format_;
-    // Instructions on constructing the batch input and the CPU buffer for
-    // storing mutable data
+    // profile.
     using BatchInputData =
         std::pair<inference::BatchInput, std::unique_ptr<AllocatedMemory>>;
-    std::vector<std::shared_ptr<BatchInputData>> batch_inputs_;
+    struct IOBindingInfo {
+        IOBindingInfo() : byte_size_(0), buffer_(nullptr), buffer_is_ragged_(false),
+        is_linear_format_(false), format_element_size_(0) {}
+    uint64_t byte_size_;
+    void* buffer_;
+    bool buffer_is_ragged_;
+    bool is_linear_format_;
+    size_t format_element_size_;
+    // Instructions on constructing the batch input and the CPU buffer for
+    // storing mutable data
+    std::shared_ptr<BatchInputData> batch_input_;
     // Store the pair of input name to look up and output shape
     // for output scattering
-    std::vector<std::pair<std::string, std::vector<int64_t>>> io_shape_mapping_;
+    std::pair<std::string, std::vector<int64_t>> io_shape_mapping_;
+    };
+
+    // The array sizes are equal to Context::num_expected_bindings_
+    std::vector<IOBindingInfo> io_binding_infos_;
 
     // The pointer to the CUDA buffer for each binding index of the TensorRT
     // engine. This is used to match the TensorRT context execution declaration
@@ -375,10 +383,6 @@ class PlanBackend : public InferenceBackend {
 
     // The request details of the ongoing model execution
     std::unique_ptr<Payload> payload_;
-
-    // map from binding_index to pair of index of full dims to
-    // be padded and the padding offset.
-    std::unordered_map<int, std::pair<int, int64_t>> padding_info_;
   };
 
   // CUDA engine shared across all model instances on the same device.

--- a/src/backends/tensorrt/plan_utils.cc
+++ b/src/backends/tensorrt/plan_utils.cc
@@ -409,7 +409,7 @@ const std::string
 DimsDebugString(const nvinfer1::Dims& dims)
 {
   std::vector<int64_t> dims_vec;
-  DimsToDimVec(dims, {0, 0}, &dims_vec);
+  DimsToDimVec(dims, &dims_vec);
   return DimsListToString(dims_vec);
 }
 

--- a/src/backends/tensorrt/plan_utils.cc
+++ b/src/backends/tensorrt/plan_utils.cc
@@ -47,50 +47,6 @@ ConvertTrtTypeToDataType(nvinfer1::DataType trt_type)
   return inference::DataType::TYPE_INVALID;
 }
 
-MemoryFormat
-ConvertTrtFmtToFmt(nvinfer1::TensorFormat trt_fmt)
-{
-  switch (trt_fmt) {
-    case nvinfer1::TensorFormat::kLINEAR:
-      return MemoryFormat::LINEAR;
-    case nvinfer1::TensorFormat::kCHW2:
-      return MemoryFormat::CHW2;
-    case nvinfer1::TensorFormat::kCHW4:
-      return MemoryFormat::CHW4;
-    case nvinfer1::TensorFormat::kHWC8:
-      return MemoryFormat::HWC8;
-    case nvinfer1::TensorFormat::kCHW16:
-      return MemoryFormat::CHW16;
-    case nvinfer1::TensorFormat::kCHW32:
-      return MemoryFormat::CHW32;
-  }
-
-  return MemoryFormat::INVALID;
-}
-
-const std::string
-MemoryFormat_Name(MemoryFormat fmt)
-{
-  switch (fmt) {
-    case MemoryFormat::LINEAR:
-      return "LINEAR";
-    case MemoryFormat::CHW2:
-      return "CHW2";
-    case MemoryFormat::CHW4:
-      return "CHW4";
-    case MemoryFormat::HWC8:
-      return "HWC8";
-    case MemoryFormat::CHW16:
-      return "CHW16";
-    case MemoryFormat::CHW32:
-      return "CHW32";
-    case MemoryFormat::INVALID:
-      return "INVALID";
-  }
-
-  return "INVALID";
-}
-
 bool
 UseTensorRTv2API(const nvinfer1::ICudaEngine* engine)
 {
@@ -99,36 +55,6 @@ UseTensorRTv2API(const nvinfer1::ICudaEngine* engine)
   // an implicit batch dimension to detect whether or not
   // to use the TensorRT V2 API.
   return !engine->hasImplicitBatchDimension();
-}
-
-int
-MemoryFormat_VectorSize(MemoryFormat fmt)
-{
-  unsigned int vector_size = 1;
-  switch (fmt) {
-    case MemoryFormat::LINEAR:
-      vector_size = 1;
-      break;
-    case MemoryFormat::CHW2:
-      vector_size = 2;
-      break;
-    case MemoryFormat::CHW4:
-      vector_size = 4;
-      break;
-    case MemoryFormat::HWC8:
-      vector_size = 8;
-      break;
-    case MemoryFormat::CHW16:
-      vector_size = 16;
-      break;
-    case MemoryFormat::CHW32:
-      vector_size = 32;
-      break;
-    default:
-      vector_size = 1;  // In the default case, assume LINEAR
-      break;
-  }
-  return vector_size;
 }
 
 std::pair<bool, nvinfer1::DataType>

--- a/src/backends/tensorrt/plan_utils.cc
+++ b/src/backends/tensorrt/plan_utils.cc
@@ -258,8 +258,7 @@ MaximumDims(
         return Status(
             Status::Code::INVALID_ARG,
             "can not maximize dimension " + DimsListToString(dims) + " to " +
-                DimsDebugString(max_profile_dims) +
-                " due to incompatibility.");
+                DimsDebugString(max_profile_dims) + " due to incompatibility.");
       }
     }
   }
@@ -350,8 +349,7 @@ ValidateShapeValues(
 }
 
 void
-DimsToDimVec(
-    const nvinfer1::Dims& model_dims, std::vector<int64_t>* dims)
+DimsToDimVec(const nvinfer1::Dims& model_dims, std::vector<int64_t>* dims)
 {
   dims->clear();
   for (int i = 0; i < model_dims.nbDims; ++i) {
@@ -360,8 +358,7 @@ DimsToDimVec(
 }
 
 bool
-DimVecToDims(
-    const std::vector<int64_t>& dim_vec, nvinfer1::Dims* dims)
+DimVecToDims(const std::vector<int64_t>& dim_vec, nvinfer1::Dims* dims)
 {
   if (dim_vec.size() > dims->MAX_DIMS) {
     return false;

--- a/src/backends/tensorrt/plan_utils.h
+++ b/src/backends/tensorrt/plan_utils.h
@@ -75,11 +75,9 @@ Status MaximumDims(
     const bool support_batching, const int max_batch_size,
     std::vector<int64_t>* maximum_dims);
 
-void DimsToDimVec(
-    const nvinfer1::Dims& model_dims, std::vector<int64_t>* dims);
+void DimsToDimVec(const nvinfer1::Dims& model_dims, std::vector<int64_t>* dims);
 
-bool DimVecToDims(
-    const std::vector<int64_t>& dim_vec, nvinfer1::Dims* dims);
+bool DimVecToDims(const std::vector<int64_t>& dim_vec, nvinfer1::Dims* dims);
 
 int64_t GetElementCount(const nvinfer1::Dims& dims);
 

--- a/src/backends/tensorrt/plan_utils.h
+++ b/src/backends/tensorrt/plan_utils.h
@@ -32,30 +32,7 @@
 
 namespace nvidia { namespace inferenceserver {
 
-// The memory layouts for i/o tensors
-enum class MemoryFormat {
-  // Row major linear format.
-  LINEAR,
-  // Two wide channel vectorized row major format.
-  CHW2,
-  // Four wide channel vectorized row major format.
-  CHW4,
-  // Eight channel format where C is padded to a multiple of 8.
-  HWC8,
-  // Sixteen wide channel vectorized row major format.
-  CHW16,
-  // Thirty-two wide channel vectorized row major format.
-  CHW32,
-  // Invalid Memory format
-  INVALID
-};
-
 bool UseTensorRTv2API(const nvinfer1::ICudaEngine* engine);
-
-MemoryFormat ConvertTrtFmtToFmt(nvinfer1::TensorFormat trt_fmt);
-
-const std::string MemoryFormat_Name(MemoryFormat fmt);
-int MemoryFormat_VectorSize(MemoryFormat fmt);
 
 inference::DataType ConvertTrtTypeToDataType(nvinfer1::DataType trt_type);
 

--- a/src/backends/tensorrt/plan_utils.h
+++ b/src/backends/tensorrt/plan_utils.h
@@ -55,7 +55,7 @@ Status CompareDimsSupported(
     const std::string& model_name, const std::string& tensor_name,
     const nvinfer1::Dims& model_dims, const DimsList& dims,
     const bool supports_batching, const bool contains_explicit_batch,
-    const bool compare_exact, const std::pair<int, int64_t>& padding);
+    const bool compare_exact);
 
 Status CompareShapeDimsSupported(
     const std::string& model_name, const std::string& tensor_name,

--- a/src/backends/tensorrt/plan_utils.h
+++ b/src/backends/tensorrt/plan_utils.h
@@ -56,7 +56,6 @@ MemoryFormat ConvertTrtFmtToFmt(nvinfer1::TensorFormat trt_fmt);
 
 const std::string MemoryFormat_Name(MemoryFormat fmt);
 int MemoryFormat_VectorSize(MemoryFormat fmt);
-int MemoryFormat_VectorDim(MemoryFormat fmt);
 
 inference::DataType ConvertTrtTypeToDataType(nvinfer1::DataType trt_type);
 
@@ -97,15 +96,15 @@ Status ValidateShapeValues(
 Status MaximumDims(
     const nvinfer1::Dims& max_profile_dims, const DimsList& dims,
     const bool support_batching, const int max_batch_size,
-    const std::pair<int, int64_t>& padding, std::vector<int64_t>* maximum_dims);
+    std::vector<int64_t>* maximum_dims);
 
 void DimsToDimVec(
-    const nvinfer1::Dims& model_dims, const std::pair<int, int64_t>& padding,
-    std::vector<int64_t>* dims);
+    const nvinfer1::Dims& model_dims, std::vector<int64_t>* dims);
 
 bool DimVecToDims(
-    const std::vector<int64_t>& dim_vec, const std::pair<int, int64_t>& padding,
-    nvinfer1::Dims* dims);
+    const std::vector<int64_t>& dim_vec, nvinfer1::Dims* dims);
+
+int64_t GetElementCount(const nvinfer1::Dims& dims);
 
 bool ContainsWildcard(const nvinfer1::Dims& dims);
 
@@ -121,8 +120,7 @@ template <typename T>
 Status
 ValidateDimension(
     const T& this_dims, const nvinfer1::Dims& min_dims,
-    const nvinfer1::Dims& max_dims, const bool skip_first_dimension,
-    const std::pair<int, int64_t>& padding)
+    const nvinfer1::Dims& max_dims, const bool skip_first_dimension)
 {
   const int nonbatch_start_idx = (skip_first_dimension ? 1 : 0);
   if (int(this_dims.size() + nonbatch_start_idx) != max_dims.nbDims) {
@@ -138,18 +136,15 @@ ValidateDimension(
     if (this_dims[i] == -1) {
       continue;
     }
-    auto this_dim = (i == (padding.first - nonbatch_start_idx))
-                        ? (this_dims[i] - padding.second)
-                        : this_dims[i];
-    if (this_dim < min_dims.d[i + nonbatch_start_idx] ||
-        this_dim > max_dims.d[i + nonbatch_start_idx]) {
+    if (this_dims[i] < min_dims.d[i + nonbatch_start_idx] ||
+        this_dims[i] > max_dims.d[i + nonbatch_start_idx]) {
       return Status(
           Status::Code::INTERNAL,
           "model expected the shape of dimension " + std::to_string(i) +
               " to be between " +
               std::to_string(min_dims.d[i + nonbatch_start_idx]) + " and " +
               std::to_string(max_dims.d[i + nonbatch_start_idx]) +
-              " but received " + std::to_string(this_dim));
+              " but received " + std::to_string(this_dims[i]));
     }
   }
   return Status::Success;

--- a/src/core/backend_context.cc
+++ b/src/core/backend_context.cc
@@ -652,8 +652,6 @@ BackendInputCollector::ProcessTensor(
 
     const InferenceRequest::Input* request_input;
     Status status = request->ImmutableInput(name, &request_input);
-    const size_t request_byte_size =
-        GetByteSize(datatype, request_input->ShapeWithBatchDim());
     if (!status.IsOk() && (response != nullptr)) {
       InferenceResponse::SendWithStatus(
           std::move(response), TRITONSERVER_RESPONSE_COMPLETE_FINAL, status);
@@ -663,7 +661,7 @@ BackendInputCollector::ProcessTensor(
           memory_type_id, use_pinned_memory_type, &response);
     }
 
-    buffer_offset += request_byte_size;
+    buffer_offset += request_input->Data()->TotalByteSize();
   }
 
   // Done with the tensor, flush any pending pinned copies.


### PR DESCRIPTION
In server-client communication, the input shape will still be in linear format so that plan backend can set binding dimension properly, but it will expect the client to prepare the input data in the corresponding non-linear form.

Cleaned up the use of `binding_index` and `io_index`. `binding_index` is the index that takes profile index into account, and it is used to prepare the executing profile properly, `io_index` is used to refer to io information that is consistent across profiles.