### PR TITLE
Fix the perf_analyzer for non-batching TFServing models

### DIFF
--- a/src/clients/c++/perf_analyzer/inference_profiler.cc
+++ b/src/clients/c++/perf_analyzer/inference_profiler.cc
@@ -729,7 +729,7 @@ InferenceProfiler::SummarizeClientStat(
   summary.on_sequence_model =
       ((parser_->SchedulerType() == ModelParser::SEQUENCE) ||
        (parser_->SchedulerType() == ModelParser::ENSEMBLE_SEQUENCE));
-  summary.batch_size = manager_->BatchSize();
+  summary.batch_size = std::max(manager_->BatchSize(), (size_t)1);
   summary.client_stats.request_count = valid_request_count;
   summary.client_stats.sequence_count = valid_sequence_count;
   summary.client_stats.delayed_request_count = delayed_request_count;

--- a/src/clients/c++/perf_analyzer/main.cc
+++ b/src/clients/c++/perf_analyzer/main.cc
@@ -1096,7 +1096,6 @@ main(int argc, char** argv)
       return 1;
     } else if (!using_batch_size) {
       batch_size = 0;
-      return 1;
     }
   } else if (kind == cb::TORCHSERVE) {
     if (user_data.empty()) {


### PR DESCRIPTION
```
root@e0b4737f4a08:/work# /tmp/host/perf_analyzer  -m resnet50v1.5_fp16_savedmodel --service-kind tfserving -i grpc --shape input:4,224,224,3
*** Measurement Settings ***
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 526
    Throughput: 105.2 infer/sec
    Avg latency: 9506 usec (standard deviation 303 usec)
    p50 latency: 9440 usec
    p90 latency: 9915 usec
    p95 latency: 10133 usec
    p99 latency: 10571 usec
    Avg gRPC time: 9477 usec ((un)marshal request/response 828 usec + response wait 8649 usec)
Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 105.2 infer/sec, latency 9506 usec
```