### PR TITLE
Raise timeout to account for test slowdown related failures

### DIFF
--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -57,7 +57,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000"
-    SERVER_TIMEOUT=1200
+    SERVER_TIMEOUT=2400
     rm -f $LEAKCHECK_LOG_BASE*
 fi
 

--- a/qa/L0_sequence_batcher/test.sh
+++ b/qa/L0_sequence_batcher/test.sh
@@ -45,7 +45,7 @@ BATCHER_TEST=sequence_batcher_test.py
 if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000"
-    SERVER_TIMEOUT=1200
+    SERVER_TIMEOUT=2400
     rm -f *.valgrind.log
 
     # Shortened tests due valgrind overhead


### PR DESCRIPTION
Investigated test failures in L0_infer_valgrind and L0_sequence_batcher_valgrind. The errors in the logs show they are timing out, and they seem to pass locally. I am increasing the server timeout to account for this. 