### PR TITLE
Validate whether shapes are provided when providing data through json

### DIFF
--- a/src/clients/c++/perf_analyzer/data_loader.cc
+++ b/src/clients/c++/perf_analyzer/data_loader.cc
@@ -359,6 +359,20 @@ DataLoader::ReadInputTensorData(
               ", step id: " + std::to_string(step_index) + ")");
         }
       }
+
+      // Validate if a fixed shape is available for the input tensor.
+      int element_count;
+      auto shape_it = input_shapes_.find(key_name);
+      if (shape_it != input_shapes_.end()) {
+        element_count = ElementCount(shape_it->second);
+      } else {
+        element_count = ElementCount(input.second.shape_);
+      }
+      if (element_count < 0) {
+        return cb::Error(
+            "The variable-sized input tensor \"" + input.second.name_ +
+            "\" is missing shape, see --shape option.");
+      }
     } else {
       return cb::Error(
           "missing input " + input.first +


### PR DESCRIPTION
The check for shape availability was missing in our pipeline when reading data from json.
See here: https://github.com/triton-inference-server/server/issues/2431#issuecomment-763228814