### PR TITLE
Fix trailing zeros for type BYTES

### DIFF
--- a/qa/L0_backend_identity/identity_test.py
+++ b/qa/L0_backend_identity/identity_test.py
@@ -28,8 +28,6 @@
 
 import argparse
 import numpy as np
-import os
-import re
 import sys
 import requests as httpreq
 from builtins import range
@@ -160,7 +158,7 @@ if __name__ == '__main__':
     with client_util.InferenceServerClient(FLAGS.url,
                                            verbose=FLAGS.verbose) as client:
         for model_name, np_dtype, shape in (
-            # yapf: disable
+                # yapf: disable
             ("identity_fp32", np.float32, [1, 0]),
             ("identity_fp32", np.float32, [1, 5]),
             ("identity_uint32", np.uint32, [4, 0]),
@@ -173,8 +171,9 @@ if __name__ == '__main__':
                 input_data = (16384 * np.random.randn(*shape)).astype(np_dtype)
             else:
                 in0 = (16384 * np.ones(shape, dtype='int'))
-                in0n = np.array([str(x) for x in in0.reshape(in0.size)],
-                                dtype=object)
+                in0n = np.array(
+                    [str(x).encode('utf-8') for x in in0.reshape(in0.size)],
+                    dtype=object)
                 input_data = in0n.reshape(in0.shape)
             inputs = [
                 client_util.InferInput("INPUT0", input_data.shape,
@@ -190,9 +189,6 @@ if __name__ == '__main__':
             if output_data is None:
                 print("error: expected 'OUTPUT0'")
                 sys.exit(1)
-
-            if np_dtype == object:
-                output_data = np.char.decode(output_data)
 
             if not np.array_equal(output_data, input_data):
                 print("error: expected output {} to match input {}".format(

--- a/qa/L0_infer_reshape/infer_reshape_test.py
+++ b/qa/L0_infer_reshape/infer_reshape_test.py
@@ -308,7 +308,7 @@ class InferReshapeTest(tu.TestResultCollector):
         self._full_reshape(np.int32, input_shapes=([1, 4, 1], [8], [2, 2, 3]))
 
     def test_oo1(self):
-        self._full_reshape(np.object, input_shapes=([1],), no_batch=False)
+        self._full_reshape(np.object_, input_shapes=([1],), no_batch=False)
 
 
 if __name__ == '__main__':

--- a/qa/L0_nullchar_string/nullchar_string_client.py
+++ b/qa/L0_nullchar_string/nullchar_string_client.py
@@ -80,14 +80,14 @@ if __name__ == '__main__':
 
     # Create the data for the input tensor. It contains a null character in
     # the middle of the string.
-    tmp_str = "abc\0def"
+    tmp_str = "abc\0def".encode('utf-8')
     input0_data = np.array([tmp_str], dtype=object)
 
     # Send inference request to the inference server. Get results for
     # output tensor.
     inputs = [
         client_util.InferInput("INPUT0", input0_data.shape,
-                               np_to_triton_dtype(np.object))
+                               np_to_triton_dtype(np.object_))
     ]
     inputs[0].set_data_from_numpy(input0_data)
 
@@ -96,13 +96,6 @@ if __name__ == '__main__':
     # We expect there to be 1 result (with batch-size 1). Compare the input
     # and output tensor calculated by the model. They must be the same.
     output0_data = results.as_numpy('OUTPUT0')
-    # Element type returned is different between HTTP and GRPC client.
-    # The former is str and the latter is bytes
-    output0_data2 = np.array([
-        output0_data[0]
-        if type(output0_data[0]) == str else output0_data[0].decode('utf8')
-    ],
-                             dtype=object)
 
-    print(input0_data, "?=?", output0_data2)
-    assert np.equal(input0_data, output0_data2).all()
+    print(input0_data, "?=?", output0_data)
+    assert np.equal(input0_data, output0_data).all()

--- a/qa/L0_sequence_stress/sequence_stress.py
+++ b/qa/L0_sequence_stress/sequence_stress.py
@@ -112,10 +112,11 @@ def check_sequence_async(client_metadata,
             seq_start = ("start" in flag_str)
             seq_end = ("end" in flag_str)
 
-        if input_dtype == np.object:
+        if input_dtype == np.object_:
             in0 = np.full(tensor_shape, value, dtype=np.int32)
-            in0n = np.array([str(x) for x in in0.reshape(in0.size)],
-                            dtype=object)
+            in0n = np.array(
+                [str(x).encode('utf-8') for x in in0.reshape(in0.size)],
+                dtype=object)
             in0 = in0n.reshape(tensor_shape)
         else:
             in0 = np.full(tensor_shape, value, dtype=input_dtype)
@@ -157,7 +158,7 @@ def check_sequence_async(client_metadata,
                                             result))
 
         if expected is not None:
-            if input_dtype == np.object:
+            if input_dtype == np.object_:
                 assert int(
                     result
                 ) == expected, "{}: expected result {}, got {}".format(

--- a/qa/L0_string_io/string_client_test.py
+++ b/qa/L0_string_io/string_client_test.py
@@ -39,12 +39,10 @@ import test_util as tu
 
 class ClientStringTest(tu.TestResultCollector):
 
-    def _test_unicode_bytes(self):
+    def _test_unicode_bytes(self, model_name):
         # We use a simple model that takes an input tensor of 8 byte strings
         # and returns an output tensors of 8 strings. The output tensor
         # is the same as the input tensor.
-        model_name = "graphdef_nobatch_zero_1_object"
-        model_version = ""
 
         # Create the inference server client for the model.
         triton_client = tritonhttpclient.InferenceServerClient("localhost:8000",

--- a/qa/L0_string_io/test.sh
+++ b/qa/L0_string_io/test.sh
@@ -49,6 +49,12 @@ source ../common/util.sh
 rm -f $CLIENT_LOG $SERVER_LOG
 rm -fr models && mkdir models
 cp -r /data/inferenceserver/${REPO_VERSION}/qa_identity_model_repository/graphdef_nobatch_zero_1_object models/.
+cp -r ../python_models/string models/.
+mkdir models/string/1/
+mv models/string/model.py models/string/1/model.py
+
+(cd models/string && \
+          sed -i "s/\[ 1 \]/\[ 8 \]/" config.pbtxt)
 
 run_server
 if [ "$SERVER_PID" == "0" ]; then

--- a/qa/common/check_massif_log.py
+++ b/qa/common/check_massif_log.py
@@ -29,6 +29,7 @@ import sys
 import re
 from collections import defaultdict
 
+
 def parse_massif_out(filename):
     """
     Extract the allocation data from the massif output file, and compile

--- a/qa/common/gen_qa_custom_ops_models.py
+++ b/qa/common/gen_qa_custom_ops_models.py
@@ -357,7 +357,8 @@ def create_visionop_modelfile(models_dir, model_version):
             super(CustomVisionNet, self).__init__()
 
         def forward(self, input, boxes):
-            return torch.ops.torchvision.roi_align(input, boxes, 1.0, 5, 5, -1, False)
+            return torch.ops.torchvision.roi_align(input, boxes, 1.0, 5, 5, -1,
+                                                   False)
 
     visionCustomModel = CustomVisionNet()
     visionCustomModel.eval()

--- a/qa/common/gen_qa_trt_plugin_models.py
+++ b/qa/common/gen_qa_trt_plugin_models.py
@@ -244,10 +244,24 @@ def create_plugin_models(models_dir):
                           np.float32, np.float32)
 
     # custom Normalize_TRT
-    create_plan_modelconfig(models_dir, 8, model_version, "Normalize_TRT",
-                            (16, 16, 16,), (16, 16, 16,), np.float32, np.float32)
-    create_plan_modelfile(models_dir, 8, model_version, "Normalize_TRT",
-                          (16, 16, 16,), (16, 16, 16,), np.float32, np.float32)
+    create_plan_modelconfig(models_dir, 8, model_version, "Normalize_TRT", (
+        16,
+        16,
+        16,
+    ), (
+        16,
+        16,
+        16,
+    ), np.float32, np.float32)
+    create_plan_modelfile(models_dir, 8, model_version, "Normalize_TRT", (
+        16,
+        16,
+        16,
+    ), (
+        16,
+        16,
+        16,
+    ), np.float32, np.float32)
 
 
 if __name__ == '__main__':

--- a/qa/common/shm_util.py
+++ b/qa/common/shm_util.py
@@ -43,7 +43,7 @@ def _range_repr_dtype(dtype):
         return np.int16
     elif dtype == np.float16:
         return np.int8
-    elif dtype == np.object:  # TYPE_STRING
+    elif dtype == np.object_:  # TYPE_STRING
         return np.int32
     return dtype
 
@@ -59,8 +59,15 @@ def create_set_shm_regions(input0_list, input1_list, output0_byte_size,
     if not (use_system_shared_memory or use_cuda_shared_memory):
         return [], []
 
-    input0_byte_size = sum([i0.nbytes for i0 in input0_list])
-    input1_byte_size = sum([i1.nbytes for i1 in input1_list])
+    if input0_list[0].dtype == np.object_:
+        input0_byte_size = sum([serialized_byte_size(i0) for i0 in input0_list])
+    else:
+        input0_byte_size = sum([i0.nbytes for i0 in input0_list])
+
+    if input1_list[0].dtype == np.object_:
+        input1_byte_size = sum([serialized_byte_size(i1) for i1 in input1_list])
+    else:
+        input1_byte_size = sum([i1.nbytes for i1 in input1_list])
 
     if shm_region_names is None:
         shm_region_names = ['input0', 'input1', 'output0', 'output1']

--- a/qa/common/test_util.py
+++ b/qa/common/test_util.py
@@ -78,9 +78,9 @@ def validate_for_tf_model(input_dtype, output0_dtype, output1_dtype,
     # If the input type is string the output type must be string or
     # int32. This is because the QA models we generate convert strings
     # internally to int32 for compute.
-    if ((input_dtype == np.object) and
-        (((output0_dtype != np.object) and (output0_dtype != np.int32)) or
-         ((output1_dtype != np.object) and (output1_dtype != np.int32)))):
+    if ((input_dtype == np.object_) and
+        (((output0_dtype != np.object_) and (output0_dtype != np.int32)) or
+         ((output1_dtype != np.object_) and (output1_dtype != np.int32)))):
         return False
 
     return True
@@ -136,13 +136,13 @@ def validate_for_ensemble_model(ensemble_type, input_dtype, output0_dtype,
     # data type
     # Test types that use identity for both input and output
     test_type_involved = ["reshape", "zero", "fan"]
-    if input_dtype == np.object or output0_dtype == np.object or output1_dtype == np.object:
+    if input_dtype == np.object_ or output0_dtype == np.object_ or output1_dtype == np.object_:
         for type_str in test_type_involved:
             if type_str in ensemble_type:
                 return False
 
     # Otherwise, check input / output separately
-    if input_dtype == np.object and "sequence" in ensemble_type:
+    if input_dtype == np.object_ and "sequence" in ensemble_type:
         return False
 
     return True
@@ -155,9 +155,9 @@ def validate_for_onnx_model(input_dtype, output0_dtype, output1_dtype,
     # If the input type is string the output type must be string or
     # int32. This is because the QA models we generate convert strings
     # internally to int32 for compute.
-    if ((input_dtype == np.object) and
-        (((output0_dtype != np.object) and (output0_dtype != np.int32)) or
-         ((output1_dtype != np.object) and (output1_dtype != np.int32)))):
+    if ((input_dtype == np.object_) and
+        (((output0_dtype != np.object_) and (output0_dtype != np.int32)) or
+         ((output1_dtype != np.object_) and (output1_dtype != np.int32)))):
         return False
 
     return True
@@ -168,9 +168,9 @@ def validate_for_libtorch_model(input_dtype, output0_dtype, output1_dtype,
     """Return True if input and output dtypes are supported by a libtorch model."""
 
     # STRING, FLOAT16 and UINT16 data types are not supported currently
-    if (input_dtype == np.object) or (output0_dtype
-                                      == np.object) or (output1_dtype
-                                                        == np.object):
+    if (input_dtype == np.object_) or (output0_dtype
+                                       == np.object_) or (output1_dtype
+                                                          == np.object_):
         return False
     if (input_dtype == np.uint16) or (output0_dtype
                                       == np.uint16) or (output1_dtype

--- a/qa/python_models/add_sub/model.py
+++ b/qa/python_models/add_sub/model.py
@@ -60,7 +60,7 @@ class TritonPythonModel:
             in_0 = pb_utils.get_input_tensor_by_name(request, "INPUT0")
             in_1 = pb_utils.get_input_tensor_by_name(request, "INPUT1")
             if in_0.as_numpy().dtype.type is np.bytes_ or in_0.as_numpy(
-            ).dtype == np.object:
+            ).dtype == np.object_:
                 out_0, out_1 = (in_0.as_numpy().astype(np.int32) + in_1.as_numpy().astype(np.int32),\
                     in_0.as_numpy().astype(np.int32) - in_1.as_numpy().astype(np.int32))
             else:

--- a/qa/python_models/init_args/model.py
+++ b/qa/python_models/init_args/model.py
@@ -33,6 +33,7 @@ import triton_python_backend_utils as pb_utils
 
 
 class TritonPythonModel:
+
     def initialize(self, args):
         self.args = args
         if args['model_name'] != 'init_args' or args[

--- a/qa/python_models/model_env/model.py
+++ b/qa/python_models/model_env/model.py
@@ -46,4 +46,3 @@ class TritonPythonModel:
             out_tensor = pb_utils.Tensor("OUT", input_tensor.as_numpy())
             responses.append(pb_utils.InferenceResponse([out_tensor], error))
         return responses
-

--- a/qa/python_models/multi_file/model.py
+++ b/qa/python_models/multi_file/model.py
@@ -46,4 +46,3 @@ class TritonPythonModel:
             out_tensor = pb_utils.Tensor("OUT", input_tensor.as_numpy())
             responses.append(pb_utils.InferenceResponse([out_tensor], error))
         return responses
-

--- a/qa/python_models/string/model.py
+++ b/qa/python_models/string/model.py
@@ -46,6 +46,5 @@ class TritonPythonModel:
             input_tensors = request.inputs()
             in_0 = pb_utils.get_input_tensor_by_name(request, "INPUT0")
             out_tensor_0 = pb_utils.Tensor("OUTPUT0", in_0.as_numpy())
-            responses.append(
-                pb_utils.InferenceResponse([out_tensor_0]))
+            responses.append(pb_utils.InferenceResponse([out_tensor_0]))
         return responses

--- a/qa/python_models/sub_add/model.py
+++ b/qa/python_models/sub_add/model.py
@@ -60,7 +60,7 @@ class TritonPythonModel:
             in_0 = pb_utils.get_input_tensor_by_name(request, "INPUT0")
             in_1 = pb_utils.get_input_tensor_by_name(request, "INPUT1")
             if in_0.as_numpy().dtype.type is np.bytes_ or in_0.as_numpy(
-            ).dtype == np.object:
+            ).dtype == np.object_:
                 out_0, out_1 = (in_0.as_numpy().astype(np.int32) - in_1.as_numpy().astype(np.int32),\
                     in_0.as_numpy().astype(np.int32) + in_1.as_numpy().astype(np.int32))
             else:

--- a/src/clients/python/examples/grpc_image_client.py
+++ b/src/clients/python/examples/grpc_image_client.py
@@ -76,7 +76,7 @@ def deserialize_bytes_tensor(encoded_tensor):
         sb = struct.unpack_from("<{}s".format(l), val_buf, offset)[0]
         offset += l
         strs.append(sb)
-    return (np.array(strs, dtype=bytes))
+    return (np.array(strs, dtype=np.object_))
 
 
 def parse_model(model_metadata, model_config):

--- a/src/clients/python/examples/image_client.py
+++ b/src/clients/python/examples/image_client.py
@@ -269,7 +269,7 @@ def postprocess(results, output_name, batch_size, batching):
         if not batching:
             results = [results]
         for result in results:
-            if output_array.dtype.type == np.bytes_:
+            if output_array.dtype.type == np.object_:
                 cls = "".join(chr(x) for x in result).split(':')
             else:
                 cls = result.split(':')

--- a/src/clients/python/examples/simple_grpc_sequence_stream_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_sequence_stream_infer_client.py
@@ -178,11 +178,11 @@ if __name__ == '__main__':
             recv_count = recv_count + 1
 
     for i in range(len(result0_list)):
-        seq0_expected = 1 if (i == 0) else values[i-1]
-        seq1_expected = 101 if (i == 0) else values[i-1] * -1
+        seq0_expected = 1 if (i == 0) else values[i - 1]
+        seq1_expected = 101 if (i == 0) else values[i - 1] * -1
         # The dyna_sequence custom backend adds the correlation ID
         # to the last request in a sequence.
-        if FLAGS.dyna and (i != 0) and (values[i-1] == 1):
+        if FLAGS.dyna and (i != 0) and (values[i - 1] == 1):
             seq0_expected += sequence_id0
             seq1_expected += sequence_id1
 

--- a/src/clients/python/examples/simple_grpc_sequence_sync_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_sequence_sync_infer_client.py
@@ -137,11 +137,11 @@ if __name__ == '__main__':
         sys.exit(1)
 
     for i in range(len(result0_list)):
-        seq0_expected = 1 if (i == 0) else values[i-1]
-        seq1_expected = 101 if (i == 0) else values[i-1] * -1
+        seq0_expected = 1 if (i == 0) else values[i - 1]
+        seq1_expected = 101 if (i == 0) else values[i - 1] * -1
         # The dyna_sequence custom backend adds the correlation ID
         # to the last request in a sequence.
-        if FLAGS.dyna and (i != 0) and (values[i-1] == 1):
+        if FLAGS.dyna and (i != 0) and (values[i - 1] == 1):
             seq0_expected += sequence_id0
             seq1_expected += sequence_id1
 

--- a/src/clients/python/examples/simple_grpc_shm_string_client.py
+++ b/src/clients/python/examples/simple_grpc_shm_string_client.py
@@ -76,25 +76,29 @@ if __name__ == '__main__':
     # Create the data for the two input tensors. Initialize the first
     # to unique integers and the second to all ones.
     in0 = np.arange(start=0, stop=16, dtype=np.int32)
-    in0n = np.array([str(x) for x in in0.flatten()], dtype=object)
+    in0n = np.array([str(x).encode('utf-8') for x in in0.flatten()],
+                    dtype=object)
     input0_data = in0n.reshape(in0.shape)
     in1 = np.ones(shape=16, dtype=np.int32)
-    in1n = np.array([str(x) for x in in1.flatten()], dtype=object)
+    in1n = np.array([str(x).encode('utf-8') for x in in1.flatten()],
+                    dtype=object)
     input1_data = in1n.reshape(in1.shape)
 
-    expected_sum = np.array([str(x) for x in np.add(in0, in1).flatten()],
-                            dtype=object)
-    expected_diff = np.array([str(x) for x in np.subtract(in0, in1).flatten()],
-                             dtype=object)
+    expected_sum = np.array(
+        [str(x).encode('utf-8') for x in np.add(in0, in1).flatten()],
+        dtype=object)
+    expected_diff = np.array(
+        [str(x).encode('utf-8') for x in np.subtract(in0, in1).flatten()],
+        dtype=object)
     expected_sum_serialized = utils.serialize_byte_tensor(expected_sum)
     expected_diff_serialized = utils.serialize_byte_tensor(expected_diff)
 
     input0_data_serialized = utils.serialize_byte_tensor(input0_data)
     input1_data_serialized = utils.serialize_byte_tensor(input1_data)
-    input0_byte_size = input0_data_serialized.size * input0_data_serialized.itemsize
-    input1_byte_size = input1_data_serialized.size * input1_data_serialized.itemsize
-    output0_byte_size = expected_sum_serialized.size * expected_sum_serialized.itemsize
-    output1_byte_size = expected_diff_serialized.size * expected_diff_serialized.itemsize
+    input0_byte_size = utils.serialized_byte_size(input0_data_serialized)
+    input1_byte_size = utils.serialized_byte_size(input1_data_serialized)
+    output0_byte_size = utils.serialized_byte_size(expected_sum_serialized)
+    output1_byte_size = utils.serialized_byte_size(expected_diff_serialized)
     output_byte_size = max(input0_byte_size, input1_byte_size) + 1
 
     # Create Output0 and Output1 in Shared Memory and store shared memory handles
@@ -171,10 +175,12 @@ if __name__ == '__main__':
         sys.exit(1)
 
     for i in range(16):
-        r0 = output0_data[0][i].decode("utf-8")
-        r1 = output1_data[0][i].decode("utf-8")
-        print(str(input0_data[i]) + " + " + str(input1_data[i]) + " = " + r0)
-        print(str(input0_data[i]) + " - " + str(input1_data[i]) + " = " + r1)
+        r0 = output0_data[0][i]
+        r1 = output1_data[0][i]
+        print(
+            str(input0_data[i]) + " + " + str(input1_data[i]) + " = " + str(r0))
+        print(
+            str(input0_data[i]) + " - " + str(input1_data[i]) + " = " + str(r1))
 
         if expected_sum[i] != r0:
             print("shm infer error: incorrect sum")

--- a/src/clients/python/examples/simple_grpc_string_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_string_infer_client.py
@@ -68,9 +68,11 @@ if __name__ == '__main__':
     expected_sum = np.add(in0, in1)
     expected_diff = np.subtract(in0, in1)
 
-    in0n = np.array([str(x) for x in in0.reshape(in0.size)], dtype=object)
+    in0n = np.array([str(x).encode('utf-8') for x in in0.reshape(in0.size)],
+                    dtype=object)
     input0_data = in0n.reshape(in0.shape)
-    in1n = np.array([str(x) for x in in1.reshape(in1.size)], dtype=object)
+    in1n = np.array([str(x).encode('utf-8') for x in in1.reshape(in1.size)],
+                    dtype=object)
     input1_data = in1n.reshape(in1.shape)
 
     # Initialize the data

--- a/src/clients/python/examples/simple_http_sequence_sync_infer_client.py
+++ b/src/clients/python/examples/simple_http_sequence_sync_infer_client.py
@@ -137,11 +137,11 @@ if __name__ == '__main__':
         sys.exit(1)
 
     for i in range(len(result0_list)):
-        seq0_expected = 1 if (i == 0) else values[i-1]
-        seq1_expected = 101 if (i == 0) else values[i-1] * -1
+        seq0_expected = 1 if (i == 0) else values[i - 1]
+        seq1_expected = 101 if (i == 0) else values[i - 1] * -1
         # The dyna_sequence custom backend adds the correlation ID
         # to the last request in a sequence.
-        if FLAGS.dyna and (i != 0) and (values[i-1] == 1):
+        if FLAGS.dyna and (i != 0) and (values[i - 1] == 1):
             seq0_expected += sequence_id0
             seq1_expected += sequence_id1
 

--- a/src/clients/python/examples/simple_http_shm_string_client.py
+++ b/src/clients/python/examples/simple_http_shm_string_client.py
@@ -76,26 +76,29 @@ if __name__ == '__main__':
     # Create the data for the two input tensors. Initialize the first
     # to unique integers and the second to all ones.
     in0 = np.arange(start=0, stop=16, dtype=np.int32)
-    in0n = np.array([str(x) for x in in0.flatten()], dtype=object)
+    in0n = np.array([str(x).encode('utf-8') for x in in0.flatten()],
+                    dtype=object)
     input0_data = in0n.reshape(in0.shape)
     in1 = np.ones(shape=16, dtype=np.int32)
-    in1n = np.array([str(x) for x in in1.flatten()], dtype=object)
+    in1n = np.array([str(x).encode('utf-8') for x in in1.flatten()],
+                    dtype=object)
     input1_data = in1n.reshape(in1.shape)
 
-    expected_sum = np.array([str(x) for x in np.add(in0, in1).flatten()],
-                            dtype=object)
-    expected_diff = np.array([str(x) for x in np.subtract(in0, in1).flatten()],
-                             dtype=object)
+    expected_sum = np.array(
+        [str(x).encode('utf-8') for x in np.add(in0, in1).flatten()],
+        dtype=object)
+    expected_diff = np.array(
+        [str(x).encode('utf-8') for x in np.subtract(in0, in1).flatten()],
+        dtype=object)
     expected_sum_serialized = utils.serialize_byte_tensor(expected_sum)
     expected_diff_serialized = utils.serialize_byte_tensor(expected_diff)
 
     input0_data_serialized = utils.serialize_byte_tensor(input0_data)
     input1_data_serialized = utils.serialize_byte_tensor(input1_data)
-    input0_byte_size = input0_data_serialized.size * input0_data_serialized.itemsize
-    input1_byte_size = input1_data_serialized.size * input1_data_serialized.itemsize
-    output0_byte_size = expected_sum_serialized.size * expected_sum_serialized.itemsize
-    output1_byte_size = expected_diff_serialized.size * expected_diff_serialized.itemsize
-    output_byte_size = max(input0_byte_size, input1_byte_size) + 1
+    input0_byte_size = utils.serialized_byte_size(input0_data_serialized)
+    input1_byte_size = utils.serialized_byte_size(input1_data_serialized)
+    output0_byte_size = utils.serialized_byte_size(expected_sum_serialized)
+    output1_byte_size = utils.serialized_byte_size(expected_diff_serialized)
 
     # Create Output0 and Output1 in Shared Memory and store shared memory handles
     shm_op0_handle = shm.create_shared_memory_region("output0_data",
@@ -171,10 +174,12 @@ if __name__ == '__main__':
         sys.exit(1)
 
     for i in range(16):
-        r0 = output0_data[0][i].decode("utf-8")
-        r1 = output1_data[0][i].decode("utf-8")
-        print(str(input0_data[i]) + " + " + str(input1_data[i]) + " = " + r0)
-        print(str(input0_data[i]) + " - " + str(input1_data[i]) + " = " + r1)
+        r0 = output0_data[0][i]
+        r1 = output1_data[0][i]
+        print(
+            str(input0_data[i]) + " + " + str(input1_data[i]) + " = " + str(r0))
+        print(
+            str(input0_data[i]) + " - " + str(input1_data[i]) + " = " + str(r1))
 
         if expected_sum[i] != r0:
             print("shm infer error: incorrect sum")

--- a/src/clients/python/library/tritonclient/grpc/__init__.py
+++ b/src/clients/python/library/tritonclient/grpc/__init__.py
@@ -1443,7 +1443,11 @@ class InferInput:
         self._input.parameters.pop('shared_memory_offset', None)
 
         if self._input.datatype == "BYTES":
-            self._raw_content = serialize_byte_tensor(input_tensor).tobytes()
+            serialized_output = serialize_byte_tensor(input_tensor)
+            if serialized_output.size > 0:
+                self._raw_content = serialized_output.item()
+            else:
+                self._raw_content = b''
         else:
             self._raw_content = input_tensor.tobytes()
 

--- a/src/clients/python/library/tritonclient/http/__init__.py
+++ b/src/clients/python/library/tritonclient/http/__init__.py
@@ -1402,7 +1402,11 @@ class InferInput:
         else:
             self._data = None
             if self._datatype == "BYTES":
-                self._raw_data = serialize_byte_tensor(input_tensor).tobytes()
+                serialized_output = serialize_byte_tensor(input_tensor)
+                if serialized_output.size > 0:
+                    self._raw_data = serialized_output.item()
+                else:
+                    self._raw_data = b''
             else:
                 self._raw_data = input_tensor.tobytes()
             self._parameters['binary_data_size'] = len(self._raw_data)

--- a/src/clients/python/library/tritonclient/utils/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/__init__.py
@@ -35,6 +35,33 @@ def raise_error(msg):
     raise InferenceServerException(msg=msg) from None
 
 
+def serialized_byte_size(tensor_value):
+    """
+    Get the underlying number of bytes for a numpy ndarray.
+
+    Parameters
+    ----------
+    tensor_value : numpy.ndarray
+        Numpy array to calculate the number of bytes for.
+
+    Returns
+    -------
+    int
+        Number of bytes present in this tensor
+    """
+
+    if tensor_value.dtype != np.object_:
+        raise_error('The tensor_value dtype must be np.object_')
+
+    if tensor_value.size > 0:
+        total_bytes = 0
+        for obj in np.nditer(tensor_value, flags=["refs_ok"], order='C'):
+            total_bytes += len(obj.item())
+        return total_bytes
+    else:
+        return 0
+
+
 class InferenceServerException(Exception):
     """Exception indicating non-Success status.
 
@@ -45,7 +72,7 @@ class InferenceServerException(Exception):
 
     status : str
         The error code
-    
+
     debug_details : str
         The additional details on the error
 
@@ -122,7 +149,7 @@ def np_to_triton_dtype(np_dtype):
         return "FP32"
     elif np_dtype == np.float64:
         return "FP64"
-    elif np_dtype == np.object or np_dtype.type == np.bytes_:
+    elif np_dtype == np.object_ or np_dtype.type == np.bytes_:
         return "BYTES"
     return None
 
@@ -153,7 +180,7 @@ def triton_to_np_dtype(dtype):
     elif dtype == "FP64":
         return np.float64
     elif dtype == "BYTES":
-        return np.object
+        return np.object_
     return None
 
 
@@ -180,14 +207,14 @@ def serialize_byte_tensor(input_tensor):
         """
 
     if input_tensor.size == 0:
-        return np.empty([0])
+        return np.empty([0], dtype=np.object_)
 
     # If the input is a tensor of string/bytes objects, then must flatten those into
     # a 1-dimensional array containing the 4-byte byte size followed by the
     # actual element bytes. All elements are concatenated together in "C"
     # order.
-    if (input_tensor.dtype == np.object) or (input_tensor.dtype.type
-                                             == np.bytes_):
+    if (input_tensor.dtype == np.object_) or (input_tensor.dtype.type
+                                              == np.bytes_):
         flattened = bytes()
         for obj in np.nditer(input_tensor, flags=["refs_ok"], order='C'):
             # If directly passing bytes to BYTES type,
@@ -202,9 +229,10 @@ def serialize_byte_tensor(input_tensor):
                 s = str(obj).encode('utf-8')
             flattened += struct.pack("<I", len(s))
             flattened += s
-        flattened_array = np.asarray(flattened)
+        flattened_array = np.asarray(flattened, dtype=np.object_)
         if not flattened_array.flags['C_CONTIGUOUS']:
-            flattened_array = np.ascontiguousarray(flattened_array)
+            flattened_array = np.ascontiguousarray(flattened_array,
+                                                   dtype=np.object_)
         return flattened_array
     else:
         raise_error("cannot serialize bytes tensor: invalid datatype")
@@ -238,4 +266,4 @@ def deserialize_bytes_tensor(encoded_tensor):
         sb = struct.unpack_from("<{}s".format(l), val_buf, offset)[0]
         offset += l
         strs.append(sb)
-    return (np.array(strs, dtype=bytes))
+    return (np.array(strs, dtype=np.object_))

--- a/src/clients/python/library/tritonclient/utils/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/__init__.py
@@ -186,25 +186,26 @@ def triton_to_np_dtype(dtype):
 
 def serialize_byte_tensor(input_tensor):
     """
-        Serializes a bytes tensor into a flat numpy array of length prepend bytes.
-        Can pass bytes tensor as numpy array of bytes with dtype of np.bytes_,
-        numpy strings with dtype of np.str_ or python strings with dtype of np.object.
+    Serializes a bytes tensor into a flat numpy array of length prepended
+    bytes. The numpy array should use dtype of np.object_. For np.bytes_,
+    numpy will remove trailing zeros at the end of byte sequence and because
+    of this it should be avoided.
 
-        Parameters
-        ----------
-        input_tensor : np.array
-            The bytes tensor to serialize.
+    Parameters
+    ----------
+    input_tensor : np.array
+        The bytes tensor to serialize.
 
-        Returns
-        -------
-        serialized_bytes_tensor : np.array
-            The 1-D numpy array of type uint8 containing the serialized bytes in 'C' order.
+    Returns
+    -------
+    serialized_bytes_tensor : np.array
+        The 1-D numpy array of type uint8 containing the serialized bytes in 'C' order.
 
-        Raises
-        ------
-        InferenceServerException
-            If unable to serialize the given tensor.
-        """
+    Raises
+    ------
+    InferenceServerException
+        If unable to serialize the given tensor.
+    """
 
     if input_tensor.size == 0:
         return np.empty([0], dtype=np.object_)
@@ -220,13 +221,10 @@ def serialize_byte_tensor(input_tensor):
             # If directly passing bytes to BYTES type,
             # don't convert it to str as Python will encode the
             # bytes which may distort the meaning
-            if obj.dtype.type == np.bytes_:
-                if type(obj.item()) == bytes:
-                    s = obj.item()
-                else:
-                    s = bytes(obj)
+            if type(obj.item()) == bytes:
+                s = obj.item()
             else:
-                s = str(obj).encode('utf-8')
+                s = bytes(obj)
             flattened += struct.pack("<I", len(s))
             flattened += s
         flattened_array = np.asarray(flattened, dtype=np.object_)

--- a/src/clients/python/library/tritonclient/utils/shared_memory/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/shared_memory/__init__.py
@@ -150,10 +150,17 @@ def set_shared_memory_region(shm_handle, input_values):
     offset_current = 0
     for input_value in input_values:
         input_value = np.ascontiguousarray(input_value).flatten()
-        byte_size = input_value.size * input_value.itemsize
-        _raise_if_error(
-            c_int(_cshm_shared_memory_region_set(shm_handle, c_uint64(offset_current), \
-                c_uint64(byte_size), input_value.ctypes.data_as(c_void_p))))
+        if input_value.dtype == np.object_:
+            input_value = input_value.item()
+            byte_size = np.dtype(np.byte).itemsize * len(input_value)
+            _raise_if_error(
+                c_int(_cshm_shared_memory_region_set(shm_handle, c_uint64(offset_current), \
+                    c_uint64(byte_size), cast(input_value, c_void_p))))
+        else:
+            byte_size = input_value.size * input_value.itemsize
+            _raise_if_error(
+                c_int(_cshm_shared_memory_region_set(shm_handle, c_uint64(offset_current), \
+                    c_uint64(byte_size), input_value.ctypes.data_as(c_void_p))))
         offset_current += byte_size
     return
 
@@ -186,7 +193,7 @@ def get_contents_as_numpy(shm_handle, datatype, shape):
             c_int(_cshm_get_shared_memory_handle_info(shm_handle, byref(shm_addr), byref(shm_key), byref(shm_fd), \
                                     byref(offset), byref(byte_size))))
     start_pos = offset.value
-    if (datatype != np.object) and (datatype != np.bytes_):
+    if (datatype != np.object_) and (datatype != np.bytes_):
         requested_byte_size = np.prod(shape) * np.dtype(datatype).itemsize
         cval_len = start_pos + requested_byte_size
         if byte_size.value < cval_len:


### PR DESCRIPTION
Backward compatibility notes:

* All the shared memory operations on string need to be updated to fix the number of bytes calculation (we can include the function used in the `infer_util` in the Python package to facilitate this `get_number_of_bytes_for_npobject`).
* If a user code relied on the encoding to `utf-8` be performed in the client code for `np.object` that will no longer be the case (It was merged in the previous PR).
* The serialized tensor will be `np.object` instead of `np.bytes`.
* `np.bytes_` still works for regular inference (without shared memory).
