### PR TITLE
DALI Backend tests for CI: identity and rn50_ensemble

### DIFF
--- a/qa/L0_backend_dali/test.sh
+++ b/qa/L0_backend_dali/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+DALI_BACKEND_DIR=/data/dali_backend_dir
+
+git clone --single-branch --depth=1 -b $DALI_BACKEND_REPO_TAG https://github.com/triton-inference-server/dali_backend.git $DALI_BACKEND_DIR
+
+sh ./test_identity.sh $DALI_BACKEND_DIR
+sh ./test_rn50_ensemble.sh $DALI_BACKEND_DIR

--- a/qa/L0_backend_dali/test.sh
+++ b/qa/L0_backend_dali/test.sh
@@ -25,7 +25,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-DALI_BACKEND_DIR=/data/dali_backend_dir
+DALI_BACKEND_DIR=`pwd`/dali_backend_dir
+
+if [ -z ${DALI_BACKEND_REPO_TAG+unused} ]; then
+  echo -e "\n***\n*** Test FAILED: DALI_BACKEND_REPO_TAG is undefined\n***"
+  exit 1
+fi
 
 git clone --single-branch --depth=1 -b $DALI_BACKEND_REPO_TAG https://github.com/triton-inference-server/dali_backend.git $DALI_BACKEND_DIR
 

--- a/qa/L0_backend_dali/test_identity.sh
+++ b/qa/L0_backend_dali/test_identity.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+export CUDA_VISIBLE_DEVICES=0
+
+DALI_BACKEND_DIR=$1
+
+CLIENT_PY=$DALI_BACKEND_DIR/qa/identity/identity_client.py
+CLIENT_LOG="./client.log"
+
+MODEL_REPO=$DALI_BACKEND_DIR/docs/examples/identity/model_repository
+
+SERVER=/opt/tritonserver/bin/tritonserver
+SERVER_ARGS="--model-repository=$MODEL_REPO"
+SERVER_LOG="./inference_server.log"
+source ../common/util.sh
+
+pushd $MODEL_REPO/..
+sh setup_identity_example.sh
+popd
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+  echo -e "\n***\n*** Failed to start $SERVER $SERVER_ARGS\n***"
+  cat $SERVER_LOG
+  exit 1
+fi
+
+RET=0
+
+set +e
+python $CLIENT_PY --model_name dali_identity -v --batch_size 32 >>$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+  RET=1
+fi
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+  echo -e "\n***\n*** Test Passed\n***"
+else
+  cat $CLIENT_LOG
+  echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/qa/L0_backend_dali/test_rn50_ensemble.sh
+++ b/qa/L0_backend_dali/test_rn50_ensemble.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+export CUDA_VISIBLE_DEVICES=0
+
+DALI_BACKEND_DIR=$1
+
+CLIENT_PY=$DALI_BACKEND_DIR/qa/rn50_ensemble/ensemble_client.py
+CLIENT_LOG="./client.log"
+
+MODEL_REPO=$DALI_BACKEND_DIR/docs/examples/rn50_ensemble/model_repository
+
+SERVER=/opt/tritonserver/bin/tritonserver
+SERVER_ARGS="--model-repository=$MODEL_REPO"
+SERVER_LOG="./inference_server.log"
+source ../common/util.sh
+
+pushd $MODEL_REPO/..
+sh setup_resnet50_example.sh
+popd
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+  echo -e "\n***\n*** Failed to start $SERVER $SERVER_ARGS\n***"
+  cat $SERVER_LOG
+  exit 1
+fi
+
+RET=0
+
+set +e
+python $CLIENT_PY --img_dir $DALI_BACKEND_DIR/qa/rn50_ensemble/images --model_name ensemble_dali_resnet -v --batch_size 3 >>$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+  RET=1
+fi
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+  echo -e "\n***\n*** Test Passed\n***"
+else
+  cat $CLIENT_LOG
+  echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET


### PR DESCRIPTION
Test scripts, that add 2 tests for dali_backend:
1. `identity`
2. `rn50_ensemble`

Please refer to https://github.com/triton-inference-server/dali_backend/pull/3 for more details

I'm not sure, that my convention (running `.sh` scripts in a `test.sh` script) is going to work. Please advise

Signed-off-by: szalpal <mszolucha@nvidia.com>