### PR TITLE
Fix perf_analyzer report for ensemble models

### DIFF
--- a/src/clients/c++/perf_analyzer/inference_profiler.h
+++ b/src/clients/c++/perf_analyzer/inference_profiler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -53,6 +53,14 @@ struct LoadStatus {
   double avg_ips = 0;
   // Stores the average latency within the stability window
   uint64_t avg_latency = 0;
+};
+
+// Holds the total of the timiming components of composing models of an
+// ensemble.
+struct EnsembleDurations {
+  EnsembleDurations() : total_queue_time_us(0), total_compute_time_us(0) {}
+  uint64_t total_queue_time_us;
+  uint64_t total_compute_time_us;
 };
 
 /// Holds the server-side inference statisitcs of the target model and its


### PR DESCRIPTION
Fixes #2429 .
Perf analyzer will report the queue and compute time as the sum of its composing models. This PR makes report more comprehensible and less confusing.

### Before
```
  Server: 
    Inference count: 677
    Execution count: 677
    Successful request count: 677
    Avg request latency: 8348 usec
    Total avg compute input time : 82 usec
    Total avg compute infer time : 7875 usec
    Total avg compute output time : 223 usec
    Total avg queue time : 0 usec

  Composing models: 
  dali, version: 
      Inference count: 677
      Execution count: 677
      Successful request count: 677
      Avg request latency: 2307 usec (overhead 3 usec + queue 42 usec + compute input 5 usec + compute infer 2220 usec + compute output 37 usec)

  resnet50_fp32_libtorch, version: 
      Inference count: 677
      Execution count: 677
      Successful request count: 677
      Avg request latency: 6000 usec (overhead 48 usec + queue 36 usec + compute input 76 usec + compute infer 5654 usec + compute output 186 usec)
```

### After
```
  Server: 
    Inference count: 678
    Execution count: 678
    Successful request count: 678
    Avg request latency: 8312 usec (overhead 98 usec + queue 90 usec + compute 8124 usec)

  Composing models: 
  dali, version: 
      Inference count: 678
      Execution count: 678
      Successful request count: 678
      Avg request latency: 2223 usec (overhead 3 usec + queue 56 usec + compute input 6 usec + compute infer 2123 usec + compute output 35 usec)

  resnet50_fp32_libtorch, version: 
      Inference count: 678
      Execution count: 678
      Successful request count: 678
      Avg request latency: 6044 usec (overhead 50 usec + queue 34 usec + compute input 75 usec + compute infer 5728 usec + compute output 157 usec)
```
