### PR TITLE
Increased leak depth in check_valgrind_log

### DIFF
--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -404,7 +404,7 @@ function check_test_results () {
 function check_valgrind_log () {
     local valgrind_log=$1
 
-    leak_records=$(grep "are definitely lost" -A 8 $valgrind_log | awk \
+    leak_records=$(grep "are definitely lost" -A 12 $valgrind_log | awk \
     'BEGIN{RS="--";acc=0} !(/cnmem/||/tensorflow::NewSession/||/dl-init/|| \
     /dl-open/||/dlerror/||/libtorch/) \
     {print;acc+=1} END{print acc}')


### PR DESCRIPTION
Symbols on the whitelist were lost for very deep stack traces, this increases the size of the leaks records retrieved by grep from 8 lines to 12 lines. 