### PR TITLE
TF Serving Client Backend for perf_analyzer

### DIFF
--- a/src/clients/c++/examples/simple_grpc_sequence_stream_infer_client.cc
+++ b/src/clients/c++/examples/simple_grpc_sequence_stream_infer_client.cc
@@ -273,11 +273,11 @@ main(int argc, char** argv)
 
 
   for (size_t i = 0; i < result0_data.size(); i++) {
-    int32_t seq0_expected = (i == 0) ? 1 : values[i-1];
-    int32_t seq1_expected = (i == 0) ? 101 : values[i-1] * -1;
+    int32_t seq0_expected = (i == 0) ? 1 : values[i - 1];
+    int32_t seq1_expected = (i == 0) ? 101 : values[i - 1] * -1;
     // The dyna_sequence custom backend adds the sequence ID to
     // the last request in a sequence.
-    if (dyna_sequence && (i != 0) && (values[i-1] == 1)) {
+    if (dyna_sequence && (i != 0) && (values[i - 1] == 1)) {
       seq0_expected += sequence_id0;
       seq1_expected += sequence_id1;
     }

--- a/src/clients/c++/examples/simple_grpc_sequence_sync_infer_client.cc
+++ b/src/clients/c++/examples/simple_grpc_sequence_sync_infer_client.cc
@@ -217,11 +217,11 @@ main(int argc, char** argv)
   }
 
   for (size_t i = 0; i < result0_data.size(); i++) {
-    int32_t seq0_expected = (i == 0) ? 1 : values[i-1];
-    int32_t seq1_expected = (i == 0) ? 101 : values[i-1] * -1;
+    int32_t seq0_expected = (i == 0) ? 1 : values[i - 1];
+    int32_t seq1_expected = (i == 0) ? 101 : values[i - 1] * -1;
     // The dyna_sequence custom backend adds the sequence ID to
     // the last request in a sequence.
-    if (dyna_sequence && (i != 0) && (values[i-1] == 1)) {
+    if (dyna_sequence && (i != 0) && (values[i - 1] == 1)) {
       seq0_expected += sequence_id0;
       seq1_expected += sequence_id1;
     }

--- a/src/clients/c++/examples/simple_http_sequence_sync_infer_client.cc
+++ b/src/clients/c++/examples/simple_http_sequence_sync_infer_client.cc
@@ -217,11 +217,11 @@ main(int argc, char** argv)
   }
 
   for (size_t i = 0; i < result0_data.size(); i++) {
-    int32_t seq0_expected = (i == 0) ? 1 : values[i-1];
-    int32_t seq1_expected = (i == 0) ? 101 : values[i-1] * -1;
+    int32_t seq0_expected = (i == 0) ? 1 : values[i - 1];
+    int32_t seq1_expected = (i == 0) ? 101 : values[i - 1] * -1;
     // The dyna_sequence custom backend adds the sequence ID to
     // the last request in a sequence.
-    if (dyna_sequence && (i != 0) && (values[i-1] == 1)) {
+    if (dyna_sequence && (i != 0) && (values[i - 1] == 1)) {
       seq0_expected += sequence_id0;
       seq1_expected += sequence_id1;
     }

--- a/src/clients/c++/perf_analyzer/client_backend/CMakeLists.txt
+++ b/src/clients/c++/perf_analyzer/client_backend/CMakeLists.txt
@@ -26,11 +26,75 @@
 
 cmake_minimum_required (VERSION 3.18)
 
+FetchContent_Declare(tensorflow-serving-repo
+  PREFIX tensorflow-serving-rep
+)
+FetchContent_GetProperties(tensorflow-serving-repo)
+if(NOT tensorflow-serving-repo_POPULATED)
+  FetchContent_Populate(tensorflow-serving-repo
+  GIT_REPOSITORY "https://github.com/tensorflow/serving.git"
+  GIT_TAG "2.3.0"
+ SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-serving-repo/src/tensorflow_serving"
+)
+endif()
+
+FetchContent_Declare(tensorflow-repo
+  PREFIX tensorflow-repo
+  SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-repo/src/tensorflow"
+)
+FetchContent_GetProperties(tensorflow-repo)
+if(NOT tensorflow-repo_POPULATED)
+  FetchContent_Populate(tensorflow-repo
+  GIT_REPOSITORY "https://github.com/tensorflow/tensorflow.git"
+  GIT_TAG "v2.3.0"
+ SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-repo/src/tensorflow"
+)
+endif()
+
+
+set(TENSORFLOW_PATH ${CMAKE_CURRENT_BINARY_DIR}/tensorflow-repo/src/tensorflow)
+set(TFSERVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/tensorflow-serving-repo/src/tensorflow_serving)
+
+# Copy the repos to a proto staging area.
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/protos)
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${TENSORFLOW_PATH}/tensorflow
+                                                           ${CMAKE_BINARY_DIR}/protos/tensorflow)
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_directory ${TFSERVE_PATH}/tensorflow_serving
+                                                           ${CMAKE_BINARY_DIR}/protos/tensorflow_serving)
+
+# Protobuf compiler dependency.
+include(tensorflow_serving/CompileProto.cmake)
+
+# Protobuf sources of the TensorFlow Serving to be compiled without a gRPC plugin.
+file(GLOB_RECURSE TFSERVING_PROTOS ${CMAKE_BINARY_DIR}/protos/tensorflow_serving/*.proto)
+file(GLOB TF_EXAMPLE_PROTOS ${CMAKE_BINARY_DIR}/protos/tensorflow/core/example/*.proto)
+file(GLOB TF_FW_PROTOS ${CMAKE_BINARY_DIR}/protos/tensorflow/core/framework/*.proto)
+file(GLOB TF_PROTOBUF_PROTOS ${CMAKE_BINARY_DIR}/protos/tensorflow/core/protobuf/*.proto)
+
+# This is a dirty hack to prevent unneccesary leaking dependency
+list(FILTER TF_PROTOBUF_PROTOS EXCLUDE REGEX "autotuning.proto$|conv_autotuning.proto$")
+
+# Compiling CPP sources from proto files.
+compile_proto(0 "${CMAKE_BINARY_DIR}/protos" "${CMAKE_CURRENT_BINARY_DIR}/compiled" PB_SOURCES PB_HEADERS
+        ${TFSERVING_PROTOS}  ${TF_EXAMPLE_PROTOS} ${TF_FW_PROTOS} ${TF_PROTOBUF_PROTOS})
+
+# Compiling CPP sources with gRPC plugin.
+compile_proto(1 "${CMAKE_BINARY_DIR}/protos" "${CMAKE_CURRENT_BINARY_DIR}/compiled" PB_GRPC_SOURCES PB_GRPC_HEADERS
+        ${CMAKE_BINARY_DIR}/protos/tensorflow_serving/apis/prediction_service.proto)
+
+# Including compiled files.
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/compiled)
+
 set(
   CLIENT_BACKEND_SRCS
   client_backend.cc
   triton/triton_client_backend.cc
   ../../examples/shm_utils.cc
+  tensorflow_serving/tfserve_client_backend.cc
+  tensorflow_serving/tfserve_infer_input.cc
+  tensorflow_serving/grpc_client.cc
+  ${PB_SOURCES}
+  ${PB_GRPC_SOURCES}
 )
 
 set(
@@ -38,6 +102,11 @@ set(
   client_backend.h
   triton/triton_client_backend.h
   ../../examples/shm_utils.h
+  tensorflow_serving/tfserve_client_backend.h
+  tensorflow_serving/tfserve_infer_input.h
+  tensorflow_serving/grpc_client.h
+  ${PB_HEADERS} 
+  ${PB_GRPC_HEADERS} 
 )
 
 add_library(
@@ -52,6 +121,10 @@ target_link_libraries(
   PRIVATE model-config-library
   PRIVATE TRITON::grpcclient_static
   PRIVATE TRITON::httpclient_static
+  PRIVATE gRPC::grpc++
+  PRIVATE gRPC::grpc
+  PUBLIC protobuf::libprotobuf
+
 )
 
 if(${TRITON_ENABLE_GPU})

--- a/src/clients/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/client_backend.cc
@@ -25,7 +25,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
+#include "src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h"
 #include "src/clients/c++/perf_analyzer/client_backend/triton/triton_client_backend.h"
+
 
 namespace perfanalyzer { namespace clientbackend {
 
@@ -102,6 +104,9 @@ ClientBackend::Create(
   std::unique_ptr<ClientBackend> local_backend;
   if (kind == TRITON) {
     RETURN_IF_CB_ERROR(TritonClientBackend::Create(
+        url, protocol, http_headers, verbose, &local_backend));
+  } else if (kind == TENSORFLOW_SERVING) {
+    RETURN_IF_CB_ERROR(TFServeClientBackend::Create(
         url, protocol, http_headers, verbose, &local_backend));
   } else {
     return Error("unsupported client backend requested");
@@ -286,6 +291,9 @@ InferInput::Create(
   if (kind == TRITON) {
     RETURN_IF_CB_ERROR(
         TritonInferInput::Create(infer_input, name, dims, datatype));
+  } else if (kind == TENSORFLOW_SERVING) {
+    RETURN_IF_CB_ERROR(
+        TFServeInferInput::Create(infer_input, name, dims, datatype));
   } else {
     return Error(
         "unsupported client backend provided to create InferInput object");
@@ -346,6 +354,8 @@ InferRequestedOutput::Create(
   if (kind == TRITON) {
     RETURN_IF_CB_ERROR(
         TritonInferRequestedOutput::Create(infer_output, name, class_count));
+  } else if (kind == TENSORFLOW_SERVING) {
+    RETURN_IF_CB_ERROR(TFServeInferRequestedOutput::Create(infer_output, name));
   } else {
     return Error(
         "unsupported client backend provided to create InferRequestedOutput "

--- a/src/clients/c++/perf_analyzer/client_backend/client_backend.h
+++ b/src/clients/c++/perf_analyzer/client_backend/client_backend.h
@@ -136,6 +136,8 @@ struct InferOptions {
   std::string model_name_;
   /// The version of the model.
   std::string model_version_;
+  /// The model signature name for TF models.
+  std::string model_signature_name_;
   /// An identifier for the request.
   std::string request_id_;
   /// The unique identifier for the sequence being represented by the

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/CompileProto.cmake
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/CompileProto.cmake
@@ -1,3 +1,29 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 # A function that creates CPP sources from proto files.
 function(COMPILE_PROTO USE_GRPC PROTO_PATH OUT_PATH SRCS HDRS)
 

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/CompileProto.cmake
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/CompileProto.cmake
@@ -1,0 +1,90 @@
+# A function that creates CPP sources from proto files.
+function(COMPILE_PROTO USE_GRPC PROTO_PATH OUT_PATH SRCS HDRS)
+
+    # Checking args.
+    if(NOT ARGN)
+        message(SEND_ERROR "Error: COMPILE_PROTO() called without any proto files")
+        return()
+    endif()
+
+    # To collect paths to created sources and headers.
+    set(${SRCS})
+    set(${HDRS})
+
+
+
+    # Getting actual absolute paths to all protos location and output directory.
+    get_filename_component(ABS_PROTO_PATH "${PROTO_PATH}" ABSOLUTE)
+    get_filename_component(ABS_OUT_PATH "${OUT_PATH}" ABSOLUTE)
+
+    # Launching sources generation for all proto files.
+    foreach(FIL ${ARGN})
+
+        # Getting the absolute path and filename without extension for the current proto file.
+        get_filename_component(ABS_FIL "${FIL}" ABSOLUTE)
+        get_filename_component(FIL_WE  "${FIL}" NAME_WE)
+
+        # Getting the relative dir of the proto file (relative to the protos root dir).
+        file(RELATIVE_PATH REL_FIL_TO_PROTO "${ABS_PROTO_PATH}" "${ABS_FIL}")
+        get_filename_component(REL_DIR_TO_PROTO "${REL_FIL_TO_PROTO}" DIRECTORY)
+
+        # Preparing a path to label created sources from proto.
+        set(COMPILED_NAME_TEMPLATE "${ABS_OUT_PATH}/${REL_DIR_TO_PROTO}/${FIL_WE}")
+
+
+
+        # Firing sources generation command with gRPC application.
+        if(${USE_GRPC})
+            set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+
+            # Marking created files for CMake.
+            list(APPEND ${SRCS} "${COMPILED_NAME_TEMPLATE}.grpc.pb.cc")
+            list(APPEND ${HDRS} "${COMPILED_NAME_TEMPLATE}.grpc.pb.h")
+
+            # Launching proto compilation command.
+            add_custom_command(
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${ABS_OUT_PATH}"
+                    OUTPUT
+                        "${COMPILED_NAME_TEMPLATE}.grpc.pb.cc"
+                        "${COMPILED_NAME_TEMPLATE}.grpc.pb.h"
+                    COMMAND
+                        ${Protobuf_PROTOC_EXECUTABLE}
+                    ARGS
+                        --grpc_out=${ABS_OUT_PATH}
+                        --plugin=protoc-gen-grpc=${_GRPC_CPP_PLUGIN_EXECUTABLE}
+                        --proto_path=${ABS_PROTO_PATH}
+                        ${ABS_FIL}
+                    DEPENDS
+                        ${ABS_FIL} ${Protobuf_PROTOC_EXECUTABLE}
+                    COMMENT
+                        "Running gRPC C++ protocol buffer compiler on ${FIL}"
+                    VERBATIM)
+
+        # Without gRPC.
+        else()
+            list(APPEND ${SRCS} "${COMPILED_NAME_TEMPLATE}.pb.cc")
+            list(APPEND ${HDRS} "${COMPILED_NAME_TEMPLATE}.pb.h")
+            add_custom_command(
+                    COMMAND ${CMAKE_COMMAND} -E make_directory "${ABS_OUT_PATH}"
+                    OUTPUT
+                        "${COMPILED_NAME_TEMPLATE}.pb.cc"
+                        "${COMPILED_NAME_TEMPLATE}.pb.h"
+                    COMMAND
+                        ${Protobuf_PROTOC_EXECUTABLE}
+                    ARGS
+                        --cpp_out=${ABS_OUT_PATH}
+                        --proto_path=${ABS_PROTO_PATH}
+                        ${ABS_FIL}
+                    DEPENDS
+                        ${ABS_FIL} ${Protobuf_PROTOC_EXECUTABLE}
+                    COMMENT
+                        "Running C++ protocol buffer compiler on ${FIL}"
+                    VERBATIM)
+        endif()
+    endforeach()
+
+    # Returning generated sources list.
+    set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+    set(${SRCS} ${${SRCS}} PARENT_SCOPE)
+    set(${HDRS} ${${HDRS}} PARENT_SCOPE)
+endfunction()

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.cc
@@ -1,0 +1,694 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.h"
+#include "src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h"
+
+
+#include <chrono>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+
+/// Type alias for string-TensorProto map.
+typedef google::protobuf::Map<std::string, tensorflow::TensorProto>
+    StringKeyedProtos;
+
+namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+
+namespace {
+
+// Use map to keep track of GRPC channels. <key, value> : <url, Channel*>
+// If context is created on url that has established Channel, then reuse it.
+std::map<std::string, std::shared_ptr<grpc::Channel>> grpc_channel_map_;
+std::mutex grpc_channel_map_mtx_;
+
+void
+GetTensorFlowDataType(const std::string& datatype, tensorflow::DataType* dtype)
+{
+  if (datatype == "FP16") {
+    *dtype = tensorflow::DataType::DT_HALF;
+  } else if (datatype == "FP32") {
+    *dtype = tensorflow::DataType::DT_FLOAT;
+  } else if (datatype == "FP64") {
+    *dtype = tensorflow::DataType::DT_DOUBLE;
+  } else if (datatype == "INT32") {
+    *dtype = tensorflow::DataType::DT_INT32;
+  } else if (datatype == "INT16") {
+    *dtype = tensorflow::DataType::DT_INT16;
+  } else if (datatype == "UINT16") {
+    *dtype = tensorflow::DataType::DT_UINT16;
+  } else if (datatype == "INT8") {
+    *dtype = tensorflow::DataType::DT_INT8;
+  } else if (datatype == "UINT8") {
+    *dtype = tensorflow::DataType::DT_UINT8;
+  } else if (datatype == "BYTES") {
+    *dtype = tensorflow::DataType::DT_STRING;
+  } else if (datatype == "INT64") {
+    *dtype = tensorflow::DataType::DT_INT64;
+  } else if (datatype == "BOOL") {
+    *dtype = tensorflow::DataType::DT_BOOL;
+  } else if (datatype == "UINT32") {
+    *dtype = tensorflow::DataType::DT_UINT32;
+  } else if (datatype == "UINT64") {
+    *dtype = tensorflow::DataType::DT_UINT64;
+  } else {
+    *dtype = tensorflow::DT_INVALID;
+  }
+}
+
+void
+ReadFile(const std::string& filename, std::string& data)
+{
+  data.clear();
+  if (!filename.empty()) {
+    std::ifstream file(filename.c_str(), std::ios::in);
+    if (file.is_open()) {
+      std::stringstream ss;
+      ss << file.rdbuf();
+      file.close();
+      data = ss.str();
+    }
+  }
+}
+
+std::shared_ptr<grpc::Channel>
+GetChannel(const std::string& url, bool use_ssl, const SslOptions& ssl_options)
+{
+  std::lock_guard<std::mutex> lock(grpc_channel_map_mtx_);
+
+  const auto& channel_itr = grpc_channel_map_.find(url);
+  if (channel_itr != grpc_channel_map_.end()) {
+    return channel_itr->second;
+  } else {
+    grpc::ChannelArguments arguments;
+    arguments.SetMaxSendMessageSize(nic::MAX_GRPC_MESSAGE_SIZE);
+    arguments.SetMaxReceiveMessageSize(nic::MAX_GRPC_MESSAGE_SIZE);
+    std::shared_ptr<grpc::ChannelCredentials> credentials;
+    if (use_ssl) {
+      std::string root;
+      std::string key;
+      std::string cert;
+      ReadFile(ssl_options.root_certificates, root);
+      ReadFile(ssl_options.private_key, key);
+      ReadFile(ssl_options.certificate_chain, cert);
+      grpc::SslCredentialsOptions opts = {root, key, cert};
+      credentials = grpc::SslCredentials(opts);
+    } else {
+      credentials = grpc::InsecureChannelCredentials();
+    }
+    std::shared_ptr<grpc::Channel> channel =
+        grpc::CreateCustomChannel(url, credentials, arguments);
+    grpc_channel_map_.insert(std::make_pair(url, channel));
+    return channel;
+  }
+}
+
+}  // namespace
+
+//==============================================================================
+// An GrpcInferRequest represents an inflght inference request on gRPC.
+//
+class GrpcInferRequest {
+ public:
+  GrpcInferRequest(TFServeOnCompleteFn callback = nullptr)
+      : callback_(callback), grpc_status_(),
+        grpc_response_(std::make_shared<tensorflow::serving::PredictResponse>())
+  {
+  }
+
+  nic::RequestTimers& Timer() { return timer_; }
+  friend GrpcClient;
+
+ private:
+  TFServeOnCompleteFn callback_;
+  // Variables for GRPC call
+  grpc::ClientContext grpc_context_;
+  grpc::Status grpc_status_;
+  std::shared_ptr<tensorflow::serving::PredictResponse> grpc_response_;
+  // The timers for infer request.
+  nic::RequestTimers timer_;
+};
+
+//==============================================================================
+
+Error
+GrpcClient::Create(
+    std::unique_ptr<GrpcClient>* client, const std::string& server_url,
+    bool verbose, bool use_ssl, const SslOptions& ssl_options)
+{
+  client->reset(new GrpcClient(server_url, verbose, use_ssl, ssl_options));
+  return Error::Success;
+}
+
+Error
+GrpcClient::ModelMetadata(
+    tensorflow::serving::GetModelMetadataResponse* model_metadata,
+    const std::string& model_name, const std::string& model_version,
+    const Headers& headers)
+{
+  model_metadata->Clear();
+  Error err;
+
+  tensorflow::serving::GetModelMetadataRequest request;
+  grpc::ClientContext context;
+
+  for (const auto& it : headers) {
+    context.AddMetadata(it.first, it.second);
+  }
+
+  request.mutable_model_spec()->set_name(model_name);
+  if (!model_version.empty()) {
+    request.mutable_model_spec()->set_version_label(model_version);
+  }
+  request.add_metadata_field("signature_def");
+  grpc::Status grpc_status =
+      stub_->GetModelMetadata(&context, request, model_metadata);
+  if (grpc_status.ok()) {
+    if (verbose_) {
+      std::cout << model_metadata->DebugString() << std::endl;
+    }
+  } else {
+    err = Error(grpc_status.error_message());
+  }
+
+  return err;
+}
+
+Error
+GrpcClient::Infer(
+    InferResult** result, const InferOptions& options,
+    const std::vector<InferInput*>& inputs,
+    const std::vector<const InferRequestedOutput*>& outputs,
+    const Headers& headers)
+{
+  Error err;
+
+  grpc::ClientContext context;
+
+  std::shared_ptr<GrpcInferRequest> sync_request(new GrpcInferRequest());
+
+  sync_request->Timer().Reset();
+  sync_request->Timer().CaptureTimestamp(
+      nic::RequestTimers::Kind::REQUEST_START);
+  // Use send timer to measure time for marshalling infer request
+  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::SEND_START);
+  for (const auto& it : headers) {
+    context.AddMetadata(it.first, it.second);
+  }
+
+  err = PreRunProcessing(options, inputs, outputs);
+  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::SEND_END);
+  if (!err.IsOk()) {
+    return err;
+  }
+  sync_request->grpc_response_->Clear();
+  sync_request->grpc_status_ = stub_->Predict(
+      &context, infer_request_, sync_request->grpc_response_.get());
+
+  if (!sync_request->grpc_status_.ok()) {
+    err = Error(sync_request->grpc_status_.error_message());
+  }
+
+  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::RECV_START);
+  InferResult::Create(result, sync_request->grpc_response_, err);
+  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::RECV_END);
+
+  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::REQUEST_END);
+
+  nic::Error update_err = UpdateInferStat(sync_request->Timer());
+  if (!update_err.IsOk()) {
+    std::cerr << "Failed to update context stat: " << update_err << std::endl;
+  }
+
+  if (sync_request->grpc_status_.ok()) {
+    if (verbose_) {
+      std::cout << sync_request->grpc_response_->DebugString() << std::endl;
+    }
+  }
+
+  return (*result)->RequestStatus();
+}
+
+Error
+GrpcClient::AsyncInfer(
+    TFServeOnCompleteFn callback, const InferOptions& options,
+    const std::vector<InferInput*>& inputs,
+    const std::vector<const InferRequestedOutput*>& outputs,
+    const Headers& headers)
+{
+  if (callback == nullptr) {
+    return Error(
+        "Callback function must be provided along with AsyncInfer() call.");
+  }
+  if (!worker_.joinable()) {
+    worker_ = std::thread(&GrpcClient::AsyncTransfer, this);
+  }
+
+  GrpcInferRequest* async_request;
+  async_request = new GrpcInferRequest(std::move(callback));
+
+  async_request->Timer().CaptureTimestamp(
+      nic::RequestTimers::Kind::REQUEST_START);
+  async_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::SEND_START);
+  for (const auto& it : headers) {
+    async_request->grpc_context_.AddMetadata(it.first, it.second);
+  }
+
+  Error err = PreRunProcessing(options, inputs, outputs);
+  if (!err.IsOk()) {
+    delete async_request;
+    return err;
+  }
+
+  async_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::SEND_END);
+
+  std::unique_ptr<
+      grpc::ClientAsyncResponseReader<tensorflow::serving::PredictResponse>>
+      rpc(stub_->PrepareAsyncPredict(
+          &async_request->grpc_context_, infer_request_,
+          &async_request_completion_queue_));
+
+  rpc->StartCall();
+
+  rpc->Finish(
+      async_request->grpc_response_.get(), &async_request->grpc_status_,
+      (void*)async_request);
+
+  if (verbose_) {
+    std::cout << "Sent request";
+    if (options.request_id_.size() != 0) {
+      std::cout << " '" << options.request_id_ << "'";
+    }
+    std::cout << std::endl;
+  }
+
+  return Error::Success;
+}
+
+void
+GrpcClient::AsyncTransfer()
+{
+  while (!exiting_) {
+    // GRPC async APIs are thread-safe https://github.com/grpc/grpc/issues/4486
+    GrpcInferRequest* raw_async_request;
+    bool ok = true;
+    bool status =
+        async_request_completion_queue_.Next((void**)(&raw_async_request), &ok);
+    std::shared_ptr<GrpcInferRequest> async_request;
+    if (!ok) {
+      fprintf(stderr, "Unexpected not ok on client side.\n");
+    }
+    if (!status) {
+      if (!exiting_) {
+        fprintf(stderr, "Completion queue is closed.\n");
+      }
+    } else if (raw_async_request == nullptr) {
+      fprintf(stderr, "Unexpected null tag received at client.\n");
+    } else {
+      async_request.reset(raw_async_request);
+      InferResult* async_result;
+      Error err;
+      if (!async_request->grpc_status_.ok()) {
+        err = Error(async_request->grpc_status_.error_message());
+      }
+      async_request->Timer().CaptureTimestamp(
+          nic::RequestTimers::Kind::RECV_START);
+      InferResult::Create(&async_result, async_request->grpc_response_, err);
+      async_request->Timer().CaptureTimestamp(
+          nic::RequestTimers::Kind::RECV_END);
+      async_request->Timer().CaptureTimestamp(
+          nic::RequestTimers::Kind::REQUEST_END);
+      nic::Error update_err = UpdateInferStat(async_request->Timer());
+      if (!update_err.IsOk()) {
+        std::cerr << "Failed to update context stat: " << update_err
+                  << std::endl;
+      }
+      if (async_request->grpc_status_.ok()) {
+        if (verbose_) {
+          std::cout << async_request->grpc_response_->DebugString()
+                    << std::endl;
+        }
+      }
+      async_request->callback_(async_result);
+    }
+  }
+}
+
+Error
+GrpcClient::PreRunProcessing(
+    const InferOptions& options, const std::vector<InferInput*>& inputs,
+    const std::vector<const InferRequestedOutput*>& outputs)
+{
+  // Populate the request protobuf
+
+  // Describing model name and signature from remote server.
+  infer_request_.mutable_model_spec()->set_name(options.model_name_);
+  if (!options.model_version_.empty()) {
+    infer_request_.mutable_model_spec()->set_version_label(
+        options.model_version_);
+  }
+  if (!options.model_signature_name_.empty()) {
+    infer_request_.mutable_model_spec()->set_signature_name(
+        options.model_signature_name_);
+  }
+
+  // Describing remote model inputs shape.
+  StringKeyedProtos& keyed_proto_inputs = *infer_request_.mutable_inputs();
+  std::set<std::string> request_inputs;
+
+  for (const auto input : inputs) {
+    auto raw_input = dynamic_cast<TFServeInferInput*>(input);
+    request_inputs.insert(raw_input->Name());
+    // Add new TensorProto submessages only if required, otherwise
+    // reuse the submessages already available.
+    auto itr = keyed_proto_inputs.find(raw_input->Name());
+    if (itr == keyed_proto_inputs.end()) {
+      itr = keyed_proto_inputs
+                .insert(google::protobuf::MapPair<
+                        std::string, tensorflow::TensorProto>(
+                    raw_input->Name(), tensorflow::TensorProto()))
+                .first;
+    }
+
+    // Set datatype
+    tensorflow::DataType tf_dtype = tensorflow::DT_INVALID;
+    GetTensorFlowDataType(raw_input->Datatype(), &tf_dtype);
+    itr->second.set_dtype(tf_dtype);
+    if (tf_dtype == tensorflow::DT_INVALID) {
+      return Error(
+          "failed to retrieve the TF datatype for " + raw_input->Name());
+    }
+
+    // Populate the shape
+    itr->second.mutable_tensor_shape()->Clear();
+    for (const auto dim : raw_input->Shape()) {
+      itr->second.mutable_tensor_shape()->add_dim()->set_size(dim);
+    }
+
+    raw_input->PrepareForRequest();
+    // There is an extra copy into the buffer to collect all the input
+    // batches. This is a room for improvement for later.
+    bool end_of_input = false;
+
+    // auto* raw_contents = itr->second.mutable_float_val()->mutable_data();
+    size_t content_size;
+    raw_input->ByteSize(&content_size);
+    temp_buffer_.clear();
+    temp_buffer_.reserve(content_size);
+    while (!end_of_input) {
+      const uint8_t* buf;
+      size_t buf_size;
+      raw_input->GetNext(&buf, &buf_size, &end_of_input);
+      if (buf != nullptr) {
+        temp_buffer_.append(reinterpret_cast<const char*>(buf), buf_size);
+      }
+    }
+    ClearAllInputFields(&itr->second);
+    PopulateInputData(raw_input, &itr->second);
+  }
+
+  // Remove extra tensor protos, if any.
+  std::set<std::string> extra_inputs;
+  for (const auto& iter : keyed_proto_inputs) {
+    if (request_inputs.find(iter.first) == request_inputs.end()) {
+      extra_inputs.insert(iter.first);
+    }
+  }
+  for (const auto& extra_input : extra_inputs) {
+    keyed_proto_inputs.erase(extra_input);
+  }
+
+  if (infer_request_.ByteSizeLong() > INT_MAX) {
+    size_t request_size = infer_request_.ByteSizeLong();
+    infer_request_.Clear();
+    return Error(
+        "Request has byte size " + std::to_string(request_size) +
+        " which exceed gRPC's byte size limit " + std::to_string(INT_MAX) +
+        ".");
+  }
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::ClearAllInputFields(tensorflow::TensorProto* input_tensor_proto)
+{
+  input_tensor_proto->mutable_half_val()->Clear();
+  input_tensor_proto->mutable_float_val()->Clear();
+  input_tensor_proto->mutable_double_val()->Clear();
+  input_tensor_proto->mutable_int_val()->Clear();
+  input_tensor_proto->mutable_string_val()->Clear();
+  input_tensor_proto->mutable_int64_val()->Clear();
+  input_tensor_proto->mutable_bool_val()->Clear();
+  input_tensor_proto->mutable_uint32_val()->Clear();
+  input_tensor_proto->mutable_uint64_val()->Clear();
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateInputData(
+    TFServeInferInput* input, tensorflow::TensorProto* input_tensor_proto)
+{
+  if (input->Datatype() == "FP16") {
+    RETURN_IF_CB_ERROR(PopulateHalfVal(input_tensor_proto));
+  } else if (input->Datatype() == "FP32") {
+    RETURN_IF_CB_ERROR(PopulateFloatVal(input_tensor_proto));
+  } else if (input->Datatype() == "FP64") {
+    RETURN_IF_CB_ERROR(PopulateDoubleVal(input_tensor_proto));
+  } else if (input->Datatype() == "INT32") {
+    RETURN_IF_CB_ERROR(PopulateIntVal(input_tensor_proto));
+  } else if (input->Datatype() == "INT16") {
+    RETURN_IF_CB_ERROR(PopulateIntVal(input_tensor_proto, 2));
+  } else if (input->Datatype() == "UINT16") {
+    RETURN_IF_CB_ERROR(PopulateIntVal(input_tensor_proto, 2));
+  } else if (input->Datatype() == "INT8") {
+    RETURN_IF_CB_ERROR(PopulateIntVal(input_tensor_proto, 1));
+  } else if (input->Datatype() == "UINT8") {
+    RETURN_IF_CB_ERROR(PopulateIntVal(input_tensor_proto, 1));
+  } else if (input->Datatype() == "BYTES") {
+    RETURN_IF_CB_ERROR(PopulateStrVal(input_tensor_proto));
+  } else if (input->Datatype() == "INT64") {
+    RETURN_IF_CB_ERROR(PopulateInt64Val(input_tensor_proto));
+  } else if (input->Datatype() == "BOOL") {
+    RETURN_IF_CB_ERROR(PopulateBoolVal(input_tensor_proto));
+  } else if (input->Datatype() == "UINT32") {
+    RETURN_IF_CB_ERROR(PopulateUintVal(input_tensor_proto));
+  } else if (input->Datatype() == "UINT64") {
+    RETURN_IF_CB_ERROR(PopulateUint64Val(input_tensor_proto));
+  } else {
+    return Error("unsupported datatype for populating input data");
+  }
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateHalfVal(tensorflow::TensorProto* input_tensor_proto)
+{
+  // Building FP16 one by one. Note that since protobuf has no int16 type, we'll
+  // have some pointless zero padding for each value here.
+  uint64_t copied_byte_size = 0;
+  while (copied_byte_size < temp_buffer_.size()) {
+    int32_t elem;
+    memcpy(&elem, (temp_buffer_.c_str() + copied_byte_size), 2);
+    input_tensor_proto->add_half_val(elem);
+    copied_byte_size += 2;
+  }
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateFloatVal(tensorflow::TensorProto* input_tensor_proto)
+{
+  input_tensor_proto->mutable_float_val()->Reserve(temp_buffer_.size());
+  memcpy(
+      input_tensor_proto->mutable_float_val()->mutable_data(),
+      temp_buffer_.c_str(), temp_buffer_.size());
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateDoubleVal(tensorflow::TensorProto* input_tensor_proto)
+{
+  input_tensor_proto->mutable_double_val()->Reserve(temp_buffer_.size());
+  memcpy(
+      input_tensor_proto->mutable_double_val()->mutable_data(),
+      temp_buffer_.c_str(), temp_buffer_.size());
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateIntVal(
+    tensorflow::TensorProto* input_tensor_proto, size_t step_size)
+{
+  if (step_size == 4) {
+    input_tensor_proto->mutable_int_val()->Reserve(temp_buffer_.size());
+    memcpy(
+        input_tensor_proto->mutable_int_val()->mutable_data(),
+        temp_buffer_.c_str(), temp_buffer_.size());
+  } else {
+    // Note that since protobuf has no int16/int8 type, we'll
+    // have some pointless zero padding for each value here and
+    // need to build the tensor one element at a time
+    uint64_t copied_byte_size = 0;
+    while (copied_byte_size < temp_buffer_.size()) {
+      int32_t elem;
+      memcpy(&elem, (temp_buffer_.c_str() + copied_byte_size), step_size);
+      input_tensor_proto->add_int_val(elem);
+      copied_byte_size += step_size;
+    }
+  }
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateStrVal(tensorflow::TensorProto* input_tensor_proto)
+{
+  uint64_t copied_byte_size = 0;
+  while (copied_byte_size < temp_buffer_.size()) {
+    int32_t string_length = *((int*)(temp_buffer_.c_str() + copied_byte_size));
+    input_tensor_proto->add_string_val(std::string(
+        (temp_buffer_.c_str() + copied_byte_size + 4), string_length));
+    copied_byte_size += string_length;
+  }
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateBoolVal(tensorflow::TensorProto* input_tensor_proto)
+{
+  input_tensor_proto->mutable_bool_val()->Reserve(temp_buffer_.size());
+  memcpy(
+      input_tensor_proto->mutable_bool_val()->mutable_data(),
+      temp_buffer_.c_str(), temp_buffer_.size());
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateInt64Val(tensorflow::TensorProto* input_tensor_proto)
+{
+  input_tensor_proto->mutable_int64_val()->Reserve(temp_buffer_.size());
+  memcpy(
+      input_tensor_proto->mutable_int64_val()->mutable_data(),
+      temp_buffer_.c_str(), temp_buffer_.size());
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateUintVal(tensorflow::TensorProto* input_tensor_proto)
+{
+  input_tensor_proto->mutable_uint32_val()->Reserve(temp_buffer_.size());
+  memcpy(
+      input_tensor_proto->mutable_uint32_val()->mutable_data(),
+      temp_buffer_.c_str(), temp_buffer_.size());
+
+  return Error::Success;
+}
+
+Error
+GrpcClient::PopulateUint64Val(tensorflow::TensorProto* input_tensor_proto)
+{
+  input_tensor_proto->mutable_uint64_val()->Reserve(temp_buffer_.size());
+  memcpy(
+      input_tensor_proto->mutable_uint64_val()->mutable_data(),
+      temp_buffer_.c_str(), temp_buffer_.size());
+
+  return Error::Success;
+}
+
+GrpcClient::GrpcClient(
+    const std::string& url, bool verbose, bool use_ssl,
+    const SslOptions& ssl_options)
+    : InferenceServerClient(verbose),
+      stub_(tensorflow::serving::PredictionService::NewStub(
+          GetChannel(url, use_ssl, ssl_options)))
+{
+}
+
+GrpcClient::~GrpcClient()
+{
+  exiting_ = true;
+  // Close complete queue and wait for the worker thread to return
+  async_request_completion_queue_.Shutdown();
+
+  // thread not joinable if AsyncInfer() is not called
+  // (it is default constructed thread before the first AsyncInfer() call)
+  if (worker_.joinable()) {
+    worker_.join();
+  }
+
+  bool has_next = true;
+  GrpcInferRequest* async_request;
+  bool ok;
+  do {
+    has_next =
+        async_request_completion_queue_.Next((void**)&async_request, &ok);
+    if (has_next && async_request != nullptr) {
+      delete async_request;
+    }
+  } while (has_next);
+}
+
+//======================================================================
+
+Error
+InferResult::Create(
+    InferResult** infer_result,
+    std::shared_ptr<tensorflow::serving::PredictResponse> response,
+    Error& request_status)
+{
+  *infer_result =
+      reinterpret_cast<InferResult*>(new InferResult(response, request_status));
+  return Error::Success;
+}
+
+Error
+InferResult::RequestStatus() const
+{
+  return request_status_;
+}
+
+InferResult::InferResult(
+    std::shared_ptr<tensorflow::serving::PredictResponse> response,
+    Error& request_status)
+    : response_(response), request_status_(request_status)
+{
+}
+
+//======================================================================
+
+}}}  // namespace perfanalyzer::clientbackend::tfserving

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.h
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.h
@@ -1,0 +1,213 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include "src/clients/c++/library/common.h"
+#include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
+#include "src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h"
+
+
+#include <grpc++/grpc++.h>
+
+#include "tensorflow_serving/apis/prediction_service.grpc.pb.h"
+
+namespace nic = nvidia::inferenceserver::client;
+
+namespace perfanalyzer { namespace clientbackend { namespace tfserving {
+
+struct SslOptions {
+  explicit SslOptions() {}
+  // File containing the PEM encoding of the server root certificates.
+  // If this parameter is empty, the default roots will be used. The
+  // default roots can be overridden using the
+  // GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environment variable pointing
+  // to a file on the file system containing the roots.
+  std::string root_certificates;
+  // File containing the PEM encoding of the client's private key.
+  // This parameter can be empty if the client does not have a
+  // private key.
+  std::string private_key;
+  // File containing the PEM encoding of the client's certificate chain.
+  // This parameter can be empty if the client does not have a
+  // certificate chain.
+  std::string certificate_chain;
+};
+
+class InferResult;
+
+using TFServeOnCompleteFn = std::function<void(InferResult*)>;
+
+//==============================================================================
+/// An GrpcClient object is used to perform any kind of communication with the
+/// TFserving service using gRPC protocol. None of the functions are thread
+/// safe.
+///
+/// \code
+///   std::unique_ptr<GrpcClient> client;
+///   GrpcClient::Create(&client, "localhost:8500");
+///   ...
+///   ...
+/// \endcode
+///
+class GrpcClient : public nic::InferenceServerClient {
+ public:
+  ~GrpcClient();
+
+  /// Create a client that can be used to communicate with the server.
+  /// \param client Returns a new InferenceServerGrpcClient object.
+  /// \param server_url The inference server name and port.
+  /// \param verbose If true generate verbose output when contacting
+  /// the inference server.
+  /// \param use_ssl If true use encrypted channel to the server.
+  /// \param ssl_options Specifies the files required for
+  /// SSL encryption and authorization.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      std::unique_ptr<GrpcClient>* client, const std::string& server_url,
+      bool verbose = false, bool use_ssl = false,
+      const SslOptions& ssl_options = SslOptions());
+
+  /// Contact the inference server and get the metadata of specified model.
+  /// \param model_metadata Returns model metadata as ModelMetadataResponse
+  /// message.
+  /// \param model_name The name of the model to get metadata.
+  /// \param model_version The version of the model to get metadata.
+  /// The default value is an empty string which means then the server will
+  /// choose a version based on the model and internal policy.
+  /// \param headers Optional map specifying additional HTTP headers to include
+  /// in the metadata of gRPC request.
+  /// \return Error object indicating success or failure of the request.
+  Error ModelMetadata(
+      tensorflow::serving::GetModelMetadataResponse* model_metadata,
+      const std::string& model_name, const std::string& model_version = "",
+      const Headers& headers = Headers());
+
+  /// Run synchronous inference on server.
+  /// \param result Returns the result of inference.
+  /// \param options The options for inference request.
+  /// \param inputs The vector of InferInput describing the model inputs.
+  /// \param outputs Optional vector of InferRequestedOutput describing how the
+  /// output must be returned. If not provided then all the outputs in the model
+  /// config will be returned as default settings.
+  /// \param headers Optional map specifying additional HTTP headers to include
+  /// in the metadata of gRPC request.
+  /// \return Error object indicating success or failure of the
+  /// request.
+  Error Infer(
+      InferResult** result, const InferOptions& options,
+      const std::vector<InferInput*>& inputs,
+      const std::vector<const InferRequestedOutput*>& outputs =
+          std::vector<const InferRequestedOutput*>(),
+      const Headers& headers = Headers());
+
+  /// Run asynchronous inference on server.
+  /// Once the request is completed, the InferResult pointer will be passed to
+  /// the provided 'callback' function. Upon the invocation of callback
+  /// function, the ownership of InferResult object is transfered to the
+  /// function caller. It is then the caller's choice on either retrieving the
+  /// results inside the callback function or deferring it to a different thread
+  /// so that the client is unblocked. In order to prevent memory leak, user
+  /// must ensure this object gets deleted.
+  /// \param callback The callback function to be invoked on request completion.
+  /// \param options The options for inference request.
+  /// \param inputs The vector of InferInput describing the model inputs.
+  /// \param outputs Optional vector of InferRequestedOutput describing how the
+  /// output must be returned. If not provided then all the outputs in the model
+  /// config will be returned as default settings.
+  /// \param headers Optional map specifying additional HTTP headers to include
+  /// in the metadata of gRPC request.
+  /// \return Error object indicating success or failure of the request.
+  Error AsyncInfer(
+      TFServeOnCompleteFn callback, const InferOptions& options,
+      const std::vector<InferInput*>& inputs,
+      const std::vector<const InferRequestedOutput*>& outputs =
+          std::vector<const InferRequestedOutput*>(),
+      const Headers& headers = Headers());
+
+ private:
+  GrpcClient(
+      const std::string& url, bool verbose, bool use_ssl,
+      const SslOptions& ssl_options);
+  Error PreRunProcessing(
+      const InferOptions& options, const std::vector<InferInput*>& inputs,
+      const std::vector<const InferRequestedOutput*>& outputs);
+  void AsyncTransfer();
+  Error ClearAllInputFields(tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateInputData(
+      TFServeInferInput* input, tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateHalfVal(tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateFloatVal(tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateDoubleVal(tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateIntVal(
+      tensorflow::TensorProto* input_tensor_proto, size_t step_size = 4);
+  Error PopulateStrVal(tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateBoolVal(tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateInt64Val(tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateUintVal(tensorflow::TensorProto* input_tensor_proto);
+  Error PopulateUint64Val(tensorflow::TensorProto* input_tensor_proto);
+
+  // The producer-consumer queue used to communicate asynchronously with
+  // the GRPC runtime.
+  grpc::CompletionQueue async_request_completion_queue_;
+
+  bool enable_stream_stats_;
+  std::mutex stream_mutex_;
+
+  // GRPC end point.
+  std::unique_ptr<tensorflow::serving::PredictionService::Stub> stub_;
+  // request for GRPC call, one request object can be used for multiple calls
+  // since it can be overwritten as soon as the GRPC send finishes.
+  tensorflow::serving::PredictRequest infer_request_;
+  // A temporary buffer to hold serialized data
+  std::string temp_buffer_;
+};
+
+//======================================================================
+
+class InferResult {
+ public:
+  static Error Create(
+      InferResult** infer_result,
+      std::shared_ptr<tensorflow::serving::PredictResponse> response,
+      Error& request_status);
+
+
+  Error RequestStatus() const;
+  Error Id(std::string* id) const;
+  std::string DebugString() const { return response_->DebugString(); }
+
+ private:
+  InferResult(
+      std::shared_ptr<tensorflow::serving::PredictResponse> response,
+      Error& request_status);
+
+  std::shared_ptr<tensorflow::serving::PredictResponse> response_;
+  Error request_status_;
+};
+
+//======================================================================
+
+}}}  // namespace perfanalyzer::clientbackend::tfserving

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
@@ -1,0 +1,186 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h"
+
+#include "src/clients/c++/examples/json_utils.h"
+
+namespace perfanalyzer { namespace clientbackend {
+
+//==============================================================================
+
+Error
+TFServeClientBackend::Create(
+    const std::string& url, const ProtocolType protocol,
+    std::shared_ptr<Headers> http_headers, const bool verbose,
+    std::unique_ptr<ClientBackend>* client_backend)
+{
+  if (protocol == ProtocolType::HTTP) {
+    return Error(
+        "perf_analyzer does not support http protocol with TF serving");
+  }
+  std::unique_ptr<TFServeClientBackend> tfserve_client_backend(
+      new TFServeClientBackend(http_headers));
+
+  RETURN_IF_CB_ERROR(tfs::GrpcClient::Create(
+      &(tfserve_client_backend->grpc_client_), url, verbose));
+
+  *client_backend = std::move(tfserve_client_backend);
+
+  return Error::Success;
+}
+
+Error
+TFServeClientBackend::ModelMetadata(
+    rapidjson::Document* model_metadata, const std::string& model_name,
+    const std::string& model_version)
+{
+  tensorflow::serving::GetModelMetadataResponse metadata_proto;
+  RETURN_IF_CB_ERROR(grpc_client_->ModelMetadata(
+      &metadata_proto, model_name, model_version, *http_headers_));
+
+  std::string metadata;
+  ::google::protobuf::util::JsonPrintOptions options;
+  options.preserve_proto_field_names = true;
+  options.always_print_primitive_fields = true;
+  ::google::protobuf::util::MessageToJsonString(
+      metadata_proto, &metadata, options);
+
+  RETURN_IF_TRITON_ERROR(nic::ParseJson(model_metadata, metadata));
+
+  return Error::Success;
+}
+
+Error
+TFServeClientBackend::Infer(
+    InferResult** result, const InferOptions& options,
+    const std::vector<InferInput*>& inputs,
+    const std::vector<const InferRequestedOutput*>& outputs)
+{
+  tfs::InferResult* tfserve_result;
+  RETURN_IF_CB_ERROR(grpc_client_->Infer(
+      &tfserve_result, options, inputs, outputs, *http_headers_));
+
+  *result = new TFServeInferResult(tfserve_result);
+
+  return Error::Success;
+}
+
+Error
+TFServeClientBackend::AsyncInfer(
+    OnCompleteFn callback, const InferOptions& options,
+    const std::vector<InferInput*>& inputs,
+    const std::vector<const InferRequestedOutput*>& outputs)
+{
+  auto wrapped_callback = [callback](tfs::InferResult* client_result) {
+    InferResult* result = new TFServeInferResult(client_result);
+    callback(result);
+  };
+
+  RETURN_IF_CB_ERROR(grpc_client_->AsyncInfer(
+      wrapped_callback, options, inputs, outputs, *http_headers_));
+
+  return Error::Success;
+}
+
+
+Error
+TFServeClientBackend::ClientInferStat(InferStat* infer_stat)
+{
+  // Reusing the common library utilities to collect and report the
+  // client side statistics.
+  nic::InferStat client_infer_stat;
+
+  RETURN_IF_TRITON_ERROR(grpc_client_->ClientInferStat(&client_infer_stat));
+
+  ParseInferStat(client_infer_stat, infer_stat);
+
+  return Error::Success;
+}
+
+void
+TFServeClientBackend::ParseInferStat(
+    const nic::InferStat& tfserve_infer_stat, InferStat* infer_stat)
+{
+  infer_stat->completed_request_count =
+      tfserve_infer_stat.completed_request_count;
+  infer_stat->cumulative_total_request_time_ns =
+      tfserve_infer_stat.cumulative_total_request_time_ns;
+  infer_stat->cumulative_send_time_ns =
+      tfserve_infer_stat.cumulative_send_time_ns;
+  infer_stat->cumulative_receive_time_ns =
+      tfserve_infer_stat.cumulative_receive_time_ns;
+}
+
+//==============================================================================
+
+Error
+TFServeInferRequestedOutput::Create(
+    InferRequestedOutput** infer_output, const std::string name)
+{
+  TFServeInferRequestedOutput* local_infer_output =
+      new TFServeInferRequestedOutput();
+
+  nic::InferRequestedOutput* tfserve_infer_output;
+  RETURN_IF_TRITON_ERROR(
+      nic::InferRequestedOutput::Create(&tfserve_infer_output, name));
+  local_infer_output->output_.reset(tfserve_infer_output);
+
+  *infer_output = local_infer_output;
+
+  return Error::Success;
+}
+
+TFServeInferRequestedOutput::TFServeInferRequestedOutput()
+    : InferRequestedOutput(BackendKind::TENSORFLOW_SERVING)
+{
+}
+
+//==============================================================================
+
+TFServeInferResult::TFServeInferResult(tfs::InferResult* result)
+{
+  result_.reset(result);
+}
+
+Error
+TFServeInferResult::Id(std::string* id) const
+{
+  id->clear();
+  return Error::Success;
+}
+
+Error
+TFServeInferResult::RequestStatus() const
+{
+  RETURN_IF_CB_ERROR(result_->RequestStatus());
+  return Error::Success;
+}
+
+//==============================================================================
+
+
+}}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
@@ -1,0 +1,137 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+
+#include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
+#include "src/clients/c++/perf_analyzer/perf_utils.h"
+
+#include "src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.h"
+
+#define RETURN_IF_TRITON_ERROR(S)       \
+  do {                                  \
+    const nic::Error& status__ = (S);   \
+    if (!status__.IsOk()) {             \
+      return Error(status__.Message()); \
+    }                                   \
+  } while (false)
+
+namespace nic = nvidia::inferenceserver::client;
+namespace tfs = perfanalyzer::clientbackend::tfserving;
+
+namespace perfanalyzer { namespace clientbackend {
+
+//==============================================================================
+/// TFServeClientBackend is used to generate load on the TF serving isntance
+///
+class TFServeClientBackend : public ClientBackend {
+ public:
+  /// Create a TFserving client backend which can be used to interact with the
+  /// server.
+  /// \param url The inference server url and port.
+  /// \param protocol The protocol type used.
+  /// \param http_headers Map of HTTP headers. The map key/value indicates
+  /// the header name/value.
+  /// \param verbose Enables the verbose mode.
+  /// \param client_backend Returns a new TFServeClientBackend
+  /// object.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      const std::string& url, const ProtocolType protocol,
+      std::shared_ptr<Headers> http_headers, const bool verbose,
+      std::unique_ptr<ClientBackend>* client_backend);
+
+  /// See ClientBackend::ModelMetadata()
+  Error ModelMetadata(
+      rapidjson::Document* model_metadata, const std::string& model_name,
+      const std::string& model_version) override;
+
+  /// See ClientBackend::Infer()
+  Error Infer(
+      InferResult** result, const InferOptions& options,
+      const std::vector<InferInput*>& inputs,
+      const std::vector<const InferRequestedOutput*>& outputs) override;
+
+  /// See ClientBackend::AsyncInfer()
+  Error AsyncInfer(
+      OnCompleteFn callback, const InferOptions& options,
+      const std::vector<InferInput*>& inputs,
+      const std::vector<const InferRequestedOutput*>& outputs) override;
+
+  /// See ClientBackend::ClientInferStat()
+  Error ClientInferStat(InferStat* infer_stat) override;
+
+ private:
+  TFServeClientBackend(std::shared_ptr<Headers> http_headers)
+      : ClientBackend(BackendKind::TENSORFLOW_SERVING),
+        http_headers_(http_headers)
+  {
+  }
+
+  void ParseInferStat(
+      const nic::InferStat& tfserve_infer_stat, InferStat* infer_stat);
+
+  std::unique_ptr<tfs::GrpcClient> grpc_client_;
+
+  std::shared_ptr<Headers> http_headers_;
+};
+
+//==============================================================
+/// TFServeInferRequestedOutput is a wrapper around
+/// InferRequestedOutput object of triton common client library.
+///
+class TFServeInferRequestedOutput : public InferRequestedOutput {
+ public:
+  static Error Create(
+      InferRequestedOutput** infer_output, const std::string name);
+  /// Returns the raw InferRequestedOutput object required by TFserving client
+  /// library.
+  nic::InferRequestedOutput* Get() const { return output_.get(); }
+
+ private:
+  explicit TFServeInferRequestedOutput();
+
+  std::unique_ptr<nic::InferRequestedOutput> output_;
+};
+
+//==============================================================
+/// TFServeInferResult is a wrapper around InferResult object of
+/// TF serving InferResult object.
+///
+class TFServeInferResult : public InferResult {
+ public:
+  explicit TFServeInferResult(tfs::InferResult* result);
+  /// See InferResult::Id()
+  Error Id(std::string* id) const override;
+  /// See InferResult::RequestStatus()
+  Error RequestStatus() const override;
+
+ private:
+  std::unique_ptr<tfs::InferResult> result_;
+};
+
+}}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.cc
@@ -1,0 +1,111 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h"
+
+namespace perfanalyzer { namespace clientbackend {
+
+Error
+TFServeInferInput::Create(
+    InferInput** infer_input, const std::string& name,
+    const std::vector<int64_t>& dims, const std::string& datatype)
+{
+  TFServeInferInput* local_infer_input =
+      new TFServeInferInput(name, dims, datatype);
+
+  *infer_input = local_infer_input;
+  return Error::Success;
+}
+
+Error
+TFServeInferInput::SetShape(const std::vector<int64_t>& shape)
+{
+  shape_ = shape;
+  return Error::Success;
+}
+
+Error
+TFServeInferInput::Reset()
+{
+  bufs_.clear();
+  buf_byte_sizes_.clear();
+  bufs_idx_ = 0;
+  byte_size_ = 0;
+  return Error::Success;
+}
+
+Error
+TFServeInferInput::AppendRaw(const uint8_t* input, size_t input_byte_size)
+{
+  byte_size_ += input_byte_size;
+
+  bufs_.push_back(input);
+  buf_byte_sizes_.push_back(input_byte_size);
+
+  return Error::Success;
+}
+
+Error
+TFServeInferInput::ByteSize(size_t* byte_size) const
+{
+  *byte_size = byte_size_;
+  return Error::Success;
+}
+
+Error
+TFServeInferInput::PrepareForRequest()
+{
+  // Reset position so request sends entire input.
+  bufs_idx_ = 0;
+  buf_pos_ = 0;
+  return Error::Success;
+}
+
+Error
+TFServeInferInput::GetNext(
+    const uint8_t** buf, size_t* input_bytes, bool* end_of_input)
+{
+  if (bufs_idx_ < bufs_.size()) {
+    *buf = bufs_[bufs_idx_];
+    *input_bytes = buf_byte_sizes_[bufs_idx_];
+    bufs_idx_++;
+  } else {
+    *buf = nullptr;
+    *input_bytes = 0;
+  }
+  *end_of_input = (bufs_idx_ >= bufs_.size());
+
+  return Error::Success;
+}
+
+TFServeInferInput::TFServeInferInput(
+    const std::string& name, const std::vector<int64_t>& dims,
+    const std::string& datatype)
+    : InferInput(BackendKind::TENSORFLOW_SERVING, name, datatype), shape_(dims)
+{
+}
+
+}}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_infer_input.h
@@ -1,0 +1,75 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+
+#include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
+#include "src/clients/c++/perf_analyzer/perf_utils.h"
+
+
+namespace perfanalyzer { namespace clientbackend {
+
+//==============================================================
+/// TFServeInferInput instance holds the information regarding
+/// model input tensors and their corresponding generated data.
+///
+class TFServeInferInput : public InferInput {
+ public:
+  static Error Create(
+      InferInput** infer_input, const std::string& name,
+      const std::vector<int64_t>& dims, const std::string& datatype);
+  /// See InferInput::Shape()
+  const std::vector<int64_t>& Shape() const override { return shape_; }
+  /// See InferInput::SetShape()
+  Error SetShape(const std::vector<int64_t>& shape) override;
+  /// See InferInput::Reset()
+  Error Reset() override;
+  /// See InferInput::AppendRaw()
+  Error AppendRaw(const uint8_t* input, size_t input_byte_size) override;
+  /// Gets the size of data added into this input in bytes.
+  /// \param byte_size The size of data added in bytes.
+  /// \return Error object indicating success or failure.
+  Error ByteSize(size_t* byte_size) const;
+  /// Resets the heads to start providing data from the begining.
+  Error PrepareForRequest();
+  /// Get the next chunk of data if available.
+  Error GetNext(const uint8_t** buf, size_t* input_bytes, bool* end_of_input);
+
+ private:
+  explicit TFServeInferInput(
+      const std::string& name, const std::vector<int64_t>& dims,
+      const std::string& datatype);
+
+  std::vector<int64_t> shape_;
+  size_t byte_size_;
+
+  size_t bufs_idx_, buf_pos_;
+  std::vector<const uint8_t*> bufs_;
+  std::vector<size_t> buf_byte_sizes_;
+};
+
+}}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/clients/c++/perf_analyzer/concurrency_manager.cc
@@ -260,6 +260,8 @@ ConcurrencyManager::Infer(
           factory_->CreateClientBackend(&(ctxs.back()->infer_backend_));
       ctxs.back()->options_.reset(new cb::InferOptions(parser_->ModelName()));
       ctxs.back()->options_->model_version_ = parser_->ModelVersion();
+      ctxs.back()->options_->model_signature_name_ =
+          parser_->ModelSignatureName();
       thread_stat->contexts_stat_.emplace_back();
       if (shared_memory_type_ == SharedMemoryType::NO_SHARED_MEMORY) {
         thread_stat->status_ = PrepareInfer(ctxs.back().get());

--- a/src/clients/c++/perf_analyzer/inference_profiler.cc
+++ b/src/clients/c++/perf_analyzer/inference_profiler.cc
@@ -242,14 +242,19 @@ InferenceProfiler::InferenceProfiler(
 {
   load_parameters_.stability_threshold = stability_threshold;
   load_parameters_.stability_window = 3;
-  // Measure and report client library stats only when the model
-  // is not decoupled.
-  include_lib_stats_ = (!parser_->IsDecoupled());
-  // Measure and report server statistics only when the server
-  // supports the statistics extension.
-  std::set<std::string> extensions;
-  profile_backend_->ServerExtensions(&extensions);
-  include_server_stats_ = (extensions.find("statistics") != extensions.end());
+  if (profile_backend_->Kind() == cb::BackendKind::TRITON) {
+    // Measure and report client library stats only when the model
+    // is not decoupled.
+    include_lib_stats_ = (!parser_->IsDecoupled());
+    // Measure and report server statistics only when the server
+    // supports the statistics extension.
+    std::set<std::string> extensions;
+    profile_backend_->ServerExtensions(&extensions);
+    include_server_stats_ = (extensions.find("statistics") != extensions.end());
+  } else {
+    include_lib_stats_ = true;
+    include_server_stats_ = false;
+  }
 }
 
 cb::Error

--- a/src/clients/c++/perf_analyzer/main.cc
+++ b/src/clients/c++/perf_analyzer/main.cc
@@ -212,8 +212,10 @@ Usage(char** argv, const std::string& msg = std::string())
 
   std::cerr << "Usage: " << argv[0] << " [options]" << std::endl;
   std::cerr << "==== SYNOPSIS ====\n \n";
+  std::cerr << "\t--service-kind <\"triton\"|\"tfserving\">" << std::endl;
   std::cerr << "\t-m <model name>" << std::endl;
   std::cerr << "\t-x <model version>" << std::endl;
+  std::cerr << "\t--model-signature-name <model signature name>" << std::endl;
   std::cerr << "\t-v" << std::endl;
   std::cerr << std::endl;
   std::cerr << "I. MEASUREMENT PARAMETERS: " << std::endl;
@@ -272,6 +274,14 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "==== OPTIONS ==== \n \n";
 
   std::cerr
+      << FormatMessage(
+             " --service-kind: Describes the kind of service perf_analyzer "
+             "to generate load for. The options are \"triton\" and "
+             "\"tfserving\". Default value is \"triton\".",
+             18)
+      << std::endl;
+
+  std::cerr
       << std::setw(9) << std::left << " -m: "
       << FormatMessage(
              "This is a required argument and is used to specify the model"
@@ -284,6 +294,13 @@ Usage(char** argv, const std::string& msg = std::string())
                    " the most recent version (that is, the highest numbered"
                    " version) of the model will be used.",
                    9)
+            << std::endl;
+  std::cerr << FormatMessage(
+                   " --model-signature-name: The signature name of the saved "
+                   "model to use. Default value is \"serving_default\". This "
+                   "option will be ignored if --service-kind is not "
+                   "\"tfserving\".",
+                   18)
             << std::endl;
   std::cerr << std::setw(9) << std::left
             << " -v: " << FormatMessage("Enables verbose mode.", 9)
@@ -529,8 +546,10 @@ Usage(char** argv, const std::string& msg = std::string())
   std::cerr << "III. SERVER DETAILS: " << std::endl;
   std::cerr << std::setw(9) << std::left << " -u: "
             << FormatMessage(
-                   "Specify URL to the server. Default is \"localhost:8000\" "
-                   "if using HTTP and \"localhost:8001\" if using gRPC. ",
+                   "Specify URL to the server. When using triton default is "
+                   "\"localhost:8000\" if using HTTP and \"localhost:8001\" "
+                   "if using gRPC. When using tfserving default is "
+                   "\"localhost:8500\". ",
                    9)
             << std::endl;
   std::cerr << std::setw(9) << std::left << " -i: "
@@ -571,6 +590,7 @@ Usage(char** argv, const std::string& msg = std::string())
 int
 main(int argc, char** argv)
 {
+  cb::BackendKind kind(cb::BackendKind::TRITON);
   bool verbose = false;
   bool extra_verbose = false;
   bool streaming = false;
@@ -587,6 +607,7 @@ main(int argc, char** argv)
   size_t max_trials = 10;
   std::string model_name;
   std::string model_version;
+  std::string model_signature_name("serving_default");
   std::string url("localhost:8000");
   std::string filename("");
   cb::ProtocolType protocol = cb::ProtocolType::HTTP;
@@ -642,6 +663,8 @@ main(int argc, char** argv)
       {"request-intervals", 1, 0, 20},
       {"shared-memory", 1, 0, 21},
       {"output-shared-memory-size", 1, 0, 22},
+      {"service-kind", 1, 0, 23},
+      {"model-signature-name", 1, 0, 24},
       {0, 0, 0, 0}};
 
   // Parse commandline...
@@ -845,8 +868,23 @@ main(int argc, char** argv)
         }
         break;
       }
-      case 22:
+      case 22: {
         output_shm_size = std::atoi(optarg);
+        break;
+      }
+      case 23: {
+        std::string arg = optarg;
+        if (arg.compare("triton") == 0) {
+          kind = cb::TRITON;
+        } else if (arg.compare("tfserving") == 0) {
+          kind = cb::TENSORFLOW_SERVING;
+        } else {
+          Usage(argv, "unsupported --service-kind specified");
+        }
+        break;
+      }
+      case 24:
+        model_signature_name = optarg;
         break;
       case 'v':
         extra_verbose = verbose;
@@ -1022,7 +1060,36 @@ main(int argc, char** argv)
   }
 
   if (!url_specified && (protocol == cb::ProtocolType::GRPC)) {
-    url = "localhost:8001";
+    if (kind == cb::BackendKind::TRITON) {
+      url = "localhost:8001";
+    } else if (kind == cb::BackendKind::TENSORFLOW_SERVING) {
+      url = "localhost:8500";
+    }
+  }
+
+  if (kind == cb::TENSORFLOW_SERVING) {
+    if (protocol != cb::ProtocolType::GRPC) {
+      std::cerr
+          << "perf_analyzer supports only grpc protocol for TensorFlow Serving."
+          << std::endl;
+      return 1;
+    } else if (streaming) {
+      std::cerr
+          << "perf_analyzer does not support streaming for TensorFlow Serving."
+          << std::endl;
+      return 1;
+    } else if (async) {
+      std::cerr
+          << "perf_analyzer does not support async API for TensorFlow Serving."
+          << std::endl;
+      return 1;
+    } else if (batch_size > 1) {
+      std::cerr
+          << "perf_analyzer does not support -b flag with TensorFlow Serving "
+             "backend. See --shape to specify explicit batch dimension."
+          << std::endl;
+      return 1;
+    }
   }
 
   bool target_concurrency =
@@ -1040,8 +1107,7 @@ main(int argc, char** argv)
   std::shared_ptr<cb::ClientBackendFactory> factory;
   FAIL_IF_ERR(
       cb::ClientBackendFactory::Create(
-          cb::BackendKind::TRITON, url, protocol, http_headers, extra_verbose,
-          &factory),
+          kind, url, protocol, http_headers, extra_verbose, &factory),
       "failed to create client factory");
 
   std::unique_ptr<cb::ClientBackend> backend;
@@ -1049,19 +1115,36 @@ main(int argc, char** argv)
       factory->CreateClientBackend(&backend),
       "failed to create triton client backend");
 
-  std::shared_ptr<pa::ModelParser> parser = std::make_shared<pa::ModelParser>();
-  rapidjson::Document model_metadata;
-  FAIL_IF_ERR(
-      backend->ModelMetadata(&model_metadata, model_name, model_version),
-      "failed to get model metadata");
-  rapidjson::Document model_config;
-  FAIL_IF_ERR(
-      backend->ModelConfig(&model_config, model_name, model_version),
-      "failed to get model config");
-  FAIL_IF_ERR(
-      parser->Init(
-          model_metadata, model_config, model_version, input_shapes, backend),
-      "failed to create model parser");
+  std::shared_ptr<pa::ModelParser> parser =
+      std::make_shared<pa::ModelParser>(kind);
+  if (kind == cb::BackendKind::TRITON) {
+    rapidjson::Document model_metadata;
+    FAIL_IF_ERR(
+        backend->ModelMetadata(&model_metadata, model_name, model_version),
+        "failed to get model metadata");
+    rapidjson::Document model_config;
+    FAIL_IF_ERR(
+        backend->ModelConfig(&model_config, model_name, model_version),
+        "failed to get model config");
+    FAIL_IF_ERR(
+        parser->InitTriton(
+            model_metadata, model_config, model_version, input_shapes, backend),
+        "failed to create model parser");
+  } else if (kind == cb::BackendKind::TENSORFLOW_SERVING) {
+    rapidjson::Document model_metadata;
+    FAIL_IF_ERR(
+        backend->ModelMetadata(&model_metadata, model_name, model_version),
+        "failed to get model metadata");
+    FAIL_IF_ERR(
+        parser->InitTFServe(
+            model_metadata, model_name, model_version, model_signature_name,
+            input_shapes, backend),
+        "failed to create model parser");
+
+  } else {
+    std::cerr << "unsupported client backend kind" << std::endl;
+    return 1;
+  }
 
   if ((parser->MaxBatchSize() == 0) && batch_size > 1) {
     std::cerr << "can not specify batch size > 1 as the model does not support "

--- a/src/clients/c++/perf_analyzer/main.cc
+++ b/src/clients/c++/perf_analyzer/main.cc
@@ -1248,9 +1248,11 @@ main(int argc, char** argv)
       "failed to create profiler");
 
   // pre-run report
-  std::cout << "*** Measurement Settings ***" << std::endl
-            << "  Batch size: " << batch_size << std::endl
-            << "  Measurement window: " << measurement_window_ms << " msec"
+  std::cout << "*** Measurement Settings ***" << std::endl;
+  if (kind == cb::BackendKind::TRITON) {
+    std::cout << "  Batch size: " << batch_size << std::endl;
+  }
+  std::cout << "  Measurement window: " << measurement_window_ms << " msec"
             << std::endl;
   if (concurrency_range[SEARCH_RANGE::kEND] != 1) {
     std::cout << "  Latency limit: " << latency_threshold_ms << " msec"

--- a/src/clients/c++/perf_analyzer/model_parser.h
+++ b/src/clients/c++/perf_analyzer/model_parser.h
@@ -59,8 +59,9 @@ class ModelParser {
     ENSEMBLE_SEQUENCE
   };
 
-  ModelParser()
-      : inputs_(std::make_shared<ModelTensorMap>()),
+  explicit ModelParser(cb::BackendKind backend_kind)
+      : backend_kind_(backend_kind),
+        inputs_(std::make_shared<ModelTensorMap>()),
         outputs_(std::make_shared<ModelTensorMap>()),
         composing_models_map_(std::make_shared<ComposingModelMap>()),
         scheduler_type_(NONE), max_batch_size_(0), is_decoupled_(false)
@@ -68,7 +69,7 @@ class ModelParser {
   }
 
   /// Initializes the ModelParser with the metadata and config rapidjson DOM
-  /// for the target model
+  /// for the target model obtained from Triton service
   /// \param metadata The metadata of the target model.
   /// \param config The config of the target model.
   /// \param model_version The version of target model.
@@ -76,9 +77,25 @@ class ModelParser {
   /// if a certain input has wildcard in its dimension.
   /// \param backend The backend object.
   /// \return cb::Error object indicating success or failure.
-  cb::Error Init(
+  cb::Error InitTriton(
       const rapidjson::Document& metadata, const rapidjson::Document& config,
       const std::string& model_version,
+      const std::unordered_map<std::string, std::vector<int64_t>>& input_shapes,
+      std::unique_ptr<cb::ClientBackend>& backend);
+
+  /// Initializes the ModelParser with the metadata and config rapidjson DOM
+  /// for the target model obtained from TF serving service.
+  /// \param metadata The metadata of the target model.
+  /// \param model_name The name of target model.
+  /// \param model_version The version of target model.
+  /// \param model_signature_name The signature name of target model.
+  /// \param input_shapes The user provided default shapes which will be use
+  /// if a certain input has wildcard in its dimension.
+  /// \param backend The backend object.
+  /// \return cb::Error object indicating success or failure.
+  cb::Error InitTFServe(
+      const rapidjson::Document& metadata, const std::string& model_name,
+      const std::string& model_version, const std::string& model_signature_name,
       const std::unordered_map<std::string, std::vector<int64_t>>& input_shapes,
       std::unique_ptr<cb::ClientBackend>& backend);
 
@@ -89,6 +106,13 @@ class ModelParser {
   /// Get the version of target model
   /// \return Model version as string
   const std::string& ModelVersion() const { return model_version_; }
+
+  /// Get the signature name of target model
+  /// \return Model signature name as string
+  const std::string& ModelSignatureName() const
+  {
+    return model_signature_name_;
+  }
 
   /// Get the scheduler type for the model
   ModelSchedulerType SchedulerType() const { return scheduler_type_; }
@@ -125,12 +149,15 @@ class ModelParser {
       const rapidjson::Document& config, const std::string& model_version,
       std::unique_ptr<cb::ClientBackend>& backend, bool* is_sequential);
 
+  cb::BackendKind backend_kind_;
+
   std::shared_ptr<ModelTensorMap> inputs_;
   std::shared_ptr<ModelTensorMap> outputs_;
   std::shared_ptr<ComposingModelMap> composing_models_map_;
 
   std::string model_name_;
   std::string model_version_;
+  std::string model_signature_name_;
   ModelSchedulerType scheduler_type_;
   size_t max_batch_size_;
   bool is_decoupled_;

--- a/src/clients/c++/perf_analyzer/perf_utils.cc
+++ b/src/clients/c++/perf_analyzer/perf_utils.cc
@@ -50,6 +50,42 @@ ParseProtocol(const std::string& str)
 }
 
 cb::Error
+ConvertDTypeFromTFS(const std::string& tf_dtype, std::string* datatype)
+{
+  if (tf_dtype == "DT_HALF") {
+    *datatype = "FP16";
+  } else if (tf_dtype == "DT_FLOAT") {
+    *datatype = "FP32";
+  } else if (tf_dtype == "DT_DOUBLE") {
+    *datatype = "FP64";
+  } else if (tf_dtype == "DT_INT32") {
+    *datatype = "INT32";
+  } else if (tf_dtype == "DT_INT16") {
+    *datatype = "INT16";
+  } else if (tf_dtype == "DT_UINT16") {
+    *datatype = "UINT16";
+  } else if (tf_dtype == "DT_INT8") {
+    *datatype = "INT8";
+  } else if (tf_dtype == "DT_UNIT8") {
+    *datatype = "UINT8";
+  } else if (tf_dtype == "DT_STRING") {
+    *datatype = "BYTES";
+  } else if (tf_dtype == "DT_INT64") {
+    *datatype = "INT64";
+  } else if (tf_dtype == "DT_BOOL") {
+    *datatype = "BOOL";
+  } else if (tf_dtype == "DT_UINT32") {
+    *datatype = "UINT32";
+  } else if (tf_dtype == "DT_UINT64") {
+    *datatype = "UINT64";
+  } else {
+    return cb::Error("unsupported datatype encountered " + tf_dtype);
+  }
+
+  return cb::Error::Success;
+}
+
+cb::Error
 ReadFile(const std::string& path, std::vector<char>* contents)
 {
   std::ifstream in(path, std::ios::in | std::ios::binary);

--- a/src/clients/c++/perf_analyzer/perf_utils.h
+++ b/src/clients/c++/perf_analyzer/perf_utils.h
@@ -82,6 +82,14 @@ enum SharedMemoryType {
 
 constexpr uint64_t NO_LIMIT = 0;
 
+// Converts the datatype from tensorflow to perf analyzer space
+// \param tf_dtype The data type string returned from the model metadata.
+// \param datatype Returns the datatype in perf_analyzer space.
+// \return error status. Returns Non-Ok if an error is encountered during
+//  read operation.
+cb::Error ConvertDTypeFromTFS(
+    const std::string& tf_dtype, std::string* datatype);
+
 // Parse the communication protocol type
 cb::ProtocolType ParseProtocol(const std::string& str);
 

--- a/src/clients/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/clients/c++/perf_analyzer/request_rate_manager.cc
@@ -188,6 +188,7 @@ RequestRateManager::Infer(
   thread_stat->status_ = factory_->CreateClientBackend(&(ctx->infer_backend_));
   ctx->options_.reset(new cb::InferOptions(parser_->ModelName()));
   ctx->options_->model_version_ = parser_->ModelVersion();
+  ctx->options_->model_signature_name_ = parser_->ModelSignatureName();
 
   thread_stat->contexts_stat_.emplace_back();
 


### PR DESCRIPTION
There are two important things to note:
By default, perf_analyzer will use the "serving_default" signature. The model might name the predict engine differently. In this case, use "--model-signature-name" option with perf_client.
The model metadata didn't carry any information regarding whether the first variable dimension is batching or not. I have hence, simplified the logic. The batch dimension, if present, should be provided explicitly to the perf_analyzer using --shape option. For instance, above --shape x:3,1 is generating request of batch size 3 to the model.  One can generate, batch size 10 requests by specifying --shape x:10,1.

**Also, I understand the build is not very clean but it does what it supposed to do. I will address improving the build through another ticket after we are done implementing torchserve.**

perf_analyzer running on TF Serving instance: 

```
root@ffc7411518be:/# /tmp/host/perf_analyzer --service-kind tfserving -m half_plus_two --shape x:3,1 -i grpc -v
*** Measurement Settings ***
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Pass [1] throughput: 3384.2 infer/sec. Avg latency: 294 usec (std 106 usec)
  Pass [2] throughput: 3415.2 infer/sec. Avg latency: 291 usec (std 99 usec)
  Pass [3] throughput: 3390.2 infer/sec. Avg latency: 294 usec (std 107 usec)
  Client: 
    Request count: 16951
    Throughput: 3390.2 infer/sec
    Avg latency: 294 usec (standard deviation 107 usec)
    p50 latency: 267 usec
    p90 latency: 377 usec
    p95 latency: 435 usec
    p99 latency: 633 usec
    Avg gRPC time: 283 usec (marshal 4 usec + response wait 279 usec + unmarshal 0 usec)
Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 3390.2 infer/sec, latency 294 usec
```
