### PR TITLE
Add generation scripts for OpenVino models (No variable shapes)

### DIFF
--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -46,7 +46,7 @@ USE_HTTP = (os.environ.get('USE_HTTP', 1) != "0")
 assert USE_GRPC or USE_HTTP, "USE_GRPC or USE_HTTP must be non-zero"
 
 BACKENDS = os.environ.get('BACKENDS',
-                          "graphdef savedmodel onnx libtorch plan python python_dlpack")
+                          "graphdef savedmodel onnx libtorch plan python python_dlpack openvino")
 ENSEMBLES = bool(int(os.environ.get('ENSEMBLES', 1)))
 
 np_dtype_string = np.dtype(object)

--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -108,7 +108,7 @@ if [ "$TRITON_SERVER_CPU_ONLY" == "1" ]; then
 fi
 
 # If BACKENDS not specified, set to all
-BACKENDS=${BACKENDS:=BACKENDS=${BACKENDS:="graphdef savedmodel onnx libtorch plan python python_dlpack openvino"}
+BACKENDS=${BACKENDS:="graphdef savedmodel onnx libtorch plan python python_dlpack openvino"}
 export BACKENDS
 
 # If ENSEMBLES not specified, set to 1
@@ -231,7 +231,7 @@ for TARGET in cpu gpu; do
 
     KIND="KIND_GPU" && [[ "$TARGET" == "cpu" ]] && KIND="KIND_CPU"
     for FW in $BACKENDS; do
-      if [ "$FW" != "plan" ] && [ "$FW" != "python" ];then
+      if [ "$FW" != "plan" ] && [ "$FW" != "python" ] && [ "$FW" != "openvino" ];then
         for MC in `ls models/${FW}*/config.pbtxt`; do
             echo "instance_group [ { kind: ${KIND} }]" >> $MC
         done

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -108,7 +108,7 @@ if [ "$TRITON_SERVER_CPU_ONLY" == "1" ]; then
 fi
 
 # If BACKENDS not specified, set to all
-BACKENDS=${BACKENDS:="graphdef savedmodel onnx libtorch plan python python_dlpack"}
+BACKENDS=${BACKENDS:=BACKENDS=${BACKENDS:="graphdef savedmodel onnx libtorch plan python python_dlpack openvino"}
 export BACKENDS
 
 # If ENSEMBLES not specified, set to 1
@@ -203,7 +203,7 @@ for TARGET in cpu gpu; do
 
       # Copy identity backend models and ensembles
       for BACKEND in $BACKENDS; do
-        if [ "$BACKEND" != "python" ] && [ "$BACKEND" != "python_dlpack" ]; then
+        if [ "$BACKEND" != "python" ] && [ "$BACKEND" != "python_dlpack" ] && [ "$BACKEND" != "openvino" ]; then
             cp -r ${DATADIR}/qa_ensemble_model_repository/qa_model_repository/*${BACKEND}* \
               models/.
         fi
@@ -235,7 +235,7 @@ for TARGET in cpu gpu; do
         for MC in `ls models/${FW}*/config.pbtxt`; do
             echo "instance_group [ { kind: ${KIND} }]" >> $MC
         done
-      elif [ "$FW" == "python" ]; then
+      elif [ "$FW" == "python" ] || [ "$FW" == "openvino" ]; then
         for MC in `ls models/${FW}*/config.pbtxt`; do
             echo "instance_group [ { kind: KIND_CPU }]" >> $MC
         done

--- a/qa/common/gen_qa_dyna_sequence_models.py
+++ b/qa/common/gen_qa_dyna_sequence_models.py
@@ -1385,15 +1385,16 @@ def create_openvino_modelfile(models_dir, model_version, max_batch, dtype,
                                           shape):
         return
 
+    batch_dim = [] if max_batch == 0 else [max_batch,]
     model_name = tu.get_dyna_sequence_model_name(
         "openvino_nobatch" if max_batch == 0 else "openvino", dtype)
     model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
 
-    in0 = ng.parameter(shape=shape, dtype=dtype, name="INPUT")
-    start = ng.parameter(shape=shape, dtype=dtype, name="START")
-    end = ng.parameter(shape=shape, dtype=dtype, name="END")
-    ready = ng.parameter(shape=shape, dtype=dtype, name="READY")
-    corrid = ng.parameter(shape=shape, dtype=np.uint64, name="CORRID")
+    in0 = ng.parameter(shape=batch_dim + shape, dtype=dtype, name="INPUT")
+    start = ng.parameter(shape=batch_dim + shape, dtype=dtype, name="START")
+    end = ng.parameter(shape=batch_dim + shape, dtype=dtype, name="END")
+    ready = ng.parameter(shape=batch_dim + shape, dtype=dtype, name="READY")
+    corrid = ng.parameter(shape=batch_dim + shape, dtype=dtype, name="CORRID")
 
     tmp1 = ng.add(in0, start)
     tmp2 = ng.multiply(end, corrid)
@@ -1403,10 +1404,6 @@ def create_openvino_modelfile(models_dir, model_version, max_batch, dtype,
     function = ng.impl.Function([op0], [in0, start, end, ready, corrid],
                                 model_name)
     ie_network = IENetwork(ng.impl.Function.to_capsule(function))
-
-    # Batch size needs to be a positive integer value
-    if max_batch != 0:
-        ie_network.batch_size = max_batch
 
     try:
         os.makedirs(model_version_dir)

--- a/qa/common/gen_qa_dyna_sequence_models.py
+++ b/qa/common/gen_qa_dyna_sequence_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_dyna_sequence_models.py
+++ b/qa/common/gen_qa_dyna_sequence_models.py
@@ -1378,6 +1378,138 @@ instance_group [
         cfile.write(config)
 
 
+def create_openvino_modelfile(models_dir, model_version, max_batch, dtype,
+                              shape):
+
+    if not tu.validate_for_openvino_model(dtype, dtype, dtype, shape, shape,
+                                          shape):
+        return
+
+    model_name = tu.get_dyna_sequence_model_name(
+        "openvino_nobatch" if max_batch == 0 else "openvino", dtype)
+    model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
+
+    in0 = ng.parameter(shape=shape, dtype=dtype, name="INPUT")
+    start = ng.parameter(shape=shape, dtype=dtype, name="START")
+    end = ng.parameter(shape=shape, dtype=dtype, name="END")
+    ready = ng.parameter(shape=shape, dtype=dtype, name="READY")
+    corrid = ng.parameter(shape=shape, dtype=np.uint64, name="CORRID")
+
+    tmp1 = ng.add(in0, start)
+    tmp2 = ng.multiply(end, corrid)
+    tmp = ng.add(tmp1, tmp2)
+    op0 = ng.multiply(tmp, ready, name="OUTPUT")
+
+    function = ng.impl.Function([op0], [in0, start, end, ready, corrid],
+                                model_name)
+    ie_network = IENetwork(ng.impl.Function.to_capsule(function))
+
+    # Batch size needs to be a positive integer value
+    if max_batch != 0:
+        ie_network.batch_size = max_batch
+
+    try:
+        os.makedirs(model_version_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    ie_network.serialize(model_version_dir + "/model.xml",
+                         model_version_dir + "/model.bin")
+
+
+def create_openvino_modelconfig(models_dir, model_version, max_batch, dtype,
+                                shape):
+
+    if not tu.validate_for_openvino_model(dtype, dtype, dtype, shape, shape,
+                                          shape):
+        return
+
+    model_name = tu.get_dyna_sequence_model_name(
+        "openvino_nobatch" if max_batch == 0 else "openvino", dtype)
+    config_dir = models_dir + "/" + model_name
+    config = '''
+name: "{}"
+backend: "openvino"
+max_batch_size: {}
+sequence_batching {{
+  max_sequence_idle_microseconds: 5000000
+  {}
+  control_input [
+    {{
+      name: "START"
+      control [
+        {{
+          kind: CONTROL_SEQUENCE_START
+          {}_false_true: [ 0, 1 ]
+        }}
+      ]
+    }},
+    {{
+      name: "END"
+      control [
+        {{
+          kind: CONTROL_SEQUENCE_END
+          {}_false_true: [ 0, 1 ]
+        }}
+      ]
+    }},
+    {{
+      name: "READY"
+      control [
+        {{
+          kind: CONTROL_SEQUENCE_READY
+          {}_false_true: [ 0, 1 ]
+        }}
+      ]
+    }},
+    {{
+      name: "CORRID"
+      control [
+        {{
+          kind: CONTROL_SEQUENCE_CORRID
+          data_type: TYPE_INT32
+        }}
+      ]
+    }}
+  ]
+}}
+input [
+  {{
+    name: "INPUT"
+    data_type: {}
+    dims: [ {} ]
+  }}
+]
+output [
+  {{
+    name: "OUTPUT"
+    data_type: {}
+    dims: [ 1 ]
+  }}
+]
+instance_group [
+  {{
+    kind: KIND_CPU
+  }}
+]
+'''.format(
+        model_name, max_batch,
+        "oldest { max_candidate_sequences: 6\npreferred_batch_size: [ 4 ]\nmax_queue_delay_microseconds: 0\n}"
+        if max_batch > 0 else "", "int32" if dtype == np.int32 else "fp32",
+        "int32" if dtype == np.int32 else "fp32",
+        "int32" if dtype == np.int32 else "fp32", np_to_model_dtype(dtype),
+        tu.shape_to_dims_str(shape), np_to_model_dtype(dtype),
+        tu.shape_to_dims_str(shape), np_to_model_dtype(dtype))
+
+    try:
+        os.makedirs(config_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    with open(config_dir + "/config.pbtxt", "w") as cfile:
+        cfile.write(config)
+
+
 def create_shape_tensor_models(models_dir, dtype, shape, no_batch=True):
     model_version = 1
 
@@ -1442,6 +1574,15 @@ def create_models(models_dir, dtype, shape, no_batch=True):
             create_libtorch_modelfile(models_dir, model_version, 0, dtype,
                                       shape)
 
+    if FLAGS.openvino:
+        create_openvino_modelconfig(models_dir, model_version, 8, dtype, shape)
+        create_openvino_modelfile(models_dir, model_version, 8, dtype, shape)
+        if no_batch:
+            create_openvino_modelconfig(models_dir, model_version, 0, dtype,
+                                        shape)
+            create_openvino_modelfile(models_dir, model_version, 0, dtype,
+                                      shape)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -1480,6 +1621,10 @@ if __name__ == '__main__':
                         required=False,
                         action='store_true',
                         help='Generate Pytorch LibTorch models')
+    parser.add_argument('--openvino',
+                        required=False,
+                        action='store_true',
+                        help='Generate OpenVino models')
     parser.add_argument('--variable',
                         required=False,
                         action='store_true',
@@ -1496,6 +1641,9 @@ if __name__ == '__main__':
     if FLAGS.libtorch:
         import torch
         from torch import nn
+    if FLAGS.openvino:
+        from openvino.inference_engine import IECore, IENetwork
+        import ngraph as ng
 
     import test_util as tu
 

--- a/qa/common/gen_qa_identity_models.py
+++ b/qa/common/gen_qa_identity_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -54,7 +54,11 @@ TRITON_VERSION=21.07
 ONNX_VERSION=1.7.0
 ONNX_OPSET=0
 
+# OPENVINO version
+OPENVINO_VERSION=2021.1.110
+
 ONNX_IMAGE=${ONNX_IMAGE:=ubuntu:20.04}
+OPENVINO_IMAGE=${OPENVINO_IMAGE:=ubuntu:18.04}
 PYTORCH_IMAGE=${PYTORCH_IMAGE:=nvcr.io/nvidia/pytorch:$TRITON_VERSION-py3}
 TENSORFLOW_IMAGE=${TENSORFLOW_IMAGE:=nvcr.io/nvidia/tensorflow:$TRITON_VERSION-tf1-py3}
 TENSORRT_IMAGE=${TENSORRT_IMAGE:=nvcr.io/nvidia/tensorrt:$TRITON_VERSION-py3}
@@ -147,6 +151,44 @@ NOSHAPEDESTDIR=/tmp/noshapemodels
 PLGDESTDIR=/tmp/pluginmodels
 RAGGEDDESTDIR=/tmp/raggedmodels
 FORMATDESTDIR=/tmp/formatmodels
+
+# OPENVINO
+cat >$HOST_SRCDIR/$OPENVINOSCRIPT <<EOF
+#!/bin/bash
+set -e
+export DEBIAN_FRONTEND=noninteractive
+apt-get update && \
+    apt-get install -y --no-install-recommends build-essential cmake libprotobuf-dev \
+            protobuf-compiler python3.6 python3.6-dev python3-pip wget gnupg2 \
+            software-properties-common
+ln -s /usr/bin/python3 /usr/bin/python
+
+OPENVINO_VERSION=2021.1.110
+(wget https://apt.repos.intel.com/openvino/2021/GPG-PUB-KEY-INTEL-OPENVINO-2021 && \
+    apt-key add GPG-PUB-KEY-INTEL-OPENVINO-2021 && rm GPG-PUB-KEY-INTEL-OPENVINO-2021 && \
+    cd /etc/apt/sources.list.d && \
+    echo "deb https://apt.repos.intel.com/openvino/2021 all main">intel-openvino-2021.list && \
+    apt update && \
+    apt install -y intel-openvino-dev-ubuntu18-${OPENVINO_VERSION})
+
+pip3 install numpy setuptools
+
+INSTALL_DIR=/opt/intel/openvino_${OPENVINO_VERSION}
+PYTHONPATH=${INSTALL_DIR}/python/python3.6
+source ${INSTALL_DIR}/bin/setupvars.sh .
+
+# PS: Since variable shape tensors are not allowed, identity models may fail to generate
+python3 $SRCDIR/gen_qa_models.py --openvino --models_dir=$DESTDIR
+chmod -R 777 $DESTDIR
+python3 $SRCDIR/gen_qa_identity_models.py --openvino --models_dir=$IDENTITYDESTDIR
+chmod -R 777 $IDENTITYDESTDIR
+python3 $SRCDIR/gen_qa_reshape_models.py --openvino --models_dir=$RESHAPEDESTDIR
+chmod -R 777 $RESHAPEDESTDIR
+python3 $SRCDIR/gen_qa_sequence_models.py --openvino --models_dir=$SEQDESTDIR
+chmod -R 777 $SEQDESTDIR
+python3 $SRCDIR/gen_qa_dyna_sequence_models.py --openvino --models_dir=$DYNASEQDESTDIR
+chmod -R 777 $DYNASEQDESTDIR
+EOF
 
 # ONNX
 cat >$HOST_SRCDIR/$ONNXSCRIPT <<EOF

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -55,10 +55,9 @@ ONNX_VERSION=1.7.0
 ONNX_OPSET=0
 
 # OPENVINO version
-OPENVINO_VERSION=2021.1.110
+OPENVINO_VERSION=2021.2.200
 
 ONNX_IMAGE=${ONNX_IMAGE:=ubuntu:20.04}
-OPENVINO_IMAGE=${OPENVINO_IMAGE:=ubuntu:18.04}
 PYTORCH_IMAGE=${PYTORCH_IMAGE:=nvcr.io/nvidia/pytorch:$TRITON_VERSION-py3}
 TENSORFLOW_IMAGE=${TENSORFLOW_IMAGE:=nvcr.io/nvidia/tensorflow:$TRITON_VERSION-tf1-py3}
 TENSORRT_IMAGE=${TENSORRT_IMAGE:=nvcr.io/nvidia/tensorrt:$TRITON_VERSION-py3}
@@ -131,6 +130,7 @@ cp ./test_util.py $HOST_SRCDIR/.
 cp ./gen_tag_sigdef.py $HOST_SRCDIR/.
 
 ONNXSCRIPT=onnx_gen.cmds
+OPENVINOSCRIPT=openvino_gen.cmds
 TORCHSCRIPT=torch_gen.cmds
 TFSCRIPT=tf_gen.cmds
 TRTSCRIPT=trt_gen.cmds
@@ -159,23 +159,21 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 apt-get update && \
     apt-get install -y --no-install-recommends build-essential cmake libprotobuf-dev \
-            protobuf-compiler python3.6 python3.6-dev python3-pip wget gnupg2 \
+            protobuf-compiler python3 python3-dev python3-pip wget gnupg2 \
             software-properties-common
 ln -s /usr/bin/python3 /usr/bin/python
 
-OPENVINO_VERSION=2021.1.110
 (wget https://apt.repos.intel.com/openvino/2021/GPG-PUB-KEY-INTEL-OPENVINO-2021 && \
     apt-key add GPG-PUB-KEY-INTEL-OPENVINO-2021 && rm GPG-PUB-KEY-INTEL-OPENVINO-2021 && \
     cd /etc/apt/sources.list.d && \
     echo "deb https://apt.repos.intel.com/openvino/2021 all main">intel-openvino-2021.list && \
     apt update && \
-    apt install -y intel-openvino-dev-ubuntu18-${OPENVINO_VERSION})
+    apt install -y intel-openvino-dev-ubuntu20-${OPENVINO_VERSION})
 
 pip3 install numpy setuptools
 
-INSTALL_DIR=/opt/intel/openvino_${OPENVINO_VERSION}
-PYTHONPATH=${INSTALL_DIR}/python/python3.6
-source ${INSTALL_DIR}/bin/setupvars.sh .
+PYTHONPATH=/opt/intel/openvino_${OPENVINO_VERSION}/python/python3
+source /opt/intel/openvino_${OPENVINO_VERSION}/bin/setupvars.sh .
 
 # PS: Since variable shape tensors are not allowed, identity models may fail to generate
 python3 $SRCDIR/gen_qa_models.py --openvino --models_dir=$DESTDIR
@@ -189,6 +187,29 @@ chmod -R 777 $SEQDESTDIR
 python3 $SRCDIR/gen_qa_dyna_sequence_models.py --openvino --models_dir=$DYNASEQDESTDIR
 chmod -R 777 $DYNASEQDESTDIR
 EOF
+
+chmod a+x $HOST_SRCDIR/$OPENVINOSCRIPT
+if [ $? -ne 0 ]; then
+    echo -e "Failed: chmod"
+    exit 1
+fi
+
+docker pull $ONNX_IMAGE
+docker run --gpus device=$CUDA_DEVICE --rm -it --entrypoint $SRCDIR/$OPENVINOSCRIPT \
+       --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
+       --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
+       --mount type=bind,source=$HOST_VARDESTDIR,target=$VARDESTDIR \
+       --mount type=bind,source=$HOST_IDENTITYDESTDIR,target=$IDENTITYDESTDIR \
+       --mount type=bind,source=$HOST_RESHAPEDESTDIR,target=$RESHAPEDESTDIR \
+       --mount type=bind,source=$HOST_SEQDESTDIR,target=$SEQDESTDIR \
+       --mount type=bind,source=$HOST_DYNASEQDESTDIR,target=$DYNASEQDESTDIR \
+       --mount type=bind,source=$HOST_VARSEQDESTDIR,target=$VARSEQDESTDIR \
+       --mount type=bind,source=$HOST_RAGGEDDESTDIR,target=$RAGGEDDESTDIR \
+       $ONNX_IMAGE
+if [ $? -ne 0 ]; then
+    echo -e "Failed"
+    exit 1
+fi
 
 # ONNX
 cat >$HOST_SRCDIR/$ONNXSCRIPT <<EOF

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -55,9 +55,9 @@ ONNX_VERSION=1.7.0
 ONNX_OPSET=0
 
 # OPENVINO version
-OPENVINO_VERSION=2021.2.200
+OPENVINO_VERSION=2021.4.582
 
-ONNX_IMAGE=${ONNX_IMAGE:=ubuntu:20.04}
+UBUNTU_IMAGE=${UBUNTU_IMAGE:=ubuntu:20.04}
 PYTORCH_IMAGE=${PYTORCH_IMAGE:=nvcr.io/nvidia/pytorch:$TRITON_VERSION-py3}
 TENSORFLOW_IMAGE=${TENSORFLOW_IMAGE:=nvcr.io/nvidia/tensorflow:$TRITON_VERSION-tf1-py3}
 TENSORRT_IMAGE=${TENSORRT_IMAGE:=nvcr.io/nvidia/tensorrt:$TRITON_VERSION-py3}
@@ -194,7 +194,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-docker pull $ONNX_IMAGE
+docker pull $UBUNTU_IMAGE
 docker run --gpus device=$CUDA_DEVICE --rm -it --entrypoint $SRCDIR/$OPENVINOSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
@@ -205,7 +205,7 @@ docker run --gpus device=$CUDA_DEVICE --rm -it --entrypoint $SRCDIR/$OPENVINOSCR
        --mount type=bind,source=$HOST_DYNASEQDESTDIR,target=$DYNASEQDESTDIR \
        --mount type=bind,source=$HOST_VARSEQDESTDIR,target=$VARSEQDESTDIR \
        --mount type=bind,source=$HOST_RAGGEDDESTDIR,target=$RAGGEDDESTDIR \
-       $ONNX_IMAGE
+       $UBUNTU_IMAGE
 if [ $? -ne 0 ]; then
     echo -e "Failed"
     exit 1
@@ -246,7 +246,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-docker pull $ONNX_IMAGE
+docker pull $UBUNTU_IMAGE
 docker run --gpus device=$CUDA_DEVICE --rm --entrypoint $SRCDIR/$ONNXSCRIPT \
        --mount type=bind,source=$HOST_SRCDIR,target=$SRCDIR \
        --mount type=bind,source=$HOST_DESTDIR,target=$DESTDIR \
@@ -257,7 +257,7 @@ docker run --gpus device=$CUDA_DEVICE --rm --entrypoint $SRCDIR/$ONNXSCRIPT \
        --mount type=bind,source=$HOST_DYNASEQDESTDIR,target=$DYNASEQDESTDIR \
        --mount type=bind,source=$HOST_VARSEQDESTDIR,target=$VARSEQDESTDIR \
        --mount type=bind,source=$HOST_RAGGEDDESTDIR,target=$RAGGEDDESTDIR \
-       $ONNX_IMAGE
+       $UBUNTU_IMAGE
 if [ $? -ne 0 ]; then
     echo -e "Failed"
     exit 1

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -175,11 +175,12 @@ pip3 install numpy setuptools
 PYTHONPATH=/opt/intel/openvino_${OPENVINO_VERSION}/python/python3
 source /opt/intel/openvino_${OPENVINO_VERSION}/bin/setupvars.sh .
 
-# PS: Since variable shape tensors are not allowed, identity models may fail to generate
+# Since variable shape tensors are not allowed, identity models may fail to generate.
+# TODO Add variable size tensor models after DLIS-2827 adds support for variable shape tensors.
 python3 $SRCDIR/gen_qa_models.py --openvino --models_dir=$DESTDIR
 chmod -R 777 $DESTDIR
-python3 $SRCDIR/gen_qa_identity_models.py --openvino --models_dir=$IDENTITYDESTDIR
-chmod -R 777 $IDENTITYDESTDIR
+# python3 $SRCDIR/gen_qa_identity_models.py --openvino --models_dir=$IDENTITYDESTDIR
+# chmod -R 777 $IDENTITYDESTDIR
 python3 $SRCDIR/gen_qa_reshape_models.py --openvino --models_dir=$RESHAPEDESTDIR
 chmod -R 777 $RESHAPEDESTDIR
 python3 $SRCDIR/gen_qa_sequence_models.py --openvino --models_dir=$SEQDESTDIR

--- a/qa/common/gen_qa_models.py
+++ b/qa/common/gen_qa_models.py
@@ -1347,10 +1347,6 @@ def create_openvino_modelfile(models_dir,
     function = ng.impl.Function([op0, op1], [in0, in1], model_name)
     ie_network = IENetwork(ng.impl.Function.to_capsule(function))
 
-    # Batch size needs to be a positive integer value
-    # if max_batch != 0:
-    #     ie_network.batch_size = max_batch
-
     try:
         os.makedirs(model_version_dir)
     except OSError as ex:

--- a/qa/common/gen_qa_models.py
+++ b/qa/common/gen_qa_models.py
@@ -1309,6 +1309,136 @@ output [
             lfile.write("label" + str(l) + "\n")
 
 
+def create_openvino_modelfile(models_dir,
+                              max_batch,
+                              model_version,
+                              input_shape,
+                              output0_shape,
+                              output1_shape,
+                              input_dtype,
+                              output0_dtype,
+                              output1_dtype,
+                              swap=False):
+
+    if not tu.validate_for_openvino_model(input_dtype, output0_dtype,
+                                          output1_dtype, input_shape,
+                                          output0_shape, output1_shape):
+        return
+
+    # Create the model
+    model_name = tu.get_model_name(
+        "openvino_nobatch" if max_batch == 0 else "openvino", input_dtype,
+        output0_dtype, output1_dtype)
+    model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
+
+    in0 = ng.parameter(shape=input_shape, dtype=input_dtype, name="INPUT0")
+    in1 = ng.parameter(shape=input_shape, dtype=input_dtype, name="INPUT1")
+
+    r0 = ng.add(in0, in1) if not swap else ng.subtract(in0, in1)
+    r1 = ng.subtract(in0, in1) if not swap else ng.add(in0, in1)
+
+    result0 = ng.reshape(r0, output0_shape)
+    result1 = ng.reshape(r1, output1_shape)
+
+    op0 = ng.convert(result0, destination_type=output0_dtype, name="OUTPUT0")
+    op1 = ng.convert(result1, destination_type=output1_dtype, name="OUTPUT1")
+
+    function = ng.impl.Function([op0, op1], [in0, in1], model_name)
+    ie_network = IENetwork(ng.impl.Function.to_capsule(function))
+
+    # Batch size needs to be a positive integer value
+    if max_batch != 0:
+        ie_network.batch_size = max_batch
+
+    try:
+        os.makedirs(model_version_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    ie_network.serialize(model_version_dir + "/model.xml",
+                         model_version_dir + "/model.bin")
+
+
+def create_openvino_modelconfig(models_dir, max_batch, model_version,
+                                input_shape, output0_shape, output1_shape,
+                                input_dtype, output0_dtype, output1_dtype,
+                                output0_label_cnt, version_policy):
+
+    if not tu.validate_for_openvino_model(input_dtype, output0_dtype,
+                                          output1_dtype, input_shape,
+                                          output0_shape, output1_shape):
+        return
+
+    # Unpack version policy
+    version_policy_str = "{ latest { num_versions: 1 }}"
+    if version_policy is not None:
+        type, val = version_policy
+        if type == 'latest':
+            version_policy_str = "{{ latest {{ num_versions: {} }}}}".format(
+                val)
+        elif type == 'specific':
+            version_policy_str = "{{ specific {{ versions: {} }}}}".format(val)
+        else:
+            version_policy_str = "{ all { }}"
+
+    # Use a different model name for the non-batching variant
+    model_name = tu.get_model_name(
+        "openvino_nobatch" if max_batch == 0 else "openvino", input_dtype,
+        output0_dtype, output1_dtype)
+    config_dir = models_dir + "/" + model_name
+
+    # platform is empty and backend is 'openvino' for openvino model
+    config = '''
+name: "{}"
+backend: "openvino"
+max_batch_size: {}
+version_policy: {}
+input [
+  {{
+    name: "INPUT0"
+    data_type: {}
+    dims: [ {} ]
+  }},
+  {{
+    name: "INPUT1"
+    data_type: {}
+    dims: [ {} ]
+  }}
+]
+output [
+  {{
+    name: "OUTPUT0"
+    data_type: {}
+    dims: [ {} ]
+    label_filename: "output0_labels.txt"
+   }},
+  {{
+    name: "OUTPUT1"
+    data_type: {}
+    dims: [ {} ]
+  }}
+]
+'''.format(model_name, max_batch, version_policy_str,
+           np_to_model_dtype(input_dtype), tu.shape_to_dims_str(input_shape),
+           np_to_model_dtype(input_dtype), tu.shape_to_dims_str(input_shape),
+           np_to_model_dtype(output0_dtype),
+           tu.shape_to_dims_str(output0_shape),
+           np_to_model_dtype(output1_dtype),
+           tu.shape_to_dims_str(output1_shape))
+
+    try:
+        os.makedirs(config_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    with open(config_dir + "/config.pbtxt", "w") as cfile:
+        cfile.write(config)
+
+    with open(config_dir + "/output0_labels.txt", "w") as lfile:
+        for l in range(output0_label_cnt):
+            lfile.write("label" + str(l) + "\n")
+
+
 def create_models(models_dir,
                   input_dtype,
                   output0_dtype,
@@ -1446,6 +1576,24 @@ def create_models(models_dir,
                                   output0_shape, output1_shape, input_dtype,
                                   output0_dtype, output1_dtype)
 
+    if FLAGS.openvino:
+        # max-batch 8
+        create_openvino_modelconfig(models_dir, 8, model_version, input_shape,
+                                    output0_shape, output1_shape, input_dtype,
+                                    output0_dtype, output1_dtype,
+                                    output0_label_cnt, version_policy)
+        create_openvino_modelfile(models_dir, 8, model_version, input_shape,
+                                  output0_shape, output1_shape, input_dtype,
+                                  output0_dtype, output1_dtype)
+        # max-batch 0
+        create_openvino_modelconfig(models_dir, 0, model_version, input_shape,
+                                    output0_shape, output1_shape, input_dtype,
+                                    output0_dtype, output1_dtype,
+                                    output0_label_cnt, version_policy)
+        create_openvino_modelfile(models_dir, 0, model_version, input_shape,
+                                  output0_shape, output1_shape, input_dtype,
+                                  output0_dtype, output1_dtype)
+
     if FLAGS.ensemble:
         for pair in emu.platform_types_and_validation():
             if not pair[1](input_dtype, output0_dtype, output1_dtype,
@@ -1532,6 +1680,10 @@ if __name__ == '__main__':
                         required=False,
                         action='store_true',
                         help='Generate Pytorch LibTorch models')
+    parser.add_argument('--openvino',
+                        required=False,
+                        action='store_true',
+                        help='Generate Openvino models')
     parser.add_argument('--variable',
                         required=False,
                         action='store_true',
@@ -1554,6 +1706,9 @@ if __name__ == '__main__':
     if FLAGS.libtorch:
         import torch
         from torch import nn
+    if FLAGS.openvino:
+        from openvino.inference_engine import IECore, IENetwork
+        import ngraph as ng
 
     import test_util as tu
 
@@ -1776,6 +1931,36 @@ if __name__ == '__main__':
                                           vt,
                                           swap=True)
                 create_libtorch_modelfile(FLAGS.models_dir,
+                                          0,
+                                          3, (16,), (16,), (16,),
+                                          vt,
+                                          vt,
+                                          vt,
+                                          swap=True)
+        if FLAGS.openvino:
+            for vt in [np.float16, np.float32, np.int8, np.int16, np.int32]:
+                create_openvino_modelfile(FLAGS.models_dir,
+                                          8,
+                                          2, (16,), (16,), (16,),
+                                          vt,
+                                          vt,
+                                          vt,
+                                          swap=True)
+                create_openvino_modelfile(FLAGS.models_dir,
+                                          8,
+                                          3, (16,), (16,), (16,),
+                                          vt,
+                                          vt,
+                                          vt,
+                                          swap=True)
+                create_openvino_modelfile(FLAGS.models_dir,
+                                          0,
+                                          2, (16,), (16,), (16,),
+                                          vt,
+                                          vt,
+                                          vt,
+                                          swap=True)
+                create_openvino_modelfile(FLAGS.models_dir,
                                           0,
                                           3, (16,), (16,), (16,),
                                           vt,

--- a/qa/common/gen_qa_models.py
+++ b/qa/common/gen_qa_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_reshape_models.py
+++ b/qa/common/gen_qa_reshape_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_reshape_models.py
+++ b/qa/common/gen_qa_reshape_models.py
@@ -747,7 +747,7 @@ def create_openvino_modelfile(models_dir, model_version, max_batch, dtype,
         "openvino_nobatch" if max_batch == 0 else "openvino", io_cnt, dtype)
     model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
 
-    batch_dim = () if max_batch == 0 else (max_batch,)
+    batch_dim = [] if max_batch == 0 else [max_batch,]
     openvino_inputs = []
     openvino_outputs = []
     for io_num in range(io_cnt):
@@ -767,10 +767,6 @@ def create_openvino_modelfile(models_dir, model_version, max_batch, dtype,
 
     function = ng.impl.Function(openvino_outputs, openvino_inputs, model_name)
     ie_network = IENetwork(ng.impl.Function.to_capsule(function))
-
-    # Batch size needs to be a positive integer value
-    # if max_batch != 0:
-    #     ie_network.batch_size = max_batch
 
     try:
         os.makedirs(model_version_dir)

--- a/qa/common/gen_qa_reshape_models.py
+++ b/qa/common/gen_qa_reshape_models.py
@@ -635,6 +635,7 @@ def create_onnx_modelfile(models_dir, model_version, max_batch, dtype,
     if not tu.validate_for_onnx_model(dtype, dtype, dtype, input_shapes[0],
                                       input_shapes[0], input_shapes[0]):
         return
+
     onnx_dtype = np_to_onnx_dtype(dtype)
     io_cnt = len(input_shapes)
 
@@ -721,6 +722,117 @@ def create_onnx_modelconfig(models_dir, model_version, max_batch, dtype,
                                             output_model_shapes,
                                             emu.repeat(None, io_cnt),
                                             force_tensor_number_suffix=True)
+
+    try:
+        os.makedirs(config_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    with open(config_dir + "/config.pbtxt", "w") as cfile:
+        cfile.write(config)
+
+
+def create_openvino_modelfile(models_dir, model_version, max_batch, dtype,
+                              input_shapes, output_shapes):
+
+    assert len(input_shapes) == len(output_shapes)
+    if not tu.validate_for_openvino_model(dtype, dtype, dtype, input_shapes[0],
+                                          input_shapes[0], input_shapes[0]):
+        return
+
+    io_cnt = len(input_shapes)
+
+    # Create the model
+    model_name = tu.get_zero_model_name(
+        "openvino_nobatch" if max_batch == 0 else "openvino", io_cnt, dtype)
+    model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
+
+    openvino_inputs = []
+    openvino_outputs = []
+    for io_num in range(io_cnt):
+        in_name = "INPUT{}".format(io_num)
+        out_name = "OUTPUT{}".format(io_num)
+        openvino_inputs.append(
+            ng.parameter(shape=input_shapes[io_num], dtype=dtype, name=in_name))
+
+        if input_shapes[io_num] == output_shapes[io_num]:
+            openvino_outputs.append(
+                ng.result(openvino_inputs[io_num], name=out_name))
+        else:
+            openvino_outputs.append(
+                ng.reshape(openvino_inputs[io_num],
+                           output_shapes[io_num],
+                           name=out_name))
+
+    function = ng.impl.Function(openvino_outputs, openvino_inputs, model_name)
+    ie_network = IENetwork(ng.impl.Function.to_capsule(function))
+
+    # Batch size needs to be a positive integer value
+    if max_batch != 0:
+        ie_network.batch_size = max_batch
+
+    try:
+        os.makedirs(model_version_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    ie_network.serialize(model_version_dir + "/model.xml",
+                         model_version_dir + "/model.bin")
+
+
+def create_openvino_modelconfig(models_dir, model_version, max_batch, dtype,
+                                input_shapes, input_model_shapes, output_shapes,
+                                output_model_shapes):
+
+    assert len(input_shapes) == len(input_model_shapes)
+    assert len(output_shapes) == len(output_model_shapes)
+    assert len(input_shapes) == len(output_shapes)
+    if not tu.validate_for_openvino_model(dtype, dtype, dtype, input_shapes[0],
+                                          input_shapes[0], input_shapes[0]):
+        return
+
+    io_cnt = len(input_shapes)
+
+    # Use a different model name for the non-batching variant
+    model_name = tu.get_zero_model_name(
+        "openvino_nobatch" if max_batch == 0 else "openvino", io_cnt, dtype)
+    config_dir = models_dir + "/" + model_name
+
+    config = '''
+name: "{}"
+backend: "openvino"
+max_batch_size: {}
+'''.format(model_name, max_batch)
+
+    for io_num in range(io_cnt):
+        config += '''
+input [
+  {{
+    name: "INPUT__{}"
+    data_type: {}
+    dims: [ {} ]
+    {}
+  }}
+]
+output [
+  {{
+    name: "OUTPUT__{}"
+    data_type: {}
+    dims: [ {} ]
+    {}
+  }}
+]
+'''.format(
+            io_num, np_to_model_dtype(dtype),
+            tu.shape_to_dims_str(input_shapes[io_num]),
+            "reshape: {{ shape: [ {} ] }}".format(
+                tu.shape_to_dims_str(input_model_shapes[io_num]))
+            if input_shapes[io_num] != input_model_shapes[io_num] else "",
+            io_num, np_to_model_dtype(dtype),
+            tu.shape_to_dims_str(output_shapes[io_num]),
+            "reshape: {{ shape: [ {} ] }}".format(
+                tu.shape_to_dims_str(output_model_shapes[io_num]))
+            if output_shapes[io_num] != output_model_shapes[io_num] else "")
 
     try:
         os.makedirs(config_dir)
@@ -861,6 +973,33 @@ def create_libtorch_models(models_dir,
                                       input_model_shapes, output_model_shapes)
 
 
+def create_openvino_models(models_dir,
+                           dtype,
+                           input_shapes,
+                           input_model_shapes,
+                           output_shapes=None,
+                           output_model_shapes=None,
+                           no_batch=True):
+    model_version = 1
+    if output_shapes is None:
+        output_shapes = input_shapes
+    if output_model_shapes is None:
+        output_model_shapes = input_model_shapes
+
+    if FLAGS.openvino:
+        create_openvino_modelconfig(models_dir, model_version, 8, dtype,
+                                    input_shapes, input_model_shapes,
+                                    output_shapes, output_model_shapes)
+        create_openvino_modelfile(models_dir, model_version, 8, dtype,
+                                  input_model_shapes, output_model_shapes)
+        if no_batch:
+            create_openvino_modelconfig(models_dir, model_version, 0, dtype,
+                                        input_shapes, input_model_shapes,
+                                        output_shapes, output_model_shapes)
+            create_openvino_modelfile(models_dir, model_version, 0, dtype,
+                                      input_model_shapes, output_model_shapes)
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--models_dir',
@@ -893,6 +1032,10 @@ if __name__ == '__main__':
                         required=False,
                         action='store_true',
                         help='Generate Pytorch LibTorch models')
+    parser.add_argument('--openvino',
+                        required=False,
+                        action='store_true',
+                        help='Generate OpenVino models')
     parser.add_argument('--ensemble',
                         required=False,
                         action='store_true',
@@ -913,11 +1056,14 @@ if __name__ == '__main__':
     if FLAGS.libtorch:
         import torch
         from torch import nn
+    if FLAGS.openvino:
+        from openvino.inference_engine import IECore, IENetwork
+        import ngraph as ng
 
     import test_util as tu
 
-    # TensorRT and LibTorch must be handled separately since it doesn't support
-    # zero-sized tensors.
+    # TensorRT, OpenVino and LibTorch must be handled separately since they
+    # don't support zero-sized tensors.
     create_models(FLAGS.models_dir,
                   np_dtype_string, ([1],), ([],),
                   no_batch=False)
@@ -935,6 +1081,14 @@ if __name__ == '__main__':
                            no_batch=False)
     create_libtorch_models(FLAGS.models_dir, np.float32,
                            ([4, 4], [2], [2, 2, 3]), ([16], [1, 2], [3, 2, 2]))
+    create_openvino_models(FLAGS.models_dir,
+                           np.float32, ([1],), ([1, 1, 1],),
+                           no_batch=False)
+    create_openvino_models(FLAGS.models_dir,
+                           np.float32, ([1], [8]), ([1, 1, 1], [4, 1, 2]),
+                           no_batch=False)
+    create_openvino_models(FLAGS.models_dir, np.float32,
+                           ([4, 4], [2], [2, 2, 3]), ([16], [1, 2], [3, 2, 2]))
     create_trt_models(FLAGS.models_dir, np.float32, ([1], [8]),
                       ([1, 1, 1], [4, 1, 2]))
 
@@ -946,6 +1100,12 @@ if __name__ == '__main__':
                   output_model_shapes=([16], [1, 2], [3, 2, 2], [1]))
 
     create_libtorch_models(FLAGS.models_dir,
+                           np.float32, ([4, 4], [2], [2, 2, 3], [1]),
+                           ([16], [1, 2], [3, 2, 2], [1]),
+                           output_shapes=([16], [1, 2], [3, 2, 2], [1]),
+                           output_model_shapes=([16], [1, 2], [3, 2, 2], [1]))
+
+    create_openvino_models(FLAGS.models_dir,
                            np.float32, ([4, 4], [2], [2, 2, 3], [1]),
                            ([16], [1, 2], [3, 2, 2], [1]),
                            output_shapes=([16], [1, 2], [3, 2, 2], [1]),

--- a/qa/common/gen_qa_sequence_models.py
+++ b/qa/common/gen_qa_sequence_models.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_sequence_models.py
+++ b/qa/common/gen_qa_sequence_models.py
@@ -1166,6 +1166,111 @@ instance_group [
         cfile.write(config)
 
 
+def create_openvino_modelfile(models_dir, model_version, max_batch, dtype,
+                              shape):
+
+    if not tu.validate_for_openvino_model(dtype, dtype, dtype, shape, shape,
+                                          shape):
+        return
+
+    model_name = tu.get_sequence_model_name(
+        "openvino_nobatch" if max_batch == 0 else "openvino", dtype)
+    model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
+
+    in0 = ng.parameter(shape=shape, dtype=dtype, name="INPUT")
+    start = ng.parameter(shape=shape, dtype=dtype, name="START")
+    ready = ng.parameter(shape=shape, dtype=dtype, name="READY")
+
+    tmp = ng.add(in0, start)
+    op0 = ng.multiply(tmp, ready, name="OUTPUT")
+
+    function = ng.impl.Function([op0], [in0, start, ready], model_name)
+    ie_network = IENetwork(ng.impl.Function.to_capsule(function))
+
+    # Batch size needs to be a positive integer value
+    if max_batch != 0:
+        ie_network.batch_size = max_batch
+
+    try:
+        os.makedirs(model_version_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    ie_network.serialize(model_version_dir + "/model.xml",
+                         model_version_dir + "/model.bin")
+
+
+def create_openvino_modelconfig(models_dir, model_version, max_batch, dtype,
+                                shape):
+
+    if not tu.validate_for_openvino_model(dtype, dtype, dtype, shape, shape,
+                                          shape):
+        return
+
+    model_name = tu.get_sequence_model_name(
+        "openvino_nobatch" if max_batch == 0 else "openvino", dtype)
+    config_dir = models_dir + "/" + model_name
+    config = '''
+name: "{}"
+backend: "openvino"
+max_batch_size: {}
+sequence_batching {{
+  max_sequence_idle_microseconds: 5000000
+  control_input [
+    {{
+      name: "START"
+      control [
+        {{
+          kind: CONTROL_SEQUENCE_START
+          {}_false_true: [ 0, 1 ]
+        }}
+      ]
+    }},
+    {{
+      name: "READY"
+      control [
+        {{
+          kind: CONTROL_SEQUENCE_READY
+          {}_false_true: [ 0, 1 ]
+        }}
+      ]
+    }}
+  ]
+}}
+input [
+  {{
+    name: "INPUT"
+    data_type: {}
+    dims: [ {} ]
+  }}
+]
+output [
+  {{
+    name: "OUTPUT"
+    data_type: {}
+    dims: [ 1 ]
+  }}
+]
+instance_group [
+  {{
+    kind: KIND_CPU
+  }}
+]
+'''.format(model_name, max_batch, "int32" if dtype == np.int32 else "fp32",
+           "int32" if dtype == np.int32 else "fp32", np_to_model_dtype(dtype),
+           tu.shape_to_dims_str(shape), np_to_model_dtype(dtype),
+           tu.shape_to_dims_str(shape), np_to_model_dtype(dtype),
+           tu.shape_to_dims_str(shape), np_to_model_dtype(dtype))
+
+    try:
+        os.makedirs(config_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    with open(config_dir + "/config.pbtxt", "w") as cfile:
+        cfile.write(config)
+
+
 def create_shape_tensor_models(models_dir, dtype, shape, no_batch=True):
     model_version = 1
 
@@ -1230,6 +1335,15 @@ def create_models(models_dir, dtype, shape, no_batch=True):
             create_libtorch_modelfile(models_dir, model_version, 0, dtype,
                                       shape)
 
+    if FLAGS.openvino:
+        create_openvino_modelconfig(models_dir, model_version, 8, dtype, shape)
+        create_openvino_modelfile(models_dir, model_version, 8, dtype, shape)
+        if no_batch:
+            create_openvino_modelconfig(models_dir, model_version, 0, dtype,
+                                        shape)
+            create_openvino_modelfile(models_dir, model_version, 0, dtype,
+                                      shape)
+
     if FLAGS.ensemble:
         for pair in emu.platform_types_and_validation():
             config_shape = shape
@@ -1290,6 +1404,10 @@ if __name__ == '__main__':
                         required=False,
                         action='store_true',
                         help='Generate Pytorch LibTorch models')
+    parser.add_argument('--openvino',
+                        required=False,
+                        action='store_true',
+                        help='Generate OpenVino models')
     parser.add_argument('--variable',
                         required=False,
                         action='store_true',
@@ -1312,6 +1430,9 @@ if __name__ == '__main__':
     if FLAGS.libtorch:
         import torch
         from torch import nn
+    if FLAGS.openvino:
+        from openvino.inference_engine import IECore, IENetwork
+        import ngraph as ng
 
     import test_util as tu
 

--- a/qa/common/test_util.py
+++ b/qa/common/test_util.py
@@ -165,6 +165,21 @@ def validate_for_libtorch_model(input_dtype, output0_dtype, output1_dtype,
     return True
 
 
+def validate_for_openvino_model(input_dtype, output0_dtype, output1_dtype,
+                                input_shape, output0_shape, output1_shape):
+    """Return True if input and output dtypes are supported by an OpenVino model."""
+
+    supported_datatypes = [np.int8, np.int32, np.float16, np.float32]
+    if not input_dtype in supported_datatypes:
+        return False
+    if not output0_dtype in supported_datatypes:
+        return False
+    if not output1_dtype in supported_datatypes:
+        return False
+
+    return True
+
+
 def get_model_name(pf, input_dtype, output0_dtype, output1_dtype):
     return "{}_{}_{}_{}".format(pf,
                                 np.dtype(input_dtype).name,

--- a/qa/common/test_util.py
+++ b/qa/common/test_util.py
@@ -169,7 +169,8 @@ def validate_for_openvino_model(input_dtype, output0_dtype, output1_dtype,
                                 input_shape, output0_shape, output1_shape):
     """Return True if input and output dtypes are supported by an OpenVino model."""
 
-    supported_datatypes = [np.int8, np.int32, np.float16, np.float32]
+    # float16 is not supported on CPU by OpenVino 
+    supported_datatypes = [np.int8, np.int32, np.float32]
     if not input_dtype in supported_datatypes:
         return False
     if not output0_dtype in supported_datatypes:

--- a/qa/common/test_util.py
+++ b/qa/common/test_util.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -176,6 +176,11 @@ def validate_for_openvino_model(input_dtype, output0_dtype, output1_dtype,
     if not output0_dtype in supported_datatypes:
         return False
     if not output1_dtype in supported_datatypes:
+        return False
+
+    # Return false if input dtype != output dtype and shape > 1 dims
+    # https://github.com/openvinotoolkit/openvino/issues/7173
+    if ((output1_dtype != input_dtype) or (output0_dtype != input_dtype)) and len(input_shape) > 1:
         return False
 
     return True


### PR DESCRIPTION
~https://github.com/openvinotoolkit/openvino/issues/4798 prevents this from working till the next release i.e. 2021.3~
Moving forward to Openvino 2021.4 
Openvino does not support variable shape tensors 
- This impacts batch as well as variable shape [-1] models such as identity models.
- Hence for now while we generate all non-variable models but enable just L0_infer

PS: Bug filed against Openvino for multi dims models with different I/O dtypes such as addsub with inputs of FP32 dtype and outputs of INT32 dtype
https://github.com/openvinotoolkit/openvino/issues/7173 