### PR TITLE
Fix memory leak in python client shared memory

### DIFF
--- a/src/clients/python/library/tritonclient/utils/shared_memory/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/shared_memory/__init__.py
@@ -252,8 +252,8 @@ class SharedMemoryException(Exception):
             -2: "unable to get shared memory descriptor",
             -3: "unable to initialize the size",
             -4: "unable to read/mmap the shared memory region",
-            -5: "unable to munmap the shared memory region",
-            -6: "unable to unlink the shared memory region"
+            -5: "unable to unlink the shared memory region",
+            -6: "unable to munmap the shared memory region"
         }
         self._msg = None
         if type(err) == str:

--- a/src/clients/python/library/tritonclient/utils/shared_memory/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/shared_memory/__init__.py
@@ -252,7 +252,8 @@ class SharedMemoryException(Exception):
             -2: "unable to get shared memory descriptor",
             -3: "unable to initialize the size",
             -4: "unable to read/mmap the shared memory region",
-            -5: "unable to unlink the shared memory region"
+            -5: "unable to munmap the shared memory region",
+            -6: "unable to unlink the shared memory region"
         }
         self._msg = None
         if type(err) == str:

--- a/src/clients/python/library/tritonclient/utils/shared_memory/shared_memory.cc
+++ b/src/clients/python/library/tritonclient/utils/shared_memory/shared_memory.cc
@@ -130,12 +130,21 @@ GetSharedMemoryHandleInfo(
 int
 SharedMemoryRegionDestroy(void* shm_handle)
 {
-  std::string shm_key =
-      reinterpret_cast<SharedMemoryHandle*>(shm_handle)->shm_key_;
-  int shm_fd = shm_unlink(shm_key.c_str());
-  if (shm_fd == -1) {
+  SharedMemoryHandle* handle =
+      reinterpret_cast<SharedMemoryHandle*>(shm_handle);
+  char* shm_addr = reinterpret_cast<char*>(handle->base_addr_);
+  size_t byte_size = handle->byte_size_;
+  int status = munmap(shm_addr, byte_size);
+  if (status == -1) {
     return -5;
   }
+
+  std::string shm_key = handle->shm_key_.c_str();
+  int shm_fd = shm_unlink(shm_key.c_str());
+  if (shm_fd == -1) {
+    return -6;
+  }
+
   return 0;
 }
 

--- a/src/clients/python/library/tritonclient/utils/shared_memory/shared_memory.cc
+++ b/src/clients/python/library/tritonclient/utils/shared_memory/shared_memory.cc
@@ -132,15 +132,13 @@ SharedMemoryRegionDestroy(void* shm_handle)
 {
   SharedMemoryHandle* handle =
       reinterpret_cast<SharedMemoryHandle*>(shm_handle);
-  char* shm_addr = reinterpret_cast<char*>(handle->base_addr_);
-  size_t byte_size = handle->byte_size_;
-  int status = munmap(shm_addr, byte_size);
+  void* shm_addr = reinterpret_cast<char*>(handle->base_addr_);
+  int status = munmap(shm_addr, handle->byte_size_);
   if (status == -1) {
     return -6;
   }
 
-  std::string shm_key = handle->shm_key_.c_str();
-  int shm_fd = shm_unlink(shm_key.c_str());
+  int shm_fd = shm_unlink(handle->shm_key_.c_str());
   if (shm_fd == -1) {
     return -5;
   }

--- a/src/clients/python/library/tritonclient/utils/shared_memory/shared_memory.cc
+++ b/src/clients/python/library/tritonclient/utils/shared_memory/shared_memory.cc
@@ -136,13 +136,13 @@ SharedMemoryRegionDestroy(void* shm_handle)
   size_t byte_size = handle->byte_size_;
   int status = munmap(shm_addr, byte_size);
   if (status == -1) {
-    return -5;
+    return -6;
   }
 
   std::string shm_key = handle->shm_key_.c_str();
   int shm_fd = shm_unlink(shm_key.c_str());
   if (shm_fd == -1) {
-    return -6;
+    return -5;
   }
 
   return 0;


### PR DESCRIPTION
- must munmap before shm_unlink