### PR TITLE
Enable ragged test in L0_batcher, L0_dyna_sequence_batcher

### DIFF
--- a/qa/L0_batcher/batcher_test.py
+++ b/qa/L0_batcher/batcher_test.py
@@ -59,7 +59,7 @@ assert USE_GRPC or USE_HTTP, "USE_GRPC or USE_HTTP must be non-zero"
 BACKENDS = os.environ.get('BACKENDS', "graphdef savedmodel onnx libtorch plan")
 
 _trials = BACKENDS.split(" ")
-_ragged_batch_supported_trials = ("custom",)
+_ragged_batch_supported_trials = ["custom",]
 if "plan" in _trials:
     _ragged_batch_supported_trials.append("plan")
 if "onnx" in _trials:

--- a/qa/L0_batcher/batcher_test.py
+++ b/qa/L0_batcher/batcher_test.py
@@ -59,7 +59,11 @@ assert USE_GRPC or USE_HTTP, "USE_GRPC or USE_HTTP must be non-zero"
 BACKENDS = os.environ.get('BACKENDS', "graphdef savedmodel onnx libtorch plan")
 
 _trials = BACKENDS.split(" ")
-_ragged_batch_supported_trials = ()
+_ragged_batch_supported_trials = ("custom",)
+if "plan" in _trials:
+    _ragged_batch_supported_trials.append("plan")
+if "onnx" in _trials:
+    _ragged_batch_supported_trials.append("onnx")
 
 _max_queue_delay_ms = 10000
 

--- a/qa/L0_batcher/test.sh
+++ b/qa/L0_batcher/test.sh
@@ -169,7 +169,7 @@ if [[ $BACKENDS == *"plan"* ]]; then
     # Use nobatch model to match the ragged test requirement
     cp -r $DATADIR/qa_identity_model_repository/plan_nobatch_zero_1_float32 var_models/plan_zero_1_float32 && \
         (cd var_models/plan_zero_1_float32 && \
-            sed -i "s/nobatch//" config.pbtxt && \
+            sed -i "s/nobatch_//" config.pbtxt && \
             sed -i "s/^max_batch_size:.*/max_batch_size: 8/" config.pbtxt && \
             sed -i "s/name: \"INPUT0\"/name: \"INPUT0\"\\nallow_ragged_batch: true/" config.pbtxt && \
             echo "batch_output [{target_name: \"OUTPUT0\" \
@@ -181,7 +181,7 @@ if [[ $BACKENDS == *"onnx"* ]]; then
     # Use nobatch model to match the ragged test requirement
     cp -r $DATADIR/qa_identity_model_repository/onnx_nobatch_zero_1_float32 var_models/onnx_zero_1_float32 && \
         (cd var_models/onnx_zero_1_float32 && \
-            sed -i "s/nobatch//" config.pbtxt && \
+            sed -i "s/nobatch_//" config.pbtxt && \
             sed -i "s/^max_batch_size:.*/max_batch_size: 8/" config.pbtxt && \
             sed -i "s/name: \"INPUT0\"/name: \"INPUT0\"\\nallow_ragged_batch: true/" config.pbtxt && \
             echo "batch_output [{target_name: \"OUTPUT0\" \

--- a/qa/L0_dyna_sequence_batcher/dyna_sequence_batcher_test.py
+++ b/qa/L0_dyna_sequence_batcher/dyna_sequence_batcher_test.py
@@ -46,12 +46,12 @@ _test_cuda_shared_memory = bool(
 
 _no_batching = (int(os.environ.get('NO_BATCHING', 0)) == 1)
 
-_trials = ("savedmodel", "graphdef", "plan", "onnx", "libtorch")
+_trials = ("custom", "savedmodel", "graphdef", "plan", "onnx", "libtorch")
 if _no_batching:
     _trials += ("savedmodel_nobatch", "graphdef_nobatch", "plan_nobatch",
                 "onnx_nobatch", "libtorch_nobatch")
 
-_ragged_batch_supported_trials = list()
+_ragged_batch_supported_trials = list("custom")
 
 _protocols = ("http", "grpc")
 _max_sequence_idle_ms = 5000

--- a/qa/L0_dyna_sequence_batcher/dyna_sequence_batcher_test.py
+++ b/qa/L0_dyna_sequence_batcher/dyna_sequence_batcher_test.py
@@ -51,7 +51,7 @@ if _no_batching:
     _trials += ("savedmodel_nobatch", "graphdef_nobatch", "plan_nobatch",
                 "onnx_nobatch", "libtorch_nobatch")
 
-_ragged_batch_supported_trials = list("custom")
+_ragged_batch_supported_trials = ["custom",]
 
 _protocols = ("http", "grpc")
 _max_sequence_idle_ms = 5000


### PR DESCRIPTION
L0_sequence_batcher already has ragged test enabled, so no change is needed.

Only the ragged test in L0_batcher added additional TRT and ONNX because we can use existing models to construct the "ragged models" expected by the test, but extra amount of effort will be needed for the test in (dyna) sequence. However, this should be fine since the batcher tests are mainly focusing on testing whether the requests will be batched appropriately, testing with one backend (sequence / dyna_sequence test model) will be sufficient.