### PR TITLE
Add check for (remaining) mapped system / allocated cuda shared memory regions

### DIFF
--- a/src/clients/python/examples/simple_grpc_cudashm_client.py
+++ b/src/clients/python/examples/simple_grpc_cudashm_client.py
@@ -169,9 +169,11 @@ if __name__ == '__main__':
 
     print(triton_client.get_cuda_shared_memory_status())
     triton_client.unregister_cuda_shared_memory()
+    assert len(cudashm.allocated_shared_memory_regions()) == 4
     cudashm.destroy_shared_memory_region(shm_ip0_handle)
     cudashm.destroy_shared_memory_region(shm_ip1_handle)
     cudashm.destroy_shared_memory_region(shm_op0_handle)
     cudashm.destroy_shared_memory_region(shm_op1_handle)
+    assert len(cudashm.allocated_shared_memory_regions()) == 0
 
     print('PASS: cudashm')

--- a/src/clients/python/examples/simple_grpc_shm_client.py
+++ b/src/clients/python/examples/simple_grpc_shm_client.py
@@ -170,9 +170,11 @@ if __name__ == '__main__':
 
     print(triton_client.get_system_shared_memory_status())
     triton_client.unregister_system_shared_memory()
+    assert len(shm.mapped_shared_memory_regions()) == 4
     shm.destroy_shared_memory_region(shm_ip0_handle)
     shm.destroy_shared_memory_region(shm_ip1_handle)
     shm.destroy_shared_memory_region(shm_op0_handle)
     shm.destroy_shared_memory_region(shm_op1_handle)
+    assert len(shm.mapped_shared_memory_regions()) == 0
 
     print('PASS: shm')

--- a/src/clients/python/examples/simple_grpc_shm_string_client.py
+++ b/src/clients/python/examples/simple_grpc_shm_string_client.py
@@ -185,9 +185,11 @@ if __name__ == '__main__':
 
     print(triton_client.get_system_shared_memory_status())
     triton_client.unregister_system_shared_memory()
+    assert len(shm.mapped_shared_memory_regions()) == 4
     shm.destroy_shared_memory_region(shm_ip0_handle)
     shm.destroy_shared_memory_region(shm_ip1_handle)
     shm.destroy_shared_memory_region(shm_op0_handle)
     shm.destroy_shared_memory_region(shm_op1_handle)
+    assert len(shm.mapped_shared_memory_regions()) == 0
 
     print('PASS: system shared memory')

--- a/src/clients/python/examples/simple_http_cudashm_client.py
+++ b/src/clients/python/examples/simple_http_cudashm_client.py
@@ -166,9 +166,11 @@ if __name__ == '__main__':
 
     print(triton_client.get_cuda_shared_memory_status())
     triton_client.unregister_cuda_shared_memory()
+    assert len(cudashm.allocated_shared_memory_regions()) == 4
     cudashm.destroy_shared_memory_region(shm_ip0_handle)
     cudashm.destroy_shared_memory_region(shm_ip1_handle)
     cudashm.destroy_shared_memory_region(shm_op0_handle)
     cudashm.destroy_shared_memory_region(shm_op1_handle)
+    assert len(cudashm.allocated_shared_memory_regions()) == 0
 
     print('PASS: cuda shared memory')

--- a/src/clients/python/examples/simple_http_shm_client.py
+++ b/src/clients/python/examples/simple_http_shm_client.py
@@ -168,9 +168,11 @@ if __name__ == '__main__':
 
     print(triton_client.get_system_shared_memory_status())
     triton_client.unregister_system_shared_memory()
+    assert len(shm.mapped_shared_memory_regions()) == 4
     shm.destroy_shared_memory_region(shm_ip0_handle)
     shm.destroy_shared_memory_region(shm_ip1_handle)
     shm.destroy_shared_memory_region(shm_op0_handle)
     shm.destroy_shared_memory_region(shm_op1_handle)
+    assert len(shm.mapped_shared_memory_regions()) == 0
 
     print('PASS: system shared memory')

--- a/src/clients/python/examples/simple_http_shm_string_client.py
+++ b/src/clients/python/examples/simple_http_shm_string_client.py
@@ -185,9 +185,11 @@ if __name__ == '__main__':
 
     print(triton_client.get_system_shared_memory_status())
     triton_client.unregister_system_shared_memory()
+    assert len(shm.mapped_shared_memory_regions()) == 4
     shm.destroy_shared_memory_region(shm_ip0_handle)
     shm.destroy_shared_memory_region(shm_ip1_handle)
     shm.destroy_shared_memory_region(shm_op0_handle)
     shm.destroy_shared_memory_region(shm_op1_handle)
+    assert len(shm.mapped_shared_memory_regions()) == 0
 
     print('PASS: system shared memory')

--- a/src/clients/python/library/tritonclient/utils/cuda_shared_memory/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/cuda_shared_memory/__init__.py
@@ -75,6 +75,8 @@ _ccudashm_shared_memory_region_destroy = _ccudashm.CudaSharedMemoryRegionDestroy
 _ccudashm_shared_memory_region_destroy.restype = c_int
 _ccudashm_shared_memory_region_destroy.argtypes = [c_void_p]
 
+allocated_shm_regions = []
+
 
 def _raise_if_error(errno):
     """
@@ -120,13 +122,13 @@ def create_shared_memory_region(triton_shm_name, byte_size, device_id):
             _ccudashm_shared_memory_region_create(triton_shm_name, byte_size,
                                                   device_id,
                                                   byref(cuda_shm_handle))))
+    allocated_shm_regions.append(cuda_shm_handle)
 
     return cuda_shm_handle
 
 
 def get_raw_handle(cuda_shm_handle):
-    """Returns the underlying raw serialized cudaIPC handle
-    in base64 encoding.
+    """Returns the underlying raw serialized cudaIPC handle in base64 encoding.
 
     Parameters
     ----------
@@ -137,7 +139,7 @@ def get_raw_handle(cuda_shm_handle):
     -------
     bytes
         The raw serialized cudaIPC handle of underlying cuda shared memory
-        in base64 encoding
+        in base64 encoding.
 
     """
     craw_handle = c_char_p()
@@ -148,8 +150,7 @@ def get_raw_handle(cuda_shm_handle):
 
 
 def set_shared_memory_region(cuda_shm_handle, input_values):
-    """Copy the contents of the numpy array into a shared memory region with
-    the specified identifier, offset and size.
+    """Copy the contents of the numpy array into the cuda shared memory region.
 
     Parameters
     ----------
@@ -184,7 +185,7 @@ def set_shared_memory_region(cuda_shm_handle, input_values):
 
 
 def get_contents_as_numpy(cuda_shm_handle, datatype, shape):
-    """Generates a numpy array using the data stored in the shared memory
+    """Generates a numpy array using the data stored in the cuda shared memory
     region specified with the handle.
 
     Parameters
@@ -218,7 +219,7 @@ def get_contents_as_numpy(cuda_shm_handle, datatype, shape):
             cval_len = start_pos + requested_byte_size
             if byte_size.value < cval_len:
                 _raise_error(
-                    "The size of shared memory is unsufficient to provide numpy array with requested size"
+                    "The size of the shared memory region is unsufficient to provide numpy array with requested size"
                 )
             if cval_len == 0:
                 result = np.empty(shape, dtype=datatype)
@@ -254,6 +255,18 @@ def get_contents_as_numpy(cuda_shm_handle, datatype, shape):
         return result
 
 
+def allocated_shared_memory_regions():
+    """Return all cuda shared memory regions that were allocated but not freed.
+
+    Returns
+    -------
+    list
+        The list of cuda shared memory handles corresponding to the allocated regions.
+    """
+
+    return allocated_shm_regions
+
+
 def destroy_shared_memory_region(cuda_shm_handle):
     """Close a cuda shared memory region with the specified handle.
 
@@ -265,11 +278,13 @@ def destroy_shared_memory_region(cuda_shm_handle):
     Raises
     ------
     CudaSharedMemoryException
-        If unable to close the cuda_shm_handle shared memory region and free the device memory.
+        If unable to close the cuda shared memory region and free the device memory.
     """
 
     _raise_if_error(
         c_int(_ccudashm_shared_memory_region_destroy(cuda_shm_handle)))
+    allocated_shm_regions.remove(cuda_shm_handle)
+
     return
 
 

--- a/src/clients/python/library/tritonclient/utils/shared_memory/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/shared_memory/__init__.py
@@ -92,7 +92,7 @@ def _raise_error(msg):
 
 
 def create_shared_memory_region(triton_shm_name, shm_key, byte_size):
-    """Creates a shared memory region with the specified name and size.
+    """Creates a system shared memory region with the specified name and size.
 
     Parameters
     ----------
@@ -106,7 +106,7 @@ def create_shared_memory_region(triton_shm_name, shm_key, byte_size):
     Returns
     -------
     shm_handle : c_void_p
-        The handle for the shared memory region.
+        The handle for the system shared memory region.
 
     Raises
     ------
@@ -125,19 +125,19 @@ def create_shared_memory_region(triton_shm_name, shm_key, byte_size):
 
 
 def set_shared_memory_region(shm_handle, input_values):
-    """Copy the contents of the numpy array into a shared memory region.
+    """Copy the contents of the numpy array into the system shared memory region.
 
     Parameters
     ----------
     shm_handle : c_void_p
-        The handle for the shared memory region.
+        The handle for the system shared memory region.
     input_values : list
         The list of numpy arrays to be copied into the shared memory region.
 
     Raises
     ------
     SharedMemoryException
-        If unable to mmap or set values in the shared memory region.
+        If unable to mmap or set values in the system shared memory region.
     """
 
     if not isinstance(input_values, (list, tuple)):
@@ -159,13 +159,13 @@ def set_shared_memory_region(shm_handle, input_values):
 
 
 def get_contents_as_numpy(shm_handle, datatype, shape):
-    """Generates a numpy array using the data stored in the shared memory
+    """Generates a numpy array using the data stored in the system shared memory
     region specified with the handle.
 
     Parameters
     ----------
-    cuda_shm_handle : c_void_p
-        The handle for the cuda shared memory region.
+    shm_handle : c_void_p
+        The handle for the system shared memory region.
     datatype : np.dtype
         The datatype of the array to be returned.
     shape : list
@@ -174,7 +174,7 @@ def get_contents_as_numpy(shm_handle, datatype, shape):
     Returns
     -------
     np.array
-        The numpy array generated using contents from the specified shared
+        The numpy array generated using the contents of the specified shared
         memory region.
     """
     shm_fd = c_int()
@@ -191,7 +191,7 @@ def get_contents_as_numpy(shm_handle, datatype, shape):
         cval_len = start_pos + requested_byte_size
         if byte_size.value < cval_len:
             _raise_error(
-                "The size of shared memory is unsufficient to provide numpy array with requested size"
+                "The size of the shared memory region is unsufficient to provide numpy array with requested size"
             )
         if cval_len == 0:
             result = np.empty(shape, dtype=datatype)
@@ -223,24 +223,24 @@ def get_contents_as_numpy(shm_handle, datatype, shape):
 
 
 def mapped_shared_memory_regions():
-    """Return all shared memory regions that were mapped but not unmapped/destoryed.
+    """Return all system shared memory regions that were mapped but not unmapped/destoryed.
 
     Returns
     -------
     list
-        The list of shared memory regions.
+        The list of mapped system shared memory regions.
     """
 
     return mapped_shm_regions
 
 
 def destroy_shared_memory_region(shm_handle):
-    """Unlink a shared memory region with the specified handle.
+    """Unlink a system shared memory region with the specified handle.
 
     Parameters
     ----------
     shm_handle : c_void_p
-        The handle for the shared memory region.
+        The handle for the system shared memory region.
 
     Raises
     ------


### PR DESCRIPTION
On the python shared memory library side: 
User should confirm `shm.mapped_shared_memory_regions()` to be empty before the python client exits. This will ensure that the user does not cause any shared memory leaks by leaving a process mapped / un-destroyed before exiting.
To destroy these regions the user must call `shm.destroy_shared_memory_region(<shm_handle>)`

Similarly on the cuda shared memory side the user must use: `cudashm.allocated_shared_memory_regions()`