### PR TITLE
Fix nvtx annotations

### DIFF
--- a/src/core/nvtx.h
+++ b/src/core/nvtx.h
@@ -28,7 +28,6 @@
 #ifdef TRITON_ENABLE_NVTX
 
 #include <nvtx3/nvToolsExt.h>
-#include "src/core/logging.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -37,21 +36,13 @@ class NvtxRange {
  public:
   explicit NvtxRange(const std::string& label)
   {
-    depth_ = nvtxRangePushA(label.c_str());
-    if (depth_ < 0) {
-      LOG_ERROR << "Unable to start NVTX range '" << label << "'";
-    }
+    nvtxRangePushA(label.c_str());
   }
 
   ~NvtxRange()
   {
-    if (depth_ >= 0) {
-      nvtxRangePop();
-    }
+    nvtxRangePop();
   }
-
- private:
-  int depth_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/nvtx.h
+++ b/src/core/nvtx.h
@@ -34,20 +34,11 @@ namespace nvidia { namespace inferenceserver {
 // Updates a server stat with duration measured by a C++ scope.
 class NvtxRange {
  public:
-  explicit NvtxRange(const char* label)
-  {
-    nvtxRangePushA(label);
-  }
+  explicit NvtxRange(const char* label) { nvtxRangePushA(label); }
 
-  explicit NvtxRange(const std::string& label)
-    : NvtxRange(label.c_str())
-  {
-  }
+  explicit NvtxRange(const std::string& label) : NvtxRange(label.c_str()) {}
 
-  ~NvtxRange()
-  {
-    nvtxRangePop();
-  }
+  ~NvtxRange() { nvtxRangePop(); }
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/nvtx.h
+++ b/src/core/nvtx.h
@@ -34,9 +34,14 @@ namespace nvidia { namespace inferenceserver {
 // Updates a server stat with duration measured by a C++ scope.
 class NvtxRange {
  public:
-  explicit NvtxRange(const std::string& label)
+  explicit NvtxRange(const char* label)
   {
-    nvtxRangePushA(label.c_str());
+    nvtxRangePushA(label);
+  }
+
+  explicit NvtxRange(const std::string& label)
+    : NvtxRange(label.c_str())
+  {
   }
 
   ~NvtxRange()


### PR DESCRIPTION
For performance reasons, some tools will return a fixed value when
implementing the callback for `nvtxRangePushA`. Keeping track of the
nesting level for each thread requires accessing thread local data which
does not come for free.

For instance, Nsight Systems always returns `-1`. Following the previous
code logic, all ranges would be pushed but never popped.

Applications should not to detect failures in the tool via return codes
of NVTX API functions. It is intentionally something NVTX was designed to
prevent. We want the application to always take the same branches,
whether a tool is profiling the application or not.

This PR:
* Modifies the `NvtxRange` class to ignore the return value of
  `nvtxRangePushA`.
* Overload the constructor of `NvtxRange` to prevent potential
  unnecessary string copies
* Format the `nvtx.h` file by running `clang-format`.