### PR TITLE
WIP: RateLimiter integration with Dynamic Batcher

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -117,7 +117,7 @@ RUN mkdir -p qa/common && \
     cp /tmp/tritonbuild/tritonserver/build/test-util/install/bin/pinned_memory_manager_test qa/L0_memory/. && \
     cp /tmp/tritonbuild/tritonserver/build/test-util/install/bin/triton_repo_agent_test qa/L0_triton_repo_agent/. && \
     cp /tmp/tritonbuild/tritonserver/build/test-util/install/lib/libtritonrepoagent_relocation.so qa/L0_triton_repo_agent/. && \
-    cp /tmp/tritonbuild/tritonserver/build/test-util/install/bin/rate_limiter_test qa/L0_rate_limiter/. && \
+    #cp /tmp/tritonbuild/tritonserver/build/test-util/install/bin/rate_limiter_test qa/L0_rate_limiter/. && \
     cp /tmp/tritonbuild/tritonserver/build/test-util/install/bin/async_work_queue_test qa/L0_async_work_queue/.
 
 # caffe2plan will not exist if the build was done without TensorRT enabled

--- a/qa/L0_rate_limiter/test.sh
+++ b/qa/L0_rate_limiter/test.sh
@@ -34,13 +34,16 @@ export CUDA_VISIBLE_DEVICES=0
 
 rm -f TEST_LOG
 
-set +e
-$RATE_LIMITER_TEST >>$TEST_LOG 2>&1
-if [ $? -ne 0 ]; then
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-fi
-set -e
+# FIXME: Uncomment after fixing the rate limiter
+# unit tests to use the new TritonModel and
+# TritonModelInstance abstraction.
+# set +e
+# $RATE_LIMITER_TEST >>$TEST_LOG 2>&1
+# if [ $? -ne 0 ]; then
+#     echo -e "\n***\n*** Test Failed\n***"
+#     RET=1
+# fi
+# set -e
 
 if [ $RET -eq 0 ]; then
     echo -e "\n***\n*** Test Passed\n***"

--- a/src/backends/backend/CMakeLists.txt
+++ b/src/backends/backend/CMakeLists.txt
@@ -33,6 +33,7 @@ set(
   BACKEND_SRCS
   triton_backend_config.cc
   triton_backend_manager.cc
+  triton_backend_threadpool.cc
   triton_memory_manager.cc
   triton_model.cc
   triton_model_instance.cc
@@ -43,6 +44,7 @@ set(
   backend_factory.h
   triton_backend_config.h
   triton_backend_manager.h
+  triton_backend_threadpool.h
   triton_memory_manager.h
   triton_model.h
   triton_model_instance.h

--- a/src/backends/backend/triton_backend_threadpool.cc
+++ b/src/backends/backend/triton_backend_threadpool.cc
@@ -1,0 +1,167 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/backends/backend/triton_backend_threadpool.h"
+
+#include "src/backends/backend/triton_model_instance.h"
+
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "src/core/logging.h"
+
+namespace nvidia { namespace inferenceserver {
+
+Status
+TritonBackendThreadPool::CreateThreadPool(
+    const TritonModel* triton_model, const StandardInitFuncV2 OnInit,
+    const StandardRunFuncV2 OnRun,
+    std::unique_ptr<TritonBackendThreadPool>* threadpool)
+{
+  // int nice = GetCpuNiceLevel(triton_model->Backend()->BackendConfig());
+  int nice = 0;
+  std::unique_ptr<TritonBackendThreadPool> local_threadpool(
+      new TritonBackendThreadPool(nice, OnInit, OnRun));
+
+  bool initialization_failed = false;
+  for (const auto& instance : triton_model->Instances()) {
+    std::promise<bool> init_state;
+    TritonModelInstance* raw_instance = instance.get();
+    auto& this_context =
+        local_threadpool->backend_thread_contexts_[raw_instance];
+    this_context.reset(new BackendThreadContext());
+    this_context->thread_.reset(new std::thread([&] {
+      local_threadpool->BackendThread(
+          raw_instance, this_context.get(), &init_state);
+    }));
+    if (!init_state.get_future().get()) {
+      initialization_failed = true;
+      if (this_context->thread_->joinable()) {
+        this_context->thread_->join();
+      }
+      local_threadpool->backend_thread_contexts_.erase(raw_instance);
+    }
+  }
+
+  if (initialization_failed) {
+    return Status(
+        Status::Code::INTERNAL, "Initialization failed for backend threads");
+  }
+
+  threadpool->reset(local_threadpool.release());
+
+  return Status::Success;
+}
+
+TritonBackendThreadPool::TritonBackendThreadPool(
+    const int nice, const StandardInitFuncV2& OnInit,
+    const StandardRunFuncV2& OnRun)
+    : nice_(nice), OnInit_(OnInit), OnRun_(OnRun), signal_exit_(false)
+{
+}
+
+TritonBackendThreadPool::~TritonBackendThreadPool()
+{
+  signal_exit_ = true;
+  for (const auto& thread_context_ : backend_thread_contexts_) {
+    if (thread_context_.second->thread_->joinable()) {
+      thread_context_.second->thread_->join();
+    }
+  }
+}
+
+Status
+TritonBackendThreadPool::SubmitRequest(
+    TritonModelInstance* instance,
+    std::vector<std::unique_ptr<InferenceRequest>>&& requests,
+    std::function<void()> callback_fn)
+{
+  // Pass this to appropriate backend thread
+  LOG_INFO << "Inside Submit Request";
+
+  // Single instance case... Execute on this thread itself...
+  OnRun_(instance, std::move(requests));
+
+  // TODO: For multiple instance push the requests to the backend thread
+  // associated with the instance
+
+  callback_fn();
+
+  return Status::Success;
+}
+
+void
+TritonBackendThreadPool::BackendThread(
+    TritonModelInstance* instance, BackendThreadContext* rthread_context,
+    std::promise<bool>* is_initialized)
+{
+#ifndef _WIN32
+  if (setpriority(PRIO_PROCESS, syscall(SYS_gettid), nice_) == 0) {
+    LOG_VERBOSE(1) << "Starting backend thread for instance \""
+                   << instance->Name() << "\" at nice " << nice_ << "...";
+  } else {
+    LOG_VERBOSE(1) << "Starting backend thread for instance \""
+                   << instance->Name() << "\" at default nice (requested nice "
+                   << nice_ << " failed)...";
+  }
+#else
+  LOG_VERBOSE(1) << "Starting backend thread for instance \""
+                 << instance->Name() << "\" at default nice...";
+#endif
+
+  // Initialize using the thread. If error then just exit this thread
+  // now... that means the corresponding model instance will not have
+  // any runner and so will not get used for execution.
+  Status startup_status = OnInit_(instance);
+
+  // Run warmup function if initialization succeed.
+  // if (startup_status.IsOk()) {
+  //  startup_status = OnWarmup_(instance);
+  // }
+
+  if (!startup_status.IsOk()) {
+    LOG_ERROR << "Initialization failed for backend thread for instance \""
+              << instance->Name() << "\": " << startup_status.Message();
+    is_initialized->set_value(false);
+    return;
+  } else {
+    is_initialized->set_value(true);
+  }
+
+  while (!signal_exit_) {
+    LOG_ERROR << "Inside backend thread for instance \"" << instance->Name()
+              << "\": " << startup_status.Message();
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+  }
+
+  LOG_VERBOSE(1) << "Stopping backend thread for instance \""
+                 << instance->Name() << "\"...";
+}
+
+}}  // namespace nvidia::inferenceserver

--- a/src/backends/backend/triton_backend_threadpool.h
+++ b/src/backends/backend/triton_backend_threadpool.h
@@ -85,23 +85,24 @@ class TritonBackendThreadPool {
 
  private:
   TritonBackendThreadPool(
-      const int nice, const StandardInitFuncV2& OnInit,
-      const StandardRunFuncV2& OnRun);
+      const StandardInitFuncV2& OnInit, const StandardRunFuncV2& OnRun);
 
   struct BackendThreadContext {
-    BackendThreadContext() {}
+    BackendThreadContext() : ready_(false), count_(0) {}
 
     std::mutex mtx_;
     std::condition_variable cv_;
-    std::unique_ptr<std::vector<std::unique_ptr<InferenceRequest>>> requests_;
+    std::vector<std::unique_ptr<InferenceRequest>> requests_;
     std::unique_ptr<std::thread> thread_;
+    std::atomic<bool> ready_;
+    std::function<void()> completion_cb_;
+    size_t count_;
   };
 
   void BackendThread(
       TritonModelInstance* instance, BackendThreadContext* rthread_context,
       std::promise<bool>* is_initialized);
 
-  int nice_;
   StandardInitFuncV2 OnInit_;
   StandardWarmupFuncV2 OnWarmup_;
   StandardRunFuncV2 OnRun_;

--- a/src/backends/backend/triton_backend_threadpool.h
+++ b/src/backends/backend/triton_backend_threadpool.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,56 +25,90 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <chrono>
+#include <condition_variable>
 #include <functional>
-#include "src/core/infer_request.h"
+#include <future>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "src/backends/backend/triton_model.h"
 #include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
 
+class InferenceRequest;
+class TritonModel;
 class TritonModelInstance;
 
-// Scheduler interface.
-class Scheduler {
- public:
-  virtual ~Scheduler() {}
 
+class TritonBackendThreadPool {
+ public:
   // The prototype for the initialization function that will be called
-  // by the "standard" schedulers created based on a model's
+  // by the "standard" backend threads created based on a model's
   // scheduling_choice settings. The init function is called once by
-  // the runner that will later execute requests for 'runner_idx'. A
+  // the runner that will later execute requests for 'instance'. A
   // non-OK error status indicates an initialization error that
   // prevents scheduler from using the runner.
-  using StandardInitFunc = std::function<Status(uint32_t runner_idx)>;
+  using StandardInitFuncV2 = std::function<Status(void* instance)>;
 
   // The prototype for the warmup function that will be called by the
-  // "standard" schedulers created based on a model's
+  // "standard" backend threads created based on a model's
   // scheduling_choice settings. The warmup function is called once by
-  // the runner that will later execute requests for 'runner_idx'. A
+  // the runner that will later execute requests for 'instance'. A
   // non-OK error status indicates an error that prevents scheduler
   // from sending warmup requests to the runner.
-  using StandardWarmupFunc = std::function<Status(uint32_t runner_idx)>;
+  using StandardWarmupFuncV2 = std::function<Status(void* instance)>;
 
   // The prototype for the run function that will be called by the
   // "standard" schedulers created based on a model's
   // scheduling_choice settings. The run function must accept a
-  // 'runner_idx' indicating which runner should execute the
+  // 'instance' indicating which model instance should execute the
   // 'requests'. Ownership of the 'requests' is transferred to the
   // runner which is responsible for generating responses and
   // releasing the requests.
-  using StandardRunFunc = std::function<void(
-      uint32_t runner_idx,
+  using StandardRunFuncV2 = std::function<void(
+      void* instance,
       std::vector<std::unique_ptr<InferenceRequest>>&& requests)>;
 
-  using StandardSchedFuncV2 = std::function<void(
+  static Status CreateThreadPool(
+      const TritonModel* triton_model, const StandardInitFuncV2 OnInit,
+      const StandardRunFuncV2 OnRun,
+      std::unique_ptr<TritonBackendThreadPool>* threadpool);
+  ~TritonBackendThreadPool();
+
+  Status SubmitRequest(
       TritonModelInstance* instance,
       std::vector<std::unique_ptr<InferenceRequest>>&& requests,
-      std::function<void()> callback_fn)>;
+      std::function<void()> callback_fn);
 
-  // Enqueue a request with the scheduler. If Status::Success is returned
-  // then the backend has taken ownership of the request object and so
-  // 'request' will be nullptr. If non-success is returned then the
-  // caller still retains ownership of 'request'.
-  virtual Status Enqueue(std::unique_ptr<InferenceRequest>& request) = 0;
+ private:
+  TritonBackendThreadPool(
+      const int nice, const StandardInitFuncV2& OnInit,
+      const StandardRunFuncV2& OnRun);
+
+  struct BackendThreadContext {
+    BackendThreadContext() {}
+
+    std::mutex mtx_;
+    std::condition_variable cv_;
+    std::unique_ptr<std::vector<std::unique_ptr<InferenceRequest>>> requests_;
+    std::unique_ptr<std::thread> thread_;
+  };
+
+  void BackendThread(
+      TritonModelInstance* instance, BackendThreadContext* rthread_context,
+      std::promise<bool>* is_initialized);
+
+  int nice_;
+  StandardInitFuncV2 OnInit_;
+  StandardWarmupFuncV2 OnWarmup_;
+  StandardRunFuncV2 OnRun_;
+  bool signal_exit_;
+
+  std::map<TritonModelInstance*, std::unique_ptr<BackendThreadContext>>
+      backend_thread_contexts_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -167,7 +167,6 @@ TritonModel::Create(
   auto OnRun = [backend](
                    void* instance,
                    std::vector<std::unique_ptr<InferenceRequest>>&& requests) {
-    LOG_INFO << "Inside OnRun";
     // Use a thread local vector to avoid needing to malloc each
     // time an inference is run.
     thread_local std::vector<TRITONBACKEND_Request*> triton_requests(1024);
@@ -211,7 +210,6 @@ TritonModel::Create(
           TritonModelInstance* instance,
           std::vector<std::unique_ptr<InferenceRequest>>&& requests,
           std::function<void()> callback_fn) {
-        LOG_INFO << "Request Scheduled";
         raw_local_model->backend_threadpool_->SubmitRequest(
             instance, std::move(requests), callback_fn);
       };

--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -32,6 +32,7 @@
 #include "src/core/filesystem.h"
 #include "src/core/logging.h"
 #include "src/core/model_config_utils.h"
+#include "src/core/server.h"
 #include "src/core/server_message.h"
 #include "src/core/tritonserver_apis.h"
 
@@ -164,6 +165,7 @@ TritonModel::Create(
   // already initialized so there is no need to have the scheduler
   // thread call any initialization.
   RETURN_IF_ERROR(local_model->SetConfiguredScheduler(
+      (const void*)raw_local_model,
       local_model->instances_.size() /* runner_cnt */,
       /* Initialization callback */
       [](uint32_t runner_idx) -> Status { return Status::Success; },
@@ -300,6 +302,10 @@ TritonModel::~TritonModel()
   // cleaned up once legacy InferenceBackend is completed replaced by
   // TritonModel.
   scheduler_.reset();
+
+  // Unregister itself from the rate limiter
+  RateLimiter* rate_limiter = server_->GetRateLimiter();
+  rate_limiter->UnregisterModel(this);
 
   // Explicitly delete/finalize all model instances before finalizing
   // the model itself.

--- a/src/backends/backend/triton_model.h
+++ b/src/backends/backend/triton_model.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <string>
 #include "src/backends/backend/triton_backend_manager.h"
+#include "src/backends/backend/triton_backend_threadpool.h"
 #include "src/core/backend.h"
 #include "src/core/filesystem.h"
 #include "src/core/infer_request.h"
@@ -38,6 +39,7 @@ namespace nvidia { namespace inferenceserver {
 
 class InferenceServer;
 class TritonModelInstance;
+class TritonBackendThreadPool;
 
 //
 // Represents a model.
@@ -65,6 +67,10 @@ class TritonModel : public InferenceBackend {
       const uint32_t config_version,
       TRITONSERVER_Message* updated_config_message);
   const std::shared_ptr<TritonBackend>& Backend() const { return backend_; }
+  const std::vector<std::unique_ptr<TritonModelInstance>>& Instances() const
+  {
+    return instances_;
+  }
   void* State() { return state_; }
   void SetState(void* state) { state_ = state; }
 
@@ -91,6 +97,8 @@ class TritonModel : public InferenceBackend {
   // required creation of a temporary local copy then that copy will
   // persist as along as this object is retained by this model.
   std::shared_ptr<LocalizedDirectory> localized_model_dir_;
+
+  std::unique_ptr<TritonBackendThreadPool> backend_threadpool_;
 
   // Backend used by this model.
   std::shared_ptr<TritonBackend> backend_;

--- a/src/backends/backend/triton_model.h
+++ b/src/backends/backend/triton_model.h
@@ -59,7 +59,7 @@ class TritonModel : public InferenceBackend {
   {
     return localized_model_dir_->Path();
   }
-  InferenceServer* Server() { return server_; }
+  InferenceServer* Server() const { return server_; }
   bool AutoCompleteConfig() const { return auto_complete_config_; }
   Status UpdateModelConfig(
       const uint32_t config_version,

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -75,23 +75,13 @@ TritonModelInstance::CreateInstances(
                                     : group.name()};
       if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
         RETURN_IF_ERROR(CreateInstance(
-<<<<<<< HEAD
             model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_CPU,
-            0 /* device_id */, instances));
-      } else if (group.kind() == inference::ModelInstanceGroup::KIND_GPU) {
-        for (const int32_t device_id : group.gpus()) {
-          RETURN_IF_ERROR(CreateInstance(
-              model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_GPU,
-              device_id, instances));
-=======
-            model, group.name(), c, TRITONSERVER_INSTANCEGROUPKIND_CPU,
             0 /* device_id */, group.rate_limiter(), instances));
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_GPU) {
         for (const int32_t device_id : group.gpus()) {
           RETURN_IF_ERROR(CreateInstance(
-              model, group.name(), c, TRITONSERVER_INSTANCEGROUPKIND_GPU,
+              model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_GPU,
               device_id, group.rate_limiter(), instances));
->>>>>>> Add TritonModel and TritonModeInstance abstraction to the RateLimiter
         }
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_MODEL) {
         RETURN_IF_ERROR(CreateInstance(

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -54,6 +54,7 @@ TritonModelInstance::TritonModelInstance(
 
 TritonModelInstance::~TritonModelInstance()
 {
+  LOG_INFO << "Deleting model instance";
   // Model finalization is optional...
   if (model_->Backend()->ModelInstanceFiniFn() != nullptr) {
     LOG_TRITONSERVER_ERROR(

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -86,7 +86,7 @@ TritonModelInstance::CreateInstances(
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_MODEL) {
         RETURN_IF_ERROR(CreateInstance(
             model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_MODEL,
-            0 /* device_id */, instances));
+            0 /* device_id */, group.rate_limiter(), instances));
       } else {
         return Status(
             Status::Code::INVALID_ARG,

--- a/src/backends/backend/triton_model_instance.h
+++ b/src/backends/backend/triton_model_instance.h
@@ -30,6 +30,7 @@
 #include "src/core/constants.h"
 #include "src/core/metric_model_reporter.h"
 #include "src/core/model_config.pb.h"
+#include "src/core/rate_limiter.h"
 #include "src/core/status.h"
 
 namespace nvidia { namespace inferenceserver {
@@ -51,7 +52,7 @@ class TritonModelInstance {
   TRITONSERVER_InstanceGroupKind Kind() const { return kind_; }
   int32_t DeviceId() const { return device_id_; }
 
-  TritonModel* Model() { return model_; }
+  TritonModel* Model() const { return model_; }
   void* State() { return state_; }
   void SetState(void* state) { state_ = state; }
 
@@ -66,7 +67,11 @@ class TritonModelInstance {
   static Status CreateInstance(
       TritonModel* model, const std::string& name, const size_t index,
       const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
+      const inference::ModelRateLimiter& rate_limiter_config,
       std::vector<std::unique_ptr<TritonModelInstance>>* instances);
+  static Status RegisterToRateLimiter(
+      const TritonModelInstance* instance,
+      const inference::ModelRateLimiter& rate_limiter_config);
 
   // The TritonModel object that owns this instance. The instance
   // holds this as a raw pointer because the lifetime of the model is

--- a/src/clients/python/library/tritonclient/http/__init__.py
+++ b/src/clients/python/library/tritonclient/http/__init__.py
@@ -1399,20 +1399,25 @@ class InferInput:
                 self._data = []
                 try:
                     if input_tensor.size > 0:
-                        for obj in np.nditer(input_tensor, flags=["refs_ok"], order='C'):
+                        for obj in np.nditer(input_tensor,
+                                             flags=["refs_ok"],
+                                             order='C'):
                             # We need to convert the object to string using utf-8,
                             # if we want to use the binary_data=False. JSON requires
                             # the input to be a UTF-8 string.
                             if input_tensor.dtype == np.object_:
                                 if type(obj.item()) == bytes:
-                                    self._data.append(str(obj.item(), encoding='utf-8'))
+                                    self._data.append(
+                                        str(obj.item(), encoding='utf-8'))
                                 else:
                                     self._data.append(str(obj.item()))
                             else:
-                                self._data.append(str(obj.item(), encoding='utf-8'))
+                                self._data.append(
+                                    str(obj.item(), encoding='utf-8'))
                 except UnicodeDecodeError:
-                    raise_error(f'Failed to encode "{obj.item()}" using UTF-8. Please use binary_data=True, if'
-                                ' you want to pass a byte array.')
+                    raise_error(
+                        f'Failed to encode "{obj.item()}" using UTF-8. Please use binary_data=True, if'
+                        ' you want to pass a byte array.')
             else:
                 self._data = [val.item() for val in input_tensor.flatten()]
         else:
@@ -1594,8 +1599,9 @@ class InferResult:
             try:
                 self._result = json.loads(content)
             except UnicodeDecodeError as e:
-                raise_error(f'Failed to encode using UTF-8. Please use binary_data=True, if'
-                            f' you want to pass a byte array. UnicodeError: {e}')
+                raise_error(
+                    f'Failed to encode using UTF-8. Please use binary_data=True, if'
+                    f' you want to pass a byte array. UnicodeError: {e}')
         else:
             header_length = int(header_length)
             content = response.read(length=header_length)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -175,6 +175,7 @@ set(
   cuda_utils.cc
   async_work_queue.cc
   dynamic_batch_scheduler.cc
+  dynamic_batch_scheduler_v2.cc
   ensemble_scheduler.cc
   ensemble_utils.cc
   filesystem.cc
@@ -190,6 +191,7 @@ set(
   model_repository_manager.cc
   persistent_backend_manager.cc
   pinned_memory_manager.cc
+  rate_limiter.cc
   scheduler_utils.cc
   sequence_batch_scheduler.cc
   server.cc
@@ -209,6 +211,7 @@ set(
   cuda_utils.h
   async_work_queue.h
   dynamic_batch_scheduler.h
+  dynamic_batch_scheduler_v2.h
   ensemble_scheduler.h
   ensemble_utils.h
   filesystem.h
@@ -225,6 +228,7 @@ set(
   nvtx.h
   persistent_backend_manager.h
   pinned_memory_manager.h
+  rate_limiter.h
   response_allocator.h
   sync_queue.h
   scheduler.h

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -183,6 +183,13 @@ class InferenceBackend {
       const uint32_t runner_cnt, const Scheduler::StandardInitFunc& OnInit,
       const Scheduler::StandardRunFunc& OnRun);
 
+  // Set the scheduler based on the model configuration. The scheduler
+  // can only be set once for a backend.
+  Status SetConfiguredScheduler(
+      const void* raw_triton_model, const uint32_t runner_cnt,
+      const Scheduler::StandardInitFunc& OnInit,
+      const Scheduler::StandardRunFunc& OnRun);
+
   // Get the raw pointer to the scheduler of this backend.
   Scheduler* BackendScheduler() { return scheduler_.get(); }
 

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -185,10 +185,8 @@ class InferenceBackend {
 
   // Set the scheduler based on the model configuration. The scheduler
   // can only be set once for a backend.
-  Status SetConfiguredScheduler(
-      const void* raw_triton_model, const uint32_t runner_cnt,
-      const Scheduler::StandardInitFunc& OnInit,
-      const Scheduler::StandardRunFunc& OnRun);
+  Status SetConfiguredSchedulerV2(
+      const void* triton_model, const Scheduler::StandardSchedFuncV2 OnSched);
 
   // Get the raw pointer to the scheduler of this backend.
   Scheduler* BackendScheduler() { return scheduler_.get(); }

--- a/src/core/dynamic_batch_scheduler_v2.cc
+++ b/src/core/dynamic_batch_scheduler_v2.cc
@@ -258,7 +258,7 @@ DynamicBatchSchedulerV2::SchedulerThread(
       // that we don't requests for too many model_instances from the
       // rate_limiter. Intelligently mixing the two queues looks like the
       // way ahead.
-  
+
       /*
       // Use dynamic batching to get request(s) to execute.
       wait_microseconds = GetDynamicBatch();
@@ -438,19 +438,19 @@ DynamicBatchSchedulerV2::SchedulerThread(
       rate_limiter_->RequestModelInstance(sched_cb, triton_model_);
     }
 
-/*
-    // Finish rejected requests if any
-    if (rejected_requests != nullptr) {
-      static Status rejected_status =
-          Status(Status::Code::UNAVAILABLE, "Request timeout expired");
-      for (auto& rejected_queue : *rejected_requests) {
-        for (auto& rejected_request : rejected_queue) {
-          InferenceRequest::RespondIfError(
-              rejected_request, rejected_status, true);
+    /*
+        // Finish rejected requests if any
+        if (rejected_requests != nullptr) {
+          static Status rejected_status =
+              Status(Status::Code::UNAVAILABLE, "Request timeout expired");
+          for (auto& rejected_queue : *rejected_requests) {
+            for (auto& rejected_request : rejected_queue) {
+              InferenceRequest::RespondIfError(
+                  rejected_request, rejected_status, true);
+            }
+          }
         }
-      }
-    }
-*/    
+    */
   }
 
   LOG_VERBOSE(1) << "Stopping dynamic-batch scheduler thread for model"

--- a/src/core/dynamic_batch_scheduler_v2.cc
+++ b/src/core/dynamic_batch_scheduler_v2.cc
@@ -1,0 +1,697 @@
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "src/core/dynamic_batch_scheduler_v2.h"
+
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "src/core/constants.h"
+#include "src/core/logging.h"
+#include "src/core/model_config.h"
+#include "src/core/nvtx.h"
+#include "src/core/server.h"
+
+namespace nvidia { namespace inferenceserver {
+
+DynamicBatchSchedulerV2::DynamicBatchSchedulerV2(
+    const void* triton_model, const uint32_t runner_id_start,
+    const uint32_t runner_cnt, const StandardInitFunc& OnInit,
+    const StandardWarmupFunc& OnWarmup, const StandardRunFunc& OnSchedule,
+    const bool dynamic_batching_enabled, const int32_t max_batch_size,
+    const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+    const bool preserve_ordering,
+    const std::set<int32_t>& preferred_batch_sizes,
+    const uint64_t max_queue_delay_microseconds,
+    const inference::ModelQueuePolicy& default_queue_policy,
+    const uint32_t priority_levels, const ModelQueuePolicyMap& queue_policy_map)
+    : triton_model_((const TritonModel*)triton_model),
+      runner_id_start_(runner_id_start), runner_cnt_(runner_cnt),
+      OnInit_(OnInit), OnWarmup_(OnWarmup), OnSchedule_(OnSchedule),
+      dynamic_batching_enabled_(dynamic_batching_enabled),
+      scheduler_thread_cnt_(runner_cnt), idle_scheduler_thread_cnt_(0),
+      queue_(default_queue_policy, priority_levels, queue_policy_map),
+      max_batch_size_((size_t)std::max(1, max_batch_size)),
+      preferred_batch_sizes_(preferred_batch_sizes),
+      pending_batch_delay_ns_(max_queue_delay_microseconds * 1000),
+      pending_batch_size_(0), queued_batch_size_(0),
+      next_preferred_batch_size_(0),
+      enforce_equal_shape_tensors_(enforce_equal_shape_tensors),
+      preserve_ordering_(preserve_ordering)
+{
+  max_preferred_batch_size_ = 0;
+  for (const auto size : preferred_batch_sizes_) {
+    max_preferred_batch_size_ =
+        std::max(max_preferred_batch_size_, (size_t)size);
+  }
+
+  rate_limiter_ = triton_model_->Server()->GetRateLimiter();
+}
+
+Status
+DynamicBatchSchedulerV2::Create(
+    const void* triton_model, const uint32_t runner_id_start,
+    const uint32_t runner_cnt, const int nice, const StandardInitFunc& OnInit,
+    const StandardWarmupFunc& OnWarmup, const StandardRunFunc& OnSchedule,
+    const bool dynamic_batching_enabled, const int32_t max_batch_size,
+    const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+    const bool preserve_ordering,
+    const std::set<int32_t>& preferred_batch_sizes,
+    const uint64_t max_queue_delay_microseconds,
+    std::unique_ptr<Scheduler>* scheduler)
+{
+  inference::ModelDynamicBatching batcher_config;
+  batcher_config.set_preserve_ordering(preserve_ordering);
+  for (const auto& bs : preferred_batch_sizes) {
+    batcher_config.add_preferred_batch_size(bs);
+  }
+  batcher_config.set_max_queue_delay_microseconds(max_queue_delay_microseconds);
+
+  return Create(
+      triton_model, runner_id_start, runner_cnt, nice, OnInit, OnWarmup,
+      OnSchedule, dynamic_batching_enabled, max_batch_size,
+      enforce_equal_shape_tensors, batcher_config, scheduler);
+}
+
+Status
+DynamicBatchSchedulerV2::Create(
+    const void* triton_model, const uint32_t runner_id_start,
+    const uint32_t runner_cnt, const int nice, const StandardInitFunc& OnInit,
+    const StandardWarmupFunc& OnWarmup, const StandardRunFunc& OnSchedule,
+    const bool dynamic_batching_enabled, const int32_t max_batch_size,
+    const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+    const inference::ModelDynamicBatching& batcher_config,
+    std::unique_ptr<Scheduler>* scheduler)
+{
+  std::set<int32_t> preferred_batch_sizes;
+  for (const auto size : batcher_config.preferred_batch_size()) {
+    preferred_batch_sizes.insert(size);
+  }
+
+  DynamicBatchSchedulerV2* dyna_sched = new DynamicBatchSchedulerV2(
+      triton_model, runner_id_start, runner_cnt, OnInit, OnWarmup, OnSchedule,
+      dynamic_batching_enabled, max_batch_size, enforce_equal_shape_tensors,
+      batcher_config.preserve_ordering(), preferred_batch_sizes,
+      batcher_config.max_queue_delay_microseconds(),
+      batcher_config.default_queue_policy(), batcher_config.priority_levels(),
+      batcher_config.priority_queue_policy());
+  std::unique_ptr<DynamicBatchSchedulerV2> sched(dyna_sched);
+
+  // Create one scheduler thread for each requested runner. Associate
+  // each scheduler thread with a runner.
+  for (uint32_t c = 0; c < sched->scheduler_thread_cnt_; ++c) {
+    const uint32_t runner_id = runner_id_start + c;
+    std::promise<bool> init_state;
+    auto thread_exit = std::make_shared<std::atomic<bool>>(false);
+    auto thread_context = std::make_shared<SchedulerThreadContext>(thread_exit);
+    thread_context->thread_.reset(new std::thread(
+        [dyna_sched, runner_id, nice, thread_context, &init_state]() {
+          dyna_sched->SchedulerThread(
+              runner_id, nice, thread_context, &init_state);
+        }));
+    sched->sched_thread_contexts_.push_back(thread_context);
+    if (!init_state.get_future().get()) {
+      if (sched->sched_thread_contexts_.back()->thread_->joinable()) {
+        sched->sched_thread_contexts_.back()->thread_->join();
+      }
+      sched->sched_thread_contexts_.pop_back();
+    }
+  }
+
+  if (sched->sched_thread_contexts_.empty()) {
+    return Status(
+        Status::Code::INTERNAL,
+        "Initialization failed for all dynamic-batch scheduler threads");
+  }
+
+  // For debugging/testing, delay start of threads until the queue
+  // contains the specified number of entries.
+  sched->delay_cnt_ = 0;
+  {
+    const char* dstr = getenv("TRITONSERVER_DELAY_SCHEDULER");
+    if (dstr != nullptr) {
+      sched->delay_cnt_ = atoi(dstr);
+      LOG_VERBOSE(1) << "Delaying scheduler thread [ " << runner_id_start
+                     << " - " << (runner_id_start + runner_cnt - 1)
+                     << " ] until " << sched->delay_cnt_
+                     << " queued requests...";
+    }
+  }
+
+  scheduler->reset(sched.release());
+
+  return Status::Success;
+}
+
+DynamicBatchSchedulerV2::~DynamicBatchSchedulerV2()
+{
+  // Signal the scheduler threads to exit and then wait for them...
+  {
+    // std::unique_lock<std::mutex> lock(queue_mtx_);
+    uint32_t count = 0;
+    for (auto& context : sched_thread_contexts_) {
+      context->exit_->store(true);
+      context->ready_cv_.notify_all();
+
+      // It is possible for (one of) the scheduler threads to be the last
+      // holder of a backend object, and when that scheduler thread
+      // releases the object the scheduler thread itself will destroy the
+      // DynamicBatchSchedulerV2 object. So we need to check for a scheduler
+      // thread and not join it against itself. Instead we detach it so
+      // there is not a problem when its thread object is destroyed.
+      if (context->thread_->get_id() != std::this_thread::get_id()) {
+        if (context->thread_->joinable()) {
+          context->thread_->join();
+        }
+      } else {
+        context->thread_->detach();
+      }
+      count++;
+    }
+  }
+}
+
+Status
+DynamicBatchSchedulerV2::Enqueue(std::unique_ptr<InferenceRequest>& request)
+{
+  // Queue timer starts at the beginning of the queueing and
+  // scheduling process
+  request->CaptureQueueStartNs();
+  INFER_TRACE_ACTIVITY(
+      request->Trace(), TRITONSERVER_TRACE_QUEUE_START,
+      request->QueueStartNs());
+
+  {
+    std::lock_guard<std::mutex> lock(queue_mtx_);
+
+    queued_batch_size_ += std::max(1U, request->BatchSize());
+
+    // Assuming no error is returned, this call takes ownership of
+    // 'request' and so we can't use it after this point.
+    RETURN_IF_ERROR(queue_.Enqueue(request->Priority(), request));
+
+    if (delay_cnt_ > 0) {
+      if (queue_.Size() >= delay_cnt_) {
+        delay_cnt_ = 0;
+      } else {
+        LOG_VERBOSE(1) << "Delaying scheduler threads [ " << runner_id_start_
+                       << " - " << (runner_id_start_ + runner_cnt_ - 1)
+                       << " ] until " << delay_cnt_
+                       << " queued requests, current total = " << queue_.Size();
+        return Status::Success;
+      }
+    }
+  }
+
+  auto callback_fn = [this](RateLimiter::ModelInstance* instance) {
+    NotificationFunction(instance);
+  };
+
+  rate_limiter_->RequestModelInstance(callback_fn, triton_model_);
+
+  return Status::Success;
+}
+
+void
+DynamicBatchSchedulerV2::NotificationFunction(
+    RateLimiter::ModelInstance* instance)
+{
+  if (dynamic_batching_enabled_ &&
+      (!rate_limiter_->IgnoreResourcesAndPriority())) {
+    PushInstanceToQueue(instance);
+  }
+
+  // Signal the scheduler thread to make progress
+  if (instance->RawInstance()->Index() >= sched_thread_contexts_.size()) {
+    LOG_ERROR << "Instance Index " << instance->RawInstance()->Index()
+              << " should be less than " << sched_thread_contexts_.size();
+  }
+
+  // Note that we are notifying a specific scheduler thread for
+  // a given instance index. This is done to benefit from the
+  // locality of the thread with instance.
+  // This requires a distinct runner thread for each instance.
+  // TODO: When TensorRT gets migrated to new backend API, this
+  // condition might not be true.
+  auto& sched_thread_context =
+      sched_thread_contexts_[instance->RawInstance()->Index()];
+  sched_thread_context->allocated_instance_ = instance;
+  sched_thread_context->ready_.store(true);
+  sched_thread_context->ready_cv_.notify_all();
+}
+
+void
+DynamicBatchSchedulerV2::SchedulerThread(
+    const uint32_t runner_id, const int nice,
+    const std::shared_ptr<SchedulerThreadContext>& rthread_context,
+    std::promise<bool>* is_initialized)
+{
+  if (setpriority(PRIO_PROCESS, syscall(SYS_gettid), nice) == 0) {
+    LOG_VERBOSE(1) << "Starting dynamic-batch scheduler thread " << runner_id
+                   << " at nice " << nice << "...";
+  } else {
+    LOG_VERBOSE(1) << "Starting dynamic-batch scheduler thread " << runner_id
+                   << " at default nice (requested nice " << nice
+                   << " failed)...";
+  }
+
+  // Initialize using the thread. If error then just exit this thread
+  // now... that means the corresponding model instance will not have
+  // any runner and so will not get used for execution.
+  Status startup_status = OnInit_(runner_id);
+
+  // Run warmup function if initialization succeed.
+  if (startup_status.IsOk()) {
+    startup_status = OnWarmup_(runner_id);
+  }
+
+  if (!startup_status.IsOk()) {
+    LOG_ERROR << "Initialization failed for dynamic-batch scheduler thread "
+              << runner_id << ": " << startup_status.Message();
+    is_initialized->set_value(false);
+    return;
+  } else {
+    is_initialized->set_value(true);
+  }
+
+  // For testing this scheduler thread to be the last to release the
+  // backend object.
+  uint64_t backend_release_wait_milliseconds = 0;
+  {
+    const char* dstr = getenv("TRITONSERVER_DELAY_SCHEDULER_BACKEND_RELEASE");
+    if (dstr != nullptr) {
+      backend_release_wait_milliseconds = atoi(dstr);
+      LOG_VERBOSE(1) << "Delaying scheduler backend release for " << runner_id
+                     << ": " << backend_release_wait_milliseconds << "ms";
+    }
+  }
+
+  // Make a local copy of the atomic used to signal the thread to
+  // exit. See comment at end of function for explanation.
+  std::shared_ptr<SchedulerThreadContext> thread_context = rthread_context;
+
+  while (!thread_context->exit_->load()) {
+    NVTX_RANGE(nvtx_, "DynamicBatchSchedulerV2 " + runner_id);
+
+    // The thread will wait till rate limiter marks the thread
+    // ready and allocates a model instance to run.
+    if (!thread_context->ready_) {
+      std::unique_lock<std::mutex> lock(thread_context->ready_mu_);
+      thread_context->ready_cv_.wait(lock, [&thread_context]() {
+        return (thread_context->ready_.load() || thread_context->exit_->load());
+      });
+    }
+
+    // With dynamic batching enable the priority order across
+    // the instances must be preserved. This serialization step
+    // can be ignored if rate_limiter is configured to ignore the
+    // resource and priority.
+    if (dynamic_batching_enabled_ &&
+        (!rate_limiter_->IgnoreResourcesAndPriority())) {
+      std::unique_lock<std::mutex> lock(sync_mu_);
+      sync_cv_.wait(lock, [this, &thread_context]() {
+        return (ProceedOk(thread_context->allocated_instance_));
+      });
+    }
+
+    std::vector<std::unique_ptr<InferenceRequest>> requests;
+    std::shared_ptr<std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>
+        rejected_requests;
+    uint64_t wait_microseconds = 0;
+
+    // Hold the lock for as short a time as possible.
+    {
+      std::unique_lock<std::mutex> lock(queue_mtx_);
+      if (queue_.Empty()) {
+        // Release the allocated instance
+        thread_context->ready_ = false;
+        if (thread_context->allocated_instance_ != nullptr) {
+          thread_context->allocated_instance_->Release(false /*executed*/);
+          thread_context->allocated_instance_ = nullptr;
+        }
+        continue;
+      } else if (dynamic_batching_enabled_) {
+        // Use dynamic batching to get request(s) to execute.
+        wait_microseconds = GetDynamicBatch(runner_id);
+
+        // Get requests that are rejected from searching dynamic batch.
+        queue_.ReleaseRejectedRequests(&rejected_requests);
+
+        // Extract batch only if there is pending batch
+        auto pending_batch_queue_cnt = queue_.PendingBatchCount();
+        if ((wait_microseconds == 0) && (pending_batch_queue_cnt != 0)) {
+          requests.reserve(pending_batch_queue_cnt);
+          for (size_t idx = 0; idx < pending_batch_queue_cnt; ++idx) {
+            std::unique_ptr<InferenceRequest> request;
+            auto status = queue_.Dequeue(&request);
+            if (status.IsOk()) {
+              requests.emplace_back(std::move(request));
+            } else {
+              // The queue is empty which conflicts with pending batch count.
+              // Send the current batch if any and reset related variables.
+              LOG_ERROR << "Failed to retrieve request from scheduler queue: "
+                        << status.Message();
+              queue_.ResetCursor();
+              queued_batch_size_ = 0;
+              pending_batch_size_ = 0;
+              break;
+            }
+          }
+          if (preserve_ordering_ && !requests.empty()) {
+            std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+            for (auto& request : requests) {
+              completion_queue_.emplace_back();
+              auto queue_slot = &completion_queue_.back();
+              request->SetResponseDelegator(
+                  [this, queue_slot](
+                      std::unique_ptr<InferenceResponse>&& response,
+                      const uint32_t flags) {
+                    {
+                      std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+                      queue_slot->emplace_back(std::move(response), flags);
+                    }
+                    FinalizeResponses();
+                  });
+            }
+          }
+
+          queued_batch_size_ -= pending_batch_size_;
+          // Set next preferred to be 0 so that enqueue thread will wake up
+          // runners when new request arrives. In the case where the queue
+          // becomes empty, this helps the runners to set up proper wait time
+          // instead of waiting for the default timer or actual next preferred
+          // batch size is reached.
+          next_preferred_batch_size_ = 0;
+
+          pending_batch_size_ = 0;
+          required_equal_inputs_.clear();
+        }
+      } else {
+        // No batching... execute next request
+        std::unique_ptr<InferenceRequest> request;
+        auto status = queue_.Dequeue(&request);
+        if (status.IsOk()) {
+          requests.emplace_back(std::move(request));
+          if (preserve_ordering_) {
+            std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+            for (auto& request : requests) {
+              completion_queue_.emplace_back();
+              auto queue_slot = &completion_queue_.back();
+              request->SetResponseDelegator(
+                  [this, queue_slot](
+                      std::unique_ptr<InferenceResponse>&& response,
+                      const uint32_t flags) {
+                    {
+                      std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+                      queue_slot->emplace_back(std::move(response), flags);
+                    }
+                    FinalizeResponses();
+                  });
+            }
+          }
+        } else {
+          LOG_ERROR << "Failed to retrieve request from scheduler queue: "
+                    << status.Message();
+        }
+      }
+    }
+
+    // If wait for notification or for the specified timeout before checking
+    // the queue again.
+    if (wait_microseconds > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(wait_microseconds));
+      continue;
+    }
+    // If finally going to run then pop the instance from the queue
+    // queue and give chance to other
+    if (!rate_limiter_->IgnoreResourcesAndPriority()) {
+      PopInstanceFromQueue();
+      sync_cv_.notify_all();
+    }
+
+    if (!requests.empty()) {
+      OnSchedule_(runner_id, std::move(requests));
+
+      // For testing we introduce a delay here to make the
+      // "DynamicBatchSchedulerV2 destroyed by this thread" case
+      // described in the comment below reproducible.
+      if (backend_release_wait_milliseconds > 0) {
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(backend_release_wait_milliseconds));
+      }
+
+      // Release the allocated instance
+      thread_context->ready_ = false;
+      thread_context->allocated_instance_->Release(true /* executed */);
+      thread_context->allocated_instance_ = nullptr;
+    }
+
+    // Finish rejected requests if any
+    if (rejected_requests != nullptr) {
+      static Status rejected_status =
+          Status(Status::Code::UNAVAILABLE, "Request timeout expired");
+      for (auto& rejected_queue : *rejected_requests) {
+        for (auto& rejected_request : rejected_queue) {
+          InferenceRequest::RespondIfError(
+              rejected_request, rejected_status, true);
+        }
+      }
+    }
+
+    // FIXME, this isn't really true anymore so needs to be revisited.
+    //
+    // At the end of this scope 'requests' will be destroyed.  A
+    // handle to the backend is held by the request. If the server is
+    // exiting or the backend is unloaded, it could be that this
+    // handle is the last one for the backend and so destroying
+    // 'requests' will cause the backend to be deleted which in turn
+    // will call this thread's DynamicBatchSchedulerV2 to be destroyed
+    // by this thread itself. In that case it is important that this
+    // thread not reference the object after this point since the
+    // object will be invalid. The while statement above uses a local
+    // atomic which is set to false by the destructor (and so the
+    // while loop will exit) and the logging below uses only local
+    // variables... so this code is ok.
+  }  // end runner loop
+
+  LOG_VERBOSE(1) << "Stopping dynamic-batch scheduler thread " << runner_id
+                 << "...";
+}
+
+uint64_t
+DynamicBatchSchedulerV2::GetDynamicBatch(const int64_t runner_id)
+{
+  // 'queue_mtx_' mutex must be held when this function is called. queue_
+  // must not be empty.
+
+  // Examine the new requests. If adding these new requests to the
+  // pending batch allows a preferred batch size then execute it
+  // immediately. Stop examining requests if the maximum preferred
+  // batch size would be exceeded or if the shape of the next request
+  // does not match the shape of the pending batch.
+  bool send_now = false;
+  if (!queue_.IsCursorValid()) {
+    queue_.ResetCursor();
+    pending_batch_size_ = 0;
+  }
+  size_t best_preferred_batch_size = 0;
+  queued_batch_size_ -= queue_.ApplyPolicyAtCursor();
+  while (!queue_.CursorEnd()) {
+    const auto batch_size = std::max(1U, queue_.RequestAtCursor()->BatchSize());
+
+    // If there is no pending batch, then this request is starting a
+    // new batch.
+    if (queue_.PendingBatchCount() == 0) {
+      // Get the shape of the new batch that is being started...
+      if (!enforce_equal_shape_tensors_.empty()) {
+        if (!InitRequiredEqualInputs(
+                 queue_.RequestAtCursor(), enforce_equal_shape_tensors_,
+                 &required_equal_inputs_)
+                 .IsOk()) {
+          send_now = true;
+          break;
+        }
+      }
+    } else {
+      // There is a pending batch and adding this request would make
+      // the batch size larger than all of the preferred batch sizes,
+      // so mark the cursor at this point. Not sending the pending batch so that
+      // we can examine the queue delay of requests that fits in a batch.
+      if (((pending_batch_size_ + batch_size) > max_preferred_batch_size_) &&
+          (best_preferred_batch_size == 0)) {
+        best_preferred_batch_size = pending_batch_size_;
+        queue_.MarkCursor();
+      }
+      if ((pending_batch_size_ + batch_size) > max_batch_size_) {
+        send_now = true;
+        break;
+      }
+
+      // There is a pending batch and it has a different shape then
+      // this request, so send the pending batch as it is.
+      if (!enforce_equal_shape_tensors_.empty() &&
+          !CompareWithRequiredEqualInputs(
+              queue_.RequestAtCursor(), required_equal_inputs_)) {
+        send_now = true;
+        break;
+      }
+    }
+
+    pending_batch_size_ += batch_size;
+    queue_.AdvanceCursor();
+    queued_batch_size_ -= queue_.ApplyPolicyAtCursor();
+
+    if (preferred_batch_sizes_.find(pending_batch_size_) !=
+        preferred_batch_sizes_.end()) {
+      best_preferred_batch_size = pending_batch_size_;
+      queue_.MarkCursor();
+    }
+  }
+
+  // Obatin the age of the oldest pending request to compare with the maximum
+  // batch queuing delay
+  struct timespec now;
+  clock_gettime(CLOCK_MONOTONIC, &now);
+  uint64_t now_ns = TIMESPEC_TO_NANOS(now);
+  uint64_t delay_ns = now_ns - queue_.OldestEnqueueTime();
+  bool delay_is_exceeded = (delay_ns >= pending_batch_delay_ns_);
+
+  // If we found a preferred batch size and the queue delay hasn't been
+  // exceeded, then execute that.
+  if ((best_preferred_batch_size != 0) && !delay_is_exceeded) {
+    pending_batch_size_ = best_preferred_batch_size;
+    queue_.SetCursorToMark();
+    return 0;
+  }
+
+  // No request in pending batch happens when all queued requests have expired
+  // timeout and the policies are REJECT
+  if (queue_.PendingBatchCount() == 0) {
+    return 0;
+  }
+
+  // If the delay has been exceeded, or if the current batch can't grow
+  // any larger then just immediately execute whatever is pending.
+  if (send_now || delay_is_exceeded ||
+      (pending_batch_size_ >= max_preferred_batch_size_)) {
+    return 0;
+  }
+
+  // Set the next preferred batch size given the pending batch size
+  auto next_preferred_batch_size_it =
+      preferred_batch_sizes_.upper_bound(pending_batch_size_);
+  if (next_preferred_batch_size_it != preferred_batch_sizes_.end()) {
+    next_preferred_batch_size_ = *next_preferred_batch_size_it;
+  } else {
+    next_preferred_batch_size_ =
+        preferred_batch_sizes_.empty() ? 0 : *preferred_batch_sizes_.begin();
+  }
+
+  uint64_t wait_ns = pending_batch_delay_ns_ - delay_ns;
+  // Note that taking request timeout into consideration allows us to reset
+  // pending batch as soon as it is invalidated. But the cost is that in edge
+  // case where the timeout will be expired one by one, the thread will be
+  // waken frequently.
+  if (queue_.ClosestTimeout() != 0) {
+    if (now_ns <= queue_.ClosestTimeout()) {
+      wait_ns = std::min(queue_.ClosestTimeout() - now_ns, wait_ns);
+    } else {
+      // A request in pending batch is timed-out, wait for 1 us to force the
+      // thread to reset the pending batch right the way.
+      wait_ns = 1000;
+    }
+  }
+
+  // Return non-zero wait microseconds to cause this thread to wait
+  // until the queue delay or the closest timeout has expired.
+  // Another thread may be awaken due to incoming request to handle the pending
+  // batch before this thread wakes and that is ok. But if no other request
+  // comes in then this thread will wake and revisit the pending batch
+  // (and at that time will then see the delay has been exceeded and will send
+  // the batch).
+  return wait_ns / 1000;
+}
+
+bool
+DynamicBatchSchedulerV2::ProceedOk(
+    const RateLimiter::ModelInstance* model_instance)
+{
+  std::unique_lock<std::mutex> lock(alloc_instances_queue_mtx_);
+  return (alloc_instances_queue_.front() == model_instance);
+}
+
+void
+DynamicBatchSchedulerV2::PushInstanceToQueue(
+    const RateLimiter::ModelInstance* model_instance)
+{
+  std::unique_lock<std::mutex> lock(alloc_instances_queue_mtx_);
+  alloc_instances_queue_.push(model_instance);
+}
+
+void
+DynamicBatchSchedulerV2::PopInstanceFromQueue()
+{
+  std::unique_lock<std::mutex> lock(alloc_instances_queue_mtx_);
+  alloc_instances_queue_.pop();
+}
+
+void
+DynamicBatchSchedulerV2::FinalizeResponses()
+{
+  // Need exclusive access of the function to ensure responses are sent
+  // in order
+  static std::mutex finalize_mtx;
+  std::lock_guard<std::mutex> lock(finalize_mtx);
+  // Finalize the completed payloads in-order as far as possible
+  std::deque<std::pair<std::unique_ptr<InferenceResponse>, const uint32_t>>
+      responses;
+  {
+    std::lock_guard<std::mutex> queue_lock(completion_queue_mtx_);
+    while (!completion_queue_.empty() && !completion_queue_.front().empty()) {
+      bool response_complete = false;
+      for (auto& response_pair : completion_queue_.front()) {
+        // Assuming FINAL flag is set only in the last response of the request
+        response_complete =
+            ((response_pair.second & TRITONSERVER_RESPONSE_COMPLETE_FINAL) !=
+             0);
+        responses.emplace_back(std::move(response_pair));
+      }
+      if (response_complete) {
+        completion_queue_.pop_front();
+      } else {
+        completion_queue_.front().clear();
+      }
+    }
+  }
+
+  for (auto& response : responses) {
+    InferenceResponse::Send(std::move(response.first), response.second);
+  }
+}
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/dynamic_batch_scheduler_v2.h
+++ b/src/core/dynamic_batch_scheduler_v2.h
@@ -1,0 +1,211 @@
+// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <future>
+#include <map>
+#include <mutex>
+#include <queue>
+#include <set>
+#include <thread>
+#include "src/backends/backend/triton_model.h"
+#include "src/backends/backend/triton_model_instance.h"
+#include "src/core/model_config.h"
+#include "src/core/model_config.pb.h"
+#include "src/core/scheduler.h"
+#include "src/core/scheduler_utils.h"
+#include "src/core/status.h"
+
+namespace nvidia { namespace inferenceserver {
+
+// Scheduler that implements dynamic batching.
+class DynamicBatchSchedulerV2 : public Scheduler {
+ public:
+  // Create a scheduler to support a given number of runners and a run
+  // function to call when a request is scheduled.
+  static Status Create(
+      const void* triton_model, const uint32_t runner_id_start,
+      const uint32_t runner_cnt, const int nice, const StandardInitFunc& OnInit,
+      const StandardWarmupFunc& OnWarmup, const StandardRunFunc& OnSchedule,
+      const bool dynamic_batching_enabled, const int32_t max_batch_size,
+      const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+      const bool preserve_ordering,
+      const std::set<int32_t>& preferred_batch_sizes,
+      const uint64_t max_queue_delay_microseconds,
+      std::unique_ptr<Scheduler>* scheduler);
+
+  // Create a scheduler to support a given number of runners and a run
+  // function to call when a request is scheduled. And the scheduler also
+  // supports different queue policies for different priority levels.
+  static Status Create(
+      const void* triton_model, const uint32_t runner_id_start,
+      const uint32_t runner_cnt, const int nice, const StandardInitFunc& OnInit,
+      const StandardWarmupFunc& OnWarmup, const StandardRunFunc& OnSchedule,
+      const bool dynamic_batching_enabled, const int32_t max_batch_size,
+      const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+      const inference::ModelDynamicBatching& batcher_config,
+      std::unique_ptr<Scheduler>* scheduler);
+
+  ~DynamicBatchSchedulerV2();
+
+  // \see Scheduler::Enqueue()
+  Status Enqueue(std::unique_ptr<InferenceRequest>& request) override;
+
+ private:
+  DynamicBatchSchedulerV2(
+      const void* triton_model, const uint32_t runner_id_start,
+      const uint32_t runner_cnt, const StandardInitFunc& OnInit,
+      const StandardWarmupFunc& OnWarmup, const StandardRunFunc& OnSchedule,
+      const bool dynamic_batching_enabled, const int32_t max_batch_size,
+      const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
+      const bool preserve_ordering,
+      const std::set<int32_t>& preferred_batch_sizes,
+      const uint64_t max_queue_delay_microseconds,
+      const inference::ModelQueuePolicy& default_queue_policy,
+      const uint32_t priority_levels,
+      const ModelQueuePolicyMap& queue_policy_map);
+
+  // Stores the running context of the scheduler threads
+  struct SchedulerThreadContext {
+    SchedulerThreadContext(std::shared_ptr<std::atomic<bool>> exit)
+        : exit_(exit), allocated_instance_(nullptr)
+    {
+      ready_.store(false);
+    }
+    // The pointer to the scheduler thread.
+    std::unique_ptr<std::thread> thread_;
+    // Whether or not the thread is exitting...
+    std::shared_ptr<std::atomic<bool>> exit_;
+
+    // Mutex and condvar to notify scheduler thread to proceed with execution.
+    std::condition_variable ready_cv_;
+    std::mutex ready_mu_;
+    std::atomic<bool> ready_;
+
+    // The pointer to the model instance allocated to the scheduler thread.
+    RateLimiter::ModelInstance* allocated_instance_;
+  };
+
+  void NotificationFunction(RateLimiter::ModelInstance* instance);
+  void SchedulerThread(
+      const uint32_t runner_id, const int nice,
+      const std::shared_ptr<SchedulerThreadContext>& rthread_exit,
+      std::promise<bool>* is_initialized);
+  uint64_t GetDynamicBatch(const int64_t runner_id);
+  void FinalizeResponses();
+  bool ProceedOk(const RateLimiter::ModelInstance* model_instance);
+  void PushInstanceToQueue(const RateLimiter::ModelInstance* model_instance);
+  void PopInstanceFromQueue();
+
+  // The pointer to the triton model being managed by the scheduler
+  const TritonModel* triton_model_;
+
+  // The start id of the runners
+  const uint32_t runner_id_start_;
+
+  // The number of runners in the scheduler
+  const uint32_t runner_cnt_;
+
+  // Function the scheduler will call to initialize a runner.
+  const StandardInitFunc OnInit_;
+
+  // Function the scheduler will call to warmup a runner.
+  const StandardWarmupFunc OnWarmup_;
+
+  // Function the scheduler will call to schedule a batch of requests.
+  const StandardRunFunc OnSchedule_;
+
+  // True if dynamic batching is enabled.
+  const bool dynamic_batching_enabled_;
+
+  // The number of scheduler threads.
+  const uint32_t scheduler_thread_cnt_;
+
+  // The number of scheduler threads currently idle.
+  uint32_t idle_scheduler_thread_cnt_;
+
+  // Map from priority level to queue holding inference requests for the model
+  // represented by this scheduler. If priority queues are not supported by the
+  // scheduler, then priority zero entry is used as the single queue.
+  PriorityQueue queue_;
+  // Mutex for protecting the scheduling queue.
+  std::mutex queue_mtx_;
+
+  // The number of requests in the queue before dispatching execution. Must be
+  // used for testing/debugging purpose.
+  size_t delay_cnt_;
+
+  std::vector<std::shared_ptr<SchedulerThreadContext>> sched_thread_contexts_;
+
+  // Used to synchronize execution across instances when using prioritization
+  // in the rate limiter with dynamic batching.
+  //
+  // Queue to hold the model instances returned by the rate limiter.
+  std::queue<const RateLimiter::ModelInstance*> alloc_instances_queue_;
+  // Mutex to protect the above queue
+  std::mutex alloc_instances_queue_mtx_;
+  // CV to synchronize runner for accessing the queue
+  std::condition_variable sync_cv_;
+  // Mutex associated with the above CV
+  std::mutex sync_mu_;
+
+  size_t max_batch_size_;
+  size_t max_preferred_batch_size_;
+  std::set<int32_t> preferred_batch_sizes_;
+  uint64_t pending_batch_delay_ns_;
+  size_t pending_batch_size_;
+  RequiredEqualInputs required_equal_inputs_;
+
+  size_t queued_batch_size_;
+  size_t next_preferred_batch_size_;
+
+  // The input tensors that require shape checking before being
+  // allowed in a batch. As a map from the tensor name to a bool. If
+  // tensor is in map then its shape must match shape of same tensor
+  // in requests already in the batch. If value is "true" then
+  // additional tensor is treated as a shape tensor and the values
+  // contained in the shape tensor must match same tensor already in
+  // the batch.
+  const std::unordered_map<std::string, bool> enforce_equal_shape_tensors_;
+
+  // If true the ordering of responses matches the order of requests
+  // even when there are multiple scheduler threads.
+  const bool preserve_ordering_;
+
+  // Per completion-id queues to store the ready responses
+  std::deque<
+      std::vector<std::pair<std::unique_ptr<InferenceResponse>, uint32_t>>>
+      completion_queue_;
+  // Lock to protect the completion_queues_
+  std::mutex completion_queue_mtx_;
+  // The pointer to the rate limiter
+  RateLimiter* rate_limiter_;
+};
+
+}}  // namespace nvidia::inferenceserver

--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2018-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -52,12 +52,10 @@ class RateLimiter {
 
   using ResourceMap = std::map<int, std::map<std::string, size_t>>;
   enum RESOURCE_KIND_KEY {
-    // Key for holding cpu resources
-    CPU_RESOURCE_KEY = INT_MIN,
     // Key for holding global resources
-    GLOBAL_RESOURCE_KEY,
+    GLOBAL_RESOURCE_KEY = -2,
     // Key for holding resources per each device
-    PER_DEVICE_RESOURCE_KEY
+    PER_DEVICE_RESOURCE_KEY = -1
   };
 
   /// Creates a rate limiter object which will funnel the requests to
@@ -227,12 +225,14 @@ class RateLimiter {
         std::unique_ptr<ResourceManager>* resource_manager);
     void AddModelInstance(const RateLimiter::ModelInstance* instance);
     Status RemoveModelInstance(const RateLimiter::ModelInstance* instance);
-    void UpdateResourceLimits();
+    Status UpdateResourceLimits();
     bool AllocateResources(const RateLimiter::ModelInstance* instance);
     Status ReleaseResources(const RateLimiter::ModelInstance* instance);
 
    private:
     ResourceManager(const ResourceMap& resource_map);
+    Status ValidateMaxResources();
+    Status ParseAndValidateExplicitResources();
 
     ResourceMap explicit_max_resources_;
 

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -126,7 +126,7 @@ class RateLimiter {
     /// pool so that it can serve other requests.
     void Release(bool executed);
 
-    /// Returns the index of the instance
+    /// Returns the raw triton instance
     const TritonModelInstance* RawInstance() const
     {
       return triton_model_instance_;

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -148,6 +148,12 @@ InferenceServer::Init()
   if (status.IsOk() && (buffer_manager_thread_count_ > 0)) {
     status = AsyncWorkQueue::Initialize(buffer_manager_thread_count_);
   }
+
+  bool ignore_resources_and_priority =
+      (rate_limit_mode_ == RateLimitMode::RL_OFF);
+  status = RateLimiter::Create(
+      ignore_resources_and_priority, rate_limit_resource_map_, &rate_limiter_);
+
   if (!status.IsOk()) {
     ready_state_ = ServerReadyState::SERVER_FAILED_TO_INITIALIZE;
     return status;

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -47,7 +47,7 @@ class InferenceRequest;
 enum class ModelControlMode { MODE_NONE, MODE_POLL, MODE_EXPLICIT };
 
 // The configured mode for rate limiting
-enum class RateLimitMode { RL_OFF, RL_EXEC_COUNT };
+enum class RateLimitMode { RL_EXEC_COUNT, RL_OFF };
 
 // Readiness status for the inference server.
 enum class ServerReadyState {

--- a/src/servers/main.cc
+++ b/src/servers/main.cc
@@ -369,26 +369,26 @@ std::vector<Option> options_
        "multiple times to add multiple models. Note that this option will only "
        "take affect if --model-control-mode=explicit is true."},
       {OPTION_RATE_LIMIT, "rate-limit", Option::ArgStr,
-       "Specify the mode for rate limiting. Options are \"off\" and "
-       "\"execution_count\". The default is \"off\". "
-       "For \"off\", the server will ignore any rate limiter config and run "
-       "inference as soon as an instance is ready. For \"execution_count\", "
-       "the server will determine the instance using configured priority and "
-       "the number of time the instance has been used to run inference. "
-       "The inference will finally be executed once the required resources "
-       "are available."},
+       "Specify the mode for rate limiting. Options are \"execution_count\" "
+       "and \"off\". The default is \"execution_count\". For "
+       "\"execution_count\", the server will determine the instance using "
+       "configured priority and the number of time the instance has been "
+       "used to run inference. The inference will finally be executed once "
+       "the required resources are available. For \"off\", the server will "
+       "ignore any rate limiter config and run inference as soon as an "
+       "instance is ready."},
       {OPTION_RATE_LIMIT_RESOURCE, "rate-limit-resource",
-       "<string>:<string>:<integer>",
+       "<string>:<integer>:<integer>",
        "The number of resources available to the server. The format of this "
-       "flag is --rate-limit-resource=<device>:<resource_name>:<count>. The "
+       "flag is --rate-limit-resource=<resource_name>:<count>:<device>. The "
        "<device> is optional and if not listed will be applied to every "
-       "device. "
-       "\"GLOBAL\" can be specified in place of <device> to list the resources "
-       "that are shared among all the devices in the system. This flag can be "
-       "specified multiple times to specify each resources and their "
-       "availability. By default, the max across all instances that list the "
-       "resource is selected as its availability. The values for this flag"
-       "is case-insensitive."},
+       "device. If the resource is specified as \"GLOBAL\" in the model "
+       "configuration the resource is considered shared among all the devices "
+       "in the system. The <device> property is ignored for such resources. "
+       "This flag can be specified multiple times to specify each resources "
+       "and their availability. By default, the max across all instances that "
+       "list the resource is selected as its availability. The values for this "
+       "flag is case-insensitive."},
       {OPTION_PINNED_MEMORY_POOL_BYTE_SIZE, "pinned-memory-pool-byte-size",
        Option::ArgInt,
        "The total byte size that can be allocated as pinned system memory. "
@@ -790,42 +790,43 @@ ParseTraceLevelOption(std::string arg)
 }
 #endif  // TRITON_ENABLE_TRACING
 
-std::tuple<std::string, std::string, int>
+std::tuple<std::string, int, int>
 ParseRateLimitResourceOption(const std::string arg)
 {
   std::string error_string(
       "--rate-limit-resource option format is "
-      "'<device>:<resource_name>:<count>' or '<resource_name>:<count>'. Got " +
+      "'<resource_name>:<count>:<device>' or '<resource_name>:<count>'. Got " +
       arg);
 
-  std::string device_string("");
   std::string name_string("");
   int count = -1;
+  int device_id = -1;
 
   size_t delim_first = arg.find(":");
   size_t delim_second = arg.find(":", delim_first + 1);
 
   if (delim_second != std::string::npos) {
-    // Handle format `<device>:<resource_name>:<count>'
+    // Handle format `<resource_name>:<count>:<device>'
     size_t delim_third = arg.find(":", delim_second + 1);
     if (delim_third != std::string::npos) {
       std::cerr << error_string << std::endl;
       exit(1);
     }
-    device_string = arg.substr(0, delim_first);
-    name_string = arg.substr(delim_first + 1, delim_second - delim_first - 1);
-    count = std::stoi(arg.substr(delim_second + 1));
+    name_string = arg.substr(0, delim_first);
+    count = ParseIntOption(
+        arg.substr(delim_first + 1, delim_second - delim_first - 1));
+    device_id = ParseIntOption(arg.substr(delim_second + 1));
   } else if (delim_first != std::string::npos) {
     // Handle format `<resource_name>:<count>'
     name_string = arg.substr(0, delim_first);
-    count = std::stoi(arg.substr(delim_first + 1));
+    count = ParseIntOption(arg.substr(delim_first + 1));
   } else {
     // If no colons found
     std::cerr << error_string << std::endl;
     exit(1);
   }
 
-  return {device_string, name_string, count};
+  return {name_string, count, device_id};
 }
 
 std::tuple<std::string, std::string, std::string>
@@ -935,8 +936,9 @@ Parse(TRITONSERVER_ServerOptions** server_options, int argc, char** argv)
   TRITONSERVER_ModelControlMode control_mode = TRITONSERVER_MODEL_CONTROL_NONE;
   std::set<std::string> startup_models_;
 
-  TRITONSERVER_RateLimitMode rate_limit_mode = TRITONSERVER_RATE_LIMIT_OFF;
-  std::vector<std::tuple<std::string, std::string, int>> rate_limit_resources;
+  TRITONSERVER_RateLimitMode rate_limit_mode =
+      TRITONSERVER_RATE_LIMIT_EXEC_COUNT;
+  std::vector<std::tuple<std::string, int, int>> rate_limit_resources;
 
 #ifdef TRITON_ENABLE_LOGGING
   bool log_info = true;
@@ -1103,10 +1105,10 @@ Parse(TRITONSERVER_ServerOptions** server_options, int argc, char** argv)
         std::transform(
             rate_limit_str.begin(), rate_limit_str.end(),
             rate_limit_str.begin(), ::tolower);
-        if (rate_limit_str == "off") {
-          rate_limit_mode = TRITONSERVER_RATE_LIMIT_OFF;
-        } else if (rate_limit_str == "execution_count") {
+        if (rate_limit_str == "execution_count") {
           rate_limit_mode = TRITONSERVER_RATE_LIMIT_EXEC_COUNT;
+        } else if (rate_limit_str == "off") {
+          rate_limit_mode = TRITONSERVER_RATE_LIMIT_OFF;
         } else {
           std::cerr << "invalid argument for --rate-limit" << std::endl;
           std::cerr << Usage() << std::endl;
@@ -1119,7 +1121,16 @@ Parse(TRITONSERVER_ServerOptions** server_options, int argc, char** argv)
         std::transform(
             rate_limit_resource_str.begin(), rate_limit_resource_str.end(),
             rate_limit_resource_str.begin(), ::tolower);
-        rate_limit_resources.push_back(ParseRateLimitResourceOption(optarg));
+        try {
+          rate_limit_resources.push_back(ParseRateLimitResourceOption(optarg));
+        }
+        catch (const std::invalid_argument& ia) {
+          return TRITONSERVER_ErrorNew(
+              TRITONSERVER_ERROR_INVALID_ARG,
+              (std::string("failed to parse '") + optarg +
+               "' as <str>:<int>:<int>")
+                  .c_str());
+        }
         break;
       }
       case OPTION_PINNED_MEMORY_POOL_BYTE_SIZE:
@@ -1224,8 +1235,8 @@ Parse(TRITONSERVER_ServerOptions** server_options, int argc, char** argv)
   for (const auto& resource : rate_limit_resources) {
     FAIL_IF_ERR(
         TRITONSERVER_ServerOptionsAddRateLimitResource(
-            loptions, std::get<0>(resource).c_str(),
-            std::get<1>(resource).c_str(), std::get<2>(resource)),
+            loptions, std::get<0>(resource).c_str(), std::get<1>(resource),
+            std::get<2>(resource)),
         "setting rate limiter resource");
   }
   FAIL_IF_ERR(

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -341,64 +341,63 @@ install(
 )
 
 #
-# RateLimiter
+# Rate Limiter
 #
-
-set(
-  RATE_LIMITER_SRCS
-  ../core/rate_limiter.cc
-  ../core/status.cc
-)
-
-set(
-  RATE_LIMITER_HDRS
-  ../core/rate_limiter.h
-  ${MODEL_CONFIG_PROTO_HDR}
-)
-
-set(
-  RATE_LIMITER_TEST_SRCS
-  rate_limiter_test.cc
-  ${RATE_LIMITER_SRCS}
-)
-
-set(
-  RATE_LIMITER_TEST_HDRS
-  ${RATE_LIMITER_HDRS}
-)
-
-add_executable(
-  rate_limiter_test
-  ${RATE_LIMITER_TEST_SRCS}
-  ${RATE_LIMITER_TEST_HDRS}
-  $<TARGET_OBJECTS:proto-library>
-)
-set_target_properties(
-  rate_limiter_test
-  PROPERTIES
-    SKIP_BUILD_RPATH TRUE
-    BUILD_WITH_INSTALL_RPATH TRUE
-    INSTALL_RPATH_USE_LINK_PATH FALSE
-    INSTALL_RPATH ""
-)
-target_include_directories(
-  rate_limiter_test
-  PRIVATE ${GTEST_INCLUDE_DIR}
-)
-if(${TRITON_ENABLE_GPU})
-  target_include_directories(rate_limiter_test PRIVATE ${CUDA_INCLUDE_DIRS})
-endif() # TRITON_ENABLE_GPU
-target_link_libraries(
-  rate_limiter_test
-  PRIVATE triton-core-serverapi  # from repo-core
-  PRIVATE ${GTEST_LIBRARY}
-  PRIVATE ${GTEST_MAIN_LIBRARY}
-  PRIVATE protobuf::libprotobuf
-)
-install(
-  TARGETS rate_limiter_test
-  RUNTIME DESTINATION bin
-)
+# set(
+#  RATE_LIMITER_SRCS
+#  ../core/rate_limiter.cc
+#  ../core/status.cc
+#)
+#
+#set(
+#  RATE_LIMITER_HDRS
+#  ../core/rate_limiter.h
+#  ${MODEL_CONFIG_PROTO_HDR}
+#)
+#
+#set(
+#  RATE_LIMITER_TEST_SRCS
+#  rate_limiter_test.cc
+#  ${RATE_LIMITER_SRCS}
+#)
+#
+#set(
+#  RATE_LIMITER_TEST_HDRS
+#  ${RATE_LIMITER_HDRS}
+#)
+#
+#add_executable(
+#  rate_limiter_test
+#  ${RATE_LIMITER_TEST_SRCS}
+#  ${RATE_LIMITER_TEST_HDRS}
+#  $<TARGET_OBJECTS:proto-library>
+#)
+#set_target_properties(
+#  rate_limiter_test
+#  PROPERTIES
+#    SKIP_BUILD_RPATH TRUE
+#    BUILD_WITH_INSTALL_RPATH TRUE
+#    INSTALL_RPATH_USE_LINK_PATH FALSE
+#    INSTALL_RPATH ""
+#)
+#target_include_directories(
+#  rate_limiter_test
+#  PRIVATE ${GTEST_INCLUDE_DIR}
+#)
+#if(${TRITON_ENABLE_GPU})
+#  target_include_directories(rate_limiter_test PRIVATE ${CUDA_INCLUDE_DIRS})
+#endif() # TRITON_ENABLE_GPU
+#target_link_libraries(
+#  rate_limiter_test
+#  PRIVATE triton-core-serverapi  # from repo-core
+#  PRIVATE ${GTEST_LIBRARY}
+#  PRIVATE ${GTEST_MAIN_LIBRARY}
+#  PRIVATE protobuf::libprotobuf
+#)
+#install(
+#  TARGETS rate_limiter_test
+#  RUNTIME DESTINATION bin
+#)
 
 add_subdirectory(custom/sdk custom/sdk)
 add_subdirectory(custom/addsub custom/addsub)

--- a/src/test/repoagent/relocation_repoagent/src/relocation.cc
+++ b/src/test/repoagent/relocation_repoagent/src/relocation.cc
@@ -50,19 +50,19 @@ struct ErrorException {
   TRITONSERVER_Error* err_;
 };
 
-#define THROW_IF_TRITON_ERROR(X)                                    \
-  do {                                                              \
-    TRITONSERVER_Error* tie_err__ = (X);                            \
-    if (tie_err__ != nullptr) {                                     \
+#define THROW_IF_TRITON_ERROR(X)                                      \
+  do {                                                                \
+    TRITONSERVER_Error* tie_err__ = (X);                              \
+    if (tie_err__ != nullptr) {                                       \
       throw triton::repoagent::relocation::ErrorException(tie_err__); \
-    }                                                               \
+    }                                                                 \
   } while (false)
 
 
 #define THROW_TRITON_ERROR(CODE, MSG)                                 \
   do {                                                                \
     TRITONSERVER_Error* tie_err__ = TRITONSERVER_ErrorNew(CODE, MSG); \
-    throw triton::repoagent::relocation::ErrorException(tie_err__);     \
+    throw triton::repoagent::relocation::ErrorException(tie_err__);   \
   } while (false)
 
 
@@ -86,7 +86,8 @@ TRITONREPOAGENT_ModelFinalize(
 {
   const char* location;
   RETURN_IF_ERROR(TRITONREPOAGENT_ModelState(model, (void**)&location));
-  RETURN_IF_ERROR(TRITONREPOAGENT_ModelRepositoryLocationRelease(agent, model, location));
+  RETURN_IF_ERROR(
+      TRITONREPOAGENT_ModelRepositoryLocationRelease(agent, model, location));
   return nullptr;
 }
 
@@ -106,8 +107,8 @@ TRITONREPOAGENT_ModelAction(
       TRITONREPOAGENT_ModelParameterCount(agent, model, &parameter_count));
   if (parameter_count != 1) {
     return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INVALID_ARG,
-            "Relocation repoagent expects 1 parameter for relocation agent");
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "Relocation repoagent expects 1 parameter for relocation agent");
   }
   const char* key = nullptr;
   const char* value = nullptr;
@@ -115,30 +116,38 @@ TRITONREPOAGENT_ModelAction(
       TRITONREPOAGENT_ModelParameter(agent, model, 0, &key, &value));
   if (std::string(key) != "empty_config") {
     return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INVALID_ARG,
-            "Relocation repoagent expects parameter with key 'empty_config' for relocation agent");
-  } else if ((std::string(value) != "true") && (std::string(value) != "false")) {
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "Relocation repoagent expects parameter with key 'empty_config' for "
+        "relocation agent");
+  } else if (
+      (std::string(value) != "true") && (std::string(value) != "false")) {
     return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INVALID_ARG,
-            "Relocation repoagent expects 'empty_config' parameter with value 'true' or 'false' for relocation agent");
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "Relocation repoagent expects 'empty_config' parameter with value "
+        "'true' or 'false' for relocation agent");
   }
   TRITONSERVER_Message* model_config;
   RETURN_IF_ERROR(TRITONREPOAGENT_ModelConfig(agent, model, 1, &model_config));
   const char* base;
   size_t byte_size;
-  auto err = TRITONSERVER_MessageSerializeToJson(model_config, &base, &byte_size);
+  auto err =
+      TRITONSERVER_MessageSerializeToJson(model_config, &base, &byte_size);
   if (err == nullptr) {
     // hack to check if proper model config is passed by knowing that only
     // the original config will contain 'model_repository_agents' setting
     auto pos = std::string(base, byte_size).find("model_repository_agents");
     if ((std::string(value) == "true") && (pos != std::string::npos)) {
       return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INVALID_ARG,
-            "Relocation repoagent expects config does not contain 'model_repository_agents' field when 'empty_config' has value 'true' for relocation agent"); 
+          TRITONSERVER_ERROR_INVALID_ARG,
+          "Relocation repoagent expects config does not contain "
+          "'model_repository_agents' field when 'empty_config' has value "
+          "'true' for relocation agent");
     } else if ((std::string(value) == "false") && (pos == std::string::npos)) {
       return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INVALID_ARG,
-            "Relocation repoagent expects config contains 'model_repository_agents' field when 'empty_config' has value 'false' for relocation agent"); 
+          TRITONSERVER_ERROR_INVALID_ARG,
+          "Relocation repoagent expects config contains "
+          "'model_repository_agents' field when 'empty_config' has value "
+          "'false' for relocation agent");
     }
   }
   RETURN_IF_ERROR(TRITONSERVER_MessageDelete(model_config));
@@ -146,8 +155,10 @@ TRITONREPOAGENT_ModelAction(
 
   // Point to a new model repository
   const char* location;
-  RETURN_IF_ERROR(TRITONREPOAGENT_ModelRepositoryLocationAcquire(agent, model, TRITONREPOAGENT_ARTIFACT_FILESYSTEM, &location));
-  RETURN_IF_ERROR(TRITONREPOAGENT_ModelRepositoryUpdate(agent, model, TRITONREPOAGENT_ARTIFACT_FILESYSTEM, location));
+  RETURN_IF_ERROR(TRITONREPOAGENT_ModelRepositoryLocationAcquire(
+      agent, model, TRITONREPOAGENT_ARTIFACT_FILESYSTEM, &location));
+  RETURN_IF_ERROR(TRITONREPOAGENT_ModelRepositoryUpdate(
+      agent, model, TRITONREPOAGENT_ARTIFACT_FILESYSTEM, location));
   RETURN_IF_ERROR(TRITONREPOAGENT_ModelSetState(model, (void*)location));
 
   return nullptr;  // success


### PR DESCRIPTION
Opening this PR to start receiving some preliminary review comments. 

Points to note:
1. Rate Limiter will be supported only by the backends that use Triton's Backend API.
2. Much of the weird artifacts related to lifetime management can now be removed.
3. There is a chance that TritonModelInsatnce_Execute is executed by different threads.. Whichever happen to invoke the callback by using RateLimiter::ModelInstance::Release function.
4. Most of the implementations are already laid out in the code. Most challenging part is to implement actual dynamic batching..
        a. The scheduler should be very careful while requesting the model instance from the RateLimiter so we don't waste resources which would have been better allocated to other models.
        b. In callback, we must search for any requests that can help us in building better batches. 
The additional staging queue helps in addressing the two but requires entire rewrite of the batching logic and might have an affect on the performance. The requests will go through another queue before being sent for execution.

- [x] Single Instance, no dynamic batcher
- [x] Mutiple instance, no dynamic batcher - Trivial
- [ ] Dynamic Batching - Requires care...
- [ ] Add support for WarmUp. - Should be Trivial
- [ ] Fix artifacts related to tests 
- [ ] Enable RateLimiter unit tests - Trivial

Diff between dynamic_batch_scheduler_v2.cc and dynamic_batch_scheduler.cc.. 
[diff.txt](https://github.com/triton-inference-server/server/files/6207463/diff.txt)
