### PR TITLE
Fix non-decoupled custom backend to return empty responses

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -202,6 +202,8 @@ RUN cp /tmp/tritonbuild/tritonserver/build/test-util/install/lib/libidentity.so 
         qa/L0_batcher/. && \
     cp /tmp/tritonbuild/tritonserver/build/test-util/install/lib/libidentity.so \
         qa/L0_client_timeout/. && \
+    cp /tmp/tritonbuild/tritonserver/build/test-util/install/lib/libidentity.so \
+        qa/L0_custom_legacy/. && \
     mkdir -p qa/L0_infer_shm && \
     cp -r qa/L0_infer/. qa/L0_infer_shm && \
     mkdir -p qa/L0_infer_cudashm && \

--- a/qa/L0_custom_legacy/custom_legacy_test.py
+++ b/qa/L0_custom_legacy/custom_legacy_test.py
@@ -31,7 +31,6 @@ sys.path.append("../common")
 from functools import partial
 import numpy as np
 import queue
-import queue
 import unittest
 import test_util as tu
 

--- a/qa/L0_custom_legacy/custom_legacy_test.py
+++ b/qa/L0_custom_legacy/custom_legacy_test.py
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+sys.path.append("../common")
+
+from functools import partial
+import numpy as np
+import queue
+import queue
+import unittest
+import test_util as tu
+
+import tritonclient.grpc as grpcclient
+import tritonclient.http as httpclient
+from tritonclient.utils import InferenceServerException
+
+
+class UserData:
+
+    def __init__(self):
+        self._completed_requests = queue.Queue()
+
+
+def callback(user_data, result, error):
+    if error:
+        user_data._completed_requests.put(error)
+    else:
+        user_data._completed_requests.put(result)
+
+
+#
+# The simple inference tests on  leagacy custom backend.
+#
+class CustomLegacyTest(tu.TestResultCollector):
+
+    def setUp(self):
+        self.model_name_ = "custom_identity_int32"
+        self.input0_data_ = np.array([[10]], dtype=np.int32)
+
+    def _prepare_request(self, protocol):
+        if (protocol == "grpc"):
+            self.inputs_ = []
+            self.inputs_.append(grpcclient.InferInput('INPUT0', [1, 1],
+                                                      "INT32"))
+            self.outputs_ = []
+            self.outputs_.append(grpcclient.InferRequestedOutput('OUTPUT0'))
+        else:
+            self.inputs_ = []
+            self.inputs_.append(httpclient.InferInput('INPUT0', [1, 1],
+                                                      "INT32"))
+            self.outputs_ = []
+            self.outputs_.append(httpclient.InferRequestedOutput('OUTPUT0'))
+
+        self.inputs_[0].set_data_from_numpy(self.input0_data_)
+
+    def _test_no_outputs_helper(self,
+                                use_grpc=True,
+                                use_http=True,
+                                use_streaming=True):
+
+        if use_grpc:
+            triton_client = grpcclient.InferenceServerClient(
+                url="localhost:8001", verbose=True)
+            self._prepare_request("grpc")
+            result = triton_client.infer(model_name=self.model_name_,
+                                         inputs=self.inputs_,
+                                         outputs=self.outputs_,
+                                         client_timeout=1)
+            # The response should not contain any outputs
+            self.assertEqual(result.as_numpy('OUTPUT0'), None)
+
+        if use_http:
+            triton_client = httpclient.InferenceServerClient(
+                url="localhost:8000", verbose=True, network_timeout=2.0)
+            self._prepare_request("http")
+            result = triton_client.infer(model_name=self.model_name_,
+                                         inputs=self.inputs_,
+                                         outputs=self.outputs_)
+            # The response should not contain any outputs
+            self.assertEqual(result.as_numpy('OUTPUT0'), None)
+
+        if use_streaming:
+            triton_client = grpcclient.InferenceServerClient(
+                url="localhost:8001", verbose=True)
+            self._prepare_request("grpc")
+            user_data = UserData()
+
+            triton_client.stop_stream()
+            triton_client.start_stream(callback=partial(callback, user_data),
+                                       stream_timeout=1)
+            triton_client.async_stream_infer(model_name=self.model_name_,
+                                             inputs=self.inputs_,
+                                             outputs=self.outputs_)
+            result = user_data._completed_requests.get()
+            if type(result) == InferenceServerException:
+                raise result
+
+            # The response should not contain any outputs
+            self.assertEqual(result.as_numpy('OUTPUT0'), None)
+
+    # The tests needs the identity backend to be configured with "suppress_outputs"
+    # with TRUE.
+    def test_no_outputs(self):
+        self._test_no_outputs_helper()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qa/L0_custom_legacy/models/custom_identity_int32/config.pbtxt
+++ b/qa/L0_custom_legacy/models/custom_identity_int32/config.pbtxt
@@ -1,0 +1,55 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "custom_identity_int32"
+platform: "custom"
+max_batch_size: 1024
+version_policy: { latest { num_versions: 1 }}
+default_model_filename: "libidentity.so"
+instance_group [ { kind: KIND_CPU } ]
+
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_INT32
+    dims: [ -1 ]
+    
+  }
+]
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_INT32
+    dims: [ -1 ]
+  }
+]
+
+parameters [
+  {
+    key: "suppress_outputs"
+    value: { string_value: "TRUE" }
+  }
+]

--- a/qa/L0_custom_legacy/test.sh
+++ b/qa/L0_custom_legacy/test.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
+if [ "$#" -ge 1 ]; then
+    REPO_VERSION=$1
+fi
+if [ -z "$REPO_VERSION" ]; then
+    echo -e "Repository version must be specified"
+    echo -e "\n***\n*** Test Failed\n***"
+    exit 1
+fi
+
+export CUDA_VISIBLE_DEVICES=0
+
+RET=0
+
+CUSTOM_LEGACY_TEST=custom_legacy_test.py
+
+rm -f *.log
+rm -f *.log.*
+
+CLIENT_LOG=`pwd`/client.log
+DATADIR=`pwd`/models
+SERVER=/opt/tritonserver/bin/tritonserver
+SERVER_ARGS="--model-repository=$DATADIR"
+source ../common/util.sh
+
+mkdir -p $DATADIR/custom_identity_int32/1
+cp libidentity.so $DATADIR/custom_identity_int32/1/.
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+
+for i in test_no_outputs \
+   ; do
+    python $CUSTOM_LEGACY_TEST CustomLegacyTest.$i >>$CLIENT_LOG 2>&1
+    if [ $? -ne 0 ]; then
+        echo -e "\n***\n*** Test $i Failed\n***" >>$CLIENT_LOG
+            echo -e "\n***\n*** Test $i Failed\n***"
+            RET=1
+    else
+        check_test_results $CLIENT_LOG 1
+        if [ $? -ne 0 ]; then
+            cat $CLIENT_LOG
+            echo -e "\n***\n*** Test Result Verification Failed\n***"
+            RET=1
+        fi
+    fi
+done
+
+set -e
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    cat ${CLIENT_LOG}
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -140,6 +140,11 @@ class InferenceBackend {
 
   uint32_t MaxPriorityLevel() const { return max_priority_level_; }
 
+  bool DecoupledTransactionPolicy()
+  {
+    return config_.model_transaction_policy().decoupled();
+  }
+
  protected:
   struct WarmupData {
     WarmupData(const std::string& sample_name) : sample_name_(sample_name) {}


### PR DESCRIPTION
Fixes #2104 

### Before

`tritonclient.utils.InferenceServerException: Deadline Exceeded`

### After

```
POST /v2/models/custom_identity_int32/infer, headers {'Inference-Header-Content-Length': 164}
b'{"inputs":[{"name":"INPUT0","shape":[1,1],"datatype":"INT32","parameters":{"binary_data_size":4}}],"outputs":[{"name":"OUTPUT0","parameters":{"binary_data":true}}]}\n\x00\x00\x00'
<HTTPSocketPoolResponse status=200 headers={'content-type': 'application/json', 'content-length': '71'}>
bytearray(b'{"model_name":"custom_identity_int32","model_version":"1","outputs":[]}')
```