### PR TITLE
Async Model Load/Unload for GRPC endpoint

### DIFF
--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -988,9 +988,7 @@ for protocol in grpc http; do
     kill $SERVER_PID
     wait $SERVER_PID
 
-    if [[ $protocol == "grpc" ]]; then
-        unset TRITONSERVER_USE_GRPC
-    fi
+    unset TRITONSERVER_USE_GRPC
 
     LOG_IDX=$((LOG_IDX+1))
 done
@@ -1039,9 +1037,7 @@ for protocol in grpc http; do
     kill $SERVER_PID
     wait $SERVER_PID
 
-    if [[ $protocol == "grpc" ]]; then
-        unset TRITONSERVER_USE_GRPC
-    fi
+    unset TRITONSERVER_USE_GRPC
 
     LOG_IDX=$((LOG_IDX+1))
 done
@@ -1131,9 +1127,7 @@ for protocol in grpc http; do
     kill $SERVER_PID
     wait $SERVER_PID
 
-    if [[ $protocol == "grpc" ]]; then
-       unset TRITONSERVER_USE_GRPC
-    fi
+    unset TRITONSERVER_USE_GRPC
 
     LOG_IDX=$((LOG_IDX+1))
 done 

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -950,83 +950,101 @@ wait $SERVER_PID
 LOG_IDX=$((LOG_IDX+1))
 
 # LifeCycleTest.test_model_availability_on_reload
-rm -fr models config.pbtxt.*
-mkdir models
-cp -r identity_zero_1_int32 models/. && mkdir -p models/identity_zero_1_int32/1
-
-SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit \
-             --exit-timeout-secs=5 --strict-model-config=false \
-             --load-model=identity_zero_1_int32 \
-             --strict-readiness=false"
-SERVER_LOG="./inference_server_$LOG_IDX.log"
-run_server
-if [ "$SERVER_PID" == "0" ]; then
-    echo -e "\n***\n*** Failed to start $SERVER\n***"
-    cat $SERVER_LOG
-    exit 1
-fi
-
-set +e
-python $LC_TEST LifeCycleTest.test_model_availability_on_reload >>$CLIENT_LOG 2>&1
-if [ $? -ne 0 ]; then
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-else
-    check_test_results $CLIENT_LOG 1
-    if [ $? -ne 0 ]; then
-        cat $CLIENT_LOG
-        echo -e "\n***\n*** Test Result Verification Failed\n***"
-        RET=1
+for protocol in grpc http; do
+    if [[ $protocol == "grpc" ]]; then
+       export TRITONSERVER_USE_GRPC=1
     fi
-fi
-set -e
+    rm -fr models config.pbtxt.*
+    mkdir models
+    cp -r identity_zero_1_int32 models/. && mkdir -p models/identity_zero_1_int32/1
 
-kill $SERVER_PID
-wait $SERVER_PID
+    SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit \
+                 --exit-timeout-secs=5 --strict-model-config=false \
+                 --load-model=identity_zero_1_int32 \
+                 --strict-readiness=false"
+    SERVER_LOG="./inference_server_$LOG_IDX.log"
+    run_server
+    if [ "$SERVER_PID" == "0" ]; then
+        echo -e "\n***\n*** Failed to start $SERVER\n***"
+        cat $SERVER_LOG
+        exit 1
+    fi
 
-LOG_IDX=$((LOG_IDX+1))
+    set +e
+    python $LC_TEST LifeCycleTest.test_model_availability_on_reload >>$CLIENT_LOG 2>&1
+    if [ $? -ne 0 ]; then
+        echo -e "\n***\n*** Test Failed\n***"
+        RET=1
+    else
+        check_test_results $CLIENT_LOG 1
+        if [ $? -ne 0 ]; then
+            cat $CLIENT_LOG
+            echo -e "\n***\n*** Test Result Verification Failed\n***"
+            RET=1
+        fi
+    fi
+    set -e
+
+    kill $SERVER_PID
+    wait $SERVER_PID
+
+    if [[ $protocol == "grpc" ]]; then
+        unset TRITONSERVER_USE_GRPC
+    fi
+
+    LOG_IDX=$((LOG_IDX+1))
+done
 
 # LifeCycleTest.test_model_availability_on_reload_2
-rm -fr models config.pbtxt.*
-mkdir models
-cp -r identity_zero_1_int32 models/. \
-    && mkdir -p models/identity_zero_1_int32/1 \
-    && mkdir -p models/identity_zero_1_int32/2
-echo "version_policy: { specific { versions: [1] }}" >> models/identity_zero_1_int32/config.pbtxt
-cp identity_zero_1_int32/config.pbtxt config.pbtxt.v2
-echo "version_policy: { specific { versions: [2] }}" >> config.pbtxt.v2
-
-SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit \
-             --exit-timeout-secs=5 --strict-model-config=false \
-             --load-model=identity_zero_1_int32 \
-             --strict-readiness=false"
-SERVER_LOG="./inference_server_$LOG_IDX.log"
-run_server
-if [ "$SERVER_PID" == "0" ]; then
-    echo -e "\n***\n*** Failed to start $SERVER\n***"
-    cat $SERVER_LOG
-    exit 1
-fi
-
-set +e
-python $LC_TEST LifeCycleTest.test_model_availability_on_reload_2 >>$CLIENT_LOG 2>&1
-if [ $? -ne 0 ]; then
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-else
-    check_test_results $CLIENT_LOG 1
-    if [ $? -ne 0 ]; then
-        cat $CLIENT_LOG
-        echo -e "\n***\n*** Test Result Verification Failed\n***"
-        RET=1
+for protocol in grpc http; do
+    if [[ $protocol == "grpc" ]]; then
+       export TRITONSERVER_USE_GRPC=1
     fi
-fi
-set -e
+    rm -fr models config.pbtxt.*
+    mkdir models
+    cp -r identity_zero_1_int32 models/. \
+        && mkdir -p models/identity_zero_1_int32/1 \
+        && mkdir -p models/identity_zero_1_int32/2
+    echo "version_policy: { specific { versions: [1] }}" >> models/identity_zero_1_int32/config.pbtxt
+    cp identity_zero_1_int32/config.pbtxt config.pbtxt.v2
+    echo "version_policy: { specific { versions: [2] }}" >> config.pbtxt.v2
 
-kill $SERVER_PID
-wait $SERVER_PID
+    SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit \
+                 --exit-timeout-secs=5 --strict-model-config=false \
+                 --load-model=identity_zero_1_int32 \
+                 --strict-readiness=false"
+    SERVER_LOG="./inference_server_$LOG_IDX.log"
+    run_server
+    if [ "$SERVER_PID" == "0" ]; then
+        echo -e "\n***\n*** Failed to start $SERVER\n***"
+        cat $SERVER_LOG
+        exit 1
+    fi
 
-LOG_IDX=$((LOG_IDX+1))
+    set +e
+    python $LC_TEST LifeCycleTest.test_model_availability_on_reload_2 >>$CLIENT_LOG 2>&1
+    if [ $? -ne 0 ]; then
+        echo -e "\n***\n*** Test Failed\n***"
+        RET=1
+    else
+        check_test_results $CLIENT_LOG 1
+        if [ $? -ne 0 ]; then
+            cat $CLIENT_LOG
+            echo -e "\n***\n*** Test Result Verification Failed\n***"
+            RET=1
+        fi
+    fi
+    set -e
+
+    kill $SERVER_PID
+    wait $SERVER_PID
+
+    if [[ $protocol == "grpc" ]]; then
+        unset TRITONSERVER_USE_GRPC
+    fi
+
+    LOG_IDX=$((LOG_IDX+1))
+done
 
 # LifeCycleTest.test_model_reload_fail
 rm -fr models config.pbtxt.*
@@ -1072,44 +1090,53 @@ wait $SERVER_PID
 LOG_IDX=$((LOG_IDX+1))
 
 # LifeCycleTest.test_load_same_model_different_platform
-rm -fr models simple_float32_float32_float32
-mkdir models
-# Prepare two models of different platforms, but with the same name
-cp -r $DATADIR/qa_model_repository/plan_float32_float32_float32 models/simple_float32_float32_float32
-sed -i "s/plan_float32_float32_float32/simple_float32_float32_float32/" models/simple_float32_float32_float32/config.pbtxt
-cp -r $DATADIR/qa_model_repository/libtorch_float32_float32_float32 simple_float32_float32_float32
-sed -i "s/libtorch_float32_float32_float32/simple_float32_float32_float32/" simple_float32_float32_float32/config.pbtxt
-
-SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit \
-             --load-model=simple_float32_float32_float32 \
-             --exit-timeout-secs=5"
-SERVER_LOG="./inference_server_$LOG_IDX.log"
-run_server
-if [ "$SERVER_PID" == "0" ]; then
-    echo -e "\n***\n*** Failed to start $SERVER\n***"
-    cat $SERVER_LOG
-    exit 1
-fi
-
-set +e
-python $LC_TEST LifeCycleTest.test_load_same_model_different_platform >>$CLIENT_LOG 2>&1
-if [ $? -ne 0 ]; then
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-else
-    check_test_results $CLIENT_LOG 1
-    if [ $? -ne 0 ]; then
-        cat $CLIENT_LOG
-        echo -e "\n***\n*** Test Result Verification Failed\n***"
-        RET=1
+for protocol in grpc http; do
+    if [[ $protocol == "grpc" ]]; then
+       export TRITONSERVER_USE_GRPC=1
     fi
-fi
-set -e
+    rm -fr models simple_float32_float32_float32
+    mkdir models
+    # Prepare two models of different platforms, but with the same name
+    cp -r $DATADIR/qa_model_repository/plan_float32_float32_float32 models/simple_float32_float32_float32
+    sed -i "s/plan_float32_float32_float32/simple_float32_float32_float32/" models/simple_float32_float32_float32/config.pbtxt
+    cp -r $DATADIR/qa_model_repository/libtorch_float32_float32_float32 simple_float32_float32_float32
+    sed -i "s/libtorch_float32_float32_float32/simple_float32_float32_float32/" simple_float32_float32_float32/config.pbtxt
+    
+    SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit \
+                 --load-model=simple_float32_float32_float32 \
+                 --exit-timeout-secs=5"
+    SERVER_LOG="./inference_server_$LOG_IDX.log"
+    run_server
+    if [ "$SERVER_PID" == "0" ]; then
+        echo -e "\n***\n*** Failed to start $SERVER\n***"
+        cat $SERVER_LOG
+        exit 1
+    fi
 
-kill $SERVER_PID
-wait $SERVER_PID
+    set +e
+    python $LC_TEST LifeCycleTest.test_load_same_model_different_platform >>$CLIENT_LOG 2>&1
+    if [ $? -ne 0 ]; then
+        echo -e "\n***\n*** Test Failed\n***"
+        RET=1
+    else
+        check_test_results $CLIENT_LOG 1
+        if [ $? -ne 0 ]; then
+            cat $CLIENT_LOG
+            echo -e "\n***\n*** Test Result Verification Failed\n***"
+            RET=1
+        fi
+    fi
+    set -e
 
-LOG_IDX=$((LOG_IDX+1))
+    kill $SERVER_PID
+    wait $SERVER_PID
+
+    if [[ $protocol == "grpc" ]]; then
+       unset TRITONSERVER_USE_GRPC
+    fi
+
+    LOG_IDX=$((LOG_IDX+1))
+done 
 
 # Send HTTP request to control endpoint
 rm -fr models config.pbtxt.*

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -317,7 +317,7 @@ CommonCallData<ResponderType, RequestType, ResponseType>::Execute()
   OnExecute_(request_, &response_, &status_);
   step_ = Steps::WRITEREADY;
 
-  if (async) {
+  if (async_) {
     // For asynchronous operation, need to add itself onto the completion
     // queue so that the response can be written once the object is
     // taken up next for execution.

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -216,12 +216,20 @@ class CommonCallData : public GRPCServer::ICallData {
   CommonCallData(
       const std::string& name, const uint64_t id,
       const StandardRegisterFunc OnRegister,
-      const StandardCallbackFunc OnCallback)
-      : name_(name), id_(id), OnRegister_(OnRegister), OnCallback_(OnCallback),
-        responder_(&ctx_), step_(Steps::START)
+      const StandardCallbackFunc OnExecute, const bool async,
+      grpc::ServerCompletionQueue* cq)
+      : name_(name), id_(id), OnRegister_(OnRegister), OnExecute_(OnExecute),
+        async_(async), cq_(cq), responder_(&ctx_), step_(Steps::START)
   {
     OnRegister_(&ctx_, &request_, &responder_, this);
     LOG_VERBOSE(1) << "Ready for RPC '" << name_ << "', " << id_;
+  }
+
+  ~CommonCallData()
+  {
+    if (async_thread_.joinable()) {
+      async_thread_.join();
+    }
   }
 
   bool Process(bool ok) override;
@@ -231,15 +239,26 @@ class CommonCallData : public GRPCServer::ICallData {
   uint64_t Id() override { return id_; }
 
  private:
+  void Execute();
+  void AddToCompletionQueue();
+  void WriteResponse();
+
   const std::string name_;
   const uint64_t id_;
   const StandardRegisterFunc OnRegister_;
-  const StandardCallbackFunc OnCallback_;
+  const StandardCallbackFunc OnExecute_;
+  const bool async_;
+  grpc::ServerCompletionQueue* cq_;
 
   grpc::ServerContext ctx_;
+  grpc::Alarm alarm_;
 
   ResponderType responder_;
   RequestType request_;
+  ResponseType response_;
+  grpc::Status status_;
+
+  std::thread async_thread_;
 
   Steps step_;
 };
@@ -257,28 +276,68 @@ CommonCallData<ResponderType, RequestType, ResponseType>::Process(bool rpc_ok)
   // we can do since we one execute one step.
   const bool shutdown = (!rpc_ok && (step_ == Steps::START));
   if (shutdown) {
+    if (async_thread_.joinable()) {
+      async_thread_.join();
+    }
     step_ = Steps::FINISH;
   }
 
   if (step_ == Steps::START) {
-    ResponseType response;
-    grpc::Status status;
+    // Start a new request to replace this one...
+    if (!shutdown) {
+      new CommonCallData<ResponderType, RequestType, ResponseType>(
+          name_, id_ + 1, OnRegister_, OnExecute_, async_, cq_);
+    }
 
-    OnCallback_(request_, &response, &status);
-
-    step_ = Steps::COMPLETE;
-
-    responder_.Finish(response, status, this);
+    if (!async_) {
+      // For synchronous calls, execute and write response
+      // here.
+      Execute();
+      WriteResponse();
+    } else {
+      // For asynchronous calls, delegate the execution to another
+      // thread.
+      step_ = Steps::ISSUED;
+      async_thread_ = std::thread(&CommonCallData::Execute, this);
+    }
+  } else if (step_ == Steps::WRITEREADY) {
+    // Will only come here for asynchronous mode.
+    WriteResponse();
   } else if (step_ == Steps::COMPLETE) {
     step_ = Steps::FINISH;
   }
 
-  if (!shutdown && (step_ == Steps::FINISH)) {
-    new CommonCallData<ResponderType, RequestType, ResponseType>(
-        name_, id_ + 1, OnRegister_, OnCallback_);
-  }
-
   return step_ != Steps::FINISH;
+}
+
+template <typename ResponderType, typename RequestType, typename ResponseType>
+void
+CommonCallData<ResponderType, RequestType, ResponseType>::Execute()
+{
+  OnExecute_(request_, &response_, &status_);
+  step_ = Steps::WRITEREADY;
+
+  if (async) {
+    // For asynchronous operation, need to add itself onto the completion
+    // queue so that the response can be written once the object is
+    // taken up next for execution.
+    AddToCompletionQueue();
+  }
+}
+
+template <typename ResponderType, typename RequestType, typename ResponseType>
+void
+CommonCallData<ResponderType, RequestType, ResponseType>::AddToCompletionQueue()
+{
+  alarm_.Set(cq_, gpr_now(gpr_clock_type::GPR_CLOCK_REALTIME), this);
+}
+
+template <typename ResponderType, typename RequestType, typename ResponseType>
+void
+CommonCallData<ResponderType, RequestType, ResponseType>::WriteResponse()
+{
+  step_ = Steps::COMPLETE;
+  responder_.Finish(response_, status_, this);
 }
 
 //
@@ -410,7 +469,8 @@ CommonHandler::SetUpAllRequests()
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ServerLiveResponse>,
       inference::ServerLiveRequest, inference::ServerLiveResponse>(
-      "ServerLive", 0, OnRegisterServerLive, OnExecuteServerLive);
+      "ServerLive", 0, OnRegisterServerLive, OnExecuteServerLive,
+      false /* async */, cq_);
 
   //
   //  ServerReady
@@ -442,7 +502,8 @@ CommonHandler::SetUpAllRequests()
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ServerReadyResponse>,
       inference::ServerReadyRequest, inference::ServerReadyResponse>(
-      "ServerReady", 0, OnRegisterServerReady, OnExecuteServerReady);
+      "ServerReady", 0, OnRegisterServerReady, OnExecuteServerReady,
+      false /* async */, cq_);
 
   //
   //  ModelReady
@@ -480,7 +541,8 @@ CommonHandler::SetUpAllRequests()
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ModelReadyResponse>,
       inference::ModelReadyRequest, inference::ModelReadyResponse>(
-      "ModelReady", 0, OnRegisterModelReady, OnExecuteModelReady);
+      "ModelReady", 0, OnRegisterModelReady, OnExecuteModelReady,
+      false /* async */, cq_);
 
   //
   //  ServerMetadata
@@ -554,7 +616,8 @@ CommonHandler::SetUpAllRequests()
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ServerMetadataResponse>,
       inference::ServerMetadataRequest, inference::ServerMetadataResponse>(
-      "ServerMetadata", 0, OnRegisterServerMetadata, OnExecuteServerMetadata);
+      "ServerMetadata", 0, OnRegisterServerMetadata, OnExecuteServerMetadata,
+      false /* async */, cq_);
 
   //
   //  ModelMetadata
@@ -718,7 +781,8 @@ CommonHandler::SetUpAllRequests()
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ModelMetadataResponse>,
       inference::ModelMetadataRequest, inference::ModelMetadataResponse>(
-      "ModelMetadata", 0, OnRegisterModelMetadata, OnExecuteModelMetadata);
+      "ModelMetadata", 0, OnRegisterModelMetadata, OnExecuteModelMetadata,
+      false /* async */, cq_);
 
   //
   //  ModelConfig
@@ -765,7 +829,8 @@ CommonHandler::SetUpAllRequests()
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ModelConfigResponse>,
       inference::ModelConfigRequest, inference::ModelConfigResponse>(
-      "ModelConfig", 0, OnRegisterModelConfig, OnExecuteModelConfig);
+      "ModelConfig", 0, OnRegisterModelConfig, OnExecuteModelConfig,
+      false /* async */, cq_);
 
   //
   //  ModelStatistics
@@ -1031,8 +1096,8 @@ CommonHandler::SetUpAllRequests()
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::ModelStatisticsResponse>,
       inference::ModelStatisticsRequest, inference::ModelStatisticsResponse>(
-      "ModelStatistics", 0, OnRegisterModelStatistics,
-      OnExecuteModelStatistics);
+      "ModelStatistics", 0, OnRegisterModelStatistics, OnExecuteModelStatistics,
+      false /* async */, cq_);
 
 
   //
@@ -1104,7 +1169,7 @@ CommonHandler::SetUpAllRequests()
       inference::SystemSharedMemoryStatusRequest,
       inference::SystemSharedMemoryStatusResponse>(
       "SystemSharedMemoryStatus", 0, OnRegisterSystemSharedMemoryStatus,
-      OnExecuteSystemSharedMemoryStatus);
+      OnExecuteSystemSharedMemoryStatus, false /* async */, cq_);
 
 
   //
@@ -1140,7 +1205,7 @@ CommonHandler::SetUpAllRequests()
       inference::SystemSharedMemoryRegisterRequest,
       inference::SystemSharedMemoryRegisterResponse>(
       "SystemSharedMemoryRegister", 0, OnRegisterSystemSharedMemoryRegister,
-      OnExecuteSystemSharedMemoryRegister);
+      OnExecuteSystemSharedMemoryRegister, false /* async */, cq_);
 
 
   //
@@ -1180,7 +1245,7 @@ CommonHandler::SetUpAllRequests()
       inference::SystemSharedMemoryUnregisterRequest,
       inference::SystemSharedMemoryUnregisterResponse>(
       "SystemSharedMemoryUnregister", 0, OnRegisterSystemSharedMemoryUnregister,
-      OnExecuteSystemSharedMemoryUnregister);
+      OnExecuteSystemSharedMemoryUnregister, false /* async */, cq_);
 
 
   //
@@ -1243,7 +1308,7 @@ CommonHandler::SetUpAllRequests()
       inference::CudaSharedMemoryStatusRequest,
       inference::CudaSharedMemoryStatusResponse>(
       "CudaSharedMemoryStatus", 0, OnRegisterCudaSharedMemoryStatus,
-      OnExecuteCudaSharedMemoryStatus);
+      OnExecuteCudaSharedMemoryStatus, false /* async */, cq_);
 
 
   //
@@ -1291,7 +1356,7 @@ CommonHandler::SetUpAllRequests()
       inference::CudaSharedMemoryRegisterRequest,
       inference::CudaSharedMemoryRegisterResponse>(
       "CudaSharedMemoryRegister", 0, OnRegisterCudaSharedMemoryRegister,
-      OnExecuteCudaSharedMemoryRegister);
+      OnExecuteCudaSharedMemoryRegister, false /* async */, cq_);
 
   //
   // CudaSharedMemoryUnregister
@@ -1330,7 +1395,7 @@ CommonHandler::SetUpAllRequests()
       inference::CudaSharedMemoryUnregisterRequest,
       inference::CudaSharedMemoryUnregisterResponse>(
       "CudaSharedMemoryUnregister", 0, OnRegisterCudaSharedMemoryUnregister,
-      OnExecuteCudaSharedMemoryUnregister);
+      OnExecuteCudaSharedMemoryUnregister, false /* async */, cq_);
 
   //
   // RepositoryIndex
@@ -1426,8 +1491,8 @@ CommonHandler::SetUpAllRequests()
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<inference::RepositoryIndexResponse>,
       inference::RepositoryIndexRequest, inference::RepositoryIndexResponse>(
-      "RepositoryIndex", 0, OnRegisterRepositoryIndex,
-      OnExecuteRepositoryIndex);
+      "RepositoryIndex", 0, OnRegisterRepositoryIndex, OnExecuteRepositoryIndex,
+      false /* async */, cq_);
 
   //
   // RepositoryModelLoad
@@ -1467,7 +1532,7 @@ CommonHandler::SetUpAllRequests()
       inference::RepositoryModelLoadRequest,
       inference::RepositoryModelLoadResponse>(
       "RepositoryModelLoad", 0, OnRegisterRepositoryModelLoad,
-      OnExecuteRepositoryModelLoad);
+      OnExecuteRepositoryModelLoad, true /* async */, cq_);
 
   //
   // RepositoryModelUnload
@@ -1507,7 +1572,7 @@ CommonHandler::SetUpAllRequests()
       inference::RepositoryModelUnloadRequest,
       inference::RepositoryModelUnloadResponse>(
       "RepositoryModelUnload", 0, OnRegisterRepositoryModelUnload,
-      OnExecuteRepositoryModelUnload);
+      OnExecuteRepositoryModelUnload, true /* async */, cq_);
 }
 
 //=========================================================================


### PR DESCRIPTION
Only RepositoryModelUnload and RepositoryModelLoad specify the async flag true. Other RPCs are quite direct and overhead of spawning an extra thread and an extra state transition can become more pronounced.

Note that this implementation frees up the handler to serve the new incoming requests. Whenever the execution is completed the **async_thread_** will add the CallData back to the completion queue to later write response to client.