### PR TITLE
Rate Limiter for cross-model prioritization and resource constraining

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -91,7 +91,8 @@ RUN mkdir -p qa/common && \
     cp -r /workspace/docs/examples/ensemble_model_repository qa/L0_http/ && \
     cp /tmp/tritonbuild/install/bin/simple qa/L0_simple_lib/. && \
     cp /tmp/tritonbuild/install/bin/memory_alloc qa/L0_io/. && \
-    cp /tmp/tritonbuild/tritonserver/build/test-util/install/bin/memory_test qa/L0_memory/.
+    cp /tmp/tritonbuild/tritonserver/build/test-util/install/bin/memory_test qa/L0_memory/. && \
+    cp /tmp/tritonbuild/tritonserver/build/test-util/install/bin/rate_limiter_test qa/L0_rate_limiter/.
 
 # caffe2plan will not exist if the build was done without TensorRT enabled
 RUN if [ -f /tmp/tritonbuild/tritonserver/build/test-util/install/bin/caffe2plan ]; then \

--- a/qa/L0_rate_limiter/test.sh
+++ b/qa/L0_rate_limiter/test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+TEST_LOG="./rate_limiter.log"
+RATE_LIMITER_TEST=./rate_limiter_test
+
+RET=0
+
+export CUDA_VISIBLE_DEVICES=0
+
+rm -f TEST_LOG
+
+set +e
+$RATE_LIMITER_TEST >>$TEST_LOG 2>&1
+if [ $? -ne 0 ]; then
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+set -e
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    cat $TEST_LOG
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -146,6 +146,65 @@ message ModelInstanceGroup
   //@@     of instances created. Default is 1.
   int32 count = 2;
 
+  //@@
+  //@@  .. cpp:var:: message RateLimiterSpec
+  //@@
+  //@@     The specifications required by the rate limiter to properly
+  //@@     schedule the inference requests across the different models
+  //@@     and their instances.
+  //@@
+  message RateLimiterSpec
+  {
+    //@@  .. cpp:var:: message Resource
+    //@@
+    //@@     The resoure constraints required to execute an inference
+    //@@     on the instance of the model.
+    //@@
+    message Resource
+    {
+      //@@  .. cpp:var:: message global
+      //@@
+      //@@     Whether or not the resource is global. If true then the resource
+      //@@     is assumed to be shared among the GPU devices otherwise specified
+      //@@     count of the resource is assumed for each GPU device associated
+      //@@     with the instance.
+      //@@
+      bool global = 1;
+
+      //@@  .. cpp:var:: message count
+      //@@
+      //@@     The number of resources required for the execution of the model
+      //@@     instance.
+      //@@
+      uint32 count = 2;
+    }
+
+    //@@  .. cpp:var:: map<string, ResourceCount> resources
+    //@@
+    //@@     The resources required to execute the request on a model instance.
+    //@@     Resources are just names with a corresponding count. The execution
+    //@@     of the instance will be blocked until the specificied resources are
+    //@@     available. By default an instance uses no rate-limiter resources.
+    //@@
+    map<string, Resource> resources = 1;
+
+    //@@  .. cpp:var:: uint32 priority
+    //@@
+    //@@     The weighting value to be used for prioritizing across instances.
+    //@@     An instance with priority 2 will be given 1/2 the number of
+    //@@     scheduling chances as an instance_group with priority 1. The
+    //@@     default priority is 1.
+    //@@
+    uint32 priority = 2;
+  }
+
+  //@@  .. cpp:var:: RateLimiterSpec rate_limiter_spec
+  //@@
+  //@@     The rate limiter specific settings to be associated with this
+  //@@     instance group.
+  //@@
+  RateLimiterSpec rate_limiter_spec = 6;
+
   //@@  .. cpp:var:: int32 gpus (repeated)
   //@@
   //@@     GPU(s) where instances should be available. For each GPU listed,

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -74,6 +74,63 @@ enum DataType {
 }
 
 //@@
+//@@  .. cpp:var:: message ModelRateLimiter
+//@@
+//@@     The specifications required by the rate limiter to properly
+//@@     schedule the inference requests across the different models
+//@@     and their instances.
+//@@
+message ModelRateLimiter
+{
+  //@@  .. cpp:var:: message Resource
+  //@@
+  //@@     The resource property.
+  //@@
+  message Resource
+  {
+    //@@  .. cpp:var:: string name
+    //@@
+    //@@     The name associated with the resource.
+    //@@
+    string name = 1;
+
+    //@@  .. cpp:var:: bool global
+    //@@
+    //@@     Whether or not the resource is global. If true then the resource
+    //@@     is assumed to be shared among the devices otherwise specified
+    //@@     count of the resource is assumed for each device associated
+    //@@     with the instance.
+    //@@
+    bool global = 2;
+
+    //@@  .. cpp:var:: uint32 count
+    //@@
+    //@@     The number of resources required for the execution of the model
+    //@@     instance.
+    //@@
+    uint32 count = 3;
+  }
+
+  //@@  .. cpp:var:: Resource resources (repeated)
+  //@@
+  //@@     The resources required to execute the request on a model instance.
+  //@@     Resources are just names with a corresponding count. The execution
+  //@@     of the instance will be blocked until the specificied resources are
+  //@@     available. By default an instance uses no rate-limiter resources.
+  //@@
+  repeated Resource resources = 1;
+
+  //@@  .. cpp:var:: uint32 priority
+  //@@
+  //@@     The weighting value to be used for prioritizing across instances.
+  //@@     An instance with priority 2 will be given 1/2 the number of
+  //@@     scheduling chances as an instance_group with priority 1. The
+  //@@     default priority is 1.
+  //@@
+  uint32 priority = 2;
+}
+
+//@@
 //@@.. cpp:var:: message ModelInstanceGroup
 //@@
 //@@   A group of one or more instances of a model and resources made
@@ -146,64 +203,12 @@ message ModelInstanceGroup
   //@@     of instances created. Default is 1.
   int32 count = 2;
 
-  //@@
-  //@@  .. cpp:var:: message RateLimiterSpec
-  //@@
-  //@@     The specifications required by the rate limiter to properly
-  //@@     schedule the inference requests across the different models
-  //@@     and their instances.
-  //@@
-  message RateLimiterSpec
-  {
-    //@@  .. cpp:var:: message Resource
-    //@@
-    //@@     The resoure constraints required to execute an inference
-    //@@     on the instance of the model.
-    //@@
-    message Resource
-    {
-      //@@  .. cpp:var:: message global
-      //@@
-      //@@     Whether or not the resource is global. If true then the resource
-      //@@     is assumed to be shared among the GPU devices otherwise specified
-      //@@     count of the resource is assumed for each GPU device associated
-      //@@     with the instance.
-      //@@
-      bool global = 1;
-
-      //@@  .. cpp:var:: message count
-      //@@
-      //@@     The number of resources required for the execution of the model
-      //@@     instance.
-      //@@
-      uint32 count = 2;
-    }
-
-    //@@  .. cpp:var:: map<string, ResourceCount> resources
-    //@@
-    //@@     The resources required to execute the request on a model instance.
-    //@@     Resources are just names with a corresponding count. The execution
-    //@@     of the instance will be blocked until the specificied resources are
-    //@@     available. By default an instance uses no rate-limiter resources.
-    //@@
-    map<string, Resource> resources = 1;
-
-    //@@  .. cpp:var:: uint32 priority
-    //@@
-    //@@     The weighting value to be used for prioritizing across instances.
-    //@@     An instance with priority 2 will be given 1/2 the number of
-    //@@     scheduling chances as an instance_group with priority 1. The
-    //@@     default priority is 1.
-    //@@
-    uint32 priority = 2;
-  }
-
-  //@@  .. cpp:var:: RateLimiterSpec rate_limiter_spec
+  //@@  .. cpp:var:: ModelRateLimiter rate_limiter
   //@@
   //@@     The rate limiter specific settings to be associated with this
   //@@     instance group.
   //@@
-  RateLimiterSpec rate_limiter_spec = 6;
+  ModelRateLimiter rate_limiter = 6;
 
   //@@  .. cpp:var:: int32 gpus (repeated)
   //@@

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -206,7 +206,8 @@ message ModelInstanceGroup
   //@@  .. cpp:var:: ModelRateLimiter rate_limiter
   //@@
   //@@     The rate limiter specific settings to be associated with this
-  //@@     instance group.
+  //@@     instance group. Optional, if not specified no rate limiting
+  //@@     will be applied to this instance group.
   //@@
   ModelRateLimiter rate_limiter = 6;
 

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -1,0 +1,627 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/core/rate_limiter.h"
+
+namespace nvidia { namespace inferenceserver {
+
+//=========================================================================
+//  Core Implementation
+//=========================================================================
+
+Status
+RateLimiter::Create(
+    const bool enable_rate_limiting, std::unique_ptr<RateLimiter>* rate_limiter)
+{
+  std::unique_ptr<RateLimiter> local_rate_limiter(
+      new RateLimiter(enable_rate_limiting));
+  *rate_limiter = std::move(local_rate_limiter);
+
+  return Status::Success;
+}
+
+Status
+RateLimiter::LoadModel(
+    const std::string& model_name, const int64_t version,
+    const inference::ModelConfig& model_config)
+{
+  {
+    std::lock_guard<std::mutex> lk1(model_contexts_mtx_);
+    std::lock_guard<std::mutex> lk2(model_instances_mtx_);
+
+    auto& model_context = model_contexts_[std::make_pair(model_name, version)];
+    auto& model_instances =
+        model_instances_[std::make_pair(model_name, version)];
+    {
+      for (const auto& group : model_config.instance_group()) {
+        for (int c = 0; c < group.count(); c++) {
+          if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
+            LoadModelHelper(
+                model_name, version, ResourceManager::NO_GPU_DEVICE,
+                group.rate_limiter_spec(), &model_context, &model_instances);
+          } else {
+            for (int gpu_device : group.gpus()) {
+              LoadModelHelper(
+                  model_name, version, gpu_device, group.rate_limiter_spec(),
+                  &model_context, &model_instances);
+            }
+          }
+        }
+      }
+      model_context.SetSpecificQueueCount(model_instances.size());
+    }
+  }
+
+  // To reduce the number of scans, update the resources limits
+  // once all the model instances are loaded.
+  resource_manager_->UpdateResourceLimits();
+
+  return Status::Success;
+}
+
+void
+RateLimiter::LoadModelHelper(
+    const std::string& model_name, const int64_t version, const int device_id,
+    const Specification& rate_limit_spec, ModelContext* model_context,
+    std::vector<std::shared_ptr<ModelInstance>>* model_instances)
+{
+  int index = model_instances->size();
+  model_instances->push_back(std::shared_ptr<ModelInstance>(new ModelInstance(
+      model_name, version, model_context, index, device_id, rate_limit_spec,
+      [this](ModelInstance* instance) { OnStage(instance); },
+      [this](ModelInstance* instance) { OnRelease(instance); })));
+  model_context->AddAvailableInstance(model_instances->back().get());
+  resource_manager_->LoadModelInstance(model_instances->back().get());
+}
+
+
+Status
+RateLimiter::UnloadModel(const std::string& model_name, const int64_t version)
+{
+  {
+    std::lock_guard<std::mutex> lk1(model_contexts_mtx_);
+    std::lock_guard<std::mutex> lk2(model_instances_mtx_);
+
+    auto& model_context = model_contexts_[std::make_pair(model_name, version)];
+
+    model_context.Unload();
+    for (const auto& instance :
+         model_instances_[std::make_pair(model_name, version)]) {
+      instance->WaitForUnload();
+      resource_manager_->UnloadModelInstance(instance.get());
+    }
+
+    model_instances_.erase(std::make_pair(model_name, version));
+    model_contexts_.erase(std::make_pair(model_name, version));
+  }
+
+  resource_manager_->UpdateResourceLimits();
+
+  return Status::Success;
+}
+
+Status
+RateLimiter::EnqueueModelRequest(
+    const StandardScheduleFunc& OnSchedule, const std::string& model_name,
+    const int64_t version, const int instance_index)
+{
+  std::lock_guard<std::mutex> lk(model_contexts_mtx_);
+
+  auto itr = model_contexts_.find(std::make_pair(model_name, version));
+  if (itr == model_contexts_.end()) {
+    return Status(
+        Status::Code::INTERNAL, "No loaded model found with name " +
+                                    model_name + " and version " +
+                                    std::to_string(version));
+  }
+
+  if (itr->second.isUnloading()) {
+    return Status(
+        Status::Code::INTERNAL,
+        "New model requests can not be made to a model that is being unloaded");
+  }
+
+  itr->second.EnqueueModelRequest(OnSchedule, instance_index);
+  if (enable_rate_limiting_) {
+    itr->second.StageInstanceIfAvailable();
+  } else {
+    // Directly allocate an available model instance if not using rate limiter.
+    itr->second.AllocateInstanceIfAvailable();
+  }
+
+  return Status::Success;
+}
+
+RateLimiter::RateLimiter(const bool enable_rate_limiting)
+    : enable_rate_limiting_(enable_rate_limiting)
+{
+  ResourceManager::Create(&resource_manager_);
+}
+
+void
+RateLimiter::OnStage(ModelInstance* instance)
+{
+  {
+    std::lock_guard<std::recursive_mutex> lk(staged_instances_mtx_);
+    staged_instances_.push(instance);
+  }
+  AttemptAllocation();
+}
+
+void
+RateLimiter::OnRelease(ModelInstance* instance)
+{
+  auto& model_context = model_contexts_[instance->ModelIdentifier()];
+  model_context.AddAvailableInstance(instance);
+  resource_manager_->ReleaseResources(instance);
+  if (model_context.ContainsPendingRequests(instance->Index())) {
+    if (enable_rate_limiting_) {
+      model_context.StageInstanceIfAvailable();
+    } else {
+      // Directly allocate an available model instance if not using rate
+      // limiter.
+      model_context.AllocateInstanceIfAvailable();
+    }
+  }
+  AttemptAllocation();
+}
+
+void
+RateLimiter::AttemptAllocation()
+{
+  std::lock_guard<std::recursive_mutex> lk(staged_instances_mtx_);
+  if (!staged_instances_.empty()) {
+    ModelInstance* instance = staged_instances_.top();
+    if (resource_manager_->AllocateResources(instance)) {
+      staged_instances_.pop();
+      instance->Allocate();
+    }
+  }
+}
+
+//=========================================================================
+//  ModelContext Implementation
+//=========================================================================
+
+RateLimiter::ModelContext::ModelContext() : unloading_(false) {}
+
+Status
+RateLimiter::ModelContext::EnqueueModelRequest(
+    const StandardScheduleFunc& OnSchedule, const int instance_index)
+{
+  std::lock_guard<std::recursive_mutex> lk(request_queue_mtx_);
+
+  if (instance_index == -1) {
+    generic_request_queue_.push(OnSchedule);
+  } else if ((uint32_t)instance_index < specific_request_queues_.size()) {
+    specific_request_queues_[instance_index].push(OnSchedule);
+  } else {
+    return Status(
+        Status::Code::INTERNAL,
+        "expected instance index between 0 and " +
+            std::to_string(specific_request_queues_.size()) + ", got " +
+            std::to_string(instance_index));
+  }
+
+  return Status::Success;
+}
+
+void
+RateLimiter::ModelContext::AddAvailableInstance(ModelInstance* instance)
+{
+  std::lock_guard<std::recursive_mutex> lk(avbl_instances_mtx_);
+  avbl_instances_.push(instance);
+  instance->MarkAvailable();
+}
+
+void
+RateLimiter::ModelContext::StageInstanceIfAvailable()
+{
+  std::lock_guard<std::recursive_mutex> lk1(request_queue_mtx_);
+  std::lock_guard<std::recursive_mutex> lk2(avbl_instances_mtx_);
+  PriorityQueue backup_queue;
+  while (!avbl_instances_.empty()) {
+    ModelInstance* instance = avbl_instances_.top();
+    if (!specific_request_queues_[instance->Index()].empty()) {
+      // Prioritize the specific requests for the available model
+      // instance highest priority.
+      const StandardScheduleFunc func =
+          specific_request_queues_[instance->Index()].front();
+      specific_request_queues_[instance->Index()].pop();
+      instance->Stage(func);
+    } else if (!generic_request_queue_.empty()) {
+      // If request is for generic model instance then use the
+      // instance with the highest priority.
+      const StandardScheduleFunc func = generic_request_queue_.front();
+      generic_request_queue_.pop();
+      instance->Stage(func);
+    } else {
+      // If there are requests for a specific model instance then backup
+      // the model instance and keep searching through the available
+      // model instances. The prioritization will be taken care of in the
+      // staging priority queue.
+      backup_queue.push(instance);
+    }
+    avbl_instances_.pop();
+  }
+  // Restore the backup queue
+  if (!backup_queue.empty()) {
+    avbl_instances_.swap(backup_queue);
+  }
+}
+
+void
+RateLimiter::ModelContext::AllocateInstanceIfAvailable()
+{
+  std::lock_guard<std::recursive_mutex> lk1(request_queue_mtx_);
+  std::lock_guard<std::recursive_mutex> lk2(avbl_instances_mtx_);
+  PriorityQueue backup_queue;
+  while (!avbl_instances_.empty()) {
+    ModelInstance* instance = avbl_instances_.top();
+    if (!specific_request_queues_[instance->Index()].empty()) {
+      // Prioritize the specific requests for the available model
+      // instance highest priority.
+      const StandardScheduleFunc func =
+          specific_request_queues_[instance->Index()].front();
+      specific_request_queues_[instance->Index()].pop();
+      instance->DirectAllocate(func);
+    } else if (!generic_request_queue_.empty()) {
+      // If request is for generic model instance then use the
+      // instance with the highest priority.
+      const StandardScheduleFunc func = generic_request_queue_.front();
+      generic_request_queue_.pop();
+      instance->DirectAllocate(func);
+    } else {
+      // If there are requests for a specific model instance then backup
+      // the model instance and keep searching through the available
+      // model instances. The prioritization will be taken care of in the
+      // staging priority queue.
+      backup_queue.push(instance);
+    }
+    avbl_instances_.pop();
+  }
+  // Restore the backup queue
+  if (!backup_queue.empty()) {
+    avbl_instances_.swap(backup_queue);
+  }
+}
+
+void
+RateLimiter::ModelContext::SetSpecificQueueCount(int queue_count)
+{
+  std::lock_guard<std::recursive_mutex> lk(request_queue_mtx_);
+  specific_request_queues_.resize(queue_count);
+}
+
+bool
+RateLimiter::ModelContext::ContainsPendingRequests(int index)
+{
+  std::lock_guard<std::recursive_mutex> lk(request_queue_mtx_);
+  return (generic_request_queue_.size() != 0) ||
+         (specific_request_queues_[index].size() != 0);
+}
+
+void
+RateLimiter::ModelContext::Unload()
+{
+  unloading_ = true;
+}
+
+
+//=========================================================================
+//  ModelInstance Implementation
+//=========================================================================
+
+RateLimiter::ModelInstance::ModelInstance(
+    const std::string& model_name, const int64_t version,
+    RateLimiter::ModelContext* model_context, const uint32_t index,
+    const int gpu_device, const RateLimiter::Specification& spec,
+    RateLimiter::StandardStageFunc OnStage,
+    RateLimiter::StandardReleaseFunc OnRelease)
+    : model_name_(model_name), version_(version), model_context_(model_context),
+      index_(index), gpu_device_(gpu_device), spec_(spec), OnStage_(OnStage),
+      OnRelease_(OnRelease), exec_count_(0), state_(AVAILABLE)
+{
+}
+
+std::pair<std::string, int64_t>
+RateLimiter::ModelInstance::ModelIdentifier()
+{
+  return std::make_pair(model_name_, version_);
+}
+
+void
+RateLimiter::ModelInstance::MarkAvailable()
+{
+  std::lock_guard<std::mutex> lk(state_mtx_);
+  state_ = AVAILABLE;
+}
+
+Status
+RateLimiter::ModelInstance::Stage(StandardScheduleFunc OnSchedule)
+{
+  {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+
+    if (state_ != AVAILABLE) {
+      return Status(
+          Status::Code::INTERNAL,
+          "Can not stage a model instance that is not yet available");
+    }
+
+    state_ = STAGED;
+    OnSchedule_ = OnSchedule;
+  }
+
+  OnStage_(this);
+
+  return Status::Success;
+}
+
+Status
+RateLimiter::ModelInstance::Allocate()
+{
+  {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+
+    if (state_ != STAGED) {
+      return Status(
+          Status::Code::INTERNAL,
+          "Can not allocate a model instance that is not yet staged");
+    }
+
+    exec_count_++;
+    state_ = ALLOCATED;
+  }
+
+  OnSchedule_(this);
+
+  return Status::Success;
+}
+
+Status
+RateLimiter::ModelInstance::DirectAllocate(StandardScheduleFunc OnSchedule)
+{
+  {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+
+    if (state_ != AVAILABLE) {
+      return Status(
+          Status::Code::INTERNAL,
+          "Can not allocate a model instance that is not yet available");
+    }
+
+    exec_count_++;
+    state_ = ALLOCATED;
+  }
+
+  OnSchedule(this);
+
+  return Status::Success;
+}
+
+void
+RateLimiter::ModelInstance::Release()
+{
+  OnRelease_(this);
+
+  {
+    std::lock_guard<std::mutex> lk(state_mtx_);
+    if ((model_context_->isUnloading()) && (state_ == AVAILABLE) &&
+        (!model_context_->ContainsPendingRequests(index_))) {
+      state_ = UNLOADED;
+    }
+  }
+
+  cv_.notify_all();
+}
+
+void
+RateLimiter::ModelInstance::Unload()
+{
+  std::lock_guard<std::mutex> lk(state_mtx_);
+
+  if ((state_ == AVAILABLE) &&
+      (!model_context_->ContainsPendingRequests(index_))) {
+    state_ = UNLOADED;
+  }
+}
+
+void
+RateLimiter::ModelInstance::WaitForUnload()
+{
+  if (!model_context_->isUnloading()) {
+    model_context_->Unload();
+  }
+
+  Unload();
+
+  // Wait for the instance to be unloaded
+  {
+    std::unique_lock<std::mutex> lk(state_mtx_);
+    cv_.wait(lk, [this] { return state_ == UNLOADED; });
+  }
+}
+
+double
+RateLimiter::ModelInstance::ScaledPriority()
+{
+  // TODO: Different schemes for the prioritization of
+  // model instance can be added here.
+  return (exec_count_ * spec_.priority());
+}
+
+
+//=========================================================================
+//  ResourceManager Implementation
+//=========================================================================
+
+Status
+RateLimiter::ResourceManager::Create(
+    std::unique_ptr<ResourceManager>* resource_manager)
+{
+  std::unique_ptr<ResourceManager> local_resource_manager(
+      new ResourceManager());
+  *resource_manager = std::move(local_resource_manager);
+  return Status::Success;
+}
+
+void
+RateLimiter::ResourceManager::LoadModelInstance(
+    const RateLimiter::ModelInstance* instance)
+{
+  std::lock_guard<std::mutex> lk(model_resources_mtx_);
+  auto pr = model_resources_.emplace(std::make_pair(instance, ResourceMap()));
+  for (const auto& resource : instance->GetSpecification()->resources()) {
+    if (resource.second.global()) {
+      (pr.first->second[GLOBAL_RESOURCE_KEY])[resource.first] =
+          resource.second.count();
+    } else {
+      (pr.first->second[instance->DeviceId()])[resource.first] =
+          resource.second.count();
+    }
+  }
+}
+
+Status
+RateLimiter::ResourceManager::UnloadModelInstance(
+    const RateLimiter::ModelInstance* instance)
+{
+  std::lock_guard<std::mutex> lk(model_resources_mtx_);
+  const auto& itr = model_resources_.find(instance);
+  if (itr == model_resources_.end()) {
+    return Status(
+        Status::Code::INTERNAL, "Can not find the instance to unload");
+  }
+  model_resources_.erase(instance);
+  return Status::Success;
+}
+
+void
+RateLimiter::ResourceManager::UpdateResourceLimits()
+{
+  std::lock_guard<std::mutex> lk1(max_resources_mtx_);
+  std::lock_guard<std::mutex> lk2(model_resources_mtx_);
+  max_resources_.clear();
+  // Obtain the maximum resource across all the instances
+  // and use it as the default available.
+  // TODO: Add the enhancement to provide resources via CLI
+  // Will save some cycles in obtaineing the resource limits.
+  for (const auto& instance_resources : model_resources_) {
+    for (const auto& resource_device_map : instance_resources.second) {
+      auto ditr = max_resources_.find(resource_device_map.first);
+      if (ditr == max_resources_.end()) {
+        ditr =
+            max_resources_
+                .emplace(resource_device_map.first, resource_device_map.second)
+                .first;
+      } else {
+        for (const auto resource : resource_device_map.second) {
+          auto ritr = ditr->second.find(resource.first);
+          if (ritr == ditr->second.end()) {
+            ritr = ditr->second.emplace(resource.first, resource.second).first;
+          } else {
+            if (ritr->second < resource.second) {
+              ritr->second = resource.second;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+bool
+RateLimiter::ResourceManager::AllocateResources(
+    const RateLimiter::ModelInstance* instance)
+{
+  std::lock_guard<std::mutex> lk1(model_resources_mtx_);
+  std::lock_guard<std::mutex> lk2(allocated_resources_mtx_);
+  const auto& itr = model_resources_.find(instance);
+  if (itr == model_resources_.end()) {
+    return false;
+  } else {
+    // First pass to verify if resources are available
+    {
+      std::lock_guard<std::mutex> lk3(max_resources_mtx_);
+      for (const auto& ditr : itr->second) {
+        auto allocated_ditr = allocated_resources_.find(ditr.first);
+        if (allocated_ditr == allocated_resources_.end()) {
+          allocated_ditr =
+              allocated_resources_
+                  .emplace(ditr.first, std::map<std::string, uint32_t>())
+                  .first;
+        }
+        for (const auto& ritr : ditr.second) {
+          auto allocated_ritr = allocated_ditr->second.find(ritr.first);
+          if (allocated_ritr == allocated_ditr->second.end()) {
+            allocated_ritr =
+                allocated_ditr->second.emplace(ritr.first, 0).first;
+          }
+          if ((allocated_ritr->second + ritr.second) >
+              (max_resources_[ditr.first])[ritr.first]) {
+            return false;
+          }
+        }
+      }
+    }
+
+    // Second pass to actually allocate the resources
+    for (const auto& ditr : itr->second) {
+      for (const auto& ritr : ditr.second) {
+        (allocated_resources_[ditr.first])[ritr.first] += ritr.second;
+      }
+    }
+  }
+
+  return true;
+}
+
+Status
+RateLimiter::ResourceManager::ReleaseResources(
+    const RateLimiter::ModelInstance* instance)
+{
+  std::lock_guard<std::mutex> lk1(model_resources_mtx_);
+  std::lock_guard<std::mutex> lk2(allocated_resources_mtx_);
+  const auto& itr = model_resources_.find(instance);
+  if (itr == model_resources_.end()) {
+    return Status(
+        Status::Code::INTERNAL,
+        "Unable find the instance resources to release");
+  } else {
+    for (const auto& ditr : itr->second) {
+      for (const auto& ritr : ditr.second) {
+        (allocated_resources_[ditr.first])[ritr.first] -= ritr.second;
+      }
+    }
+  }
+
+  return Status::Success;
+}
+
+RateLimiter::ResourceManager::ResourceManager() {}
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -147,10 +147,10 @@ RateLimiter::EnqueueModelRequest(
 
   itr->second.EnqueueModelRequest(OnSchedule, instance_index);
   if (ignore_resources_and_priority_) {
-    itr->second.StageInstanceIfAvailable();
-  } else {
     // Directly allocate an available model instance if not using rate limiter.
     itr->second.AllocateInstanceIfAvailable();
+  } else {
+    itr->second.StageInstanceIfAvailable();
   }
 
   return Status::Success;
@@ -180,11 +180,11 @@ RateLimiter::OnRelease(ModelInstance* instance)
   resource_manager_->ReleaseResources(instance);
   if (model_context.ContainsPendingRequests(instance->Index())) {
     if (ignore_resources_and_priority_) {
-      model_context.StageInstanceIfAvailable();
-    } else {
       // Directly allocate an available model instance if not using rate
       // limiter.
       model_context.AllocateInstanceIfAvailable();
+    } else {
+      model_context.StageInstanceIfAvailable();
     }
   }
   AttemptAllocation();

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -1,0 +1,248 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+#include "src/core/model_config.pb.h"
+#include "src/core/status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+// Limits the rate at which requests are dispatched from the scheduler
+class RateLimiter {
+ public:
+  class ModelInstance;
+
+ private:
+  class ModelContext;
+
+  using StandardReleaseFunc = std::function<void(ModelInstance*)>;
+  using StandardScheduleFunc = std::function<void(ModelInstance*)>;
+  using StandardStageFunc = std::function<void(ModelInstance*)>;
+  using Specification = inference::ModelInstanceGroup::RateLimiterSpec;
+
+ public:
+  /// Creates a rate limiter object which will funnel the inference requests to
+  /// the model instances.
+  /// \param enable_rate_limiting Whether or not to enable rate limiting.
+  /// \return Status object indicating success or failure.
+  static Status Create(
+      const bool enable_rate_limiting,
+      std::unique_ptr<RateLimiter>* rate_limiter);
+
+  /// Loads the specified model to the RateLimiter
+  /// \param enable_rate_limiting Whether or not to enable rate limiting.
+  /// \return Status object indicating success or failure.
+  Status LoadModel(
+      const std::string& model_name, const int64_t version,
+      const inference::ModelConfig& model_config);
+
+  /// Unloads the specified model from the RateLimiter
+  /// \param enable_rate_limiting Whether or not to enable rate limiting.
+  /// \return Status object indicating success or failure.
+  Status UnloadModel(const std::string& model_name, const int64_t version);
+
+  /// Enqueues the callback to the specified model. In future, when the
+  /// conditions are met, the callback will be invoked and a pointer to
+  /// allocated RateLimiter::ModelInstance object will be exposed as a
+  /// parameter. The user must ensure RateLimiter::ModelInstance::Release
+  /// gets called on the instance once the inference request is complete
+  /// so that the instance and its resources are returned to the available
+  /// pool. Also, note the callback should be a light-weight call and
+  /// must not itself invoke the inference execution.
+  /// \param OnSchedule The callback function to be called when scheduling.
+  /// \param model_name The name of the model.
+  /// \param version The version of the model.
+  /// \param instance_index The index to a specific instance of the model.
+  /// The default value is -1 which means that an instance with highest
+  /// priority will be selected for the execution.
+  /// \return Status object indicating success or failure.
+  Status EnqueueModelRequest(
+      const StandardScheduleFunc& OnSchedule, const std::string& model_name,
+      const int64_t version, const int instance_index = -1);
+
+  // Holds the state of the model instance.
+  class ModelInstance {
+   public:
+    friend class RateLimiter;
+    friend class ResourceManager;
+    enum State { AVAILABLE, STAGED, ALLOCATED, UNLOADED };
+
+    /// Should be called when the request on the model instance is
+    /// complete. This function releases the resources allocated to
+    /// the model instance and sends the instance into the available
+    /// pool so that it can serve other requests.
+    void Release();
+
+    /// Returns the index of the instance
+    int32_t Index() { return index_; }
+
+   private:
+    ModelInstance(
+        const std::string& model_name, const int64_t version,
+        ModelContext* model_context, const uint32_t index, const int gpu_device,
+        const Specification& spec, StandardStageFunc OnStage,
+        StandardReleaseFunc OnRelease);
+
+    std::pair<std::string, int64_t> ModelIdentifier();
+    int32_t DeviceId() const { return gpu_device_; }
+    const Specification* GetSpecification() const { return &spec_; }
+    void MarkAvailable();
+    double ScaledPriority();
+    Status Stage(StandardScheduleFunc OnSchedule);
+    Status Allocate();
+    Status DirectAllocate(StandardScheduleFunc OnSchedule);
+    void Unload();
+    void WaitForUnload();
+
+    std::string model_name_;
+    int64_t version_;
+    ModelContext* model_context_;
+    int32_t index_;
+    int gpu_device_;
+    Specification spec_;
+    StandardStageFunc OnStage_;
+    StandardReleaseFunc OnRelease_;
+    std::atomic<uint64_t> exec_count_;
+
+    State state_;
+    bool unloading_;
+    std::mutex state_mtx_;
+
+    StandardScheduleFunc OnSchedule_;
+
+    std::condition_variable cv_;
+  };
+
+ private:
+  RateLimiter(const bool enable_rate_limiting);
+
+  void LoadModelHelper(
+      const std::string& model_name, const int64_t version, const int device_id,
+      const Specification& rate_limit_spec, ModelContext* model_context,
+      std::vector<std::shared_ptr<ModelInstance>>* model_instances);
+
+  void OnStage(ModelInstance* instance_ptr);
+  void OnRelease(ModelInstance* instance_ptr);
+  void AttemptAllocation();
+
+  class Comparator {
+   public:
+    bool operator()(ModelInstance* a, ModelInstance* b)
+    {
+      return a->ScaledPriority() > b->ScaledPriority();
+    }
+  };
+
+  using PriorityQueue = std::priority_queue<
+      ModelInstance*, std::vector<ModelInstance*>, Comparator>;
+
+  // Holds the active context to a loaded model
+  class ModelContext {
+   public:
+    ModelContext();
+
+    Status EnqueueModelRequest(
+        const StandardScheduleFunc& OnSchedule, const int instance_index);
+    void AddAvailableInstance(ModelInstance* instance);
+    void StageInstanceIfAvailable();
+    void AllocateInstanceIfAvailable();
+    void SetSpecificQueueCount(int queue_count);
+    bool ContainsPendingRequests(int32_t index);
+    void Unload();
+    bool isUnloading() { return unloading_; }
+
+   private:
+    bool unloading_;
+
+    // Queue holding pending scheduling request
+    std::queue<StandardScheduleFunc> generic_request_queue_;
+    std::vector<std::queue<StandardScheduleFunc>> specific_request_queues_;
+    std::recursive_mutex request_queue_mtx_;
+
+    // The set of instances that are available at the moment
+    PriorityQueue avbl_instances_;
+    std::recursive_mutex avbl_instances_mtx_;
+  };
+
+  // Manages and keep track of resource allocation to the model instances.
+  class ResourceManager {
+   public:
+    // GPU device number that indicates that no gpu is available for a
+    // context
+    static constexpr int NO_GPU_DEVICE = -1;
+    // Key for holding global resources
+    static constexpr int GLOBAL_RESOURCE_KEY = -2;
+
+    static Status Create(std::unique_ptr<ResourceManager>* resource_manager);
+    void LoadModelInstance(const RateLimiter::ModelInstance* instance);
+    Status UnloadModelInstance(const RateLimiter::ModelInstance* instance);
+    void UpdateResourceLimits();
+    bool AllocateResources(const RateLimiter::ModelInstance* instance);
+    Status ReleaseResources(const RateLimiter::ModelInstance* instance);
+
+   private:
+    ResourceManager();
+
+    using ResourceMap = std::map<int, std::map<std::string, uint32_t>>;
+
+    std::map<const RateLimiter::ModelInstance*, ResourceMap> model_resources_;
+    std::mutex model_resources_mtx_;
+
+    ResourceMap max_resources_;
+    std::mutex max_resources_mtx_;
+
+    ResourceMap allocated_resources_;
+    std::mutex allocated_resources_mtx_;
+  };
+
+  // Instances for the loaded models
+  std::map<
+      std::pair<std::string, int64_t>,
+      std::vector<std::shared_ptr<ModelInstance>>>
+      model_instances_;
+  std::mutex model_instances_mtx_;
+
+  // Running context of the loaded models
+  std::map<std::pair<std::string, int64_t>, ModelContext> model_contexts_;
+  std::mutex model_contexts_mtx_;
+
+  // Holds the model instances that have been staged
+  PriorityQueue staged_instances_;
+  std::recursive_mutex staged_instances_mtx_;
+
+  // Manager to keep track of the resource allocations
+  std::unique_ptr<ResourceManager> resource_manager_;
+
+  bool enable_rate_limiting_;
+};
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -60,7 +60,7 @@ class RateLimiter {
   /// will be available -> allocated -> available.
   /// \param ignore_resources_and_priority Whether or not to ignore resource
   /// constraints and cross-model priority. An available instance is directly
-  /// allocated when true.Default value is false.
+  /// allocated when true.
   /// \return Status object indicating success or failure.
   static Status Create(
       const bool ignore_resources_and_priority,

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -144,6 +144,67 @@ install(
   RUNTIME DESTINATION bin
 )
 
+#
+# RateLimiter
+#
+protobuf_generate_cpp(MODEL_CONFIG_PROTO_SRC MODEL_CONFIG_PROTO_HDR ../core/model_config.proto)
+
+set(
+  RATE_LIMITER_SRCS
+  ../core/rate_limiter.cc
+  ../core/status.cc
+)
+
+set(
+  RATE_LIMITER_HDRS
+  ../core/rate_limiter.h
+  ${MODEL_CONFIG_PROTO_HDR}
+)
+
+set(
+  RATE_LIMITER_TEST_SRCS
+  rate_limiter_test.cc
+  ${RATE_LIMITER_SRCS}
+)
+
+set(
+  RATE_LIMITER_TEST_HDRS
+  ${RATE_LIMITER_HDRS}
+)
+
+add_executable(
+  rate_limiter_test
+  ${RATE_LIMITER_TEST_SRCS}
+  ${RATE_LIMITER_TEST_HDRS}
+  $<TARGET_OBJECTS:proto-library>
+)
+set_target_properties(
+  rate_limiter_test
+  PROPERTIES
+    SKIP_BUILD_RPATH TRUE
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH_USE_LINK_PATH FALSE
+    INSTALL_RPATH ""
+)
+target_include_directories(
+  rate_limiter_test
+  PRIVATE ${GTEST_INCLUDE_DIR}
+)
+if(${TRITON_ENABLE_GPU})
+  target_include_directories(rate_limiter_test PRIVATE ${CUDA_INCLUDE_DIRS})
+endif() # TRITON_ENABLE_GPU
+target_link_libraries(
+  rate_limiter_test
+  PRIVATE triton-core-serverapi  # from repo-core
+  PRIVATE ${GTEST_LIBRARY}
+  PRIVATE ${GTEST_MAIN_LIBRARY}
+  PRIVATE protobuf::libprotobuf
+)
+install(
+  TARGETS rate_limiter_test
+  RUNTIME DESTINATION bin
+)
+
 add_subdirectory(custom/sdk custom/sdk)
 add_subdirectory(custom/addsub custom/addsub)
 add_subdirectory(custom/identity custom/identity)

--- a/src/test/rate_limiter_test.cc
+++ b/src/test/rate_limiter_test.cc
@@ -37,7 +37,7 @@ class RateLimiterTest : public ::testing::Test {
 
   void SetUp() override
   {
-    ni::RateLimiter::Create(true /* enable_rate_limiting */, &rate_limiter_);
+    ni::RateLimiter::Create(false /* ignore_resources_and_priority */, &rate_limiter_);
   }
 
   void AddInstanceGroup(
@@ -349,7 +349,7 @@ TEST_F(RateLimiterTest, NoLimiting)
       &test_config, std::vector<int>{1, 2}, 1, 1, global_resources);
 
   std::unique_ptr<ni::RateLimiter> rate_limiter;
-  ni::RateLimiter::Create(false /* enable_rate_limiting */, &rate_limiter);
+  ni::RateLimiter::Create(true /* ignore_resources_and_priority */, &rate_limiter);
 
   rate_limiter->LoadModel(model_name, version, test_config);
 

--- a/src/test/rate_limiter_test.cc
+++ b/src/test/rate_limiter_test.cc
@@ -1,0 +1,413 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "gtest/gtest.h"
+
+#include "src/core/model_config.pb.h"
+#include "src/core/rate_limiter.h"
+
+namespace ni = nvidia::inferenceserver;
+
+namespace {
+class RateLimiterTest : public ::testing::Test {
+ protected:
+  using Resources = std::map<std::string, uint32_t>;
+
+  void SetUp() override
+  {
+    ni::RateLimiter::Create(true /* enable_rate_limiting */, &rate_limiter_);
+  }
+
+  void AddInstanceGroup(
+      inference::ModelConfig* config,
+      const std::vector<int>& gpu_ids = std::vector<int>(),
+      const int instance_count = 1, const uint32_t priority = 1,
+      const Resources& global_resources = Resources(),
+      const Resources& local_resources = Resources())
+  {
+    auto group = config->add_instance_group();
+    group->set_count(instance_count);
+    if (gpu_ids.empty()) {
+      group->set_kind(inference::ModelInstanceGroup::KIND_CPU);
+    } else {
+      group->set_kind(inference::ModelInstanceGroup::KIND_GPU);
+      for (auto gpu_id : gpu_ids) {
+        group->add_gpus(gpu_id);
+      }
+    }
+    group->mutable_rate_limiter_spec()->set_priority(priority);
+
+    for (const auto& resource : global_resources) {
+      auto itr =
+          group->mutable_rate_limiter_spec()
+              ->mutable_resources()
+              ->insert(
+                  {resource.first,
+                   inference::ModelInstanceGroup::RateLimiterSpec::Resource()})
+              .first;
+      itr->second.set_global(true);
+      itr->second.set_count(resource.second);
+    }
+
+    for (const auto& resource : local_resources) {
+      auto itr =
+          group->mutable_rate_limiter_spec()
+              ->mutable_resources()
+              ->insert(
+                  {resource.first,
+                   inference::ModelInstanceGroup::RateLimiterSpec::Resource()})
+              .first;
+      itr->second.set_count(resource.second);
+    }
+  }
+
+  void TearDown() override {}
+
+  std::unique_ptr<ni::RateLimiter> rate_limiter_;
+};
+
+TEST_F(RateLimiterTest, SingleInstanceSingleInfer)
+{
+  // A simple test with a single instance
+  std::string model_name("test_model");
+  int64_t version(1);
+
+  inference::ModelConfig test_config;
+  // Create a model configuration a single instance
+  AddInstanceGroup(&test_config);
+  rate_limiter_->LoadModel(model_name, version, test_config);
+
+  std::atomic<int> callback_count(0);
+
+  auto callback_fn =
+      [&callback_count](ni::RateLimiter::ModelInstance* instance) {
+        callback_count++;
+        // Releasing the instance right away
+        instance->Release();
+      };
+
+  rate_limiter_->EnqueueModelRequest(callback_fn, model_name, version);
+
+  EXPECT_EQ(1, callback_count)
+      << "Expect callback_count: " << 1 << ", got: " << callback_count;
+}
+
+TEST_F(RateLimiterTest, SingleInstanceMultiInfer)
+{
+  // A simple test with a single instance
+  std::string model_name("test_model");
+  int64_t version(1);
+
+  inference::ModelConfig test_config;
+  // Create a model configuration a single instance
+  AddInstanceGroup(&test_config);
+  rate_limiter_->LoadModel(model_name, version, test_config);
+
+  std::queue<ni::RateLimiter::ModelInstance*> instance_queue;
+  std::mutex mtx;
+  std::atomic<int32_t> callback_count(0);
+
+  auto callback_fn = [&instance_queue, &mtx, &callback_count](
+                         ni::RateLimiter::ModelInstance* instance) {
+    callback_count++;
+    {
+      std::lock_guard<std::mutex> lk(mtx);
+      instance_queue.push(instance);
+    }
+  };
+
+  int request_count = 10;
+  // Enqueue all the requests
+  for (int i = 0; i < request_count; i++) {
+    rate_limiter_->EnqueueModelRequest(callback_fn, model_name, version);
+  }
+
+  // As there is only a single instance only one callback should be invoked.
+  // Other queued callbacks will be executed as and when they are released.
+  for (int i = 0; i < request_count; i++) {
+    EXPECT_EQ(i + 1, callback_count)
+        << "Expect callback_count: " << i + 1 << ", got: " << callback_count;
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+}
+
+TEST_F(RateLimiterTest, MultiInstanceMultiInfer)
+{
+  // A simple test with a single instance
+  std::string model_name("test_model");
+  int64_t version(1);
+
+  inference::ModelConfig test_config;
+  // Create a model configuration with two instances on different
+  // gpu devices.
+  AddInstanceGroup(&test_config, std::vector<int>{1, 2});
+  rate_limiter_->LoadModel(model_name, version, test_config);
+
+  std::queue<ni::RateLimiter::ModelInstance*> instance_queue;
+  std::mutex mtx;
+  std::atomic<int32_t> callback_count(0);
+
+  auto callback_fn = [&instance_queue, &mtx, &callback_count](
+                         ni::RateLimiter::ModelInstance* instance) {
+    callback_count++;
+    {
+      std::lock_guard<std::mutex> lk(mtx);
+      instance_queue.push(instance);
+    }
+  };
+
+  int request_count = 10;
+  // Enqueue all the requests
+  for (int i = 0; i < request_count; i++) {
+    rate_limiter_->EnqueueModelRequest(callback_fn, model_name, version);
+  }
+
+  // As there are two instances offset will be 2
+  int offset = 2;
+  for (int i = 0; i < (request_count - offset + 1); i++) {
+    EXPECT_EQ(i + offset, callback_count)
+        << "Expect callback_count: " << i + offset
+        << ", got: " << callback_count;
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+
+  // Release any other instances that might be remaining
+  while (!instance_queue.empty()) {
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+}
+
+TEST_F(RateLimiterTest, SpecificInstanceMultiInfer)
+{
+  // A simple test with a single instance
+  std::string model_name("test_model");
+  int64_t version(1);
+
+  inference::ModelConfig test_config;
+  // Create a model configuration with two instances on different
+  // gpu devices.
+  AddInstanceGroup(&test_config, std::vector<int>{1, 2});
+  rate_limiter_->LoadModel(model_name, version, test_config);
+
+  std::queue<ni::RateLimiter::ModelInstance*> instance_queue;
+  std::mutex mtx;
+  std::atomic<int32_t> callback_count(0);
+
+  auto callback_fn = [&instance_queue, &mtx, &callback_count](
+                         ni::RateLimiter::ModelInstance* instance) {
+    callback_count++;
+    {
+      std::lock_guard<std::mutex> lk(mtx);
+      instance_queue.push(instance);
+    }
+  };
+
+  int request_count = 10;
+  // Enqueue all the requests
+  for (int i = 0; i < request_count; i++) {
+    rate_limiter_->EnqueueModelRequest(
+        callback_fn, model_name, version, 0 /* instance index */);
+  }
+
+  // As there are two instances but requests are generated for a single instance
+  int offset = 1;
+  for (int i = 0; i < (request_count - offset + 1); i++) {
+    EXPECT_EQ(i + offset, callback_count)
+        << "Expect callback_count: " << i + offset
+        << ", got: " << callback_count;
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+
+  // Release any other instances that might be remaining
+  while (!instance_queue.empty()) {
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+}
+
+TEST_F(RateLimiterTest, SimplePriority)
+{
+  // A simple test with a single instance
+  std::string model_name("test_model");
+  int64_t version(1);
+
+  inference::ModelConfig test_config;
+  // Create a model configuration with two instances with different priority
+  AddInstanceGroup(&test_config, std::vector<int>(), 1, 1);
+  AddInstanceGroup(&test_config, std::vector<int>(), 1, 2);
+  rate_limiter_->LoadModel(model_name, version, test_config);
+
+  std::vector<int32_t> callback_counts{0, 0};
+
+  auto callback_fn =
+      [&callback_counts](ni::RateLimiter::ModelInstance* instance) {
+        callback_counts[instance->Index()]++;
+        // Releasing the instance right away
+        instance->Release();
+      };
+
+  int request_count = 12;
+  // Enqueue all the requests
+  for (int i = 0; i < request_count; i++) {
+    rate_limiter_->EnqueueModelRequest(callback_fn, model_name, version);
+  }
+
+  EXPECT_EQ(callback_counts[0], 8)
+      << "Expect callback_count: " << 8 << ", got: " << callback_counts[0];
+
+  EXPECT_EQ(callback_counts[1], 4)
+      << "Expect callback_count: " << 4 << ", got: " << callback_counts[1];
+}
+
+TEST_F(RateLimiterTest, SimpleResource)
+{
+  // A simple test with a single instance
+  std::string model_name("test_model");
+  int64_t version(1);
+
+  inference::ModelConfig test_config;
+
+  Resources global_resources;
+  global_resources["dummy_resource"] = 10;
+
+  AddInstanceGroup(
+      &test_config, std::vector<int>{1, 2}, 1, 1, global_resources);
+  rate_limiter_->LoadModel(model_name, version, test_config);
+
+  std::queue<ni::RateLimiter::ModelInstance*> instance_queue;
+  std::mutex mtx;
+  std::atomic<int32_t> callback_count(0);
+
+  auto callback_fn = [&instance_queue, &mtx, &callback_count](
+                         ni::RateLimiter::ModelInstance* instance) {
+    callback_count++;
+    {
+      std::lock_guard<std::mutex> lk(mtx);
+      instance_queue.push(instance);
+    }
+  };
+
+  int request_count = 10;
+  // Enqueue all the requests
+  for (int i = 0; i < request_count; i++) {
+    rate_limiter_->EnqueueModelRequest(callback_fn, model_name, version);
+  }
+
+  // Although there are two instances, but because of the resource
+  // constraint only one instance can run at a time.
+  int offset = 1;
+  for (int i = 0; i < (request_count - offset + 1); i++) {
+    EXPECT_EQ(i + offset, callback_count)
+        << "Expect callback_count: " << i + offset
+        << ", got: " << callback_count;
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+
+  // Release any other instances that might be remaining
+  while (!instance_queue.empty()) {
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+}
+
+TEST_F(RateLimiterTest, NoLimiting)
+{
+  // A simple test with a single instance
+  std::string model_name("test_model");
+  int64_t version(1);
+
+  inference::ModelConfig test_config;
+
+  Resources global_resources;
+  global_resources["dummy_resource"] = 10;
+
+  AddInstanceGroup(
+      &test_config, std::vector<int>{1, 2}, 1, 1, global_resources);
+
+  std::unique_ptr<ni::RateLimiter> rate_limiter;
+  ni::RateLimiter::Create(false /* enable_rate_limiting */, &rate_limiter);
+
+  rate_limiter->LoadModel(model_name, version, test_config);
+
+  std::queue<ni::RateLimiter::ModelInstance*> instance_queue;
+  std::mutex mtx;
+  std::atomic<int32_t> callback_count(0);
+
+  auto callback_fn = [&instance_queue, &mtx, &callback_count](
+                         ni::RateLimiter::ModelInstance* instance) {
+    callback_count++;
+    {
+      std::lock_guard<std::mutex> lk(mtx);
+      instance_queue.push(instance);
+    }
+  };
+
+  int request_count = 10;
+  // Enqueue all the requests
+  for (int i = 0; i < request_count; i++) {
+    rate_limiter->EnqueueModelRequest(callback_fn, model_name, version);
+  }
+
+  // Even though there is a resource constraint, as the rate limiting is
+  // disabled we must see execution across all the instances.
+  int offset = 2;
+  for (int i = 0; i < (request_count - offset + 1); i++) {
+    EXPECT_EQ(i + offset, callback_count)
+        << "Expect callback_count: " << i + offset
+        << ", got: " << callback_count;
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+
+  // Release any other instances that might be remaining
+  while (!instance_queue.empty()) {
+    auto instance = instance_queue.front();
+    instance_queue.pop();
+    instance->Release();
+  }
+}
+
+
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/rate_limiter_test.cc
+++ b/src/test/rate_limiter_test.cc
@@ -57,29 +57,19 @@ class RateLimiterTest : public ::testing::Test {
         group->add_gpus(gpu_id);
       }
     }
-    group->mutable_rate_limiter_spec()->set_priority(priority);
+    group->mutable_rate_limiter()->set_priority(priority);
 
     for (const auto& resource : global_resources) {
-      auto itr =
-          group->mutable_rate_limiter_spec()
-              ->mutable_resources()
-              ->insert(
-                  {resource.first,
-                   inference::ModelInstanceGroup::RateLimiterSpec::Resource()})
-              .first;
-      itr->second.set_global(true);
-      itr->second.set_count(resource.second);
+      auto rate_limiter_config = group->mutable_rate_limiter()->add_resources();
+      rate_limiter_config->set_name(resource.first);
+      rate_limiter_config->set_global(true);
+      rate_limiter_config->set_count(resource.second);
     }
 
     for (const auto& resource : local_resources) {
-      auto itr =
-          group->mutable_rate_limiter_spec()
-              ->mutable_resources()
-              ->insert(
-                  {resource.first,
-                   inference::ModelInstanceGroup::RateLimiterSpec::Resource()})
-              .first;
-      itr->second.set_count(resource.second);
+      auto rate_limiter_config = group->mutable_rate_limiter()->add_resources();
+      rate_limiter_config->set_name(resource.first);
+      rate_limiter_config->set_count(resource.second);
     }
   }
 


### PR DESCRIPTION
Note: This is just a rate limiter unit implementation and it is not connected to the server yet.

I will add the extensive testing with other PR.

The logs of the rate_limter_test covering very basic functionalities from my machine

```
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from RateLimiterTest
[ RUN      ] RateLimiterTest.SingleInstanceSingleInfer
[       OK ] RateLimiterTest.SingleInstanceSingleInfer (0 ms)
[ RUN      ] RateLimiterTest.SingleInstanceMultiInfer
[       OK ] RateLimiterTest.SingleInstanceMultiInfer (0 ms)
[ RUN      ] RateLimiterTest.MultiInstanceMultiInfer
[       OK ] RateLimiterTest.MultiInstanceMultiInfer (0 ms)
[ RUN      ] RateLimiterTest.SpecificInstanceMultiInfer
[       OK ] RateLimiterTest.SpecificInstanceMultiInfer (1 ms)
[ RUN      ] RateLimiterTest.SimplePriority
[       OK ] RateLimiterTest.SimplePriority (0 ms)
[ RUN      ] RateLimiterTest.SimpleResource
[       OK ] RateLimiterTest.SimpleResource (0 ms)
[ RUN      ] RateLimiterTest.NoLimiting
[       OK ] RateLimiterTest.NoLimiting (0 ms)
[----------] 7 tests from RateLimiterTest (1 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (1 ms total)
[  PASSED  ] 7 tests.
```
