### PR TITLE
Use a separate cuda stream to copy output 

### DIFF
--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -749,6 +749,14 @@ message ModelOptimizationPolicy
     //@@       Currently only recognized by TensorRT backend.
     //@@
     repeated GraphSpec graph_spec = 3;
+
+    //@@    .. cpp:var:: bool separate_output_stream
+    //@@
+    //@@       Uses a CUDA stream separate from the inference stream to copy the
+    //@@       output to host. Default value is false.
+    //@@       Currently only recognized by TensorRT backend.
+    //@@
+    bool separate_output_copy_stream = 4;
   }
 
   //@@


### PR DESCRIPTION
Previously, the inference stream was used to copy the output from the device to host. Using a separate stream shows some performance benefits when the size of the output is large.