### PR TITLE
Include infer output/input time in the average latency

### DIFF
--- a/qa/common/reporter.py
+++ b/qa/common/reporter.py
@@ -82,7 +82,10 @@ def annotate_csv(data, csv_file):
                 data['d_infer_per_sec'] = float(result)
             elif ((header == 'Client Send') or
                   (header == 'Network+Server Send/Recv') or
-                  (header == 'Server Queue') or (header == 'Server Compute') or
+                  (header == 'Server Queue') or
+                  (header == 'Server Compute Input') or
+                  (header == 'Server Compute Output') or
+                  (header == 'Server Compute Infer') or
                   (header == 'Client Recv')):
                 avg_latency_us += float(result)
             elif header == 'p50 latency':


### PR DESCRIPTION
It looks like 'Server Compute' field was renamed at some point and the perf results were not calculating the correct sum for average latency. This should solve the problem we were seeing with large payload perf results.