### PR TITLE
Remove Caffe2 dependency from DALI backend tests

### DIFF
--- a/qa/L0_backend_dali/test.sh
+++ b/qa/L0_backend_dali/test.sh
@@ -37,4 +37,4 @@ pip3 install --extra-index-url https://developer.download.nvidia.com/compute/red
 git clone --single-branch --depth=1 -b $DALI_BACKEND_REPO_TAG https://github.com/triton-inference-server/dali_backend.git $DALI_BACKEND_DIR
 
 /bin/bash -x ./test_identity.sh $DALI_BACKEND_DIR
-/bin/bash -x ./test_rn50_ensemble.sh $DALI_BACKEND_DIR
+/bin/bash -x ./test_inception_ensemble.sh $DALI_BACKEND_DIR

--- a/qa/L0_backend_dali/test_inception_ensemble.sh
+++ b/qa/L0_backend_dali/test_inception_ensemble.sh
@@ -29,10 +29,10 @@ export CUDA_VISIBLE_DEVICES=0
 
 DALI_BACKEND_DIR=$1
 
-CLIENT_PY=$DALI_BACKEND_DIR/qa/rn50_ensemble/ensemble_client.py
+CLIENT_PY=$DALI_BACKEND_DIR/qa/inception_ensemble/ensemble_client.py
 CLIENT_LOG="./client.log"
 
-MODEL_REPO=$DALI_BACKEND_DIR/docs/examples/rn50_ensemble/model_repository
+MODEL_REPO=$DALI_BACKEND_DIR/docs/examples/inception_ensemble/model_repository
 
 SERVER=/opt/tritonserver/bin/tritonserver
 SERVER_ARGS="--model-repository=$MODEL_REPO"
@@ -40,7 +40,7 @@ SERVER_LOG="./inference_server.log"
 source ../common/util.sh
 
 pushd $MODEL_REPO/..
-/bin/bash -x ./setup_resnet50_example.sh
+/bin/bash -x ./setup_inception_example.sh
 popd
 
 run_server
@@ -53,7 +53,7 @@ fi
 RET=0
 
 set +e
-python $CLIENT_PY --img_dir $DALI_BACKEND_DIR/qa/rn50_ensemble/images --model_name ensemble_dali_resnet -v --batch_size 3 >>$CLIENT_LOG 2>&1
+python $CLIENT_PY --img_dir $DALI_BACKEND_DIR/qa/inception_ensemble/images --model_name ensemble_dali_inception --batch_size 3 >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
   RET=1
 fi


### PR DESCRIPTION
Since Triton removes Caffe2 support, remove this dependency from DALI backend testing. Put Inception model instead of RN50.

Signed-off-by: szalpal <mszolucha@nvidia.com>