### PR TITLE
Shortened number of L0_sequence_batcher_valgrind tests to 12 tests

### DIFF
--- a/qa/L0_sequence_batcher/test.sh
+++ b/qa/L0_sequence_batcher/test.sh
@@ -53,11 +53,8 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     NO_DELAY_TESTS="test_simple_sequence \
                       test_no_sequence_start \
                       test_batch_size"
-    DELAY_TESTS="test_backlog_same_correlation_id_no_end \
-                    test_backlog_fill_no_end \
+    DELAY_TESTS="test_backlog_fill_no_end \
                     test_backlog_sequence_timeout \
-                    test_half_batch \
-                    test_skip_batch \
                     test_ragged_batch"
 fi
 


### PR DESCRIPTION
This test seems to take way too long on 20.10. Shortening it to 12 tests should allow it pass at the cost of some coverage.