### PR TITLE
Fix TensorRT autofiller to handle non-plan files in version directory

### DIFF
--- a/qa/L0_model_config/test.sh
+++ b/qa/L0_model_config/test.sh
@@ -67,6 +67,13 @@ for modelpath in \
     mkdir -p $modelpath
     cp /data/inferenceserver/${REPO_VERSION}/qa_model_repository/plan_float32_float32_float32/1/model.plan \
        $modelpath/.
+
+    # Create a dummy file which must be ignored. This test is only needed
+    # for TensorRT autofiller as it is the last backend that attempts to
+    # load the files provided in the version directory. Essentially,
+    # for autofiller of other backends, a TensorRT plan would behave
+    # like this dummy file.
+    echo "dummy_content" >> $modelpath/dummy_file.txt
 done
 
 

--- a/src/backends/tensorrt/autofill.cc
+++ b/src/backends/tensorrt/autofill.cc
@@ -455,17 +455,13 @@ AutoFillPlan::Create(
   RETURN_IF_ERROR(GetDirectoryFiles(
       version_path, true /* skip_hidden_files */, &plan_files));
 
-  nvinfer1::IRuntime* runtime;
-  nvinfer1::ICudaEngine* engine;
+  nvinfer1::IRuntime* runtime = nullptr;
+  nvinfer1::ICudaEngine* engine = nullptr;
   std::string plan_file;
   Status status;
   bool found = false;
 
   for (auto file : plan_files) {
-    // Start with a clean state for each load attempt.
-    runtime = nullptr;
-    engine = nullptr;
-
     const auto plan_path = JoinPath({version_path, file});
 
     std::string plan_data_str;
@@ -478,9 +474,11 @@ AutoFillPlan::Create(
     if (!LoadPlan(plan_data, &runtime, &engine).IsOk()) {
       if (engine != nullptr) {
         engine->destroy();
+        engine = nullptr;
       }
       if (runtime != nullptr) {
         runtime->destroy();
+        runtime = nullptr;
       }
     } else {
       plan_file = file;

--- a/src/backends/tensorrt/autofill.cc
+++ b/src/backends/tensorrt/autofill.cc
@@ -455,13 +455,17 @@ AutoFillPlan::Create(
   RETURN_IF_ERROR(GetDirectoryFiles(
       version_path, true /* skip_hidden_files */, &plan_files));
 
-  nvinfer1::IRuntime* runtime = nullptr;
-  nvinfer1::ICudaEngine* engine = nullptr;
+  nvinfer1::IRuntime* runtime;
+  nvinfer1::ICudaEngine* engine;
   std::string plan_file;
   Status status;
   bool found = false;
 
   for (auto file : plan_files) {
+    // Start with a clean state for each load attempt.
+    runtime = nullptr;
+    engine = nullptr;
+
     const auto plan_path = JoinPath({version_path, file});
 
     std::string plan_data_str;


### PR DESCRIPTION
Upon calling runtime->destroy(), the object is destroyed but not set to nullptr. In the next attempt, autofiller tries to load the model 
with the pointer to a destroyed object causing the segfault. Fix is to reset the runtime to nullptr with each iteration.

### Before

```
root@0e283331531f:/opt/tritonserver/qa/L0_trt_dynamic_shape# /opt/tritonserver/bin/tritonserver --model-repository=./models --strict-model-config=false
I1021 00:02:48.688651 219 metrics.cc:184] found 2 GPUs supporting NVML metrics
I1021 00:02:48.694152 219 metrics.cc:193]   GPU 0: GeForce GT 710
I1021 00:02:48.700276 219 metrics.cc:193]   GPU 1: TITAN RTX
I1021 00:02:48.925943 219 pinned_memory_manager.cc:195] Pinned memory pool is created at '0x200c00000' with size 268435456
I1021 00:02:48.926747 219 cuda_memory_manager.cc:98] CUDA memory pool is created on device 0 with size 67108864
W1021 00:02:50.701017 219 metrics.cc:259] failed to get power limit for GPU 0, NVML_ERROR 3
W1021 00:02:50.701068 219 metrics.cc:274] failed to get power usage for GPU 0, NVML_ERROR 3
W1021 00:02:50.701085 219 metrics.cc:296] failed to get energy consumption for GPU 0, NVML_ERROR 3
W1021 00:02:50.701102 219 metrics.cc:309] failed to get utilization for GPU 0, NVML_ERROR 3
W1021 00:02:52.703772 219 metrics.cc:259] failed to get power limit for GPU 0, NVML_ERROR 3
W1021 00:02:52.703822 219 metrics.cc:274] failed to get power usage for GPU 0, NVML_ERROR 3
W1021 00:02:52.703839 219 metrics.cc:296] failed to get energy consumption for GPU 0, NVML_ERROR 3
W1021 00:02:52.703855 219 metrics.cc:309] failed to get utilization for GPU 0, NVML_ERROR 3
W1021 00:02:54.706034 219 metrics.cc:259] failed to get power limit for GPU 0, NVML_ERROR 3
W1021 00:02:54.706090 219 metrics.cc:274] failed to get power usage for GPU 0, NVML_ERROR 3
W1021 00:02:54.706116 219 metrics.cc:296] failed to get energy consumption for GPU 0, NVML_ERROR 3
W1021 00:02:54.706140 219 metrics.cc:309] failed to get utilization for GPU 0, NVML_ERROR 3
E1021 00:03:01.495209 219 logging.cc:43] coreReadArchive.cpp (31) - Serialization Error in verifyHeader: 0 (Magic tag does not match)
E1021 00:03:01.495314 219 logging.cc:43] INVALID_STATE: std::exception
E1021 00:03:01.495324 219 logging.cc:43] INVALID_CONFIG: Deserialize the cuda engine failed.
Segmentation fault (core dumped)
```

### After
```
root@0e283331531f:/opt/tritonserver/qa/L0_trt_dynamic_shape# /opt/tritonserver/bin/tritonserver --model-repository=./models --strict-model-config=false
I1021 00:03:40.182877 226 metrics.cc:184] found 2 CUDA visible devices.
I1021 00:03:40.188861 226 metrics.cc:215]   GPU 0: TITAN RTX
I1021 00:03:40.194979 226 metrics.cc:215]   GPU 1: GeForce GT 710
I1021 00:03:40.360950 226 pinned_memory_manager.cc:195] Pinned memory pool is created at '0x200c00000' with size 268435456
I1021 00:03:40.361765 226 cuda_memory_manager.cc:98] CUDA memory pool is created on device 0 with size 67108864
W1021 00:03:42.198267 226 metrics.cc:282] failed to get power limit for GPU 1, NVML_ERROR Not Supported
W1021 00:03:42.198316 226 metrics.cc:297] failed to get power usage for GPU 1, NVML_ERROR Not Supported
W1021 00:03:42.198331 226 metrics.cc:319] failed to get energy consumption for GPU 1, NVML_ERROR Not Supported
W1021 00:03:42.198344 226 metrics.cc:332] failed to get utilization for GPU 1, NVML_ERROR Not Supported
W1021 00:03:44.200431 226 metrics.cc:282] failed to get power limit for GPU 1, NVML_ERROR Not Supported
W1021 00:03:44.200476 226 metrics.cc:297] failed to get power usage for GPU 1, NVML_ERROR Not Supported
W1021 00:03:44.200490 226 metrics.cc:319] failed to get energy consumption for GPU 1, NVML_ERROR Not Supported
W1021 00:03:44.200504 226 metrics.cc:332] failed to get utilization for GPU 1, NVML_ERROR Not Supported
W1021 00:03:46.202662 226 metrics.cc:282] failed to get power limit for GPU 1, NVML_ERROR Not Supported
W1021 00:03:46.202708 226 metrics.cc:297] failed to get power usage for GPU 1, NVML_ERROR Not Supported
W1021 00:03:46.202722 226 metrics.cc:319] failed to get energy consumption for GPU 1, NVML_ERROR Not Supported
W1021 00:03:46.202735 226 metrics.cc:332] failed to get utilization for GPU 1, NVML_ERROR Not Supported
E1021 00:03:52.932585 226 logging.cc:43] coreReadArchive.cpp (31) - Serialization Error in verifyHeader: 0 (Magic tag does not match)
E1021 00:03:52.932685 226 logging.cc:43] INVALID_STATE: std::exception
E1021 00:03:52.932694 226 logging.cc:43] INVALID_CONFIG: Deserialize the cuda engine failed.
I1021 00:03:54.690058 226 model_repository_manager.cc:794] loading: plan_float32_float32_float32-4-32:1
I1021 00:03:54.704319 226 plan_backend.cc:333] Creating instance plan_float32_float32_float32-4-32_0_0_gpu0 on GPU 0 (7.5) using model.plan
E1021 00:03:54.720435 226 logging.cc:43] Profile 0 has been chosen by another IExecutionContext. Use another profileIndex or destroy the IExecutionContext that use this profile.
W1021 00:03:54.720467 226 logging.cc:46] Could not set default profile 0 for execution context. Profile index must be set explicitly.
I1021 00:03:54.721200 226 plan_backend.cc:666] Created instance plan_float32_float32_float32-4-32_0_0_gpu0 on GPU 0 with stream priority 0 and optimization profile 6[6];
I1021 00:03:54.721367 226 model_repository_manager.cc:976] successfully loaded 'plan_float32_float32_float32-4-32' version 1
I1021 00:03:54.721525 226 server.cc:141] 
+---------+--------+------+
| Backend | Config | Path |
+---------+--------+------+
+---------+--------+------+

I1021 00:03:54.721598 226 server.cc:184] 
+-----------------------------------+---------+--------+
| Model                             | Version | Status |
+-----------------------------------+---------+--------+
| plan_float32_float32_float32-4-32 | 1       | READY  |
+-----------------------------------+---------+--------+

I1021 00:03:54.721774 226 tritonserver.cc:1620] 
+----------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
| Option                           | Value                                                                                                                                              |
+----------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
| server_id                        | triton                                                                                                                                             |
| server_version                   | 2.5.0dev                                                                                                                                           |
| server_extensions                | classification sequence model_repository schedule_policy model_configuration system_shared_memory cuda_shared_memory binary_tensor_data statistics |
| model_repository_path[0]         | ./models                                                                                                                                           |
| model_control_mode               | MODE_NONE                                                                                                                                          |
| strict_model_config              | 0                                                                                                                                                  |
| pinned_memory_pool_byte_size     | 268435456                                                                                                                                          |
| cuda_memory_pool_byte_size{0}    | 67108864                                                                                                                                           |
| min_supported_compute_capability | 6.0                                                                                                                                                |
| strict_readiness                 | 1                                                                                                                                                  |
| exit_timeout                     | 30                                                                                                                                                 |
+----------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+

I1021 00:03:54.723530 226 grpc_server.cc:3914] Started GRPCInferenceService at 0.0.0.0:8001
I1021 00:03:54.723870 226 http_server.cc:2717] Started HTTPService at 0.0.0.0:8000
I1021 00:03:54.765470 226 http_server.cc:2736] Started Metrics Service at 0.0.0.0:8002
^CInterrupt signal (2) received.
I1021 00:04:32.548301 226 server.cc:280] Waiting for in-flight requests to complete.
I1021 00:04:32.548366 226 model_repository_manager.cc:821] unloading: plan_float32_float32_float32-4-32:1
I1021 00:04:32.548566 226 server.cc:295] Timeout 30: Found 1 live models and 0 in-flight non-inference requests
I1021 00:04:32.552601 226 model_repository_manager.cc:959] successfully unloaded 'plan_float32_float32_float32-4-32' version 1
I1021 00:04:33.548740 226 server.cc:295] Timeout 29: Found 0 live models and 0 in-flight non-inference requests
```
