### PR TITLE
Fixes for backend loading via dlopen

### DIFF
--- a/src/backends/backend/triton_backend_manager.cc
+++ b/src/backends/backend/triton_backend_manager.cc
@@ -156,7 +156,7 @@ TritonBackend::ClearHandles()
 Status
 TritonBackend::LoadBackendLibrary()
 {
-  void* handle = dlopen(libpath_.c_str(), RTLD_LAZY);
+  void* handle = dlopen(libpath_.c_str(), RTLD_NOW | RTLD_LOCAL);
   if (handle == nullptr) {
     return Status(
         Status::Code::NOT_FOUND,

--- a/src/backends/backend/triton_backend_manager.h
+++ b/src/backends/backend/triton_backend_manager.h
@@ -33,7 +33,7 @@
 #include "src/core/model_config.h"
 #include "src/core/server_message.h"
 #include "src/core/status.h"
-#include "triton/core/tritonbackend.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/backends/backend/triton_memory_manager.cc
+++ b/src/backends/backend/triton_memory_manager.cc
@@ -28,8 +28,7 @@
 
 #include "src/core/pinned_memory_manager.h"
 #include "src/core/status.h"
-#include "triton/core/tritonbackend.h"
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 #ifdef TRITON_ENABLE_GPU
 #include <cuda_runtime_api.h>

--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -32,8 +32,7 @@
 #include "src/core/logging.h"
 #include "src/core/model_config_utils.h"
 #include "src/core/server_message.h"
-#include "triton/core/tritonbackend.h"
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/clients/python/library/setup.py
+++ b/src/clients/python/library/setup.py
@@ -58,6 +58,7 @@ except ImportError:
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
 
+
 def req_file(filename, folder="requirements"):
     with open(os.path.join(folder, filename)) as f:
         content = f.readlines()

--- a/src/core/infer_parameter.h
+++ b/src/core/infer_parameter.h
@@ -27,7 +27,7 @@
 
 #include <iostream>
 #include <string>
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -36,7 +36,7 @@
 #include "src/core/model_config.h"
 #include "src/core/response_allocator.h"
 #include "src/core/status.h"
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/core/infer_response.h
+++ b/src/core/infer_response.h
@@ -34,7 +34,7 @@
 #include "src/core/model_config.h"
 #include "src/core/response_allocator.h"
 #include "src/core/status.h"
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/core/infer_stats.h
+++ b/src/core/infer_stats.h
@@ -31,7 +31,7 @@
 #include <mutex>
 #include "src/core/constants.h"
 #include "src/core/status.h"
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/core/infer_trace.h
+++ b/src/core/infer_trace.h
@@ -30,7 +30,7 @@
 #include <memory>
 #include "src/core/constants.h"
 #include "src/core/status.h"
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/core/model_config.h
+++ b/src/core/model_config.h
@@ -28,7 +28,7 @@
 #include <google/protobuf/any.pb.h>
 #include <stdint.h>
 #include "src/core/model_config.pb.h"
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/core/status.h
+++ b/src/core/status.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <string>
-#include "triton/core/tritonserver.h"
+#include "src/core/tritonserver_apis.h"
 
 namespace nvidia { namespace inferenceserver {
 

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -24,8 +24,6 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "triton/core/tritonserver.h"
-
 #include <string>
 #include <vector>
 #include "src/core/backend.h"
@@ -43,6 +41,7 @@
 #include "src/core/server.h"
 #include "src/core/server_message.h"
 #include "src/core/status.h"
+#include "src/core/tritonserver_apis.h"
 
 #define TRITONJSON_STATUSTYPE nvidia::inferenceserver::Status
 #define TRITONJSON_STATUSRETURN(M)        \
@@ -802,7 +801,7 @@ TRITONSERVER_InferenceTraceModelName(
 #endif  // TRITON_ENABLE_TRACING
 }
 
-TRITONSERVER_EXPORT TRITONSERVER_Error*
+TRITONSERVER_Error*
 TRITONSERVER_InferenceTraceModelVersion(
     TRITONSERVER_InferenceTrace* trace, int64_t* model_version)
 {

--- a/src/core/tritonserver_apis.h
+++ b/src/core/tritonserver_apis.h
@@ -25,34 +25,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include "src/core/tritonserver_apis.h"
+#define _COMPILING_TRITONSERVER 1
+#define _COMPILING_TRITONBACKEND 1
 
-namespace nvidia { namespace inferenceserver {
+#include "triton/core/tritonbackend.h"
+#include "triton/core/tritonserver.h"
 
-//
-// Implementation for TRITONSERVER_ResponseAllocator.
-//
-class ResponseAllocator {
- public:
-  explicit ResponseAllocator(
-      TRITONSERVER_ResponseAllocatorAllocFn_t alloc_fn,
-      TRITONSERVER_ResponseAllocatorReleaseFn_t release_fn,
-      TRITONSERVER_ResponseAllocatorStartFn_t start_fn)
-      : alloc_fn_(alloc_fn), release_fn_(release_fn), start_fn_(start_fn)
-  {
-  }
-
-  TRITONSERVER_ResponseAllocatorAllocFn_t AllocFn() const { return alloc_fn_; }
-  TRITONSERVER_ResponseAllocatorReleaseFn_t ReleaseFn() const
-  {
-    return release_fn_;
-  }
-  TRITONSERVER_ResponseAllocatorStartFn_t StartFn() const { return start_fn_; }
-
- private:
-  TRITONSERVER_ResponseAllocatorAllocFn_t alloc_fn_;
-  TRITONSERVER_ResponseAllocatorReleaseFn_t release_fn_;
-  TRITONSERVER_ResponseAllocatorStartFn_t start_fn_;
-};
-
-}}  // namespace nvidia::inferenceserver
+#undef _COMPILING_TRITONSERVER
+#undef _COMPILING_TRITONBACKEND


### PR DESCRIPTION
Compile core to export server and backend API symbols
Use LOCAL for dlopen to avoid exposing symbols.