### PR TITLE
Using perf_analyzer built on 18.04 ubuntu and cmake in non-triton benchmarks

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -64,27 +64,23 @@ RUN apt-get update && \
     pip3 install --upgrade grpcio-tools && \
     pip3 install --upgrade pip
 
+ARG CMAKE_UBUNTU_VERSION
 # Client build requires recent version of CMake (FetchContent required)
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
       gpg --dearmor - |  \
       tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    if [[ "$CMAKE_UBUNTU_VERSION" == '20.04' ]] ; \
-      then \
-        apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
-        apt-get update && \
-        apt-get install -y --no-install-recommends \
-          cmake-data=3.18.4-0kitware1ubuntu20.04.1 cmake=3.18.4-0kitware1ubuntu20.04.1 ; \
-    elif [[ "$CMAKE_UBUNTU_VERSION" == '18.04' ]] ; \
-      then \
-        apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
-        apt-get update && \
-        apt-get install -y --no-install-recommends cmake ; \
+    if [ "$CMAKE_UBUNTU_VERSION" = "20.04" ]; then \
+      apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends \
+        cmake-data=3.18.4-0kitware1ubuntu20.04.1 cmake=3.18.4-0kitware1ubuntu20.04.1; \
+    elif [ "$CMAKE_UBUNTU_VERSION" = "18.04" ]; then \
+      apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends cmake; \
     else \
-      echo "ERROR: Only support CMAKE_UBUNTU_VERSION to be 18.04 or 20.04" && false ; \
+      echo "ERROR: Only support CMAKE_UBUNTU_VERSION to be 18.04 or 20.04" && false; \
     fi && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-      cmake-data=3.18.4-0kitware1ubuntu20.04.1 cmake=3.18.4-0kitware1ubuntu20.04.1 && \
     cmake --version
 
 # Build expects "python" executable (not python3).

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -30,6 +30,7 @@ ARG BASE_IMAGE=nvidia/cuda:11.1-devel-ubuntu20.04
 ARG TRITON_COMMON_REPO_TAG=main
 ARG TRITON_CORE_REPO_TAG=main
 ARG TRITON_MODEL_ANALYZER_REPO_TAG=main
+ARG CMAKE_UBUNTU_VERSION=20.04
 
 FROM ${BASE_IMAGE}
 
@@ -67,7 +68,20 @@ RUN apt-get update && \
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
       gpg --dearmor - |  \
       tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
+    if [[ "$CMAKE_UBUNTU_VERSION" == '20.04' ]] ; \
+      then \
+        apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' && \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+          cmake-data=3.18.4-0kitware1ubuntu20.04.1 cmake=3.18.4-0kitware1ubuntu20.04.1 ; \
+    elif [[ "$CMAKE_UBUNTU_VERSION" == '18.04' ]] ; \
+      then \
+        apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
+        apt-get update && \
+        apt-get install -y --no-install-recommends cmake ; \
+    else \
+      echo "ERROR: Only support CMAKE_UBUNTU_VERSION to be 18.04 or 20.04" && false ; \
+    fi && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       cmake-data=3.18.4-0kitware1ubuntu20.04.1 cmake=3.18.4-0kitware1ubuntu20.04.1 && \

--- a/qa/L0_perf_tfs/test.sh
+++ b/qa/L0_perf_tfs/test.sh
@@ -34,58 +34,13 @@ if [ -z "$REPO_VERSION" ]; then
     exit 1
 fi
 
-DEBIAN_FRONTEND=noninteractive
-# Build perf_analyzer from source
-apt-get update &&  \
-apt-get install -y --no-install-recommends \
-        software-properties-common \
-        autoconf \
-        automake \
-        build-essential \
-        curl \
-        git \
-        libb64-dev \
-        libopencv-dev \
-        libopencv-core-dev \
-        libssl-dev \
-        libtool \
-        pkg-config \
-        python3 \
-        python3-pip \
-        python3-dev \
-        rapidjson-dev  \
-        vim \
-        wget && \
-pip3 install --upgrade wheel setuptools && \
-pip3 install --upgrade grpcio-tools && \
-pip3 install --upgrade pip && \
-pip3 install --upgrade requests
-
-# Build expects "python" executable (not python3).
+apt update
+ # needed by perf_analyzer
+apt install -y libb64-dev
+# needed by reporter
+apt install -y python3 python3-pip python3-dev
 rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
-ln -s /usr/bin/python3 /usr/bin/python3.5
-
-wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | \
-      gpg --dearmor - |  \
-      tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null && \
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends cmake && \
-    cmake --version
-
-rm -rf server
-git clone --single-branch --depth=1 -b ${BENCHMARK_REPO_BRANCH} \
-                  https://github.com/triton-inference-server/server.git;
-
-(cd server
-mkdir builddir && cd builddir && \
-cmake -DCMAKE_BUILD_TYPE=Release \
-      -DTRITON_COMMON_REPO_TAG:STRING=main \
-      -DTRITON_CORE_REPO_TAG:STRING=main \
-      -DTRITON_ENABLE_GRPC=ON \
-      -DTRITON_ENABLE_HTTP=ON ../build && \
-make -j16 client && \
-cp client/install/bin/perf_analyzer /usr/bin/)
+pip3 install --upgrade requests
 
 REPODIR=/data/inferenceserver/${REPO_VERSION}
 rm -f *.log *.csv *.tjson *.json
@@ -110,6 +65,7 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+PERF_ANALYZER=/perf_bin/perf_analyzer
 REPORTER=../common/reporter.py
 
 # To get the minimum latency
@@ -118,9 +74,9 @@ NAME=${MODEL_NAME}_sbatch${STATIC_BATCH}
 
 # Run client
 # To warmup the model
-perf_analyzer -m ${MODEL_NAME} --service-kind tfserving -i grpc -b 1 -p 5000
+$PERF_ANALYZER -m ${MODEL_NAME} --service-kind tfserving -i grpc -b 1 -p 5000
 # Collect data
-perf_analyzer -m ${MODEL_NAME} --service-kind tfserving -i grpc -b ${STATIC_BATCH} -p 5000 -f ${NAME}.csv >> ${NAME}.log 2>&1
+$PERF_ANALYZER -m ${MODEL_NAME} --service-kind tfserving -i grpc -b ${STATIC_BATCH} -p 5000 -f ${NAME}.csv >> ${NAME}.log 2>&1
 if (( $? != 0 )); then
     RET=1
 fi
@@ -154,7 +110,7 @@ fi
 # Large static batch size case.
 STATIC_BATCH=128
 NAME=${MODEL_NAME}_sbatch${STATIC_BATCH}
-perf_analyzer -m ${MODEL_NAME} --service-kind tfserving -i grpc -b ${STATIC_BATCH} -p 5000 -f ${NAME}.csv >> ${NAME}.log 2>&1
+$PERF_ANALYZER -m ${MODEL_NAME} --service-kind tfserving -i grpc -b ${STATIC_BATCH} -p 5000 -f ${NAME}.csv >> ${NAME}.log 2>&1
 if (( $? != 0 )); then
     RET=1
 fi

--- a/qa/L0_perf_ts/test.sh
+++ b/qa/L0_perf_ts/test.sh
@@ -37,9 +37,7 @@ fi
 
 apt update
 apt install -y libb64-dev curl
-# needed by reporter
 apt install -y python3 python3-pip python3-dev
-rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
 pip3 install --upgrade requests
 
 REPODIR=/data/inferenceserver/${REPO_VERSION}
@@ -83,7 +81,7 @@ fi
 torchserve --stop
 
 echo -e "[{\"s_benchmark_kind\":\"benchmark_perf\"," >> ${NAME}.tjson
-echo -e "\"s_benchmark_name\":\"resnet50\"," >> ${NAME}.tjson
+echo -e "\"s_benchmark_name\":\"preprocess+resnet50\"," >> ${NAME}.tjson
 echo -e "\"s_server\":\"torchserve\"," >> ${NAME}.tjson
 echo -e "\"s_protocol\":\"http\"," >> ${NAME}.tjson
 echo -e "\"s_framework\":\"libtorch\"," >> ${NAME}.tjson
@@ -101,7 +99,7 @@ if [ -f $REPORTER ]; then
         URL_FLAG="-u ${BENCHMARK_REPORTER_URL}"
     fi
 
-    $REPORTER -v -o ${NAME}.json --csv ${NAME}.csv ${URL_FLAG} ${NAME}.tjson
+    python $REPORTER -v -o ${NAME}.json --csv ${NAME}.csv ${URL_FLAG} ${NAME}.tjson
     if (( $? != 0 )); then
         RET=1
     fi


### PR DESCRIPTION
Uses the same dockerfile to build sdk on ubuntu and then copy perf_analyzer binary from there. Look at the gitlab side changes for more context.

This fixes L0_perf_tfs(https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/19072257) and L0_perf_ts(https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/19095253)