### PR TITLE
Fix the statistics collection and reporting in perf_client/triton server

### DIFF
--- a/src/clients/c++/perf_analyzer/inference_profiler.cc
+++ b/src/clients/c++/perf_analyzer/inference_profiler.cc
@@ -530,7 +530,9 @@ InferenceProfiler::Measure(PerfStatus& status_summary)
   nic::InferStat start_stat;
   nic::InferStat end_stat;
 
-  RETURN_IF_ERROR(GetServerSideStatus(&start_status));
+  if (include_server_stats_) {
+    RETURN_IF_ERROR(GetServerSideStatus(&start_status));
+  }
   RETURN_IF_ERROR(manager_->GetAccumulatedClientStat(&start_stat));
 
   // Wait for specified time interval in msec
@@ -541,7 +543,9 @@ InferenceProfiler::Measure(PerfStatus& status_summary)
 
   // Get server status and then print report on difference between
   // before and after status.
-  RETURN_IF_ERROR(GetServerSideStatus(&end_status));
+  if (include_server_stats_) {
+    RETURN_IF_ERROR(GetServerSideStatus(&end_status));
+  }
 
   TimestampVector current_timestamps;
   RETURN_IF_ERROR(manager_->SwapTimestamps(current_timestamps));
@@ -577,8 +581,10 @@ InferenceProfiler::Summarize(
       start_stat, end_stat, valid_range.second - valid_range.first,
       latencies.size(), valid_sequence_count, delayed_request_count, summary));
 
-  RETURN_IF_ERROR(
-      SummarizeServerStats(start_status, end_status, &(summary.server_stats)));
+  if (include_server_stats_) {
+    RETURN_IF_ERROR(SummarizeServerStats(
+        start_status, end_status, &(summary.server_stats)));
+  }
 
   return nic::Error::Success;
 }

--- a/src/clients/c++/perf_analyzer/inference_profiler.h
+++ b/src/clients/c++/perf_analyzer/inference_profiler.h
@@ -402,4 +402,7 @@ class InferenceProfiler {
   std::unique_ptr<TritonClientWrapper> profile_client_;
   std::unique_ptr<LoadManager> manager_;
   LoadParams load_parameters_;
+
+  bool include_lib_stats_;
+  bool include_server_stats_;
 };

--- a/src/clients/c++/perf_analyzer/inference_profiler.h
+++ b/src/clients/c++/perf_analyzer/inference_profiler.h
@@ -222,6 +222,8 @@ class InferenceProfiler {
     return nic::Error::Success;
   }
 
+  bool IncludeServerStats() { return include_server_stats_; }
+
  private:
   InferenceProfiler(
       const bool verbose, const double stability_threshold,

--- a/src/clients/c++/perf_analyzer/triton_client_wrapper.h
+++ b/src/clients/c++/perf_analyzer/triton_client_wrapper.h
@@ -61,6 +61,9 @@ class TritonClientWrapper {
       std::shared_ptr<nic::Headers> http_headers, const bool verbose,
       std::unique_ptr<TritonClientWrapper>* triton_client);
 
+  /// Get the server metadata from the server
+  nic::Error ServerExtensions(std::set<std::string>* server_extensions);
+
   /// Get the model metadata from the server for specified name and
   /// version as rapidjson DOM object.
   nic::Error ModelMetadata(

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -1179,7 +1179,8 @@ EnsembleScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
 {
   // Queue timer starts at the beginning of the queueing and
   // scheduling process
-  request->CaptureQueueStartNs() INFER_TRACE_ACTIVITY(
+  request->CaptureQueueStartNs();
+  INFER_TRACE_ACTIVITY(
       request->Trace(), TRITONSERVER_TRACE_QUEUE_START,
       request->QueueStartNs());
   std::shared_ptr<EnsembleContext> context(new EnsembleContext(

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -1179,9 +1179,9 @@ EnsembleScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
 {
   // Queue timer starts at the beginning of the queueing and
   // scheduling process
-  INFER_TRACE_ACTIVITY(
+  request->CaptureQueueStartNs() INFER_TRACE_ACTIVITY(
       request->Trace(), TRITONSERVER_TRACE_QUEUE_START,
-      request->CaptureQueueStartNs());
+      request->QueueStartNs());
   std::shared_ptr<EnsembleContext> context(new EnsembleContext(
       metric_reporter_.get(), stats_aggregator_, is_, info_.get(), request,
       stream_));

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -489,9 +489,10 @@ InferenceServer::InferAsync(std::unique_ptr<InferenceRequest>& request)
   }
 
 #ifdef TRITON_ENABLE_STATS
+  request->CaptureRequestStartNs();
   INFER_TRACE_ACTIVITY(
       request->Trace(), TRITONSERVER_TRACE_REQUEST_START,
-      request->CaptureRequestStartNs());
+      request->RequestStartNs());
 #endif  // TRITON_ENABLE_STATS
 
   return InferenceRequest::Run(request);


### PR DESCRIPTION
The cases fixed are:
1. TRITON_ENABLE_STATS = OFF, TRITON_ENABLE_TRACING = OFF
1. TRITON_ENABLE_STATS = ON, TRITON_ENABLE_TRACING = OFF

Fixes #2137 

### Server without statistics extension:
```
root@285c0698ad37:/opt/tritonserver/qa/L0_grpc# /tmp/host/perf_analyzer -m simple -f test.csv
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 8308
    Throughput: 1661.6 infer/sec
    Avg latency: 600 usec (standard deviation 91 usec)
    p50 latency: 581 usec
    p90 latency: 681 usec
    p95 latency: 727 usec
    p99 latency: 944 usec
    Avg HTTP time: 597 usec (send/recv 66 usec + response wait 531 usec)
Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 1661.6 infer/sec, latency 600 usec
```

### Server with statistics extension
```
root@285c0698ad37:/opt/tritonserver/qa/L0_grpc# /tmp/host/perf_analyzer -m simple -f test.csv
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 8234
    Throughput: 1646.8 infer/sec
    Avg latency: 606 usec (standard deviation 91 usec)
    p50 latency: 584 usec
    p90 latency: 692 usec
    p95 latency: 741 usec
    p99 latency: 946 usec
    Avg HTTP time: 600 usec (send/recv 67 usec + response wait 533 usec)
  Server: 
    Inference count: 9887
    Execution count: 9887
    Successful request count: 9887
    Avg request latency: 319 usec (overhead 35 usec + queue 21 usec + compute input 16 usec + compute infer 234 usec + compute output 13 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 1646.8 infer/sec, latency 606 usec
```
