### PR TITLE
Fix crash when creating multiple instance of Tritonserver (in the same process)

### DIFF
--- a/src/core/cuda_memory_manager.cc
+++ b/src/core/cuda_memory_manager.cc
@@ -77,8 +77,8 @@ Status
 CudaMemoryManager::Create(const CudaMemoryManager::Options& options)
 {
   if (instance_ != nullptr) {
-    LOG_INFO << "New CUDA memory pools could not be created since they already "
-                "exists.";
+    LOG_WARNING << "New CUDA memory pools could not be created since they "
+                   "already exists";
     return Status::Success;
   }
 

--- a/src/core/cuda_memory_manager.cc
+++ b/src/core/cuda_memory_manager.cc
@@ -77,8 +77,9 @@ Status
 CudaMemoryManager::Create(const CudaMemoryManager::Options& options)
 {
   if (instance_ != nullptr) {
-    return Status(
-        Status::Code::ALREADY_EXISTS, "CudaMemoryManager has been created");
+    LOG_INFO << "New CUDA memory pools could not be created since they already "
+                "exists.";
+    return Status::Success;
   }
 
   std::set<int> supported_gpus;

--- a/src/core/pinned_memory_manager.cc
+++ b/src/core/pinned_memory_manager.cc
@@ -49,6 +49,7 @@ PointerToString(void* ptr)
 }  // namespace
 
 std::unique_ptr<PinnedMemoryManager> PinnedMemoryManager::instance_;
+uint64_t PinnedMemoryManager::pinned_memory_byte_size_;
 
 PinnedMemoryManager::PinnedMemoryManager(
     void* pinned_memory_buffer, uint64_t size)
@@ -179,9 +180,10 @@ Status
 PinnedMemoryManager::Create(const Options& options)
 {
   if (instance_ != nullptr) {
-    LOG_INFO << "New pinned memory pool of size "
-             << options.pinned_memory_pool_byte_size_
-             << " could not be created since one already exists.";
+    LOG_WARNING << "New pinned memory pool of size "
+                << options.pinned_memory_pool_byte_size_
+                << " could not be created since one already exists"
+                << " of size " << pinned_memory_byte_size_;
     return Status::Success;
   }
 
@@ -200,6 +202,7 @@ PinnedMemoryManager::Create(const Options& options)
 #endif  // TRITON_ENABLE_GPU
   instance_.reset(
       new PinnedMemoryManager(buffer, options.pinned_memory_pool_byte_size_));
+  pinned_memory_byte_size_ = options.pinned_memory_pool_byte_size_;
   return Status::Success;
 }
 

--- a/src/core/pinned_memory_manager.cc
+++ b/src/core/pinned_memory_manager.cc
@@ -179,8 +179,10 @@ Status
 PinnedMemoryManager::Create(const Options& options)
 {
   if (instance_ != nullptr) {
-    return Status(
-        Status::Code::ALREADY_EXISTS, "PinnedMemoryManager has been created");
+    LOG_INFO << "New pinned memory pool of size "
+             << options.pinned_memory_pool_byte_size_
+             << " could not be created since one already exists.";
+    return Status::Success;
   }
 
   void* buffer = nullptr;

--- a/src/core/pinned_memory_manager.h
+++ b/src/core/pinned_memory_manager.h
@@ -74,6 +74,7 @@ class PinnedMemoryManager {
 
  private:
   static std::unique_ptr<PinnedMemoryManager> instance_;
+  static uint64_t pinned_memory_byte_size_;
 
   std::mutex info_mtx_;
   std::map<void*, bool> memory_info_;


### PR DESCRIPTION
When creating multiple instances of `TRITONSERVER_Server` using `TRITONSERVER_ServerNew()` use the pinned and cuda memory pool defined by the first server and log the same.
- Earlier error reported that PinnedMemoryManager and CudaMemoryManager were already created 

Now just log the follow message and return success.
```
cuda_memory_manager.cc:80] New CUDA memory pools could not be created since they already exists
pinned_memory_manager.cc:182] New pinned memory pool of size 268435456 could not be created since one already exists of size 268435456
```
Note: The user must use the Pinned and CUDA memory pools as specified by the first instance of Tritonserver.