### PR TITLE
TorchServe Client Backend for perf_analyzer

### DIFF
--- a/src/clients/c++/perf_analyzer/client_backend/CMakeLists.txt
+++ b/src/clients/c++/perf_analyzer/client_backend/CMakeLists.txt
@@ -85,6 +85,14 @@ compile_proto(1 "${CMAKE_BINARY_DIR}/protos" "${CMAKE_CURRENT_BINARY_DIR}/compil
 # Including compiled files.
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/compiled)
 
+if(${TRITON_CURL_WITHOUT_CONFIG})
+  find_package(CURL REQUIRED)
+else()
+  find_package(CURL CONFIG REQUIRED)
+endif() # TRITON_CURL_WITHOUT_CONFIG
+message(STATUS "Using curl ${CURL_VERSION}")
+add_definitions(-DCURL_STATICLIB)
+
 set(
   CLIENT_BACKEND_SRCS
   client_backend.cc
@@ -95,6 +103,9 @@ set(
   tensorflow_serving/grpc_client.cc
   ${PB_SOURCES}
   ${PB_GRPC_SOURCES}
+  torchserve/torchserve_client_backend.cc
+  torchserve/torchserve_infer_input.cc
+  torchserve/http_client.cc
 )
 
 set(
@@ -107,6 +118,9 @@ set(
   tensorflow_serving/grpc_client.h
   ${PB_HEADERS} 
   ${PB_GRPC_HEADERS} 
+  torchserve/torchserve_client_backend.h
+  torchserve/torchserve_infer_input.h
+  torchserve/http_client.h
 )
 
 add_library(
@@ -123,7 +137,8 @@ target_link_libraries(
   PRIVATE TRITON::httpclient_static
   PRIVATE gRPC::grpc++
   PRIVATE gRPC::grpc
-  PUBLIC protobuf::libprotobuf
+  PRIVATE protobuf::libprotobuf
+  PRIVATE CURL::libcurl
 
 )
 

--- a/src/clients/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/client_backend.cc
@@ -26,8 +26,8 @@
 
 #include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
 #include "src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h"
+#include "src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h"
 #include "src/clients/c++/perf_analyzer/client_backend/triton/triton_client_backend.h"
-
 
 namespace perfanalyzer { namespace clientbackend {
 
@@ -107,6 +107,9 @@ ClientBackend::Create(
         url, protocol, http_headers, verbose, &local_backend));
   } else if (kind == TENSORFLOW_SERVING) {
     RETURN_IF_CB_ERROR(TFServeClientBackend::Create(
+        url, protocol, http_headers, verbose, &local_backend));
+  } else if (kind == TORCHSERVE) {
+    RETURN_IF_CB_ERROR(TorchServeClientBackend::Create(
         url, protocol, http_headers, verbose, &local_backend));
   } else {
     return Error("unsupported client backend requested");
@@ -294,6 +297,9 @@ InferInput::Create(
   } else if (kind == TENSORFLOW_SERVING) {
     RETURN_IF_CB_ERROR(
         TFServeInferInput::Create(infer_input, name, dims, datatype));
+  } else if (kind == TORCHSERVE) {
+    RETURN_IF_CB_ERROR(
+        TorchServeInferInput::Create(infer_input, name, dims, datatype));
   } else {
     return Error(
         "unsupported client backend provided to create InferInput object");
@@ -356,6 +362,9 @@ InferRequestedOutput::Create(
         TritonInferRequestedOutput::Create(infer_output, name, class_count));
   } else if (kind == TENSORFLOW_SERVING) {
     RETURN_IF_CB_ERROR(TFServeInferRequestedOutput::Create(infer_output, name));
+  } else if (kind == TORCHSERVE) {
+    RETURN_IF_CB_ERROR(
+        TorchServeInferRequestedOutput::Create(infer_output, name));
   } else {
     return Error(
         "unsupported client backend provided to create InferRequestedOutput "

--- a/src/clients/c++/perf_analyzer/client_backend/client_backend.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/client_backend.cc
@@ -362,9 +362,6 @@ InferRequestedOutput::Create(
         TritonInferRequestedOutput::Create(infer_output, name, class_count));
   } else if (kind == TENSORFLOW_SERVING) {
     RETURN_IF_CB_ERROR(TFServeInferRequestedOutput::Create(infer_output, name));
-  } else if (kind == TORCHSERVE) {
-    RETURN_IF_CB_ERROR(
-        TorchServeInferRequestedOutput::Create(infer_output, name));
   } else {
     return Error(
         "unsupported client backend provided to create InferRequestedOutput "

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.cc
@@ -27,7 +27,6 @@
 #include "src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.h"
 #include "src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h"
 
-
 #include <chrono>
 #include <cstdint>
 
@@ -87,7 +86,6 @@ HttpInferRequest::InitializeRequest()
   http_code_ = 400;
   // Prepare buffer to record the response
   infer_response_buffer_.reset(new std::string());
-
   return Error::Success;
 }
 
@@ -117,8 +115,7 @@ HttpClient::Infer(
     request_uri += "/" + options.model_version_;
   }
 
-  std::shared_ptr<HttpInferRequest> sync_request(
-      new HttpInferRequest(nullptr /* callback */, verbose_));
+  std::shared_ptr<HttpInferRequest> sync_request(new HttpInferRequest());
 
   sync_request->Timer().Reset();
   sync_request->Timer().CaptureTimestamp(
@@ -227,7 +224,6 @@ HttpClient::PreRunProcessing(
 
   std::vector<std::string> input_filepaths;
 
-
   curl_easy_setopt(curl, CURLOPT_URL, request_uri.c_str());
   curl_easy_setopt(curl, CURLOPT_USERAGENT, "libcurl-agent/1.0");
   curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
@@ -317,6 +313,7 @@ HttpClient::~HttpClient()
 }
 
 //======================================================================
+
 Error
 InferResult::Create(
     InferResult** infer_result, std::shared_ptr<HttpInferRequest> infer_request)

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.cc
@@ -1,0 +1,347 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.h"
+#include "src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h"
+
+
+#include <chrono>
+#include <cstdint>
+
+namespace perfanalyzer { namespace clientbackend { namespace torchserve {
+
+namespace {
+
+constexpr char kContentLengthHTTPHeader[] = "Content-Length";
+
+//==============================================================================
+
+// Global initialization for libcurl. Libcurl requires global
+// initialization before any other threads are created and before any
+// curl methods are used. The curl_global static object is used to
+// perform this initialization.
+class CurlGlobal {
+ public:
+  CurlGlobal();
+  ~CurlGlobal();
+
+  const Error& Status() const { return err_; }
+
+ private:
+  Error err_;
+};
+
+CurlGlobal::CurlGlobal() : err_(Error::Success)
+{
+  if (curl_global_init(CURL_GLOBAL_ALL) != 0) {
+    err_ = Error("global initialization failed");
+  }
+}
+
+CurlGlobal::~CurlGlobal()
+{
+  curl_global_cleanup();
+}
+
+static CurlGlobal curl_global;
+
+
+}  // namespace
+
+//==============================================================================
+
+HttpInferRequest::~HttpInferRequest()
+{
+  if (header_list_ != nullptr) {
+    curl_slist_free_all(static_cast<curl_slist*>(header_list_));
+    header_list_ = nullptr;
+  }
+}
+
+Error
+HttpInferRequest::InitializeRequest()
+{
+  http_code_ = 400;
+  // Prepare buffer to record the response
+  infer_response_buffer_.reset(new std::string());
+
+  return Error::Success;
+}
+
+
+//==============================================================================
+
+Error
+HttpClient::Create(
+    std::unique_ptr<HttpClient>* client, const std::string& server_url,
+    bool verbose)
+{
+  client->reset(new HttpClient(server_url, verbose));
+  return Error::Success;
+}
+
+Error
+HttpClient::Infer(
+    InferResult** result, const InferOptions& options,
+    const std::vector<InferInput*>& inputs,
+    const std::vector<const InferRequestedOutput*>& outputs,
+    const Headers& headers)
+{
+  Error err;
+
+  std::string request_uri(url_ + "/predictions/" + options.model_name_);
+  if (!options.model_version_.empty()) {
+    request_uri += "/" + options.model_version_;
+  }
+
+  std::shared_ptr<HttpInferRequest> sync_request(
+      new HttpInferRequest(nullptr /* callback */, verbose_));
+
+  sync_request->Timer().Reset();
+  sync_request->Timer().CaptureTimestamp(
+      nic::RequestTimers::Kind::REQUEST_START);
+
+  if (!curl_global.Status().IsOk()) {
+    return curl_global.Status();
+  }
+
+  err = PreRunProcessing(
+      easy_handle_, request_uri, options, inputs, outputs, headers,
+      sync_request);
+  if (!err.IsOk()) {
+    return err;
+  }
+
+  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::SEND_START);
+
+  // During this call SEND_END (except in above case), RECV_START, and
+  // RECV_END will be set.
+  // FIXME: Use the curl_mime_data_cb to correctly capture the send_end time.
+  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::SEND_END);
+  auto curl_status = curl_easy_perform(easy_handle_);
+  if (curl_status != CURLE_OK) {
+    sync_request->http_code_ = 400;
+  } else {
+    curl_easy_getinfo(
+        easy_handle_, CURLINFO_RESPONSE_CODE, &sync_request->http_code_);
+  }
+
+  curl_mime_free(mime_handle_);
+
+  InferResult::Create(result, sync_request);
+
+  sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::REQUEST_END);
+
+  nic::Error nic_err = UpdateInferStat(sync_request->Timer());
+  if (!nic_err.IsOk()) {
+    std::cerr << "Failed to update context stat: " << nic_err << std::endl;
+  }
+
+  err = (*result)->RequestStatus();
+
+  return err;
+}
+
+size_t
+HttpClient::InferResponseHeaderHandler(
+    void* contents, size_t size, size_t nmemb, void* userp)
+{
+  HttpInferRequest* request = reinterpret_cast<HttpInferRequest*>(userp);
+
+  char* buf = reinterpret_cast<char*>(contents);
+  size_t byte_size = size * nmemb;
+
+  size_t idx = strlen(kContentLengthHTTPHeader);
+  if ((idx < byte_size) && !strncasecmp(buf, kContentLengthHTTPHeader, idx)) {
+    while ((idx < byte_size) && (buf[idx] != ':')) {
+      ++idx;
+    }
+
+    if (idx < byte_size) {
+      std::string hdr(buf + idx + 1, byte_size - idx - 1);
+      request->infer_response_buffer_->reserve(std::stoi(hdr));
+    }
+  }
+
+  return byte_size;
+}
+
+size_t
+HttpClient::InferResponseHandler(
+    void* contents, size_t size, size_t nmemb, void* userp)
+{
+  HttpInferRequest* request = reinterpret_cast<HttpInferRequest*>(userp);
+
+  if (request->Timer().Timestamp(nic::RequestTimers::Kind::RECV_START) == 0) {
+    request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::RECV_START);
+  }
+
+  char* buf = reinterpret_cast<char*>(contents);
+  size_t result_bytes = size * nmemb;
+  request->infer_response_buffer_->append(buf, result_bytes);
+
+  // InferResponseHandler may be called multiple times so we overwrite
+  // RECV_END so that we always have the time of the last.
+  request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::RECV_END);
+
+  return result_bytes;
+}
+
+Error
+HttpClient::PreRunProcessing(
+    void* vcurl, std::string& request_uri, const InferOptions& options,
+    const std::vector<InferInput*>& inputs,
+    const std::vector<const InferRequestedOutput*>& outputs,
+    const Headers& headers, std::shared_ptr<HttpInferRequest>& http_request)
+{
+  CURL* curl = reinterpret_cast<CURL*>(vcurl);
+
+  // Prepare the request object to provide the data for inference.
+  Error err = http_request->InitializeRequest();
+  if (!err.IsOk()) {
+    return err;
+  }
+
+  std::vector<std::string> input_filepaths;
+
+
+  curl_easy_setopt(curl, CURLOPT_URL, request_uri.c_str());
+  curl_easy_setopt(curl, CURLOPT_USERAGENT, "libcurl-agent/1.0");
+  curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
+
+  if (verbose_) {
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  }
+
+  const long buffer_byte_size = 16 * 1024 * 1024;
+  curl_easy_setopt(curl, CURLOPT_UPLOAD_BUFFERSIZE, buffer_byte_size);
+  curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, buffer_byte_size);
+
+  // request data provided by InferRequestProvider()
+  mime_handle_ = curl_mime_init(easy_handle_);
+  // Add the buffers holding input tensor data
+  for (const auto input : inputs) {
+    TorchServeInferInput* this_input =
+        dynamic_cast<TorchServeInferInput*>(input);
+    this_input->PrepareForRequest();
+    bool end_of_input = false;
+    while (!end_of_input) {
+      const uint8_t* buf;
+      size_t buf_size;
+      this_input->GetNext(&buf, &buf_size, &end_of_input);
+      std::string file_path(
+          reinterpret_cast<const char*>(buf) + 4, buf_size - 4);
+      if (buf != nullptr) {
+        curl_mimepart* part = curl_mime_addpart((curl_mime*)mime_handle_);
+        curl_mime_filedata(part, file_path.c_str());
+        curl_mime_name(part, "data");
+        if (verbose_) {
+          input_filepaths.push_back(file_path);
+        }
+      }
+    }
+  }
+  curl_easy_setopt(easy_handle_, CURLOPT_MIMEPOST, (curl_mime*)mime_handle_);
+
+  // response headers handled by InferResponseHeaderHandler()
+  curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, InferResponseHeaderHandler);
+  curl_easy_setopt(curl, CURLOPT_HEADERDATA, http_request.get());
+
+  // response data handled by InferResponseHandler()
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, InferResponseHandler);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, http_request.get());
+
+  struct curl_slist* list = nullptr;
+  for (const auto& pr : headers) {
+    std::string hdr = pr.first + ": " + pr.second;
+    list = curl_slist_append(list, hdr.c_str());
+  }
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
+
+  // The list will be freed when the request is destructed
+  http_request->header_list_ = list;
+
+  if (verbose_) {
+    std::cout << "inference request : [";
+    bool first = true;
+    for (const auto& fn : input_filepaths) {
+      if (first) {
+        first = false;
+      } else {
+        std::cout << ",";
+      }
+      std::cout << "\"" << fn << "\"";
+    }
+    std::cout << "]" << std::endl;
+  }
+
+  return Error::Success;
+}
+
+HttpClient::HttpClient(const std::string& url, bool verbose)
+    : InferenceServerClient(verbose), url_(url),
+      easy_handle_(reinterpret_cast<void*>(curl_easy_init()))
+{
+}
+
+HttpClient::~HttpClient()
+{
+  exiting_ = true;
+
+  if (easy_handle_ != nullptr) {
+    curl_easy_cleanup(reinterpret_cast<CURL*>(easy_handle_));
+  }
+}
+
+//======================================================================
+Error
+InferResult::Create(
+    InferResult** infer_result, std::shared_ptr<HttpInferRequest> infer_request)
+{
+  *infer_result =
+      reinterpret_cast<InferResult*>(new InferResult(infer_request));
+  return Error::Success;
+}
+
+Error
+InferResult::RequestStatus() const
+{
+  return status_;
+}
+
+InferResult::InferResult(std::shared_ptr<HttpInferRequest> infer_request)
+    : infer_request_(infer_request)
+{
+  if (infer_request->http_code_ != 200) {
+    status_ = Error(
+        "inference failed with error code " +
+        std::to_string(infer_request->http_code_));
+  }
+}
+
+//======================================================================
+
+}}}  // namespace perfanalyzer::clientbackend::torchserve

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.h
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.h
@@ -1,0 +1,164 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include "src/clients/c++/library/common.h"
+#include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
+#include "src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h"
+
+#include <curl/curl.h>
+
+namespace nic = nvidia::inferenceserver::client;
+
+namespace perfanalyzer { namespace clientbackend { namespace torchserve {
+
+class InferResult;
+class HttpInferRequest;
+
+using TorchServeOnCompleteFn = std::function<void(InferResult*)>;
+
+//==============================================================================
+/// An HttpClient object is used to perform any kind of communication with the
+/// TFserving service using gRPC protocol. None of the functions are thread
+/// safe.
+///
+/// \code
+///   std::unique_ptr<HttpClient> client;
+///   HttpClient::Create(&client, "localhost:8080");
+///   ...
+///   ...
+/// \endcode
+///
+class HttpClient : public nic::InferenceServerClient {
+ public:
+  ~HttpClient();
+
+  /// Create a client that can be used to communicate with the server.
+  /// \param client Returns a new InferenceServerHttpClient object.
+  /// \param server_url The inference server name and port.
+  /// \param verbose If true generate verbose output when contacting
+  /// the inference server.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      std::unique_ptr<HttpClient>* client, const std::string& server_url,
+      const bool verbose);
+
+  /// Run synchronous inference on server.
+  /// \param result Returns the result of inference.
+  /// \param options The options for inference request.
+  /// \param inputs The vector of InferInput describing the model inputs.
+  /// \param outputs Optional vector of InferRequestedOutput describing how the
+  /// output must be returned. If not provided then all the outputs in the model
+  /// config will be returned as default settings.
+  /// \param headers Optional map specifying additional HTTP headers to include
+  /// in the metadata of gRPC request.
+  /// \return Error object indicating success or failure of the
+  /// request.
+  Error Infer(
+      InferResult** result, const InferOptions& options,
+      const std::vector<InferInput*>& inputs,
+      const std::vector<const InferRequestedOutput*>& outputs =
+          std::vector<const InferRequestedOutput*>(),
+      const Headers& headers = Headers());
+
+
+ private:
+  HttpClient(const std::string& url, bool verbose);
+  Error PreRunProcessing(
+      void* curl, std::string& request_uri, const InferOptions& options,
+      const std::vector<InferInput*>& inputs,
+      const std::vector<const InferRequestedOutput*>& outputs,
+      const Headers& headers, std::shared_ptr<HttpInferRequest>& request);
+  static size_t InferResponseHeaderHandler(
+      void* contents, size_t size, size_t nmemb, void* userp);
+  static size_t InferResponseHandler(
+      void* contents, size_t size, size_t nmemb, void* userp);
+
+  // The server url
+  const std::string url_;
+  // curl easy handle shared for all synchronous requests
+  void* easy_handle_;
+  curl_mime* mime_handle_;
+};
+
+//======================================================================
+
+class HttpInferRequest {
+ public:
+  HttpInferRequest(
+      TorchServeOnCompleteFn callback = nullptr, const bool verbose = false)
+      : callback_(callback), verbose_(verbose), header_list_(nullptr),
+        response_json_size_(0)
+  {
+  }
+
+  ~HttpInferRequest();
+
+  Error InitializeRequest();
+  nic::RequestTimers& Timer() { return timer_; }
+  std::string& DebugString() { return *infer_response_buffer_; }
+
+  friend HttpClient;
+  friend InferResult;
+
+ private:
+  TorchServeOnCompleteFn callback_;
+  bool verbose_;
+  // Pointer to the list of the HTTP request header, keep it such that it will
+  // be valid during the transfer and can be freed once transfer is completed.
+  struct curl_slist* header_list_;
+  // HTTP response code for the inference request
+  long http_code_;
+  // Buffer that accumulates the response body.
+  std::unique_ptr<std::string> infer_response_buffer_;
+  size_t response_json_size_;
+  // The timers for infer request.
+  nic::RequestTimers timer_;
+};
+
+//======================================================================
+
+class InferResult {
+ public:
+  static Error Create(
+      InferResult** infer_result,
+      std::shared_ptr<HttpInferRequest> infer_request);
+
+
+  Error RequestStatus() const;
+  Error Id(std::string* id) const;
+  std::string DebugString() const { return infer_request_->DebugString(); }
+
+ private:
+  InferResult(std::shared_ptr<HttpInferRequest> infer_request);
+
+  Error status_;
+  std::shared_ptr<HttpInferRequest> infer_request_;
+};
+
+//======================================================================
+
+}}}  // namespace perfanalyzer::clientbackend::torchserve

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
@@ -1,0 +1,147 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h"
+
+#include "src/clients/c++/examples/json_utils.h"
+
+namespace perfanalyzer { namespace clientbackend {
+
+//==============================================================================
+
+Error
+TorchServeClientBackend::Create(
+    const std::string& url, const ProtocolType protocol,
+    std::shared_ptr<Headers> http_headers, const bool verbose,
+    std::unique_ptr<ClientBackend>* client_backend)
+{
+  if (protocol == ProtocolType::GRPC) {
+    return Error(
+        "perf_analyzer does not support gRPC protocol with TorchServe");
+  }
+  std::unique_ptr<TorchServeClientBackend> torchserve_client_backend(
+      new TorchServeClientBackend(http_headers));
+
+  RETURN_IF_CB_ERROR(ts::HttpClient::Create(
+      &(torchserve_client_backend->http_client_), url, verbose));
+
+  *client_backend = std::move(torchserve_client_backend);
+
+  return Error::Success;
+}
+
+Error
+TorchServeClientBackend::Infer(
+    InferResult** result, const InferOptions& options,
+    const std::vector<InferInput*>& inputs,
+    const std::vector<const InferRequestedOutput*>& outputs)
+{
+  ts::InferResult* torchserve_result;
+  RETURN_IF_CB_ERROR(http_client_->Infer(
+      &torchserve_result, options, inputs, outputs, *http_headers_));
+
+  *result = new TorchServeInferResult(torchserve_result);
+
+  return Error::Success;
+}
+
+Error
+TorchServeClientBackend::ClientInferStat(InferStat* infer_stat)
+{
+  // Reusing the common library utilities to collect and report the
+  // client side statistics.
+  nic::InferStat client_infer_stat;
+
+  RETURN_IF_TRITON_ERROR(http_client_->ClientInferStat(&client_infer_stat));
+
+  ParseInferStat(client_infer_stat, infer_stat);
+
+  return Error::Success;
+}
+
+void
+TorchServeClientBackend::ParseInferStat(
+    const nic::InferStat& torchserve_infer_stat, InferStat* infer_stat)
+{
+  infer_stat->completed_request_count =
+      torchserve_infer_stat.completed_request_count;
+  infer_stat->cumulative_total_request_time_ns =
+      torchserve_infer_stat.cumulative_total_request_time_ns;
+  infer_stat->cumulative_send_time_ns =
+      torchserve_infer_stat.cumulative_send_time_ns;
+  infer_stat->cumulative_receive_time_ns =
+      torchserve_infer_stat.cumulative_receive_time_ns;
+}
+
+//==============================================================================
+
+Error
+TorchServeInferRequestedOutput::Create(
+    InferRequestedOutput** infer_output, const std::string name)
+{
+  TorchServeInferRequestedOutput* local_infer_output =
+      new TorchServeInferRequestedOutput();
+
+  nic::InferRequestedOutput* torchserve_infer_output;
+  RETURN_IF_TRITON_ERROR(
+      nic::InferRequestedOutput::Create(&torchserve_infer_output, name));
+  local_infer_output->output_.reset(torchserve_infer_output);
+
+  *infer_output = local_infer_output;
+
+  return Error::Success;
+}
+
+TorchServeInferRequestedOutput::TorchServeInferRequestedOutput()
+    : InferRequestedOutput(BackendKind::TORCHSERVE)
+{
+}
+
+//==============================================================================
+
+TorchServeInferResult::TorchServeInferResult(ts::InferResult* result)
+{
+  result_.reset(result);
+}
+
+Error
+TorchServeInferResult::Id(std::string* id) const
+{
+  id->clear();
+  return Error::Success;
+}
+
+Error
+TorchServeInferResult::RequestStatus() const
+{
+  RETURN_IF_CB_ERROR(result_->RequestStatus());
+  return Error::Success;
+}
+
+//==============================================================================
+
+
+}}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.cc
@@ -25,7 +25,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h"
-
 #include "src/clients/c++/examples/json_utils.h"
 
 namespace perfanalyzer { namespace clientbackend {
@@ -44,12 +43,9 @@ TorchServeClientBackend::Create(
   }
   std::unique_ptr<TorchServeClientBackend> torchserve_client_backend(
       new TorchServeClientBackend(http_headers));
-
   RETURN_IF_CB_ERROR(ts::HttpClient::Create(
       &(torchserve_client_backend->http_client_), url, verbose));
-
   *client_backend = std::move(torchserve_client_backend);
-
   return Error::Success;
 }
 
@@ -62,9 +58,7 @@ TorchServeClientBackend::Infer(
   ts::InferResult* torchserve_result;
   RETURN_IF_CB_ERROR(http_client_->Infer(
       &torchserve_result, options, inputs, outputs, *http_headers_));
-
   *result = new TorchServeInferResult(torchserve_result);
-
   return Error::Success;
 }
 
@@ -74,11 +68,8 @@ TorchServeClientBackend::ClientInferStat(InferStat* infer_stat)
   // Reusing the common library utilities to collect and report the
   // client side statistics.
   nic::InferStat client_infer_stat;
-
   RETURN_IF_TRITON_ERROR(http_client_->ClientInferStat(&client_infer_stat));
-
   ParseInferStat(client_infer_stat, infer_stat);
-
   return Error::Success;
 }
 
@@ -94,30 +85,6 @@ TorchServeClientBackend::ParseInferStat(
       torchserve_infer_stat.cumulative_send_time_ns;
   infer_stat->cumulative_receive_time_ns =
       torchserve_infer_stat.cumulative_receive_time_ns;
-}
-
-//==============================================================================
-
-Error
-TorchServeInferRequestedOutput::Create(
-    InferRequestedOutput** infer_output, const std::string name)
-{
-  TorchServeInferRequestedOutput* local_infer_output =
-      new TorchServeInferRequestedOutput();
-
-  nic::InferRequestedOutput* torchserve_infer_output;
-  RETURN_IF_TRITON_ERROR(
-      nic::InferRequestedOutput::Create(&torchserve_infer_output, name));
-  local_infer_output->output_.reset(torchserve_infer_output);
-
-  *infer_output = local_infer_output;
-
-  return Error::Success;
-}
-
-TorchServeInferRequestedOutput::TorchServeInferRequestedOutput()
-    : InferRequestedOutput(BackendKind::TORCHSERVE)
-{
 }
 
 //==============================================================================
@@ -142,6 +109,5 @@ TorchServeInferResult::RequestStatus() const
 }
 
 //==============================================================================
-
 
 }}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
@@ -84,26 +84,7 @@ class TorchServeClientBackend : public ClientBackend {
       const nic::InferStat& torchserve_infer_stat, InferStat* infer_stat);
 
   std::unique_ptr<ts::HttpClient> http_client_;
-
   std::shared_ptr<Headers> http_headers_;
-};
-
-//==============================================================
-/// TorchServeInferRequestedOutput is a wrapper around
-/// InferRequestedOutput object of triton common client library.
-///
-class TorchServeInferRequestedOutput : public InferRequestedOutput {
- public:
-  static Error Create(
-      InferRequestedOutput** infer_output, const std::string name);
-  /// Returns the raw InferRequestedOutput object required by torchserve
-  /// client library.
-  nic::InferRequestedOutput* Get() const { return output_.get(); }
-
- private:
-  explicit TorchServeInferRequestedOutput();
-
-  std::unique_ptr<nic::InferRequestedOutput> output_;
 };
 
 //==============================================================

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_client_backend.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+
+#include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
+#include "src/clients/c++/perf_analyzer/perf_utils.h"
+
+#include "src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.h"
+
+#define RETURN_IF_TRITON_ERROR(S)       \
+  do {                                  \
+    const nic::Error& status__ = (S);   \
+    if (!status__.IsOk()) {             \
+      return Error(status__.Message()); \
+    }                                   \
+  } while (false)
+
+namespace nic = nvidia::inferenceserver::client;
+namespace ts = perfanalyzer::clientbackend::torchserve;
+
+namespace perfanalyzer { namespace clientbackend {
+
+//==============================================================================
+/// TorchServeClientBackend is used to generate load on the Torchserve isntance
+///
+class TorchServeClientBackend : public ClientBackend {
+ public:
+  /// Create a torchserve client backend which can be used to interact with the
+  /// server.
+  /// \param url The inference server url and port.
+  /// \param protocol The protocol type used.
+  /// \param http_headers Map of HTTP headers. The map key/value indicates
+  /// the header name/value.
+  /// \param verbose Enables the verbose mode.
+  /// \param client_backend Returns a new TorchServeClientBackend
+  /// object.
+  /// \return Error object indicating success or failure.
+  static Error Create(
+      const std::string& url, const ProtocolType protocol,
+      std::shared_ptr<Headers> http_headers, const bool verbose,
+      std::unique_ptr<ClientBackend>* client_backend);
+
+  /// See ClientBackend::Infer()
+  Error Infer(
+      InferResult** result, const InferOptions& options,
+      const std::vector<InferInput*>& inputs,
+      const std::vector<const InferRequestedOutput*>& outputs) override;
+
+  /// See ClientBackend::ClientInferStat()
+  Error ClientInferStat(InferStat* infer_stat) override;
+
+ private:
+  TorchServeClientBackend(std::shared_ptr<Headers> http_headers)
+      : ClientBackend(BackendKind::TORCHSERVE), http_headers_(http_headers)
+  {
+  }
+
+  void ParseInferStat(
+      const nic::InferStat& torchserve_infer_stat, InferStat* infer_stat);
+
+  std::unique_ptr<ts::HttpClient> http_client_;
+
+  std::shared_ptr<Headers> http_headers_;
+};
+
+//==============================================================
+/// TorchServeInferRequestedOutput is a wrapper around
+/// InferRequestedOutput object of triton common client library.
+///
+class TorchServeInferRequestedOutput : public InferRequestedOutput {
+ public:
+  static Error Create(
+      InferRequestedOutput** infer_output, const std::string name);
+  /// Returns the raw InferRequestedOutput object required by torchserve
+  /// client library.
+  nic::InferRequestedOutput* Get() const { return output_.get(); }
+
+ private:
+  explicit TorchServeInferRequestedOutput();
+
+  std::unique_ptr<nic::InferRequestedOutput> output_;
+};
+
+//==============================================================
+/// TorchServeInferResult is a wrapper around InferResult object of
+/// torchserve InferResult object.
+///
+class TorchServeInferResult : public InferResult {
+ public:
+  explicit TorchServeInferResult(ts::InferResult* result);
+  /// See InferResult::Id()
+  Error Id(std::string* id) const override;
+  /// See InferResult::RequestStatus()
+  Error RequestStatus() const override;
+
+ private:
+  std::unique_ptr<ts::InferResult> result_;
+};
+
+}}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.cc
@@ -35,7 +35,6 @@ TorchServeInferInput::Create(
 {
   TorchServeInferInput* local_infer_input =
       new TorchServeInferInput(name, dims, datatype);
-
   *infer_input = local_infer_input;
   return Error::Success;
 }
@@ -61,10 +60,8 @@ Error
 TorchServeInferInput::AppendRaw(const uint8_t* input, size_t input_byte_size)
 {
   byte_size_ += input_byte_size;
-
   bufs_.push_back(input);
   buf_byte_sizes_.push_back(input_byte_size);
-
   return Error::Success;
 }
 
@@ -97,7 +94,6 @@ TorchServeInferInput::GetNext(
     *input_bytes = 0;
   }
   *end_of_input = (bufs_idx_ >= bufs_.size());
-
   return Error::Success;
 }
 

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.cc
@@ -1,0 +1,111 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h"
+
+namespace perfanalyzer { namespace clientbackend {
+
+Error
+TorchServeInferInput::Create(
+    InferInput** infer_input, const std::string& name,
+    const std::vector<int64_t>& dims, const std::string& datatype)
+{
+  TorchServeInferInput* local_infer_input =
+      new TorchServeInferInput(name, dims, datatype);
+
+  *infer_input = local_infer_input;
+  return Error::Success;
+}
+
+Error
+TorchServeInferInput::SetShape(const std::vector<int64_t>& shape)
+{
+  shape_ = shape;
+  return Error::Success;
+}
+
+Error
+TorchServeInferInput::Reset()
+{
+  bufs_.clear();
+  buf_byte_sizes_.clear();
+  bufs_idx_ = 0;
+  byte_size_ = 0;
+  return Error::Success;
+}
+
+Error
+TorchServeInferInput::AppendRaw(const uint8_t* input, size_t input_byte_size)
+{
+  byte_size_ += input_byte_size;
+
+  bufs_.push_back(input);
+  buf_byte_sizes_.push_back(input_byte_size);
+
+  return Error::Success;
+}
+
+Error
+TorchServeInferInput::ByteSize(size_t* byte_size) const
+{
+  *byte_size = byte_size_;
+  return Error::Success;
+}
+
+Error
+TorchServeInferInput::PrepareForRequest()
+{
+  // Reset position so request sends entire input.
+  bufs_idx_ = 0;
+  buf_pos_ = 0;
+  return Error::Success;
+}
+
+Error
+TorchServeInferInput::GetNext(
+    const uint8_t** buf, size_t* input_bytes, bool* end_of_input)
+{
+  if (bufs_idx_ < bufs_.size()) {
+    *buf = bufs_[bufs_idx_];
+    *input_bytes = buf_byte_sizes_[bufs_idx_];
+    bufs_idx_++;
+  } else {
+    *buf = nullptr;
+    *input_bytes = 0;
+  }
+  *end_of_input = (bufs_idx_ >= bufs_.size());
+
+  return Error::Success;
+}
+
+TorchServeInferInput::TorchServeInferInput(
+    const std::string& name, const std::vector<int64_t>& dims,
+    const std::string& datatype)
+    : InferInput(BackendKind::TORCHSERVE, name, datatype), shape_(dims)
+{
+}
+
+}}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <string>
+
+#include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
+#include "src/clients/c++/perf_analyzer/perf_utils.h"
+
+
+namespace perfanalyzer { namespace clientbackend {
+
+//==============================================================
+/// TorchServeInferInput instance holds the information regarding
+/// model input tensor. In this case the content held will be
+/// the path to the file holding data.
+///
+class TorchServeInferInput : public InferInput {
+ public:
+  static Error Create(
+      InferInput** infer_input, const std::string& name,
+      const std::vector<int64_t>& dims, const std::string& datatype);
+  /// See InferInput::Shape()
+  const std::vector<int64_t>& Shape() const override { return shape_; }
+  /// See InferInput::SetShape()
+  Error SetShape(const std::vector<int64_t>& shape) override;
+  /// See InferInput::Reset()
+  Error Reset() override;
+  /// See InferInput::AppendRaw()
+  Error AppendRaw(const uint8_t* input, size_t input_byte_size) override;
+  /// Gets the size of data added into this input in bytes.
+  /// \param byte_size The size of data added in bytes.
+  /// \return Error object indicating success or failure.
+  Error ByteSize(size_t* byte_size) const;
+  /// Resets the heads to start providing data from the begining.
+  Error PrepareForRequest();
+  /// Get the next chunk of data if available.
+  Error GetNext(const uint8_t** buf, size_t* input_bytes, bool* end_of_input);
+
+ private:
+  explicit TorchServeInferInput(
+      const std::string& name, const std::vector<int64_t>& dims,
+      const std::string& datatype);
+
+  std::vector<int64_t> shape_;
+  size_t byte_size_;
+
+  size_t bufs_idx_, buf_pos_;
+  std::vector<const uint8_t*> bufs_;
+  std::vector<size_t> buf_byte_sizes_;
+};
+
+}}  // namespace perfanalyzer::clientbackend

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/torchserve_infer_input.h
@@ -30,7 +30,6 @@
 #include "src/clients/c++/perf_analyzer/client_backend/client_backend.h"
 #include "src/clients/c++/perf_analyzer/perf_utils.h"
 
-
 namespace perfanalyzer { namespace clientbackend {
 
 //==============================================================
@@ -67,7 +66,6 @@ class TorchServeInferInput : public InferInput {
 
   std::vector<int64_t> shape_;
   size_t byte_size_;
-
   size_t bufs_idx_, buf_pos_;
   std::vector<const uint8_t*> bufs_;
   std::vector<size_t> buf_byte_sizes_;

--- a/src/clients/c++/perf_analyzer/main.cc
+++ b/src/clients/c++/perf_analyzer/main.cc
@@ -283,7 +283,7 @@ Usage(char** argv, const std::string& msg = std::string())
              "a json file holding data in the following format {\"data\" : "
              "[{\"TORCHSERVE_INPUT\" : [\"<complete path to the content "
              "file>\"]}, {...}...]}. The type of file here will depend on the "
-             " model. ",
+             "model.",
              18)
       << std::endl;
 

--- a/src/clients/c++/perf_analyzer/model_parser.h
+++ b/src/clients/c++/perf_analyzer/model_parser.h
@@ -100,6 +100,10 @@ class ModelParser {
       const std::unordered_map<std::string, std::vector<int64_t>>& input_shapes,
       std::unique_ptr<cb::ClientBackend>& backend);
 
+  cb::Error InitTorchServe(
+      const std::string& model_name, const std::string& model_version,
+      const int32_t batch_size);
+
   /// Get the name of the target model
   /// \return Model name as string
   const std::string& ModelName() const { return model_name_; }


### PR DESCRIPTION
```
root@71e48591fdfc:/# /tmp/host/perf_analyzer -m densenet161 -u localhost:8080 --service-kind torchserve --input-data input_data.json -b 8
 Successfully read data for 1 stream/streams with 1 step/steps.
*** Measurement Settings ***
  Batch size: 8
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 42
    Throughput: 67.2 infer/sec
    Avg latency: 118069 usec (standard deviation 11192 usec)
    p50 latency: 117551 usec
    p90 latency: 133335 usec
    p95 latency: 138522 usec
    p99 latency: 143168 usec
    Avg HTTP time: 118595 usec (send/recv 0 usec + response wait 118595 usec)
Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 67.2 infer/sec, latency 118069 usec
```

I need to run some experiments for tuning. Probably, curl_mime_filedata is more performant than directly providing the data in the body. 
~~I was having some trouble in implementing the latter case. Will try to resolve the issue and come up with the numbers.~~
Need to revisit this later. Should directly provide the filename for torchserver for now.