### PR TITLE
Disable openvino from nomodel test

### DIFF
--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -27,7 +27,7 @@
 
 REPO_VERSION=$1
 
-BACKENDS=${BACKENDS:="plan custom graphdef savedmodel onnx libtorch python openvino"}
+BACKENDS=${BACKENDS:="plan custom graphdef savedmodel onnx libtorch python"}
 STATIC_BATCH_SIZES=${STATIC_BATCH_SIZES:=1}
 DYNAMIC_BATCH_SIZES=${DYNAMIC_BATCH_SIZES:=1}
 INSTANCE_COUNTS=${INSTANCE_COUNTS:=1}

--- a/qa/L0_perf_nomodel/test.sh
+++ b/qa/L0_perf_nomodel/test.sh
@@ -139,7 +139,7 @@ TEST_CONCURRENCY+=(
     1
     16
     16)
-TEST_BACKENDS="plan custom graphdef savedmodel onnx libtorch python openvino"
+TEST_BACKENDS="plan custom graphdef savedmodel onnx libtorch python"
 
 
 mkdir -p ${REPO_VERSION}


### PR DESCRIPTION
- Model failure when moving to version 2021.1