### PR TITLE
Wrap <> pseudovariables in markdown, to avoid their interpretation as HTML

### DIFF
--- a/docs/client_libraries.md
+++ b/docs/client_libraries.md
@@ -134,7 +134,7 @@ from NGC.
 $ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3-sdk
 ```
 
-Where <xx.yy> is the version that you want to pull. Within the
+Where \<xx.yy\> is the version that you want to pull. Within the
 container the client libraries are in /workspace/install/lib, the
 corresponding headers in /workspace/install/include, and the Python
 wheel files in /workspace/install/python. The image will also contain
@@ -160,7 +160,7 @@ the Python wheel files for the Python client library.
 $ docker build -t tritonserver_sdk -f Dockerfile.sdk .
 ```
 
-You can optionally add *--build-arg "BASE_IMAGE=<base_image>"* to set
+You can optionally add *--build-arg "BASE_IMAGE=\<base_image\>"* to set
 the base image that you want the client library built against. This
 base image must be an Ubuntu CUDA image to be able to build CUDA
 shared memory support. If CUDA shared memory support is not required,
@@ -263,8 +263,8 @@ following cmake configuration.
 > cmake -G"Visual Studio 16 2019" -DTRITON_ENABLE_GPU=OFF -DTRITON_ENABLE_METRICS_GPU=OFF -DCMAKE_BUILD_TYPE=Release -DTRITON_COMMON_REPO_TAG:STRING=<tag> -DTRITON_CORE_REPO_TAG:STRING=<tag>
 ```
 
-Where <tag> is "main" if you are building the clients from the master
-branch, or <tag> is "r<x>.<y>" if you are building on a release
+Where \<tag\> is "main" if you are building the clients from the master
+branch, or \<tag\> is "r\<x\>.\<y\>" if you are building on a release
 branch.
 
 When the build completes the libraries can be found in

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -47,10 +47,10 @@ $ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3-min
 $ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3
 ```
 
-Where <xx.yy> is the version of Triton that you want to customize. The
-<xx.yy>-py3-min image is a minimal, base image that contains the CUDA,
+Where \<xx.yy\> is the version of Triton that you want to customize. The
+\<xx.yy\>-py3-min image is a minimal, base image that contains the CUDA,
 cuDNN, etc. dependencies that are required to run Triton. The
-<xx.yy>-py3 image contains the complete Triton with all options and
+\<xx.yy\>-py3 image contains the complete Triton with all options and
 backends.
 
 ### Minimum Triton

--- a/docs/model_configuration.md
+++ b/docs/model_configuration.md
@@ -114,7 +114,7 @@ expected by the model. **TorchScript Naming Convention:** Due to the
 absence of names for inputs and outputs in a TorchScript model, the
 "name" attribute of both the inputs and outputs in the configuration
 must follow a specific naming convention i.e. "\<name\>__\<index\>".
-Where <name> can be any string and <index> refers to the position of
+Where \<name\> can be any string and \<index\> refers to the position of
 the corresponding input/output. This means if there are two inputs and
 two outputs they must be named as: "INPUT__0", "INPUT__1" and
 "OUTPUT__0", "OUTPUT__1" such that "INPUT__0" refers to first input

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -137,11 +137,11 @@ typically applies when perf_analyzer is running on the same system as
 Triton. The first rule is that for minimum latency set the request
 concurrency to 1 and disable the dynamic batcher and use only 1 [model
 instance](#model-instances). The second rule is that for maximum
-throughput set the request concurrency to be 2 * <preferred batch
-size> * <model instance count>. We will discuss model instances
+throughput set the request concurrency to be `2 * <preferred batch
+size> * <model instance count>`. We will discuss model instances
 [below](#model-instances), for now we are working with one model
 instance. So for preferred-batch-size 4 we want to run perf_analyzer
-with request concurrency of 2 * 4 * 1 = 8.
+with request concurrency of `2 * 4 * 1 = 8`.
 
 ```
 $ perf_analyzer -m inception_graphdef --percentile=95 --concurrency-range 8

--- a/docs/perf_analyzer.md
+++ b/docs/perf_analyzer.md
@@ -84,7 +84,7 @@ windows. The number of outstanding inference requests is referred to
 as the *request concurrency*, and so by default perf_analyzer uses a
 request concurrency of 1.
 
-Using the --concurrency-range <start>:<end>:<step> option you can have
+Using the --concurrency-range \<start\>:\<end\>:\<step\> option you can have
 perf_analyzer collect data for a range of request concurrency
 levels. Use the --help option to see complete documentation for this
 and other options. For example, to see the latency and throughput of

--- a/docs/protocol/extension_classification.md
+++ b/docs/protocol/extension_classification.md
@@ -39,8 +39,8 @@ An inference request can use the “classification” parameter to request
 that one or more classifications be returned for an output. For such
 an output the returned tensor will not be the shape and type produced
 by the model, but will instead be type BYTES with shape [ batch-size,
-<count> ] where each element returns the classification index and
-label as a single string. The <count> dimension of the returned tensor
+\<count\> ] where each element returns the classification index and
+label as a single string. The \<count\> dimension of the returned tensor
 will equal the “count” value specified in the classification
 parameter.
 
@@ -52,10 +52,10 @@ an output tensor is [ 1, 5, 10, 4 ], the highest-valued element is 10
 by 1 (index 0). So, for example, the top-2 classifications by index
 are [ 2, 1 ].
 
-The format of the returned string will be “<value>:<index>[:<label>]”,
-where <index> is the index of the class in the model output tensor,
-<value> is the value associated with that index in the model output,
-and the <label> associated with that index is optional. For example,
+The format of the returned string will be “\<value\>:\<index\>[:\<label\>]”,
+where \<index\> is the index of the class in the model output tensor,
+\<value\> is the value associated with that index in the model output,
+and the \<label\> associated with that index is optional. For example,
 continuing the example from above, the returned tensor will be [
 “10:2”, “5:1” ]. If the model has labels associated with those
 indices, the returned tensor will be [ “10:2:apple”, “5:1:pickle” ].

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,7 +48,7 @@ Pull the image using the following command.
 $ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3
 ```
 
-Where <xx.yy> is the version of Triton that you want to pull.
+Where \<xx.yy\> is the version of Triton that you want to pull.
 
 ## Create A Model Repository
 
@@ -82,7 +82,7 @@ system GPU should be made available to Triton for inferencing.
 $ docker run --gpus=1 --rm -p8000:8000 -p8001:8001 -p8002:8002 -v/full/path/to/docs/examples/model_repository:/models nvcr.io/nvidia/tritonserver:<xx.yy>-py3 tritonserver --model-repository=/models
 ```
 
-Where <xx.yy> is the version of Triton that you want to use (and
+Where \<xx.yy\> is the version of Triton that you want to use (and
 pulled above). After you start Triton you will see output on the
 console showing the server starting up and loading the model. When you
 see output like the following, Triton is ready to accept inference
@@ -145,7 +145,7 @@ from NGC.
 $ docker pull nvcr.io/nvidia/tritonserver:<xx.yy>-py3-sdk
 ```
 
-Where <xx.yy> is the version that you want to pull. Run the client
+Where \<xx.yy\> is the version that you want to pull. Run the client
 image.
 
 ```

--- a/docs/v1_to_v2.md
+++ b/docs/v1_to_v2.md
@@ -46,8 +46,8 @@ version 2.
   * The default for --model-control-mode is changed to *none*.
 
   * --tf-allow-soft-placement and --tf-gpu-memory-fraction are renamed
-     to --backend-config="tensorflow,allow-soft-placement=<true,false>"
-     and --backend-config="tensorflow,gpu-memory-fraction=<float>".
+     to --backend-config="tensorflow,allow-soft-placement=\<true,false\>"
+     and --backend-config="tensorflow,gpu-memory-fraction=\<float\>".
 
 * The HTTP/REST and GRPC protocols, while conceptually similar to
   version 1, are completely changed in version 2. See [inference


### PR DESCRIPTION
In the Web version of the current documentation, there existed many cases when \<pseudovariables\> were used, but < and > symbols weren't properly escaped. In these cases, they were interpreted by the Markdown engines as inline HTML, and were completely invisible on the page. In this PR I escaped most of the < and > symbols in the documentation. Note, that such symbols inside the code blocks are not interpreted as inline HTML and thus there is no need to escape them.

See example:
in the comment source:  `<var1> vs \<var2\>`
rendered: <var1> vs \<var2\>