### PR TITLE
Fixing the naming of triton model instance

### DIFF
--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -69,19 +69,22 @@ TritonModelInstance::CreateInstances(
 {
   for (const auto& group : model_config.instance_group()) {
     for (int32_t c = 0; c < group.count(); ++c) {
+      std::string instance_name{group.count() > 1
+                                    ? group.name() + "_" + std::to_string(c)
+                                    : group.name()};
       if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
         RETURN_IF_ERROR(CreateInstance(
-            model, group.name(), c, TRITONSERVER_INSTANCEGROUPKIND_CPU,
+            model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_CPU,
             0 /* device_id */, instances));
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_GPU) {
         for (const int32_t device_id : group.gpus()) {
           RETURN_IF_ERROR(CreateInstance(
-              model, group.name(), c, TRITONSERVER_INSTANCEGROUPKIND_GPU,
+              model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_GPU,
               device_id, instances));
         }
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_MODEL) {
         RETURN_IF_ERROR(CreateInstance(
-            model, group.name(), c, TRITONSERVER_INSTANCEGROUPKIND_MODEL,
+            model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_MODEL,
             0 /* device_id */, instances));
       } else {
         return Status(


### PR DESCRIPTION
### Before

```
I0223 11:27:31.560848 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.382028 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.382209 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.382404 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.382567 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.382826 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.383053 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.383198 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.383331 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.383466 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.383593 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.383715 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.383841 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
I0223 11:27:32.383965 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here (CPU device 0)
```
### After
```
I0223 11:27:31.560848 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_0 (CPU device 0)
I0223 11:27:32.382028 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_1 (CPU device 0)
I0223 11:27:32.382209 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_2 (CPU device 0)
I0223 11:27:32.382404 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_3 (CPU device 0)
I0223 11:27:32.382567 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_4 (CPU device 0)
I0223 11:27:32.382826 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_5 (CPU device 0)
I0223 11:27:32.383053 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_6 (CPU device 0)
I0223 11:27:32.383198 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_7 (CPU device 0)
I0223 11:27:32.383331 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_8 (CPU device 0)
I0223 11:27:32.383466 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_9 (CPU device 0)
I0223 11:27:32.383593 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_10 (CPU device 0)
I0223 11:27:32.383715 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_11 (CPU device 0)
I0223 11:27:32.383841 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_12 (CPU device 0)
I0223 11:27:32.383965 2639 openvino.cc:1131] TRITONBACKEND_ModelInstanceInitialize: group_name_here_13 (CPU device 0)
```