### PR TITLE
fix GKE marketplace app HPA. target average value

### DIFF
--- a/deploy/gke-marketplace-app/server-deployer/chart/triton/templates/hpa.yaml
+++ b/deploy/gke-marketplace-app/server-deployer/chart/triton/templates/hpa.yaml
@@ -38,7 +38,7 @@ spec:
   - type: External
     external:
       metricName: kubernetes.io|container|accelerator|duty_cycle
-      targetAverageValue: 85
+      targetAverageValue: {{ .Values.HPATargetAverageValue }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
HPA target value shouldn't be hardcoded and should set to :https://github.com/triton-inference-server/server/blob/master/deploy/gke-marketplace-app/server-deployer/chart/triton/values.yaml#L33