### PR TITLE
Remove TF check for KIND_MODEL from Triton

### DIFF
--- a/src/core/model_config.proto
+++ b/src/core/model_config.proto
@@ -173,7 +173,6 @@ message ModelInstanceGroup
     //@@       CPU and/or GPU(s) as specified by the model or backend itself.
     //@@       The inference server will not override the model/backend
     //@@       settings.
-    //@@       Currently, this option is supported only for Tensorflow models.
     //@@
     KIND_MODEL = 3;
   }

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -1230,25 +1230,12 @@ ValidateModelConfig(
 #endif  // TRITON_ENABLE_GPU
 
     for (const auto& group : config.instance_group()) {
-      // KIND_MODEL is supported only on TensorFlow.
       if (group.kind() == inference::ModelInstanceGroup::KIND_MODEL) {
         if (group.gpus().size() > 0) {
           return Status(
               Status::Code::INVALID_ARG,
               "instance group " + group.name() + " of model " + config.name() +
                   " has kind KIND_MODEL but specifies one or more GPUs");
-        }
-#ifdef TRITON_ENABLE_TENSORFLOW
-        if (!(config.platform() == kTensorFlowGraphDefPlatform ||
-              config.platform() == kTensorFlowSavedModelPlatform))
-#endif  // TRITON_ENABLE_TENSORFLOW
-        {
-          return Status(
-              Status::Code::INVALID_ARG,
-              "instance group " + group.name() + " of model " + config.name() +
-                  "on platform " + config.platform() +
-                  " has kind KIND_MODEL which is supported only on TensorFlow "
-                  "models");
         }
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_GPU) {
 #ifndef TRITON_ENABLE_GPU


### PR DESCRIPTION
As mentioned in other PR, I think we should remove backend specific check from Triton core. This particular check prevents other backends from reflecting the model placement in the appropriate way, i.e. the model config of the backend will specify `KIND_CPU` as WAR for now while that is not true.