### PR TITLE
Fixing the sequence flag setup in perf_analyzer

### DIFF
--- a/qa/L0_perf_analyzer/test.sh
+++ b/qa/L0_perf_analyzer/test.sh
@@ -577,6 +577,14 @@ fi
 kill $SERVER_PID
 wait $SERVER_PID
 
+# Test whether there was a conflict in sending sequences
+SERVER_ERROR_STRING="The previous sequence did not end before this sequence start"
+if [ $(cat $SERVER_LOG |  grep "${SERVER_ERROR_STRING}" | wc -l) -ne 0 ]; then
+    cat $SERVER_LOG |  grep "${SERVER_ERROR_STRING}"
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
 if [ $RET -eq 0 ]; then
   echo -e "\n***\n*** Test Passed\n***"
 else

--- a/src/clients/c++/perf_analyzer/concurrency_manager.cc
+++ b/src/clients/c++/perf_analyzer/concurrency_manager.cc
@@ -315,17 +315,7 @@ ConcurrencyManager::Infer(
 
         {
           std::lock_guard<std::mutex> guard(sequence_stat_[seq_id]->mtx_);
-          if (sequence_stat_[seq_id]->remaining_queries_ == 0) {
-            ctxs[ctx_id]->options_->sequence_start_ = true;
-            InitNewSequence(seq_id);
-          }
-          if (sequence_stat_[seq_id]->remaining_queries_ == 1) {
-            ctxs[ctx_id]->options_->sequence_end_ = true;
-          }
-
-          // Set the sequence id in the options.
-          ctxs[ctx_id]->options_->sequence_id_ =
-              sequence_stat_[seq_id]->seq_id_;
+          SetInferSequenceOptions(seq_id, ctxs[ctx_id]->options_);
 
           // Update the inputs if required
           if (using_json_data_) {

--- a/src/clients/c++/perf_analyzer/load_manager.cc
+++ b/src/clients/c++/perf_analyzer/load_manager.cc
@@ -660,6 +660,20 @@ LoadManager::SetInputsSharedMemory(
 }
 
 void
+LoadManager::SetInferSequenceOptions(
+    const uint32_t seq_id, std::unique_ptr<cb::InferOptions>& options)
+{
+  options->sequence_start_ = (sequence_stat_[seq_id]->remaining_queries_ == 0);
+  options->sequence_end_ = (sequence_stat_[seq_id]->remaining_queries_ == 1);
+
+  // New sequence must be intialized before setting the id.
+  if (options->sequence_start_) {
+    InitNewSequence(seq_id);
+  }
+  options->sequence_id_ = sequence_stat_[seq_id]->seq_id_;
+}
+
+void
 LoadManager::InitNewSequence(int sequence_id)
 {
   sequence_stat_[sequence_id]->seq_id_ = next_seq_id_++;

--- a/src/clients/c++/perf_analyzer/load_manager.h
+++ b/src/clients/c++/perf_analyzer/load_manager.h
@@ -154,6 +154,8 @@ class LoadManager {
   cb::Error UpdateInputs(
       std::vector<cb::InferInput*>& inputs, int stream_index, int step_index);
 
+  void SetInferSequenceOptions(
+      const uint32_t seq_id, std::unique_ptr<cb::InferOptions>& options);
   void InitNewSequence(int sequence_id);
 
   /// Generate random sequence length based on 'offset_ratio' and

--- a/src/clients/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/clients/c++/perf_analyzer/request_rate_manager.cc
@@ -299,15 +299,7 @@ RequestRateManager::Infer(
       // Need lock to protect the order of dispatch across worker threads.
       // This also helps in reporting the realistic latencies.
       std::lock_guard<std::mutex> guard(sequence_stat_[seq_id]->mtx_);
-      if (sequence_stat_[seq_id]->remaining_queries_ == 0) {
-        ctx->options_->sequence_start_ = true;
-        InitNewSequence(seq_id);
-      }
-      if (sequence_stat_[seq_id]->remaining_queries_ == 1) {
-        ctx->options_->sequence_end_ = true;
-      }
-
-      ctx->options_->sequence_id_ = sequence_stat_[seq_id]->seq_id_;
+      SetInferSequenceOptions(seq_id, ctx->options_);
 
       // Update the inputs if required
       if (using_json_data_) {

--- a/src/clients/c++/perf_analyzer/request_rate_manager.cc
+++ b/src/clients/c++/perf_analyzer/request_rate_manager.cc
@@ -299,24 +299,26 @@ RequestRateManager::Infer(
       // Need lock to protect the order of dispatch across worker threads.
       // This also helps in reporting the realistic latencies.
       std::lock_guard<std::mutex> guard(sequence_stat_[seq_id]->mtx_);
-      SetInferSequenceOptions(seq_id, ctx->options_);
+      if (!early_exit) {
+        SetInferSequenceOptions(seq_id, ctx->options_);
 
-      // Update the inputs if required
-      if (using_json_data_) {
-        int step_id = data_loader_->GetTotalSteps(
-                          sequence_stat_[seq_id]->data_stream_id_) -
-                      sequence_stat_[seq_id]->remaining_queries_;
-        thread_stat->status_ = UpdateInputs(
-            ctx->inputs_, sequence_stat_[seq_id]->data_stream_id_, step_id);
-        if (!thread_stat->status_.IsOk()) {
-          return;
+        // Update the inputs if required
+        if (using_json_data_) {
+          int step_id = data_loader_->GetTotalSteps(
+                            sequence_stat_[seq_id]->data_stream_id_) -
+                        sequence_stat_[seq_id]->remaining_queries_;
+          thread_stat->status_ = UpdateInputs(
+              ctx->inputs_, sequence_stat_[seq_id]->data_stream_id_, step_id);
+          if (!thread_stat->status_.IsOk()) {
+            return;
+          }
         }
-      }
 
-      Request(
-          ctx, request_id++, delayed, callback_func, async_req_map,
-          thread_stat);
-      sequence_stat_[seq_id]->remaining_queries_--;
+        Request(
+            ctx, request_id++, delayed, callback_func, async_req_map,
+            thread_stat);
+        sequence_stat_[seq_id]->remaining_queries_--;
+      }
     } else {
       Request(
           ctx, request_id++, delayed, callback_func, async_req_map,
@@ -330,6 +332,7 @@ RequestRateManager::Infer(
              i += thread_config->stride_) {
           std::lock_guard<std::mutex> guard(sequence_stat_[i]->mtx_);
           if (sequence_stat_[i]->remaining_queries_ != 0) {
+            ctx->options_->sequence_start_ = false;
             ctx->options_->sequence_end_ = true;
             ctx->options_->sequence_id_ = sequence_stat_[i]->seq_id_;
             Request(


### PR DESCRIPTION
This was a glaring bug with the sequence flags in the options not being reset to false in the perf_analyzer. Fixed the bug. This might change some of the performance measurements on sequence models.