### PR TITLE
Using curl_mime_data_cb to capture HTTP send/recv times for TorchServe

### DIFF
--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.cc
@@ -119,7 +119,6 @@ HttpInferRequest::FileSize()
 Error
 HttpInferRequest::CloseFileData()
 {
-  fclose(file_ptr_.get());
   file_ptr_.reset(nullptr);
   return Error::Success;
 }

--- a/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.h
+++ b/src/clients/c++/perf_analyzer/client_backend/torchserve/http_client.h
@@ -117,7 +117,9 @@ class HttpInferRequest {
   struct Deleter {
     void operator()(FILE* file)
     {
-      // Do nothing
+      if (file != nullptr) {
+        fclose(file);
+      }
     }
   };
 


### PR DESCRIPTION
Using the callback based approach allows perf analyzer to capture and report the http send/receive times for TorchServe service.

### Before
```
root@58d21eb46ebc:/home/model-server# /tmp/host/perf_analyzer -m resnet50 -u localhost:8080 -i http --service-kind torchserve --input-data data.json
 Successfully read data for 1 stream/streams with 1 step/steps.
*** Measurement Settings ***
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 849
    Throughput: 169.8 infer/sec
    Avg latency: 5876 usec (standard deviation 528 usec)
    p50 latency: 5809 usec
    p90 latency: 5920 usec
    p95 latency: 6004 usec
    p99 latency: 7310 usec
    Avg HTTP time: 5852 usec (send/recv 0 usec + response wait 5852 usec)
Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 169.8 infer/sec, latency 5876 usec

```

### After
```
root@58d21eb46ebc:/home/model-server# /tmp/host/perf_analyzer -m resnet50 -u localhost:8080 -i http --service-kind torchserve --input-data data.json
 Successfully read data for 1 stream/streams with 1 step/steps.
*** Measurement Settings ***
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 847
    Throughput: 169.4 infer/sec
    Avg latency: 5889 usec (standard deviation 505 usec)
    p50 latency: 5793 usec
    p90 latency: 5947 usec
    p95 latency: 6484 usec
    p99 latency: 7075 usec
    Avg HTTP time: 5872 usec (**send/recv 83 usec** + response wait 5789 usec)
Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 169.4 infer/sec, latency 5889 usec
```
