### PR TITLE
Persistently load some backends even if no corresponding model is loaded

### DIFF
--- a/src/backends/backend/CMakeLists.txt
+++ b/src/backends/backend/CMakeLists.txt
@@ -31,8 +31,9 @@ cmake_minimum_required (VERSION 3.18)
 #
 set(
   BACKEND_SRCS
-  triton_memory_manager.cc
+  triton_backend_config.cc
   triton_backend_manager.cc
+  triton_memory_manager.cc
   triton_model.cc
   triton_model_instance.cc
 )
@@ -40,8 +41,9 @@ set(
 set(
   BACKEND_HDRS
   backend_factory.h
-  triton_memory_manager.h
+  triton_backend_config.h
   triton_backend_manager.h
+  triton_memory_manager.h
   triton_model.h
   triton_model_instance.h
 )

--- a/src/backends/backend/triton_backend_config.cc
+++ b/src/backends/backend/triton_backend_config.cc
@@ -1,0 +1,187 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/backends/backend/triton_backend_config.h"
+
+#include "src/core/logging.h"
+#include "src/core/model_config.h"
+#include "src/core/status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+Status
+BackendConfiguration(
+    const BackendCmdlineConfig& config, const std::string& key,
+    std::string* val)
+{
+  for (const auto& pr : config) {
+    if (pr.first == key) {
+      *val = pr.second;
+      return Status::Success;
+    }
+  }
+
+  return Status(
+      Status::Code::INTERNAL,
+      std::string("unable to find common backend configuration for '") + key +
+          "'");
+}
+
+Status
+BackendConfigurationParseStringToDouble(const std::string& str, double* val)
+{
+  try {
+    *val = std::stod(str);
+  }
+  catch (...) {
+    return Status(
+        Status::Code::INTERNAL,
+        "unable to parse common backend configuration as double");
+  }
+
+  return Status::Success;
+}
+
+Status
+BackendConfigurationParseStringToBool(const std::string& str, bool* val)
+{
+  try {
+    std::string lowercase_str{str};
+    std::transform(
+        lowercase_str.begin(), lowercase_str.end(), lowercase_str.begin(),
+        [](unsigned char c) { return std::tolower(c); });
+    *val = (lowercase_str == "true");
+  }
+  catch (...) {
+    return Status(
+        Status::Code::INTERNAL,
+        "unable to parse common backend configuration as bool");
+  }
+
+  return Status::Success;
+}
+
+Status
+BackendConfigurationGlobalBackendsDirectory(
+    const BackendCmdlineConfigMap& config_map, std::string* dir)
+{
+  const auto& itr = config_map.find(std::string());
+  if (itr == config_map.end()) {
+    return Status(
+        Status::Code::INTERNAL,
+        "unable to find global backends directory configuration");
+  }
+
+  RETURN_IF_ERROR(BackendConfiguration(itr->second, "backend-directory", dir));
+
+  return Status::Success;
+}
+
+Status
+BackendConfigurationMinComputeCapability(
+    const BackendCmdlineConfigMap& config_map, double* mcc)
+{
+#ifdef TRITON_ENABLE_GPU
+  *mcc = TRITON_MIN_COMPUTE_CAPABILITY;
+#else
+  *mcc = 0;
+#endif  // TRITON_ENABLE_GPU
+
+  const auto& itr = config_map.find(std::string());
+  if (itr == config_map.end()) {
+    return Status(
+        Status::Code::INTERNAL, "unable to find common backend configuration");
+  }
+
+  std::string min_compute_capability_str;
+  RETURN_IF_ERROR(BackendConfiguration(
+      itr->second, "min-compute-capability", &min_compute_capability_str));
+  RETURN_IF_ERROR(
+      BackendConfigurationParseStringToDouble(min_compute_capability_str, mcc));
+
+  return Status::Success;
+}
+
+Status
+BackendConfigurationAutoCompleteConfig(
+    const BackendCmdlineConfigMap& config_map, bool* acc)
+{
+  const auto& itr = config_map.find(std::string());
+  if (itr == config_map.end()) {
+    return Status(
+        Status::Code::INTERNAL, "unable to find auto-complete configuration");
+  }
+
+  std::string auto_complete_config_str;
+  RETURN_IF_ERROR(BackendConfiguration(
+      itr->second, "auto-complete-config", &auto_complete_config_str));
+  RETURN_IF_ERROR(
+      BackendConfigurationParseStringToBool(auto_complete_config_str, acc));
+
+  return Status::Success;
+}
+
+Status
+BackendConfigurationSpecializeBackendName(
+    const BackendCmdlineConfigMap& config_map, const std::string& backend_name,
+    std::string* specialized_name)
+{
+  *specialized_name = backend_name;
+  if (backend_name == "tensorflow") {
+    std::string tf_version_str = "1";
+    const auto& itr = config_map.find("tensorflow");
+    if (itr != config_map.end()) {
+      if (BackendConfiguration(itr->second, "version", &tf_version_str)
+              .IsOk()) {
+        if ((tf_version_str != "1") && (tf_version_str != "2")) {
+          return Status(
+              Status::Code::INVALID_ARG,
+              "unexpected TensorFlow library version '" + tf_version_str +
+                  "', expects 1 or 2.");
+        }
+      }
+    }
+
+    *specialized_name += tf_version_str;
+  }
+
+  return Status::Success;
+}
+
+Status
+BackendConfigurationBackendLibraryName(
+    const std::string& backend_name, std::string* libname)
+{
+#ifdef _WIN32
+  *libname = "triton_" + backend_name + ".dll";
+#else
+  *libname = "libtriton_" + backend_name + ".so";
+#endif
+
+  return Status::Success;
+}
+
+}}  // namespace nvidia::inferenceserver

--- a/src/backends/backend/triton_backend_config.h
+++ b/src/backends/backend/triton_backend_config.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include "src/core/model_config.h"
+#include "src/core/status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+/// Get a key's string value from a backend configuration.
+Status BackendConfiguration(
+    const BackendCmdlineConfig& config, const std::string& key,
+    std::string* val);
+
+/// Convert a backend configuration string  value into a double.
+Status BackendConfigurationParseStringToDouble(
+    const std::string& str, double* val);
+
+/// Convert a backend configuration string  value into a bool.
+Status BackendConfigurationParseStringToBool(const std::string& str, bool* val);
+
+/// Get the global backends directory from the backend configuration.
+Status BackendConfigurationGlobalBackendsDirectory(
+    const BackendCmdlineConfigMap& config_map, std::string* dir);
+
+/// Get the minimum compute capability from the backend configuration.
+Status BackendConfigurationMinComputeCapability(
+    const BackendCmdlineConfigMap& config_map, double* mcc);
+
+/// Get the model configuration auto-complete setting from the backend
+/// configuration.
+Status BackendConfigurationAutoCompleteConfig(
+    const BackendCmdlineConfigMap& config_map, bool* acc);
+
+/// Convert a backend name to the specialized version of that name
+/// based on the backend configuration. For example, "tensorflow" will
+/// convert to either "tensorflow1" or "tensorflow2" depending on how
+/// tritonserver is run.
+Status BackendConfigurationSpecializeBackendName(
+    const BackendCmdlineConfigMap& config_map, const std::string& backend_name,
+    std::string* specialized_name);
+
+/// Return the shared library name for a backend.
+Status BackendConfigurationBackendLibraryName(
+    const std::string& backend_name, std::string* libname);
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -144,6 +144,7 @@ set(
   metrics.cc
   model_config_utils.cc
   model_repository_manager.cc
+  persistent_backend_manager.cc
   pinned_memory_manager.cc
   scheduler_utils.cc
   sequence_batch_scheduler.cc
@@ -176,6 +177,7 @@ set(
   model_config_utils.h
   model_repository_manager.h
   nvtx.h
+  persistent_backend_manager.h
   pinned_memory_manager.h
   response_allocator.h
   sync_queue.h

--- a/src/core/persistent_backend_manager.cc
+++ b/src/core/persistent_backend_manager.cc
@@ -1,0 +1,108 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/core/persistent_backend_manager.h"
+
+#include <memory>
+#include <mutex>
+#include "src/backends/backend/triton_backend_config.h"
+#include "src/core/filesystem.h"
+#include "src/core/logging.h"
+
+namespace nvidia { namespace inferenceserver {
+
+static std::weak_ptr<PersistentBackendManager> persist_backend_manager_;
+static std::mutex mu_;
+
+Status
+PersistentBackendManager::Create(
+    const BackendCmdlineConfigMap& config_map,
+    std::shared_ptr<PersistentBackendManager>* manager)
+{
+  std::lock_guard<std::mutex> lock(mu_);
+
+  // If there is already a manager then we just use it...
+  *manager = persist_backend_manager_.lock();
+  if (*manager != nullptr) {
+    return Status::Success;
+  }
+
+  manager->reset(new PersistentBackendManager());
+  persist_backend_manager_ = *manager;
+
+  RETURN_IF_ERROR((*manager)->InitPersistentBackends(config_map));
+  return Status::Success;
+}
+
+Status
+PersistentBackendManager::InitPersistentBackends(
+    const BackendCmdlineConfigMap& config_map)
+{
+  for (const auto& be : {"pytorch", "tensorflow", "onnxruntime"}) {
+    RETURN_IF_ERROR(InitPersistentBackend(be, config_map));
+  }
+
+  return Status::Success;
+}
+
+Status
+PersistentBackendManager::InitPersistentBackend(
+    const std::string& backend_name, const BackendCmdlineConfigMap& config_map)
+{
+  std::string backends_dir;
+  std::string specialized_backend_name;
+  std::string backend_libname;
+  RETURN_IF_ERROR(
+      BackendConfigurationGlobalBackendsDirectory(config_map, &backends_dir));
+  RETURN_IF_ERROR(BackendConfigurationSpecializeBackendName(
+      config_map, backend_name, &specialized_backend_name));
+  RETURN_IF_ERROR(BackendConfigurationBackendLibraryName(
+      specialized_backend_name, &backend_libname));
+
+  const auto backend_dir = JoinPath({backends_dir, specialized_backend_name});
+  const auto backend_libpath = JoinPath({backend_dir, backend_libname});
+  bool exists = false;
+  RETURN_IF_ERROR(FileExists(backend_libpath, &exists));
+  if (exists) {
+    BackendCmdlineConfig empty_backend_cmdline_config;
+    const BackendCmdlineConfig* config;
+    const auto& itr = config_map.find(backend_name);
+    if (itr == config_map.end()) {
+      config = &empty_backend_cmdline_config;
+    } else {
+      config = &itr->second;
+    }
+
+    std::shared_ptr<TritonBackend> persist_backend;
+    RETURN_IF_ERROR(TritonBackendManager::CreateBackend(
+        backend_name, backend_dir, backend_libpath, *config, &persist_backend));
+    persist_backends_.push_back(persist_backend);
+  }
+
+  return Status::Success;
+}
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/persistent_backend_manager.h
+++ b/src/core/persistent_backend_manager.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <list>
+#include "src/backends/backend/triton_backend_manager.h"
+#include "src/core/constants.h"
+#include "src/core/model_config.h"
+#include "src/core/status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+//
+// A single manager across all InferenceServer objects that keeps the
+// persistent backends loaded as long as there is at least one
+// InferenceServer object.
+//
+class PersistentBackendManager {
+ public:
+  static Status Create(
+      const BackendCmdlineConfigMap& config_map,
+      std::shared_ptr<PersistentBackendManager>* manager);
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(PersistentBackendManager);
+  PersistentBackendManager() = default;
+  Status InitPersistentBackends(const BackendCmdlineConfigMap& config_map);
+  Status InitPersistentBackend(
+      const std::string& backend_name,
+      const BackendCmdlineConfigMap& config_map);
+
+  std::list<std::shared_ptr<TritonBackend>> persist_backends_;
+};
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -35,6 +35,7 @@
 
 #include "src/core/model_config.pb.h"
 #include "src/core/model_repository_manager.h"
+#include "src/core/persistent_backend_manager.h"
 #include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
@@ -97,9 +98,6 @@ class InferenceServer {
   Status ModelReadyVersions(
       std::map<std::string, std::vector<int64_t>>* model_versions);
 
-  // Print backends and models summary
-  Status PrintBackendAndModelSummary();
-
   /// Get the index of all models in all repositories.
   /// \param ready_only If true return only index of models that are ready.
   /// \param index Returns the index.
@@ -119,6 +117,9 @@ class InferenceServer {
 
   // Unload the corresponding model.
   Status UnloadModel(const std::string& model_name);
+
+  // Print backends and models summary
+  Status PrintBackendAndModelSummary();
 
   // Return the server version.
   const std::string& Version() const { return version_; }
@@ -255,6 +256,7 @@ class InferenceServer {
   std::atomic<uint64_t> inflight_request_counter_;
 
   std::unique_ptr<ModelRepositoryManager> model_repository_manager_;
+  std::shared_ptr<PersistentBackendManager> persist_backend_manager_;
 };
 
 }}  // namespace nvidia::inferenceserver


### PR DESCRIPTION
Needed to avoid handing that occurs in the initialization of some
framework shared libary initialization on dlopen in some cases.