### PR TITLE
Fix docker image tag in docs: py3-sdk -> py3-clientsdk

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -128,19 +128,19 @@ Use docker pull to get the client libraries and examples image
 from NGC.
 
 ```
-$ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3-sdk
+$ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3-clientsdk
 ```
 
 Where <xx.yy> is the version that you want to pull. Run the client
 image.
 
 ```
-$ docker run -it --rm --net=host nvcr.io/nvidia/tritonserver:<xx.yy>-py3-sdk
+$ docker run -it --rm --net=host nvcr.io/nvidia/tritonserver:<xx.yy>-py3-clientsdk
 ```
 
 ## Running The Image Classification Example
 
-From within the nvcr.io/nvidia/tritonserver:<xx.yy>-py3-sdk
+From within the nvcr.io/nvidia/tritonserver:<xx.yy>-py3-clientsdk
 image, run the example image-client application to perform image
 classification using the example densenet_onnx model.
 


### PR DESCRIPTION
As per the current instructions in [quickstart.md](https://github.com/triton-inference-server/server/blob/master/docs/quickstart.md), the suggested command for getting the client libraries and examples using docker is:
`$ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3-sdk`
 which will fail since there's no such tag on NVCR for any supported values for `xx.yy`

This PR adds the minor fix to update the docs to:
`$ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3-clientsdk`