### PR TITLE
Remove deprecated numpy usages from client

### DIFF
--- a/qa/L0_backend_python/python_test.py
+++ b/qa/L0_backend_python/python_test.py
@@ -123,7 +123,7 @@ class PythonTest(tu.TestResultCollector):
     def test_bool(self):
         model_name = 'identity_bool'
         with httpclient.InferenceServerClient("localhost:8000") as client:
-            input_data = np.array([[True, False, True]], dtype=np.bool)
+            input_data = np.array([[True, False, True]], dtype=bool)
             inputs = [
                 httpclient.InferInput("INPUT0", input_data.shape,
                                       np_to_triton_dtype(input_data.dtype))

--- a/qa/L0_infer_zero/infer_zero_test.py
+++ b/qa/L0_infer_zero/infer_zero_test.py
@@ -269,12 +269,12 @@ class InferZeroTest(tu.TestResultCollector):
         self._full_zero(np_dtype_string, ([1, 1], [0, 6], [2, 2]))
 
     def test_bb1_sanity(self):
-        self._full_zero(np.bool, ([
+        self._full_zero(bool, ([
             10,
         ],))
 
     def test_bb1_0(self):
-        self._full_zero(np.bool, ([
+        self._full_zero(bool, ([
             0,
         ],))
 

--- a/qa/common/gen_ensemble_model_utils.py
+++ b/qa/common/gen_ensemble_model_utils.py
@@ -34,7 +34,7 @@ np_dtype_string = np.dtype(object)
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"

--- a/qa/common/gen_qa_dyna_sequence_models.py
+++ b/qa/common/gen_qa_dyna_sequence_models.py
@@ -35,7 +35,7 @@ np_dtype_string = np.dtype(object)
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -61,7 +61,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_tf_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return tf.bool
     elif np_dtype == np.int8:
         return tf.int8
@@ -87,7 +87,7 @@ def np_to_tf_dtype(np_dtype):
 
 
 def np_to_trt_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return trt.bool
     elif np_dtype == np.int8:
         return trt.int8
@@ -101,7 +101,7 @@ def np_to_trt_dtype(np_dtype):
 
 
 def np_to_onnx_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return onnx.TensorProto.BOOL
     elif np_dtype == np.int8:
         return onnx.TensorProto.INT8
@@ -126,7 +126,7 @@ def np_to_onnx_dtype(np_dtype):
 
 
 def np_to_torch_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return torch.bool
     elif np_dtype == np.int8:
         return torch.int8

--- a/qa/common/gen_qa_identity_models.py
+++ b/qa/common/gen_qa_identity_models.py
@@ -36,7 +36,7 @@ np_dtype_string = np.dtype(object)
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -62,7 +62,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_tf_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return tf.bool
     elif np_dtype == np.int8:
         return tf.int8
@@ -88,7 +88,7 @@ def np_to_tf_dtype(np_dtype):
 
 
 def np_to_trt_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return trt.bool
     elif np_dtype == np.int8:
         return trt.int8
@@ -102,7 +102,7 @@ def np_to_trt_dtype(np_dtype):
 
 
 def np_to_onnx_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return onnx.TensorProto.BOOL
     elif np_dtype == np.int8:
         return onnx.TensorProto.INT8
@@ -128,7 +128,7 @@ def np_to_onnx_dtype(np_dtype):
 
 
 def np_to_torch_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return torch.bool
     elif np_dtype == np.int8:
         return torch.int8
@@ -1020,7 +1020,7 @@ if __name__ == '__main__':
                                    np.float32, [-1, -1],
                                    io_cnt=1)
     else:
-        create_models(FLAGS.models_dir, np.bool, [-1], io_cnt=1)
+        create_models(FLAGS.models_dir, bool, [-1], io_cnt=1)
         create_models(FLAGS.models_dir, np.float32, [-1], io_cnt=1)
         create_models(FLAGS.models_dir, np.float32, [-1], io_cnt=3)
         create_models(FLAGS.models_dir, np.float16, [-1, -1], io_cnt=1)

--- a/qa/common/gen_qa_models.py
+++ b/qa/common/gen_qa_models.py
@@ -36,7 +36,7 @@ np_dtype_string = np.dtype(object)
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -62,7 +62,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_tf_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return tf.bool
     elif np_dtype == np.int8:
         return tf.int8
@@ -88,7 +88,7 @@ def np_to_tf_dtype(np_dtype):
 
 
 def np_to_trt_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return trt.bool
     elif np_dtype == np.int8:
         return trt.int8
@@ -102,7 +102,7 @@ def np_to_trt_dtype(np_dtype):
 
 
 def np_to_onnx_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return onnx.TensorProto.BOOL
     elif np_dtype == np.int8:
         return onnx.TensorProto.INT8
@@ -128,7 +128,7 @@ def np_to_onnx_dtype(np_dtype):
 
 
 def np_to_torch_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return torch.bool
     elif np_dtype == np.int8:
         return torch.int8

--- a/qa/common/gen_qa_noshape_models.py
+++ b/qa/common/gen_qa_noshape_models.py
@@ -35,7 +35,7 @@ np_dtype_string = np.dtype(object)
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -61,7 +61,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_tf_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return tf.bool
     elif np_dtype == np.int8:
         return tf.int8

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -33,7 +33,7 @@ import numpy as np
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -59,7 +59,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_trt_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return trt.bool
     elif np_dtype == np.int8:
         return trt.int8

--- a/qa/common/gen_qa_reshape_models.py
+++ b/qa/common/gen_qa_reshape_models.py
@@ -36,7 +36,7 @@ np_dtype_string = np.dtype(object)
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -62,7 +62,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_tf_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return tf.bool
     elif np_dtype == np.int8:
         return tf.int8
@@ -88,7 +88,7 @@ def np_to_tf_dtype(np_dtype):
 
 
 def np_to_trt_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return trt.bool
     elif np_dtype == np.int8:
         return trt.int8
@@ -102,7 +102,7 @@ def np_to_trt_dtype(np_dtype):
 
 
 def np_to_onnx_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return onnx.TensorProto.BOOL
     elif np_dtype == np.int8:
         return onnx.TensorProto.INT8
@@ -128,7 +128,7 @@ def np_to_onnx_dtype(np_dtype):
 
 
 def np_to_torch_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return torch.bool
     elif np_dtype == np.int8:
         return torch.int8

--- a/qa/common/gen_qa_sequence_models.py
+++ b/qa/common/gen_qa_sequence_models.py
@@ -36,7 +36,7 @@ np_dtype_string = np.dtype(object)
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -62,7 +62,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_tf_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return tf.bool
     elif np_dtype == np.int8:
         return tf.int8
@@ -88,7 +88,7 @@ def np_to_tf_dtype(np_dtype):
 
 
 def np_to_trt_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return trt.bool
     elif np_dtype == np.int8:
         return trt.int8
@@ -102,7 +102,7 @@ def np_to_trt_dtype(np_dtype):
 
 
 def np_to_onnx_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return onnx.TensorProto.BOOL
     elif np_dtype == np.int8:
         return onnx.TensorProto.INT8
@@ -127,7 +127,7 @@ def np_to_onnx_dtype(np_dtype):
 
 
 def np_to_torch_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return torch.bool
     elif np_dtype == np.int8:
         return torch.int8

--- a/qa/common/gen_qa_trt_format_models.py
+++ b/qa/common/gen_qa_trt_format_models.py
@@ -33,7 +33,7 @@ import test_util as tu
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -59,7 +59,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_trt_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return trt.bool
     elif np_dtype == np.int8:
         return trt.int8

--- a/qa/common/gen_qa_trt_plugin_models.py
+++ b/qa/common/gen_qa_trt_plugin_models.py
@@ -39,7 +39,7 @@ PLUGIN_CREATORS = trt.get_plugin_registry().plugin_creator_list
 
 
 def np_to_model_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "TYPE_BOOL"
     elif np_dtype == np.int8:
         return "TYPE_INT8"
@@ -65,7 +65,7 @@ def np_to_model_dtype(np_dtype):
 
 
 def np_to_trt_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return trt.bool
     elif np_dtype == np.int8:
         return trt.int8

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -643,7 +643,7 @@ def infer_shape_tensor(tester,
 
         # Prepare the dummy tensor
         rtensor_dtype = _range_repr_dtype(tensor_dtype)
-        if (rtensor_dtype != np.bool):
+        if (rtensor_dtype != bool):
             dummy_in0 = np.random.randint(low=np.iinfo(rtensor_dtype).min,
                                           high=np.iinfo(rtensor_dtype).max,
                                           size=dummy_input_shapes[io_num],
@@ -882,7 +882,7 @@ def infer_zero(tester,
         output_shape = output_shapes[io_num]
 
         rtensor_dtype = _range_repr_dtype(tensor_dtype)
-        if (rtensor_dtype != np.bool):
+        if (rtensor_dtype != bool):
             input_array = np.random.randint(low=np.iinfo(rtensor_dtype).min,
                                             high=np.iinfo(rtensor_dtype).max,
                                             size=input_shape,

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -184,7 +184,7 @@ def infer_exact(tester,
                                  dtype=object).reshape(output0_array.shape)
     else:
         output0_array = output0_array.astype(output0_dtype)
-    if output1_dtype == np.object:
+    if output1_dtype == np.object_:
         output1_array = np.array([
             unicode(str(x), encoding='utf-8') for x in (output1_array.flatten())
         ],

--- a/qa/common/test_util.py
+++ b/qa/common/test_util.py
@@ -89,7 +89,7 @@ def validate_for_tf_model(input_dtype, output0_dtype, output1_dtype,
 def validate_for_trt_model(input_dtype, output0_dtype, output1_dtype,
                            input_shape, output0_shape, output1_shape):
     """Return True if input and output dtypes are supported by a TRT model."""
-    supported_datatypes = [np.bool, np.int8, np.int32, np.float16, np.float32]
+    supported_datatypes = [bool, np.int8, np.int32, np.float16, np.float32]
     if not input_dtype in supported_datatypes:
         return False
     if not output0_dtype in supported_datatypes:

--- a/src/clients/python/examples/grpc_image_client.py
+++ b/src/clients/python/examples/grpc_image_client.py
@@ -42,7 +42,7 @@ FLAGS = None
 
 def model_dtype_to_np(model_dtype):
     if model_dtype == "BOOL":
-        return np.bool
+        return bool
     elif model_dtype == "INT8":
         return np.int8
     elif model_dtype == "INT16":

--- a/src/clients/python/library/tritonclient/utils/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/__init__.py
@@ -125,7 +125,7 @@ class InferenceServerException(Exception):
 
 
 def np_to_triton_dtype(np_dtype):
-    if np_dtype == np.bool:
+    if np_dtype == bool:
         return "BOOL"
     elif np_dtype == np.int8:
         return "INT8"
@@ -156,7 +156,7 @@ def np_to_triton_dtype(np_dtype):
 
 def triton_to_np_dtype(dtype):
     if dtype == "BOOL":
-        return np.bool
+        return bool
     elif dtype == "INT8":
         return np.int8
     elif dtype == "INT16":


### PR DESCRIPTION
This PR removes the [deprecated numpy usages](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) from the codebase. 
Specifically `numpy.bool` usages and fixes one mis-use of `numpy.object`.

# Verified that deprecation warnings are gone