### PR TITLE
Add backend state summary to Triton logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -325,7 +325,7 @@ COPY --from=tritonserver_onnx /workspace/build/Release/testdata/custom_op_librar
 # - Need to find CUDA stubs if they are available since some backends
 # may need to link against them. This is identical to the logic in TF
 # container nvbuild.sh
-ARG TRITON_COMMON_REPO_TAG=main
+ARG TRITON_COMMON_REPO_TAG=imant-summary
 ARG TRITON_CORE_REPO_TAG=main
 ARG TRITON_BACKEND_REPO_TAG=main
 

--- a/src/backends/backend/triton_backend_manager.cc
+++ b/src/backends/backend/triton_backend_manager.cc
@@ -329,13 +329,15 @@ TRITONBACKEND_BackendSetState(TRITONBACKEND_Backend* backend, void* state)
 //
 
 TritonBackendManager&
-TritonBackendManager::Instance() {
+TritonBackendManager::Instance()
+{
   static TritonBackendManager triton_backend_manager{};
   return triton_backend_manager;
 }
 
 const std::unordered_map<std::string, std::weak_ptr<TritonBackend>>&
-TritonBackendManager::BackendMap() {
+TritonBackendManager::BackendMap()
+{
   return backend_map_;
 }
 
@@ -345,7 +347,7 @@ TritonBackendManager::CreateBackend(
     const BackendCmdlineConfig& backend_cmdline_config,
     std::shared_ptr<TritonBackend>* backend)
 {
-  TritonBackendManager &singleton_manager = TritonBackendManager::Instance();
+  TritonBackendManager& singleton_manager = TritonBackendManager::Instance();
 
   std::lock_guard<std::mutex> lock(singleton_manager.Mutex());
 

--- a/src/backends/backend/triton_backend_manager.cc
+++ b/src/backends/backend/triton_backend_manager.cc
@@ -327,15 +327,27 @@ TRITONBACKEND_BackendSetState(TRITONBACKEND_Backend* backend, void* state)
 //
 // TritonBackendManager
 //
+
+TritonBackendManager&
+TritonBackendManager::Instance() {
+  static TritonBackendManager triton_backend_manager{};
+  return triton_backend_manager;
+}
+
+const std::unordered_map<std::string, std::weak_ptr<TritonBackend>>&
+TritonBackendManager::BackendMap() {
+  return backend_map_;
+}
+
 Status
 TritonBackendManager::CreateBackend(
     const std::string& name, const std::string& dir, const std::string& libpath,
     const BackendCmdlineConfig& backend_cmdline_config,
     std::shared_ptr<TritonBackend>* backend)
 {
-  static TritonBackendManager singleton_manager;
+  TritonBackendManager &singleton_manager = TritonBackendManager::Instance();
 
-  std::lock_guard<std::mutex> lock(singleton_manager.mu_);
+  std::lock_guard<std::mutex> lock(singleton_manager.Mutex());
 
   const auto& itr = singleton_manager.backend_map_.find(libpath);
   if (itr != singleton_manager.backend_map_.end()) {

--- a/src/backends/backend/triton_backend_manager.h
+++ b/src/backends/backend/triton_backend_manager.h
@@ -143,8 +143,24 @@ class TritonBackendManager {
       const BackendCmdlineConfig& backend_cmdline_config,
       std::shared_ptr<TritonBackend>* backend);
 
+  static TritonBackendManager& Instance();
+  static std::mutex& Mutex() {
+    static std::mutex m;
+    return m;
+  }
+
+  TritonBackendManager() {
+
+  }
+
+  TritonBackendManager(TritonBackendManager const&) = delete;
+  TritonBackendManager(TritonBackendManager&&) = delete;
+  TritonBackendManager& operator=(TritonBackendManager const&) = delete;
+  TritonBackendManager& operator=(TritonBackendManager &&) = delete;
+
+  const std::unordered_map<std::string, std::weak_ptr<TritonBackend>>& BackendMap();
+
  private:
-  std::mutex mu_;
   std::unordered_map<std::string, std::weak_ptr<TritonBackend>> backend_map_;
 };
 

--- a/src/backends/backend/triton_backend_manager.h
+++ b/src/backends/backend/triton_backend_manager.h
@@ -144,21 +144,21 @@ class TritonBackendManager {
       std::shared_ptr<TritonBackend>* backend);
 
   static TritonBackendManager& Instance();
-  static std::mutex& Mutex() {
+  static std::mutex& Mutex()
+  {
     static std::mutex m;
     return m;
   }
 
-  TritonBackendManager() {
-
-  }
+  TritonBackendManager() {}
 
   TritonBackendManager(TritonBackendManager const&) = delete;
   TritonBackendManager(TritonBackendManager&&) = delete;
   TritonBackendManager& operator=(TritonBackendManager const&) = delete;
-  TritonBackendManager& operator=(TritonBackendManager &&) = delete;
+  TritonBackendManager& operator=(TritonBackendManager&&) = delete;
 
-  const std::unordered_map<std::string, std::weak_ptr<TritonBackend>>& BackendMap();
+  const std::unordered_map<std::string, std::weak_ptr<TritonBackend>>&
+  BackendMap();
 
  private:
   std::unordered_map<std::string, std::weak_ptr<TritonBackend>> backend_map_;

--- a/src/backends/backend/triton_backend_manager.h
+++ b/src/backends/backend/triton_backend_manager.h
@@ -149,10 +149,9 @@ class TritonBackendManager {
           std::unordered_map<std::string, std::vector<std::string>>>*
           backend_state);
 
-  TritonBackendManager(){};
-
  private:
   DISALLOW_COPY_AND_ASSIGN(TritonBackendManager);
+  TritonBackendManager() = default;
   static TritonBackendManager& Singleton();
   std::mutex mu_;
   std::unordered_map<std::string, std::weak_ptr<TritonBackend>> backend_map_;

--- a/src/backends/backend/triton_backend_manager.h
+++ b/src/backends/backend/triton_backend_manager.h
@@ -144,19 +144,18 @@ class TritonBackendManager {
       const BackendCmdlineConfig& backend_cmdline_config,
       std::shared_ptr<TritonBackend>* backend);
 
-  static std::unique_ptr<
-      std::unordered_map<std::string, std::vector<std::string>>>
-  BackendState();
+  static Status BackendState(
+      std::unique_ptr<
+          std::unordered_map<std::string, std::vector<std::string>>>*
+          backend_state);
 
   TritonBackendManager(){};
 
  private:
-  static std::unordered_map<std::string, std::vector<std::string>>
-      backend_state_;
-  static TritonBackendManager& Instance_();
+  DISALLOW_COPY_AND_ASSIGN(TritonBackendManager);
+  static TritonBackendManager& Singleton();
   std::mutex mu_;
   std::unordered_map<std::string, std::weak_ptr<TritonBackend>> backend_map_;
-  DISALLOW_COPY_AND_ASSIGN(TritonBackendManager);
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/backends/backend/triton_backend_manager.h
+++ b/src/backends/backend/triton_backend_manager.h
@@ -143,25 +143,14 @@ class TritonBackendManager {
       const BackendCmdlineConfig& backend_cmdline_config,
       std::shared_ptr<TritonBackend>* backend);
 
-  static TritonBackendManager& Instance();
-  static std::mutex& Mutex()
-  {
-    static std::mutex m;
-    return m;
-  }
-
-  TritonBackendManager() {}
-
-  TritonBackendManager(TritonBackendManager const&) = delete;
-  TritonBackendManager(TritonBackendManager&&) = delete;
-  TritonBackendManager& operator=(TritonBackendManager const&) = delete;
-  TritonBackendManager& operator=(TritonBackendManager&&) = delete;
-
-  const std::unordered_map<std::string, std::weak_ptr<TritonBackend>>&
-  BackendMap();
+  static const std::unordered_map<std::string, std::vector<std::string>>&
+  BackendState();
 
  private:
+  static std::unordered_map<std::string, std::vector<std::string>>
+      backend_state_;
   std::unordered_map<std::string, std::weak_ptr<TritonBackend>> backend_map_;
+  std::mutex m_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/backends/backend/triton_backend_manager.h
+++ b/src/backends/backend/triton_backend_manager.h
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include "src/core/constants.h"
 #include "src/core/model_config.h"
 #include "src/core/server_message.h"
 #include "src/core/status.h"
@@ -143,14 +144,19 @@ class TritonBackendManager {
       const BackendCmdlineConfig& backend_cmdline_config,
       std::shared_ptr<TritonBackend>* backend);
 
-  static const std::unordered_map<std::string, std::vector<std::string>>&
+  static std::unique_ptr<
+      std::unordered_map<std::string, std::vector<std::string>>>
   BackendState();
+
+  TritonBackendManager(){};
 
  private:
   static std::unordered_map<std::string, std::vector<std::string>>
       backend_state_;
+  static TritonBackendManager& Instance_();
+  std::mutex mu_;
   std::unordered_map<std::string, std::weak_ptr<TritonBackend>> backend_map_;
-  std::mutex m_;
+  DISALLOW_COPY_AND_ASSIGN(TritonBackendManager);
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -238,7 +238,8 @@ endif() # TRITON_ENABLE_S3
 target_link_libraries(
   server-library
   PUBLIC
-    triton-core-backendapi  # from repo-core
-    triton-core-serverapi   # from repo-core
-    triton-common-json      # from repo-common
+    triton-core-backendapi           # from repo-core
+    triton-core-serverapi            # from repo-core
+    triton-common-json               # from repo-common
+    triton-common-table-printer      # from repo-common
 )

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -699,7 +699,7 @@ ModelRepositoryManager::BackendLifeCycle::Load(
 
   switch (backend_info->state_) {
     case ModelReadyState::READY:
-      LOG_INFO << "re-loading: " << model_name << ":" << version;
+      LOG_VERBOSE(1) << "re-loading: " << model_name << ":" << version;
       backend_info->state_ = ModelReadyState::UNLOADING;
       backend_info->state_reason_.clear();
       backend_info->next_action_ = ActionType::LOAD;
@@ -711,7 +711,7 @@ ModelRepositoryManager::BackendLifeCycle::Load(
       backend_info->next_action_ = ActionType::LOAD;
       break;
     default:
-      LOG_INFO << "loading: " << model_name << ":" << version;
+      LOG_VERBOSE(1) << "loading: " << model_name << ":" << version;
       backend_info->state_ = ModelReadyState::LOADING;
       backend_info->state_reason_.clear();
       {
@@ -893,7 +893,7 @@ ModelRepositoryManager::BackendLifeCycle::CreateInferenceBackend(
           }));
       backend_info->state_ = ModelReadyState::READY;
       backend_info->state_reason_.clear();
-      LOG_INFO << "successfully loaded '" << model_name << "' version "
+      LOG_VERBOSE(1) << "successfully loaded '" << model_name << "' version "
                << version;
     } else {
       LOG_ERROR << "failed to load '" << model_name << "' version " << version

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -894,7 +894,7 @@ ModelRepositoryManager::BackendLifeCycle::CreateInferenceBackend(
       backend_info->state_ = ModelReadyState::READY;
       backend_info->state_reason_.clear();
       LOG_VERBOSE(1) << "successfully loaded '" << model_name << "' version "
-               << version;
+                     << version;
     } else {
       LOG_ERROR << "failed to load '" << model_name << "' version " << version
                 << ": " << status.AsString();

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -699,7 +699,7 @@ ModelRepositoryManager::BackendLifeCycle::Load(
 
   switch (backend_info->state_) {
     case ModelReadyState::READY:
-      LOG_VERBOSE(1) << "re-loading: " << model_name << ":" << version;
+      LOG_INFO << "re-loading: " << model_name << ":" << version;
       backend_info->state_ = ModelReadyState::UNLOADING;
       backend_info->state_reason_.clear();
       backend_info->next_action_ = ActionType::LOAD;
@@ -711,7 +711,7 @@ ModelRepositoryManager::BackendLifeCycle::Load(
       backend_info->next_action_ = ActionType::LOAD;
       break;
     default:
-      LOG_VERBOSE(1) << "loading: " << model_name << ":" << version;
+      LOG_INFO << "loading: " << model_name << ":" << version;
       backend_info->state_ = ModelReadyState::LOADING;
       backend_info->state_reason_.clear();
       {
@@ -893,8 +893,8 @@ ModelRepositoryManager::BackendLifeCycle::CreateInferenceBackend(
           }));
       backend_info->state_ = ModelReadyState::READY;
       backend_info->state_reason_.clear();
-      LOG_VERBOSE(1) << "successfully loaded '" << model_name << "' version "
-                     << version;
+      LOG_INFO << "successfully loaded '" << model_name << "' version "
+               << version;
     } else {
       LOG_ERROR << "failed to load '" << model_name << "' version " << version
                 << ": " << status.AsString();
@@ -1704,7 +1704,7 @@ ModelRepositoryManager::UpdateDependencyGraph(
       if (!ensemble->missing_upstreams_.empty()) {
         std::string name_list;
         for (auto it = ensemble->missing_upstreams_.begin();
-            it != ensemble->missing_upstreams_.end(); it++) {
+             it != ensemble->missing_upstreams_.end(); it++) {
           if (it != ensemble->missing_upstreams_.begin()) {
             name_list += ", ";
           }

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -35,7 +35,6 @@
 #include <memory>
 #include <utility>
 #include <vector>
-#include <iomanip>
 
 #include "src/core/backend.h"
 #include "src/core/constants.h"

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -156,7 +156,8 @@ InferenceServer::PrintSummary()
       }
     }
   }
-  std::unique_ptr<std::string> models_table_string = models_table->print_table();
+  std::unique_ptr<std::string> models_table_string =
+      models_table->print_table();
   LOG_INFO << *models_table_string;
 
   // Backends Summary
@@ -168,17 +169,18 @@ InferenceServer::PrintSummary()
   backend_headers.emplace_back("Config");
 
   triton::common::TablePrinter::Create(&backends_table, backend_headers);
-  TritonBackendManager& triton_backend_manager = TritonBackendManager::Instance();
+  TritonBackendManager& triton_backend_manager =
+      TritonBackendManager::Instance();
 
   std::lock_guard<std::mutex> lock(triton_backend_manager.Mutex());
   auto backend_map = triton_backend_manager.BackendMap();
 
-  for (const auto& backend_pair: backend_map) {
+  for (const auto& backend_pair : backend_map) {
     std::vector<std::string> backend_record;
     auto backend = backend_pair.second.lock();
     if (backend != nullptr) {
       backend_record.emplace_back(backend->Name());
-      const char *config_message;
+      const char* config_message;
       size_t config_message_size;
       backend->BackendConfig().Serialize(&config_message, &config_message_size);
       backend_record.emplace_back(std::string(config_message));
@@ -190,7 +192,8 @@ InferenceServer::PrintSummary()
     backend_record.emplace_back(backend_pair.first);
     backends_table->insert_row(backend_record);
   }
-  std::unique_ptr<std::string> backends_table_string = backends_table->print_table();
+  std::unique_ptr<std::string> backends_table_string =
+      backends_table->print_table();
   LOG_INFO << *backends_table_string;
 }
 

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -46,7 +46,7 @@
 #include "src/core/model_config_utils.h"
 #include "src/core/model_repository_manager.h"
 #include "src/core/pinned_memory_manager.h"
-#include "triton/common/triton_utils.h"
+#include "triton/common/table_printer.h"
 
 #ifdef TRITON_ENABLE_GPU
 #include "src/core/cuda_memory_manager.h"
@@ -124,7 +124,7 @@ InferenceServer::PrintBackendAndModelSummary()
   triton::common::TablePrinter::Create(&backends_table, backend_headers);
   auto backend_state = TritonBackendManager::BackendState();
 
-  for (const auto& backend_pair : backend_state) {
+  for (const auto& backend_pair : *backend_state) {
     std::vector<std::string> backend_record;
 
     // Backend Name
@@ -134,10 +134,10 @@ InferenceServer::PrintBackendAndModelSummary()
     for (const auto& backend_field : backend_pair.second) {
       backend_record.emplace_back(backend_field);
     }
-    backends_table->insert_row(backend_record);
+    backends_table->InsertRow(backend_record);
   }
   std::unique_ptr<std::string> backends_table_string =
-      backends_table->print_table();
+      backends_table->PrintTable();
   LOG_INFO << *backends_table_string;
 
   // Models Summary
@@ -161,7 +161,7 @@ InferenceServer::PrintBackendAndModelSummary()
       model_record.emplace_back(model_name);
       model_record.emplace_back("-");
       model_record.emplace_back("Not loaded: No model version was found");
-      models_table->insert_row(model_record);
+      models_table->InsertRow(model_record);
     } else {
       for (const auto& model_map : model_version_map) {
         std::vector<std::string> model_record;
@@ -177,12 +177,11 @@ InferenceServer::PrintBackendAndModelSummary()
         model_record.emplace_back(model_name);
         model_record.emplace_back(model_version);
         model_record.emplace_back(model_status);
-        models_table->insert_row(model_record);
+        models_table->InsertRow(model_record);
       }
     }
   }
-  std::unique_ptr<std::string> models_table_string =
-      models_table->print_table();
+  std::unique_ptr<std::string> models_table_string = models_table->PrintTable();
   LOG_INFO << *models_table_string;
 }
 

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -97,6 +97,9 @@ class InferenceServer {
   Status ModelReadyVersions(
       std::map<std::string, std::vector<int64_t>>* model_versions);
 
+  // Print backends and models summary
+  void PrintSummary();
+
   /// Get the index of all models in all repositories.
   /// \param ready_only If true return only index of models that are ready.
   /// \param index Returns the index.

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -98,7 +98,7 @@ class InferenceServer {
       std::map<std::string, std::vector<int64_t>>* model_versions);
 
   // Print backends and models summary
-  void PrintSummary();
+  void PrintBackendAndModelSummary();
 
   /// Get the index of all models in all repositories.
   /// \param ready_only If true return only index of models that are ready.

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -98,7 +98,7 @@ class InferenceServer {
       std::map<std::string, std::vector<int64_t>>* model_versions);
 
   // Print backends and models summary
-  void PrintBackendAndModelSummary();
+  Status PrintBackendAndModelSummary();
 
   /// Get the index of all models in all repositories.
   /// \param ready_only If true return only index of models that are ready.

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -1534,18 +1534,20 @@ TRITONSERVER_ServerNew(
       loptions->TensorFlowSoftPlacement());
   lserver->SetTensorFlowGPUMemoryFraction(
       loptions->TensorFlowGpuMemoryFraction());
-  
+
   std::vector<std::string> options_headers;
   options_headers.emplace_back("Option");
   options_headers.emplace_back("Value");
 
   std::unique_ptr<triton::common::TablePrinter> options_table;
   triton::common::TablePrinter::Create(&options_table, options_headers);
-  options_table->insert_row(std::vector<std::string>{"server_id", loptions->ServerId()});
+  options_table->insert_row(
+      std::vector<std::string>{"server_id", loptions->ServerId()});
 
   size_t i = 0;
-  for (const auto& model_repository_path: loptions->ModelRepositoryPaths()) {
-    options_table->insert_row(std::vector<std::string>{"model_repository_path_"+std::to_string(i), model_repository_path});
+  for (const auto& model_repository_path : loptions->ModelRepositoryPaths()) {
+    options_table->insert_row(std::vector<std::string>{
+        "model_repository_path_" + std::to_string(i), model_repository_path});
     ++i;
   }
 
@@ -1568,27 +1570,39 @@ TRITONSERVER_ServerNew(
       model_control_mode = "<unknown>";
     }
   }
-  options_table->insert_row(std::vector<std::string>{"model_control_mode", model_control_mode});
+  options_table->insert_row(
+      std::vector<std::string>{"model_control_mode", model_control_mode});
 
   i = 0;
-  for (const auto& startup_model: loptions->StartupModels()) {
-    options_table->insert_row(std::vector<std::string>{"startup_models_"+std::to_string(i), startup_model});
+  for (const auto& startup_model : loptions->StartupModels()) {
+    options_table->insert_row(std::vector<std::string>{
+        "startup_models_" + std::to_string(i), startup_model});
     ++i;
   }
-  options_table->insert_row(std::vector<std::string>{"strict_model_config", std::to_string(loptions->StrictModelConfig())});
-  options_table->insert_row(std::vector<std::string>{"pinned_memory_pool_byte_size", std::to_string(loptions->PinnedMemoryPoolByteSize())});
-  for (const auto& cuda_memory_pool: loptions->CudaMemoryPoolByteSize()) {
-    options_table->insert_row(std::vector<std::string>{"cuda_memory_pool_byte_size{"+std::to_string(cuda_memory_pool.first)+"}", std::to_string(cuda_memory_pool.second)});
+  options_table->insert_row(std::vector<std::string>{
+      "strict_model_config", std::to_string(loptions->StrictModelConfig())});
+  options_table->insert_row(std::vector<std::string>{
+      "pinned_memory_pool_byte_size",
+      std::to_string(loptions->PinnedMemoryPoolByteSize())});
+  for (const auto& cuda_memory_pool : loptions->CudaMemoryPoolByteSize()) {
+    options_table->insert_row(std::vector<std::string>{
+        "cuda_memory_pool_byte_size{" + std::to_string(cuda_memory_pool.first) +
+            "}",
+        std::to_string(cuda_memory_pool.second)});
   }
   std::stringstream compute_capability_ss;
   compute_capability_ss.setf(std::ios::fixed);
   compute_capability_ss.precision(1);
   compute_capability_ss << loptions->MinSupportedComputeCapability();
-  options_table->insert_row(std::vector<std::string>{"min_supported_compute_capability", compute_capability_ss.str()});
-  options_table->insert_row(std::vector<std::string>{"strict_readiness", std::to_string(loptions->StrictReadiness())});
-  options_table->insert_row(std::vector<std::string>{"exit_timeout", std::to_string(loptions->ExitTimeout())});
+  options_table->insert_row(std::vector<std::string>{
+      "min_supported_compute_capability", compute_capability_ss.str()});
+  options_table->insert_row(std::vector<std::string>{
+      "strict_readiness", std::to_string(loptions->StrictReadiness())});
+  options_table->insert_row(std::vector<std::string>{
+      "exit_timeout", std::to_string(loptions->ExitTimeout())});
 
-  std::unique_ptr<std::string> options_table_string = options_table->print_table();
+  std::unique_ptr<std::string> options_table_string =
+      options_table->print_table();
   LOG_INFO << *options_table_string;
 
   ni::Status status = lserver->Init();

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -50,6 +50,7 @@
       nvidia::inferenceserver::Status::Code::INTERNAL, (M))
 #define TRITONJSON_STATUSSUCCESS nvidia::inferenceserver::Status::Success
 #include "triton/common/triton_json.h"
+#include "triton/common/triton_utils.h"
 
 namespace ni = nvidia::inferenceserver;
 
@@ -1533,6 +1534,62 @@ TRITONSERVER_ServerNew(
       loptions->TensorFlowSoftPlacement());
   lserver->SetTensorFlowGPUMemoryFraction(
       loptions->TensorFlowGpuMemoryFraction());
+  
+  std::vector<std::string> options_headers;
+  options_headers.emplace_back("Option");
+  options_headers.emplace_back("Value");
+
+  std::unique_ptr<triton::common::TablePrinter> options_table;
+  triton::common::TablePrinter::Create(&options_table, options_headers);
+  options_table->insert_row(std::vector<std::string>{"server_id", loptions->ServerId()});
+
+  size_t i = 0;
+  for (const auto& model_repository_path: loptions->ModelRepositoryPaths()) {
+    options_table->insert_row(std::vector<std::string>{"model_repository_path_"+std::to_string(i), model_repository_path});
+    ++i;
+  }
+
+  std::string model_control_mode;
+  auto control_mode = loptions->ModelControlMode();
+  switch (control_mode) {
+    case ni::ModelControlMode::MODE_NONE: {
+      model_control_mode = "MODE_NONE";
+      break;
+    }
+    case ni::ModelControlMode::MODE_POLL: {
+      model_control_mode = "MODE_POLL";
+      break;
+    }
+    case ni::ModelControlMode::MODE_EXPLICIT: {
+      model_control_mode = "MODE_EXPLICIT";
+      break;
+    }
+    default: {
+      model_control_mode = "<unknown>";
+    }
+  }
+  options_table->insert_row(std::vector<std::string>{"model_control_mode", model_control_mode});
+
+  i = 0;
+  for (const auto& startup_model: loptions->StartupModels()) {
+    options_table->insert_row(std::vector<std::string>{"startup_models_"+std::to_string(i), startup_model});
+    ++i;
+  }
+  options_table->insert_row(std::vector<std::string>{"strict_model_config", std::to_string(loptions->StrictModelConfig())});
+  options_table->insert_row(std::vector<std::string>{"pinned_memory_pool_byte_size", std::to_string(loptions->PinnedMemoryPoolByteSize())});
+  for (const auto& cuda_memory_pool: loptions->CudaMemoryPoolByteSize()) {
+    options_table->insert_row(std::vector<std::string>{"cuda_memory_pool_byte_size{"+std::to_string(cuda_memory_pool.first)+"}", std::to_string(cuda_memory_pool.second)});
+  }
+  std::stringstream compute_capability_ss;
+  compute_capability_ss.setf(std::ios::fixed);
+  compute_capability_ss.precision(1);
+  compute_capability_ss << loptions->MinSupportedComputeCapability();
+  options_table->insert_row(std::vector<std::string>{"min_supported_compute_capability", compute_capability_ss.str()});
+  options_table->insert_row(std::vector<std::string>{"strict_readiness", std::to_string(loptions->StrictReadiness())});
+  options_table->insert_row(std::vector<std::string>{"exit_timeout", std::to_string(loptions->ExitTimeout())});
+
+  std::unique_ptr<std::string> options_table_string = options_table->print_table();
+  LOG_INFO << *options_table_string;
 
   ni::Status status = lserver->Init();
   if (!status.IsOk()) {

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -1542,7 +1542,17 @@ TRITONSERVER_ServerNew(
   std::unique_ptr<triton::common::TablePrinter> options_table;
   triton::common::TablePrinter::Create(&options_table, options_headers);
   options_table->insert_row(
-      std::vector<std::string>{"server_id", loptions->ServerId()});
+      std::vector<std::string>{"server_id", lserver->Id()});
+  options_table->insert_row(
+      std::vector<std::string>{"server_version", lserver->Version()});
+
+  auto extensions = lserver->Extensions();
+  std::string exts;
+  for (const auto& ext : extensions) {
+    exts.append(ext);
+  }
+  options_table->insert_row(
+      std::vector<std::string>{"server_extensions", exts});
 
   size_t i = 0;
   for (const auto& model_repository_path : loptions->ModelRepositoryPaths()) {

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -49,8 +49,8 @@
   return nvidia::inferenceserver::Status( \
       nvidia::inferenceserver::Status::Code::INTERNAL, (M))
 #define TRITONJSON_STATUSSUCCESS nvidia::inferenceserver::Status::Success
+#include "triton/common/table_printer.h"
 #include "triton/common/triton_json.h"
-#include "triton/common/triton_utils.h"
 
 namespace ni = nvidia::inferenceserver;
 
@@ -1542,9 +1542,9 @@ TRITONSERVER_ServerNew(
 
   std::unique_ptr<triton::common::TablePrinter> options_table;
   triton::common::TablePrinter::Create(&options_table, options_headers);
-  options_table->insert_row(
+  options_table->InsertRow(
       std::vector<std::string>{"server_id", lserver->Id()});
-  options_table->insert_row(
+  options_table->InsertRow(
       std::vector<std::string>{"server_version", lserver->Version()});
 
   auto extensions = lserver->Extensions();
@@ -1558,12 +1558,11 @@ TRITONSERVER_ServerNew(
   if (exts.size() > 0)
     exts.pop_back();
 
-  options_table->insert_row(
-      std::vector<std::string>{"server_extensions", exts});
+  options_table->InsertRow(std::vector<std::string>{"server_extensions", exts});
 
   size_t i = 0;
   for (const auto& model_repository_path : lserver->ModelRepositoryPaths()) {
-    options_table->insert_row(std::vector<std::string>{
+    options_table->InsertRow(std::vector<std::string>{
         "model_repository_path[" + std::to_string(i) + "]",
         model_repository_path});
     ++i;
@@ -1588,23 +1587,23 @@ TRITONSERVER_ServerNew(
       model_control_mode = "<unknown>";
     }
   }
-  options_table->insert_row(
+  options_table->InsertRow(
       std::vector<std::string>{"model_control_mode", model_control_mode});
 
   i = 0;
   for (const auto& startup_model : lserver->StartupModels()) {
-    options_table->insert_row(std::vector<std::string>{
+    options_table->InsertRow(std::vector<std::string>{
         "startup_models_" + std::to_string(i), startup_model});
     ++i;
   }
-  options_table->insert_row(std::vector<std::string>{
+  options_table->InsertRow(std::vector<std::string>{
       "strict_model_config",
       std::to_string(lserver->StrictModelConfigEnabled())});
-  options_table->insert_row(std::vector<std::string>{
+  options_table->InsertRow(std::vector<std::string>{
       "pinned_memory_pool_byte_size",
       std::to_string(lserver->PinnedMemoryPoolByteSize())});
   for (const auto& cuda_memory_pool : lserver->CudaMemoryPoolByteSize()) {
-    options_table->insert_row(std::vector<std::string>{
+    options_table->InsertRow(std::vector<std::string>{
         "cuda_memory_pool_byte_size{" + std::to_string(cuda_memory_pool.first) +
             "}",
         std::to_string(cuda_memory_pool.second)});
@@ -1613,15 +1612,15 @@ TRITONSERVER_ServerNew(
   compute_capability_ss.setf(std::ios::fixed);
   compute_capability_ss.precision(1);
   compute_capability_ss << lserver->MinSupportedComputeCapability();
-  options_table->insert_row(std::vector<std::string>{
+  options_table->InsertRow(std::vector<std::string>{
       "min_supported_compute_capability", compute_capability_ss.str()});
-  options_table->insert_row(std::vector<std::string>{
+  options_table->InsertRow(std::vector<std::string>{
       "strict_readiness", std::to_string(lserver->StrictReadinessEnabled())});
-  options_table->insert_row(std::vector<std::string>{
+  options_table->InsertRow(std::vector<std::string>{
       "exit_timeout", std::to_string(lserver->ExitTimeoutSeconds())});
 
   std::unique_ptr<std::string> options_table_string =
-      options_table->print_table();
+      options_table->PrintTable();
   LOG_INFO << *options_table_string;
 
   if (!status.IsOk()) {

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -1535,6 +1535,7 @@ TRITONSERVER_ServerNew(
   lserver->SetTensorFlowGPUMemoryFraction(
       loptions->TensorFlowGpuMemoryFraction());
 
+  ni::Status status = lserver->Init();
   std::vector<std::string> options_headers;
   options_headers.emplace_back("Option");
   options_headers.emplace_back("Value");
@@ -1550,19 +1551,26 @@ TRITONSERVER_ServerNew(
   std::string exts;
   for (const auto& ext : extensions) {
     exts.append(ext);
+    exts.append(" ");
   }
+
+  // Remove the trailing space
+  if (exts.size() > 0)
+    exts.pop_back();
+
   options_table->insert_row(
       std::vector<std::string>{"server_extensions", exts});
 
   size_t i = 0;
-  for (const auto& model_repository_path : loptions->ModelRepositoryPaths()) {
+  for (const auto& model_repository_path : lserver->ModelRepositoryPaths()) {
     options_table->insert_row(std::vector<std::string>{
-        "model_repository_path_" + std::to_string(i), model_repository_path});
+        "model_repository_path[" + std::to_string(i) + "]",
+        model_repository_path});
     ++i;
   }
 
   std::string model_control_mode;
-  auto control_mode = loptions->ModelControlMode();
+  auto control_mode = lserver->GetModelControlMode();
   switch (control_mode) {
     case ni::ModelControlMode::MODE_NONE: {
       model_control_mode = "MODE_NONE";
@@ -1584,17 +1592,18 @@ TRITONSERVER_ServerNew(
       std::vector<std::string>{"model_control_mode", model_control_mode});
 
   i = 0;
-  for (const auto& startup_model : loptions->StartupModels()) {
+  for (const auto& startup_model : lserver->StartupModels()) {
     options_table->insert_row(std::vector<std::string>{
         "startup_models_" + std::to_string(i), startup_model});
     ++i;
   }
   options_table->insert_row(std::vector<std::string>{
-      "strict_model_config", std::to_string(loptions->StrictModelConfig())});
+      "strict_model_config",
+      std::to_string(lserver->StrictModelConfigEnabled())});
   options_table->insert_row(std::vector<std::string>{
       "pinned_memory_pool_byte_size",
-      std::to_string(loptions->PinnedMemoryPoolByteSize())});
-  for (const auto& cuda_memory_pool : loptions->CudaMemoryPoolByteSize()) {
+      std::to_string(lserver->PinnedMemoryPoolByteSize())});
+  for (const auto& cuda_memory_pool : lserver->CudaMemoryPoolByteSize()) {
     options_table->insert_row(std::vector<std::string>{
         "cuda_memory_pool_byte_size{" + std::to_string(cuda_memory_pool.first) +
             "}",
@@ -1603,19 +1612,18 @@ TRITONSERVER_ServerNew(
   std::stringstream compute_capability_ss;
   compute_capability_ss.setf(std::ios::fixed);
   compute_capability_ss.precision(1);
-  compute_capability_ss << loptions->MinSupportedComputeCapability();
+  compute_capability_ss << lserver->MinSupportedComputeCapability();
   options_table->insert_row(std::vector<std::string>{
       "min_supported_compute_capability", compute_capability_ss.str()});
   options_table->insert_row(std::vector<std::string>{
-      "strict_readiness", std::to_string(loptions->StrictReadiness())});
+      "strict_readiness", std::to_string(lserver->StrictReadinessEnabled())});
   options_table->insert_row(std::vector<std::string>{
-      "exit_timeout", std::to_string(loptions->ExitTimeout())});
+      "exit_timeout", std::to_string(lserver->ExitTimeoutSeconds())});
 
   std::unique_ptr<std::string> options_table_string =
       options_table->print_table();
   LOG_INFO << *options_table_string;
 
-  ni::Status status = lserver->Init();
   if (!status.IsOk()) {
     if (loptions->ExitOnError()) {
       lserver->Stop(true /* force */);

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -1540,11 +1540,9 @@ TRITONSERVER_ServerNew(
   options_headers.emplace_back("Option");
   options_headers.emplace_back("Value");
 
-  std::unique_ptr<triton::common::TablePrinter> options_table;
-  triton::common::TablePrinter::Create(&options_table, options_headers);
-  options_table->InsertRow(
-      std::vector<std::string>{"server_id", lserver->Id()});
-  options_table->InsertRow(
+  triton::common::TablePrinter options_table(options_headers);
+  options_table.InsertRow(std::vector<std::string>{"server_id", lserver->Id()});
+  options_table.InsertRow(
       std::vector<std::string>{"server_version", lserver->Version()});
 
   auto extensions = lserver->Extensions();
@@ -1558,11 +1556,11 @@ TRITONSERVER_ServerNew(
   if (exts.size() > 0)
     exts.pop_back();
 
-  options_table->InsertRow(std::vector<std::string>{"server_extensions", exts});
+  options_table.InsertRow(std::vector<std::string>{"server_extensions", exts});
 
   size_t i = 0;
   for (const auto& model_repository_path : lserver->ModelRepositoryPaths()) {
-    options_table->InsertRow(std::vector<std::string>{
+    options_table.InsertRow(std::vector<std::string>{
         "model_repository_path[" + std::to_string(i) + "]",
         model_repository_path});
     ++i;
@@ -1587,23 +1585,23 @@ TRITONSERVER_ServerNew(
       model_control_mode = "<unknown>";
     }
   }
-  options_table->InsertRow(
+  options_table.InsertRow(
       std::vector<std::string>{"model_control_mode", model_control_mode});
 
   i = 0;
   for (const auto& startup_model : lserver->StartupModels()) {
-    options_table->InsertRow(std::vector<std::string>{
+    options_table.InsertRow(std::vector<std::string>{
         "startup_models_" + std::to_string(i), startup_model});
     ++i;
   }
-  options_table->InsertRow(std::vector<std::string>{
+  options_table.InsertRow(std::vector<std::string>{
       "strict_model_config",
       std::to_string(lserver->StrictModelConfigEnabled())});
-  options_table->InsertRow(std::vector<std::string>{
+  options_table.InsertRow(std::vector<std::string>{
       "pinned_memory_pool_byte_size",
       std::to_string(lserver->PinnedMemoryPoolByteSize())});
   for (const auto& cuda_memory_pool : lserver->CudaMemoryPoolByteSize()) {
-    options_table->InsertRow(std::vector<std::string>{
+    options_table.InsertRow(std::vector<std::string>{
         "cuda_memory_pool_byte_size{" + std::to_string(cuda_memory_pool.first) +
             "}",
         std::to_string(cuda_memory_pool.second)});
@@ -1612,16 +1610,15 @@ TRITONSERVER_ServerNew(
   compute_capability_ss.setf(std::ios::fixed);
   compute_capability_ss.precision(1);
   compute_capability_ss << lserver->MinSupportedComputeCapability();
-  options_table->InsertRow(std::vector<std::string>{
+  options_table.InsertRow(std::vector<std::string>{
       "min_supported_compute_capability", compute_capability_ss.str()});
-  options_table->InsertRow(std::vector<std::string>{
+  options_table.InsertRow(std::vector<std::string>{
       "strict_readiness", std::to_string(lserver->StrictReadinessEnabled())});
-  options_table->InsertRow(std::vector<std::string>{
+  options_table.InsertRow(std::vector<std::string>{
       "exit_timeout", std::to_string(lserver->ExitTimeoutSeconds())});
 
-  std::unique_ptr<std::string> options_table_string =
-      options_table->PrintTable();
-  LOG_INFO << *options_table_string;
+  std::string options_table_string = options_table.PrintTable();
+  LOG_INFO << options_table_string;
 
   if (!status.IsOk()) {
     if (loptions->ExitOnError()) {

--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -393,6 +393,7 @@ target_link_libraries(
   PRIVATE triton-core-backendapi
   PRIVATE triton-core-serverapi
   PRIVATE triton-common-json
+  PRIVATE triton-common-table-printer
   PRIVATE ${TRITON_EXTRA_LDFLAGS}
   PRIVATE protobuf::libprotobuf
 )


### PR DESCRIPTION
A screenshot of how the logs will look like:

![image](https://user-images.githubusercontent.com/10105175/93917214-b2bba980-fcd8-11ea-89cd-b66a0f90a7ae.png)