### PR TITLE
Allow optional base path in http url

### DIFF
--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -166,6 +166,16 @@ if [ $? -ne 0 ]; then
     RET=1
 fi
 
+# Test with the base path in url.
+$SIMPLE_INFER_CLIENT_PY -u localhost:8000/base_path -v >> ${CLIENT_LOG}.base_path_url 2>&1
+if [ $? -eq 0 ]; then
+    cat ${CLIENT_LOG}.base_path_url
+    RET=1
+fi
+if [ $(cat ${CLIENT_LOG}.base_path_url | grep "POST /base_path/v2/models/simple/infer" | wc -l) -eq 0 ]; then
+    cat ${CLIENT_LOG}.base_path_url
+    RET=1
+fi
 
 for i in \
    $SIMPLE_INFER_CLIENT \
@@ -199,6 +209,18 @@ if [ $? -ne 0 ]; then
     cat ${CLIENT_LOG}.c++.reuse
     RET=1
 fi
+
+# Test with the base path in url.
+$SIMPLE_INFER_CLIENT -u localhost:8000/base_path -v >> ${CLIENT_LOG}.c++.base_path_url 2>&1
+if [ $? -eq 0 ]; then
+    cat ${CLIENT_LOG}.c++.base_path_url
+    RET=1
+fi
+if [ $(cat ${CLIENT_LOG}.c++.base_path_url | grep "POST /base_path/v2/models/simple/infer" | wc -l) -eq 0 ]; then
+    cat ${CLIENT_LOG}.c++.base_path_url
+    RET=1
+fi
+
 
 set -e
 

--- a/src/clients/c++/library/http_client.h.in
+++ b/src/clients/c++/library/http_client.h.in
@@ -72,7 +72,8 @@ class InferenceServerHttpClient : public InferenceServerClient {
 
   /// Create a client that can be used to communicate with the server.
   /// \param client Returns a new InferenceServerHttpClient object.
-  /// \param server_url The inference server name and port.
+  /// \param server_url The inference server name, port and optional
+  /// base path in the following format: host:port/<base-path>.
   /// \param verbose If true generate verbose output when contacting
   /// the inference server.
   /// \return Error object indicating success or failure.

--- a/src/clients/python/library/tritonclient/http/__init__.py
+++ b/src/clients/python/library/tritonclient/http/__init__.py
@@ -192,10 +192,10 @@ class InferenceServerClient:
                  ssl_options=None,
                  ssl_context_factory=None,
                  insecure=False):
-        if not url.startswith("http://") and not url.startswith("https://"):
-            scheme = "https://" if ssl else "http://"
-            url = scheme + url   
-        self._parsed_url = URL(url)
+        if url.startswith("http://") or url.startswith("https://"):
+            raise_error("url should not include the scheme")
+        scheme = "https://" if ssl else "http://"
+        self._parsed_url = URL(scheme + url)
         self._base_uri = self._parsed_url.request_uri.rstrip('/')
         self._client_stub = HTTPClient.from_url(
             self._parsed_url,


### PR DESCRIPTION
Picks major implementation from PR #2047
Adds simple test cases for HTTP clients and documents the optional feature.