### PR TITLE
Support compression in gRPC transactions

### DIFF
--- a/src/clients/c++/library/grpc_client.h.in
+++ b/src/clients/c++/library/grpc_client.h.in
@@ -303,6 +303,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// config will be returned as default settings.
   /// \param headers Optional map specifying additional HTTP headers to include
   /// in the metadata of gRPC request.
+  /// \param compression_algorithm The compression algorithm to be used
+  /// by gRPC when sending requests. By default compression is not used.
   /// \return Error object indicating success or failure of the
   /// request.
   Error Infer(
@@ -310,7 +312,8 @@ class InferenceServerGrpcClient : public InferenceServerClient {
       const std::vector<InferInput*>& inputs,
       const std::vector<const InferRequestedOutput*>& outputs =
           std::vector<const InferRequestedOutput*>(),
-      const Headers& headers = Headers());
+      const Headers& headers = Headers(), 
+      grpc_compression_algorithm compression_algorithm=GRPC_COMPRESS_NONE);
 
   /// Run asynchronous inference on server.
   /// Once the request is completed, the InferResult pointer will be passed to
@@ -328,13 +331,16 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// config will be returned as default settings.
   /// \param headers Optional map specifying additional HTTP headers to include
   /// in the metadata of gRPC request.
+  /// \param compression_algorithm The compression algorithm to be used
+  /// by gRPC when sending requests. By default compression is not used.
   /// \return Error object indicating success or failure of the request.
   Error AsyncInfer(
       OnCompleteFn callback, const InferOptions& options,
       const std::vector<InferInput*>& inputs,
       const std::vector<const InferRequestedOutput*>& outputs =
           std::vector<const InferRequestedOutput*>(),
-      const Headers& headers = Headers());
+      const Headers& headers = Headers(),
+      grpc_compression_algorithm compression_algorithm=GRPC_COMPRESS_NONE);
 
   /// Starts a grpc bi-directional stream to send streaming inferences.
   /// \param callback The callback function to be invoked on receiving a
@@ -350,10 +356,13 @@ class InferenceServerGrpcClient : public InferenceServerClient {
   /// the specified time elapses.
   /// \param headers Optional map specifying additional HTTP headers to
   /// include in the metadata of gRPC request.
+  /// \param compression_algorithm The compression algorithm to be used
+  /// by gRPC when sending requests. By default compression is not used.
   /// \return Error object indicating success or failure of the request.
   Error StartStream(
       OnCompleteFn callback, bool enable_stats = true,
-      uint32_t stream_timeout = 0, const Headers& headers = Headers());
+      uint32_t stream_timeout = 0, const Headers& headers = Headers(),
+      grpc_compression_algorithm compression_algorithm=GRPC_COMPRESS_NONE);
 
   /// Stops an active grpc bi-directional stream, if one available.
   /// \return Error object indicating success or failure of the request.

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.cc
@@ -205,7 +205,8 @@ GrpcClient::Infer(
     InferResult** result, const InferOptions& options,
     const std::vector<InferInput*>& inputs,
     const std::vector<const InferRequestedOutput*>& outputs,
-    const Headers& headers)
+    const Headers& headers,
+    const grpc_compression_algorithm compression_algorithm)
 {
   Error err;
 
@@ -221,6 +222,7 @@ GrpcClient::Infer(
   for (const auto& it : headers) {
     context.AddMetadata(it.first, it.second);
   }
+  context.set_compression_algorithm(compression_algorithm);
 
   err = PreRunProcessing(options, inputs, outputs);
   sync_request->Timer().CaptureTimestamp(nic::RequestTimers::Kind::SEND_END);
@@ -260,7 +262,8 @@ GrpcClient::AsyncInfer(
     TFServeOnCompleteFn callback, const InferOptions& options,
     const std::vector<InferInput*>& inputs,
     const std::vector<const InferRequestedOutput*>& outputs,
-    const Headers& headers)
+    const Headers& headers,
+    const grpc_compression_algorithm compression_algorithm)
 {
   if (callback == nullptr) {
     return Error(
@@ -279,6 +282,7 @@ GrpcClient::AsyncInfer(
   for (const auto& it : headers) {
     async_request->grpc_context_.AddMetadata(it.first, it.second);
   }
+  async_request->grpc_context_.set_compression_algorithm(compression_algorithm);
 
   Error err = PreRunProcessing(options, inputs, outputs);
   if (!err.IsOk()) {

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.h
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/grpc_client.h
@@ -114,6 +114,8 @@ class GrpcClient : public nic::InferenceServerClient {
   /// config will be returned as default settings.
   /// \param headers Optional map specifying additional HTTP headers to include
   /// in the metadata of gRPC request.
+  /// \param compression_algorithm The compression algorithm to be used
+  /// on the grpc requests.
   /// \return Error object indicating success or failure of the
   /// request.
   Error Infer(
@@ -121,7 +123,9 @@ class GrpcClient : public nic::InferenceServerClient {
       const std::vector<InferInput*>& inputs,
       const std::vector<const InferRequestedOutput*>& outputs =
           std::vector<const InferRequestedOutput*>(),
-      const Headers& headers = Headers());
+      const Headers& headers = Headers(),
+      const grpc_compression_algorithm compression_algorithm =
+          GRPC_COMPRESS_NONE);
 
   /// Run asynchronous inference on server.
   /// Once the request is completed, the InferResult pointer will be passed to
@@ -139,13 +143,17 @@ class GrpcClient : public nic::InferenceServerClient {
   /// config will be returned as default settings.
   /// \param headers Optional map specifying additional HTTP headers to include
   /// in the metadata of gRPC request.
+  /// \param compression_algorithm The compression algorithm to be used
+  /// on the grpc requests.
   /// \return Error object indicating success or failure of the request.
   Error AsyncInfer(
       TFServeOnCompleteFn callback, const InferOptions& options,
       const std::vector<InferInput*>& inputs,
       const std::vector<const InferRequestedOutput*>& outputs =
           std::vector<const InferRequestedOutput*>(),
-      const Headers& headers = Headers());
+      const Headers& headers = Headers(),
+      const grpc_compression_algorithm compression_algorithm =
+          GRPC_COMPRESS_NONE);
 
  private:
   GrpcClient(

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.cc
@@ -35,6 +35,7 @@ namespace perfanalyzer { namespace clientbackend {
 Error
 TFServeClientBackend::Create(
     const std::string& url, const ProtocolType protocol,
+    const grpc_compression_algorithm compression_algorithm,
     std::shared_ptr<Headers> http_headers, const bool verbose,
     std::unique_ptr<ClientBackend>* client_backend)
 {
@@ -43,7 +44,7 @@ TFServeClientBackend::Create(
         "perf_analyzer does not support http protocol with TF serving");
   }
   std::unique_ptr<TFServeClientBackend> tfserve_client_backend(
-      new TFServeClientBackend(http_headers));
+      new TFServeClientBackend(compression_algorithm, http_headers));
 
   RETURN_IF_CB_ERROR(tfs::GrpcClient::Create(
       &(tfserve_client_backend->grpc_client_), url, verbose));
@@ -82,7 +83,8 @@ TFServeClientBackend::Infer(
 {
   tfs::InferResult* tfserve_result;
   RETURN_IF_CB_ERROR(grpc_client_->Infer(
-      &tfserve_result, options, inputs, outputs, *http_headers_));
+      &tfserve_result, options, inputs, outputs, *http_headers_,
+      compression_algorithm_));
 
   *result = new TFServeInferResult(tfserve_result);
 
@@ -101,7 +103,8 @@ TFServeClientBackend::AsyncInfer(
   };
 
   RETURN_IF_CB_ERROR(grpc_client_->AsyncInfer(
-      wrapped_callback, options, inputs, outputs, *http_headers_));
+      wrapped_callback, options, inputs, outputs, *http_headers_,
+      compression_algorithm_));
 
   return Error::Success;
 }

--- a/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
+++ b/src/clients/c++/perf_analyzer/client_backend/tensorflow_serving/tfserve_client_backend.h
@@ -54,6 +54,8 @@ class TFServeClientBackend : public ClientBackend {
   /// server.
   /// \param url The inference server url and port.
   /// \param protocol The protocol type used.
+  /// \param compression_algorithm The compression algorithm to be used
+  /// on the grpc requests.
   /// \param http_headers Map of HTTP headers. The map key/value indicates
   /// the header name/value.
   /// \param verbose Enables the verbose mode.
@@ -62,6 +64,7 @@ class TFServeClientBackend : public ClientBackend {
   /// \return Error object indicating success or failure.
   static Error Create(
       const std::string& url, const ProtocolType protocol,
+      const grpc_compression_algorithm compression_algorithm,
       std::shared_ptr<Headers> http_headers, const bool verbose,
       std::unique_ptr<ClientBackend>* client_backend);
 
@@ -86,8 +89,11 @@ class TFServeClientBackend : public ClientBackend {
   Error ClientInferStat(InferStat* infer_stat) override;
 
  private:
-  TFServeClientBackend(std::shared_ptr<Headers> http_headers)
+  TFServeClientBackend(
+      const grpc_compression_algorithm compression_algorithm,
+      std::shared_ptr<Headers> http_headers)
       : ClientBackend(BackendKind::TENSORFLOW_SERVING),
+        compression_algorithm_(compression_algorithm),
         http_headers_(http_headers)
   {
   }
@@ -97,6 +103,7 @@ class TFServeClientBackend : public ClientBackend {
 
   std::unique_ptr<tfs::GrpcClient> grpc_client_;
 
+  grpc_compression_algorithm compression_algorithm_;
   std::shared_ptr<Headers> http_headers_;
 };
 

--- a/src/clients/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
+++ b/src/clients/c++/perf_analyzer/client_backend/triton/triton_client_backend.h
@@ -73,6 +73,7 @@ class TritonClientBackend : public ClientBackend {
   /// \return Error object indicating success or failure.
   static Error Create(
       const std::string& url, const ProtocolType protocol,
+      const grpc_compression_algorithm compression_algorithm,
       std::shared_ptr<nic::Headers> http_headers, const bool verbose,
       std::unique_ptr<ClientBackend>* client_backend);
 
@@ -150,8 +151,11 @@ class TritonClientBackend : public ClientBackend {
 
  private:
   TritonClientBackend(
-      const ProtocolType protocol, std::shared_ptr<nic::Headers> http_headers)
+      const ProtocolType protocol,
+      const grpc_compression_algorithm compression_algorithm,
+      std::shared_ptr<nic::Headers> http_headers)
       : ClientBackend(BackendKind::TRITON), protocol_(protocol),
+        compression_algorithm_(compression_algorithm),
         http_headers_(http_headers)
   {
   }
@@ -187,6 +191,7 @@ class TritonClientBackend : public ClientBackend {
   } client_;
 
   const ProtocolType protocol_;
+  const grpc_compression_algorithm compression_algorithm_;
   std::shared_ptr<nic::Headers> http_headers_;
 };
 

--- a/src/clients/python/examples/simple_grpc_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_infer_client.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
         help='File holding PEM-encoded certicate chain. Default is None.')
     parser.add_argument(
         '-C',
-        '--compression_algorithm',
+        '--grpc-compression-algorithm',
         type=str,
         required=False,
         default=None,
@@ -129,7 +129,7 @@ if __name__ == '__main__':
         outputs=outputs,
         client_timeout=FLAGS.client_timeout,
         headers={'test': '1'},
-        compression_algorithm=FLAGS.compression_algorithm)
+        compression_algorithm=FLAGS.grpc_compression_algorithm)
 
     statistics = triton_client.get_inference_statistics(model_name=model_name)
     print(statistics)
@@ -160,7 +160,7 @@ if __name__ == '__main__':
         model_name=model_name,
         inputs=inputs,
         outputs=None,
-        compression_algorithm=FLAGS.compression_algorithm)
+        compression_algorithm=FLAGS.grpc_compression_algorithm)
 
     # Get the output arrays from the results
     output0_data = results.as_numpy('OUTPUT0')

--- a/src/clients/python/examples/simple_grpc_infer_client.py
+++ b/src/clients/python/examples/simple_grpc_infer_client.py
@@ -78,6 +78,15 @@ if __name__ == '__main__':
         required=False,
         default=None,
         help='File holding PEM-encoded certicate chain. Default is None.')
+    parser.add_argument(
+        '-C',
+        '--compression_algorithm',
+        type=str,
+        required=False,
+        default=None,
+        help=
+        'The compression algorithm to be used when sending request to server. Default is None.'
+    )
 
     FLAGS = parser.parse_args()
     try:
@@ -114,11 +123,13 @@ if __name__ == '__main__':
     outputs.append(grpcclient.InferRequestedOutput('OUTPUT1'))
 
     # Test with outputs
-    results = triton_client.infer(model_name=model_name,
-                                  inputs=inputs,
-                                  outputs=outputs,
-                                  client_timeout=FLAGS.client_timeout,
-                                  headers={'test': '1'})
+    results = triton_client.infer(
+        model_name=model_name,
+        inputs=inputs,
+        outputs=outputs,
+        client_timeout=FLAGS.client_timeout,
+        headers={'test': '1'},
+        compression_algorithm=FLAGS.compression_algorithm)
 
     statistics = triton_client.get_inference_statistics(model_name=model_name)
     print(statistics)
@@ -145,9 +156,11 @@ if __name__ == '__main__':
             sys.exit(1)
 
     # Test with no outputs
-    results = triton_client.infer(model_name=model_name,
-                                  inputs=inputs,
-                                  outputs=None)
+    results = triton_client.infer(
+        model_name=model_name,
+        inputs=inputs,
+        outputs=None,
+        compression_algorithm=FLAGS.compression_algorithm)
 
     # Get the output arrays from the results
     output0_data = results.as_numpy('OUTPUT0')

--- a/src/servers/grpc_server.h
+++ b/src/servers/grpc_server.h
@@ -52,7 +52,8 @@ class GRPCServer {
       nvidia::inferenceserver::TraceManager* trace_manager,
       const std::shared_ptr<SharedMemoryManager>& shm_manager, int32_t port,
       bool use_ssl, const SslOptions& ssl_options,
-      int infer_allocation_pool_size, std::unique_ptr<GRPCServer>* grpc_server);
+      int infer_allocation_pool_size, grpc_compression_level compression_level,
+      std::unique_ptr<GRPCServer>* grpc_server);
 
   ~GRPCServer();
 
@@ -79,7 +80,8 @@ class GRPCServer {
       nvidia::inferenceserver::TraceManager* trace_manager,
       const std::shared_ptr<SharedMemoryManager>& shm_manager,
       const std::string& server_addr, bool use_ssl,
-      const SslOptions& ssl_options, const int infer_allocation_pool_size);
+      const SslOptions& ssl_options, const int infer_allocation_pool_size,
+      grpc_compression_level compression_level);
 
   std::shared_ptr<TRITONSERVER_Server> server_;
   TraceManager* trace_manager_;
@@ -89,6 +91,7 @@ class GRPCServer {
   const SslOptions ssl_options_;
 
   const int infer_allocation_pool_size_;
+  grpc_compression_level compression_level_;
 
   std::unique_ptr<grpc::ServerCompletionQueue> common_cq_;
   std::unique_ptr<grpc::ServerCompletionQueue> model_infer_cq_;


### PR DESCRIPTION
Uses per call compression only for inference requests. Using compression for non-infer related requests is not a good idea.

client-side compression:
`I0316 12:05:30.316294326    7617 message_compress_filter.cc:265] Compressed[deflate] 204 bytes vs. 102 bytes (50.00% savings)`

server-side compression:
`I0316 12:50:35.188782589   10734 message_compress_filter.cc:265] Compressed[deflate] 187 bytes vs. 99 bytes (47.06% savings)`

performance for sure seems to suffer. The numbers are collected on RN50 saved model:

```
No Compression: Concurrency: 1, throughput: 69 infer/sec, latency 14488 usec
Deflate: Concurrency: 1, throughput: 27.8 infer/sec, latency 35990 usec
Gzip: Concurrency: 1, throughput: 27.8 infer/sec, latency 35957 usec
```