### PR TITLE
Make byte tensor serialization faster for python client

### DIFF
--- a/src/clients/python/library/tritonclient/utils/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/__init__.py
@@ -216,7 +216,7 @@ def serialize_byte_tensor(input_tensor):
     # order.
     if (input_tensor.dtype == np.object_) or (input_tensor.dtype.type
                                               == np.bytes_):
-        flattened = bytes()
+        flattened_ls = []
         for obj in np.nditer(input_tensor, flags=["refs_ok"], order='C'):
             # If directly passing bytes to BYTES type,
             # don't convert it to str as Python will encode the
@@ -228,8 +228,9 @@ def serialize_byte_tensor(input_tensor):
                     s = str(obj.item()).encode('utf-8')
             else:
                 s = obj.item()
-            flattened += struct.pack("<I", len(s))
-            flattened += s
+            flattened.append(struct.pack("<I", len(s)))
+            flattened.append(s)
+        flattened = b''.join(flattened_ls)
         flattened_array = np.asarray(flattened, dtype=np.object_)
         if not flattened_array.flags['C_CONTIGUOUS']:
             flattened_array = np.ascontiguousarray(flattened_array,

--- a/src/clients/python/library/tritonclient/utils/__init__.py
+++ b/src/clients/python/library/tritonclient/utils/__init__.py
@@ -228,8 +228,8 @@ def serialize_byte_tensor(input_tensor):
                     s = str(obj.item()).encode('utf-8')
             else:
                 s = obj.item()
-            flattened.append(struct.pack("<I", len(s)))
-            flattened.append(s)
+            flattened_ls.append(struct.pack("<I", len(s)))
+            flattened_ls.append(s)
         flattened = b''.join(flattened_ls)
         flattened_array = np.asarray(flattened, dtype=np.object_)
         if not flattened_array.flags['C_CONTIGUOUS']:


### PR DESCRIPTION
This pr improves byte tensor serialization by order of magnitude. (`6.5s` -> `10.4 ms`), thus making `set_data_from_numpy` for byte tensors much faster. 

### Todo:
- [x] Ensure tests and build pass

### Perf Comparision
```python
import tritonclient.grpc as grpcclient
import numpy as np


log_ls = ['test log '*100]*10000
log_ls = [l.encode('utf-8') for l in log_ls]
log_ar = np.array(log_ls).reshape(1,len(log_ls))

input_grpc = grpcclient.InferInput("raw_log",log_ar.shape,"BYTES")
```

##### Without this PR:
```python
input_grpc.set_data_from_numpy(log_ar)
```
```
Wall time:  6.55 s
```

##### With this PR:
```python
input_grpc.set_data_from_numpy(log_ar)
```
```
CPU times: user 9.24 ms, sys: 1.26 ms, total: 10.5 ms
Wall time: 10.4 ms
```

CC: @BartleyR, @bsuryadevara