### PR TITLE
Fix nested trace in ensemble

### DIFF
--- a/qa/L0_cmdline_trace/test.sh
+++ b/qa/L0_cmdline_trace/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -295,11 +295,26 @@ set +e
 
 $TRACE_SUMMARY -t trace_ensemble.log > summary_ensemble.log
 
+# Check if the traces are captured with proper hierarchy
 if [ `grep -c "COMPUTE_INPUT_END" summary_ensemble.log` != "7" ]; then
-    cat summary_ensemble.log
-    echo -e "\n***\n*** Test Failed\n***"
+    echo -e "Ensemble trace log expects 7 compute"
     RET=1
 fi
+for trace_str in \
+        '{"id":3,"model_name":"simple","model_version":1}' \
+        '{"id":4,"model_name":"nop_TYPE_INT32_-1","model_version":1,"parent_id":3}' \
+        '{"id":5,"model_name":"fan_plan_int32_int32_int32","model_version":1,"parent_id":3}' \
+        '{"id":6,"model_name":"nop_TYPE_INT32_-1","model_version":1,"parent_id":5}' \
+        '{"id":7,"model_name":"plan_int32_int32_int32","model_version":1,"parent_id":5}' \
+        '{"id":8,"model_name":"nop_TYPE_INT32_-1","model_version":1,"parent_id":5}' \
+        '{"id":9,"model_name":"nop_TYPE_INT32_-1","model_version":1,"parent_id":5}' \
+        '{"id":10,"model_name":"nop_TYPE_INT32_-1","model_version":1,"parent_id":3}' \
+        '{"id":11,"model_name":"nop_TYPE_INT32_-1","model_version":1,"parent_id":3}' ; do
+    if [ `grep -c ${trace_str} trace_ensemble.log` != "1" ]; then
+        echo -e "Ensemble trace log expects trace: ${trace_str}"
+        RET=1
+    fi
+done
 
 if [ `grep -c ^simple summary_ensemble.log` != "1" ]; then
     cat summary_ensemble.log

--- a/qa/L0_cmdline_trace/test.sh
+++ b/qa/L0_cmdline_trace/test.sh
@@ -295,6 +295,12 @@ set +e
 
 $TRACE_SUMMARY -t trace_ensemble.log > summary_ensemble.log
 
+if [ `grep -c "COMPUTE_INPUT_END" summary_ensemble.log` != "7" ]; then
+    cat summary_ensemble.log
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
 if [ `grep -c ^simple summary_ensemble.log` != "1" ]; then
     cat summary_ensemble.log
     echo -e "\n***\n*** Test Failed\n***"

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -173,9 +173,14 @@ InferenceRequest::Release(
   request->release_callbacks_.clear();
 
 #ifdef TRITON_ENABLE_TRACING
-  // Take ownership of trace object so it is not lost when we release
-  // the request below.
-  std::unique_ptr<InferenceTrace> trace = std::move(request->trace_);
+  // If tracing then record request end and release the trace.
+  // This must be before the request callback to ensure the trace
+  // is properly layered, as the request may be nested in an ensemble
+  // and the callback may interact with upper level trace.
+  if (request->trace_ != nullptr) {
+    request->trace_->ReportNow(TRITONSERVER_TRACE_REQUEST_END);
+    InferenceTrace::Release(std::move(request->trace_));
+  }
 #endif  // TRITON_ENABLE_TRACING
 
   void* userp = request->release_userp_;
@@ -183,16 +188,6 @@ InferenceRequest::Release(
   release_fn(
       reinterpret_cast<TRITONSERVER_InferenceRequest*>(request.release()),
       release_flags, userp);
-
-#ifdef TRITON_ENABLE_TRACING
-  // If tracing then record request end (after the callback completes
-  // so that any callback overhead is included in the request time)
-  // and release the trace.
-  if (trace != nullptr) {
-    trace->ReportNow(TRITONSERVER_TRACE_REQUEST_END);
-    InferenceTrace::Release(std::move(trace));
-  }
-#endif  // TRITON_ENABLE_TRACING
 }
 
 InferenceRequest*

--- a/src/core/infer_trace.cc
+++ b/src/core/infer_trace.cc
@@ -34,6 +34,14 @@ namespace nvidia { namespace inferenceserver {
 // parent.
 std::atomic<uint64_t> InferenceTrace::next_id_(1);
 
+std::unique_ptr<InferenceTrace>
+InferenceTrace::SpawnChildTrace()
+{
+  std::unique_ptr<InferenceTrace> ltrace(
+      new InferenceTrace(level_, id_, activity_fn_, release_fn_, userp_));
+  return ltrace;
+}
+
 void
 InferenceTrace::Release(std::unique_ptr<InferenceTrace>&& trace)
 {

--- a/src/core/infer_trace.cc
+++ b/src/core/infer_trace.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/infer_trace.h
+++ b/src/core/infer_trace.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/infer_trace.h
+++ b/src/core/infer_trace.h
@@ -52,6 +52,8 @@ class InferenceTrace {
   {
   }
 
+  std::unique_ptr<InferenceTrace> SpawnChildTrace();
+
   int64_t Id() const { return id_; }
   int64_t ParentId() const { return parent_id_; }
 

--- a/src/servers/tracer.cc
+++ b/src/servers/tracer.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions


### PR DESCRIPTION
The summary after fix:
```
File: trace_ensemble.log
simple (1):
        id: 3
        HTTP_RECV_START
                103.794us
        HTTP_RECV_END
                245.399us
        REQUEST_START
                20.291us
        QUEUE_START
                3957.801us
        HTTP_SEND_START
                18.882us
        HTTP_SEND_END
                41.437us
        REQUEST_END
nop_TYPE_INT32_-1 (1):
        id: 4
        parent id: 3
        REQUEST_START
                11.938us
        QUEUE_START
                75.141us
        COMPUTE_START
                39.37us
        COMPUTE_INPUT_END
                158.294us
        COMPUTE_OUTPUT_START
                0.206us
        COMPUTE_END
                342.193us
        REQUEST_END
fan_plan_int32_int32_int32 (1):
        id: 5
        parent id: 3
        REQUEST_START
                20.166us
        QUEUE_START
                2832.751us
        REQUEST_END
nop_TYPE_INT32_-1 (1):
        id: 6
        parent id: 5
        REQUEST_START
                9.831us
        QUEUE_START
                42.432us
        COMPUTE_START
                15.753us
        COMPUTE_INPUT_END
                51.833us
        COMPUTE_OUTPUT_START
                0.184us
        COMPUTE_END
                120.681us
        REQUEST_END
plan_int32_int32_int32 (1):
        id: 7
        parent id: 5
        REQUEST_START
                9.219us
        QUEUE_START
                156.291us
        COMPUTE_START
                706.309us
        COMPUTE_INPUT_END
                331.939us
        COMPUTE_OUTPUT_START
                411.279us
        COMPUTE_END
                278.787us
        REQUEST_END
nop_TYPE_INT32_-1 (1):
        id: 8
        parent id: 5
        REQUEST_START
                23.086us
        QUEUE_START
                57.67us
        COMPUTE_START
                25.822us
        COMPUTE_INPUT_END
                146.267us
        COMPUTE_OUTPUT_START
                0.237us
        COMPUTE_END
                44.351us
        REQUEST_END
nop_TYPE_INT32_-1 (1):
        id: 9
        parent id: 5
        REQUEST_START
                9.23us
        QUEUE_START
                284.389us
        COMPUTE_START
                15.346us
        COMPUTE_INPUT_END
                46.929us
        COMPUTE_OUTPUT_START
                0.154us
        COMPUTE_END
                259.442us
        REQUEST_END
nop_TYPE_INT32_-1 (1):
        id: 10
        parent id: 3
        REQUEST_START
                11.112us
        QUEUE_START
                90.215us
        COMPUTE_START
                14.785us
        COMPUTE_INPUT_END
                47.367us
        COMPUTE_OUTPUT_START
                0.152us
        COMPUTE_END
                37.247us
        REQUEST_END
nop_TYPE_INT32_-1 (1):
        id: 11
        parent id: 3
        REQUEST_START
                4.428us
        QUEUE_START
                201.489us
        COMPUTE_START
                13.114us
        COMPUTE_INPUT_END
                39.343us
        COMPUTE_OUTPUT_START
                0.131us
        COMPUTE_END
                291.037us
        REQUEST_END
Summary for simple (1): trace count = 1
HTTP infer request (avg): 4346.167us
        Receive (avg): 103.794us
        Send (avg): 18.882us
        Overhead (avg): 185.08us

        Handler (avg): 4038.411us
Summary for nop_TYPE_INT32_-1 (1): trace count = 6
        Handler (avg): 421.8665us
                Overhead (avg): 194.096us
                Queue (avg): 125.22266666666667us
                Compute (avg): 102.54783333333333us
                        Input (avg): 20.698333333333334us
                        Infer (avg): 81.67216666666667us
                        Output (avg): 0.17733333333333334us
Summary for fan_plan_int32_int32_int32 (1): trace count = 1
        Handler (avg): 2852.917us
Summary for plan_int32_int32_int32 (1): trace count = 1
        Handler (avg): 1893.824us
                Overhead (avg): 288.006us
                Queue (avg): 156.291us
                Compute (avg): 1449.527us
                        Input (avg): 706.309us
                        Infer (avg): 331.939us
                        Output (avg): 411.279us
```