### PR TITLE
Remove PyTorch from LD_LIBRARY_PATH; Fix PyTorch custom op docs

### DIFF
--- a/build.py
+++ b/build.py
@@ -681,12 +681,6 @@ LABEL com.nvidia.tritonserver.version="${{TRITON_SERVER_VERSION}}"
 ENV PATH /opt/tritonserver/bin:${{PATH}}
 '''.format(argmap['TRITON_VERSION'], argmap['TRITON_CONTAINER_VERSION'],
            argmap['BASE_IMAGE'])
-    if 'pytorch' in backends:
-        df += '''
-# Need to include pytorch in LD_LIBRARY_PATH since Torchvision loads custom
-# ops from that path
-ENV LD_LIBRARY_PATH /opt/tritonserver/backends/pytorch/:$LD_LIBRARY_PATH
-'''
     df += '''
 ENV TF_ADJUST_HUE_FUSED         1
 ENV TF_ADJUST_SATURATION_FUSED  1

--- a/docs/custom_operations.md
+++ b/docs/custom_operations.md
@@ -148,7 +148,9 @@ is currently no way to handle it.
 Starting with the 20.07 release of Triton the [TorchVision
 operations](https://github.com/pytorch/vision) will be included with
 the PyTorch backend and hence they do not have to be explicitly added
-as custom operations.
+as custom operations. The Pytorch shared libraries must be available
+for the TorchVision custom operations to be loaded. To do this,
+we must add /opt/tritonserver/backends/pytorch to the LD_LIBRARY_PATH.
 
 When building the custom operations shared library it is important to
 use the same version of PyTorch as is being used in Triton. You can

--- a/docs/custom_operations.md
+++ b/docs/custom_operations.md
@@ -121,22 +121,16 @@ follow the instructions in the
 [pytorch/extension-script](https://github.com/pytorch/extension-script)
 repository and your Torchscript custom operations are compiled into
 libpytcustom.so, starting Triton with the following command makes
-those operations available to all PyTorch models.
+those operations available to all PyTorch models. Since all Pytorch
+custom operations depend on one or more PyTorch shared libraries
+that must be available to the custom shared library when it is
+loading. In practice this means that you must make sure that
+/opt/tritonserver/backends/pytorch is on the library path while
+launching the server. There are several ways to control the library path
+and a common one is to use the LD_LIBRARY_PATH.
 
 ```bash
-$ LD_PRELOAD=libpytcustom.so tritonserver --model-repository=/tmp/models ...
-```
-
-All PyTorch custom operations depend on one or more PyTorch shared
-libraries that must be available to the custom shared library when it
-is loading. In practice this means that you must make sure that
-/opt/tritonserver/backends/pytorch is on the library path before issuing
-the above command. There are several ways to control the library path
-and a common one is to use the LD_LIBRARY_PATH. You can set
-LD_LIBRARY_PATH in the "docker run" command or inside the container.
-
-```bash
-$ export LD_LIBRARY_PATH=/opt/tritonserver/backends/pytorch:$LD_LIBRARY_PATH
+$ LD_LIBRARY_PATH=/opt/tritonserver/backends/pytorch:$LD_LIBRARY_PATH LD_PRELOAD=libpytcustom.so tritonserver --model-repository=/tmp/models ...
 ```
 
 A limitation of this approach is that the custom operations must be
@@ -148,9 +142,7 @@ is currently no way to handle it.
 Starting with the 20.07 release of Triton the [TorchVision
 operations](https://github.com/pytorch/vision) will be included with
 the PyTorch backend and hence they do not have to be explicitly added
-as custom operations. The Pytorch shared libraries must be available
-for the TorchVision custom operations to be loaded. To do this,
-we must add /opt/tritonserver/backends/pytorch to the LD_LIBRARY_PATH.
+as custom operations.
 
 When building the custom operations shared library it is important to
 use the same version of PyTorch as is being used in Triton. You can

--- a/qa/L0_custom_ops/test.sh
+++ b/qa/L0_custom_ops/test.sh
@@ -138,7 +138,8 @@ kill $SERVER_PID
 wait $SERVER_PID
 
 # ONNX
-mkdir -p onnx_custom_ops/custom_op/1 && \
+rm -rf onnx_custom_ops && \
+    mkdir -p onnx_custom_ops/custom_op/1 && \
     cp custom_op_test.onnx onnx_custom_ops/custom_op/1/model.onnx
 
 touch onnx_custom_ops/custom_op/config.pbtxt

--- a/qa/L0_custom_ops/test.sh
+++ b/qa/L0_custom_ops/test.sh
@@ -53,8 +53,8 @@ rm -f $SERVER_LOG $CLIENT_LOG
 RET=0
 
 # Must explicitly set LD_LIBRARY_PATH so that the custom operations
-# can find libtensorflow_framework.so and pytorch libraries.
-LD_LIBRARY_PATH=/opt/tritonserver/backends/tensorflow1:/opt/tritonserver/backends/pytorch:$LD_LIBRARY_PATH
+# can find libtensorflow_framework.so.
+LD_LIBRARY_PATH=/opt/tritonserver/backends/tensorflow1:$LD_LIBRARY_PATH
 
 # Tensorflow
 SERVER_ARGS="--model-repository=/data/inferenceserver/${REPO_VERSION}/qa_custom_ops/tf_custom_ops"
@@ -101,6 +101,10 @@ set -e
 
 kill $SERVER_PID
 wait $SERVER_PID
+
+# Must set LD_LIBRARY_PATH just for the server launch so that the 
+# custom operations can find libtorch.so and other pytorch dependencies.
+LD_LIBRARY_PATH=/opt/tritonserver/backends/pytorch:$LD_LIBRARY_PATH
 
 # Pytorch
 SERVER_ARGS="--model-repository=/data/inferenceserver/${REPO_VERSION}/qa_custom_ops/libtorch_custom_ops"


### PR DESCRIPTION
 User must add Pytorch libs to LD_LIBRARY_PATH to load models with custom ops. Not needed for torchvision default ops.