### PR TITLE
Fix L0_backend_identity failure

### DIFF
--- a/qa/L0_backend_identity/test.sh
+++ b/qa/L0_backend_identity/test.sh
@@ -31,7 +31,7 @@ CLIENT_PY=./identity_test.py
 CLIENT_LOG="./client.log"
 
 SERVER=/opt/tritonserver/bin/tritonserver
-SERVER_ARGS="--model-repository=`pwd`/all_models"
+SERVER_ARGS="--model-repository=`pwd`/all_models --log-verbose=1"
 SERVER_LOG="./inference_server.log"
 source ../common/util.sh
 


### PR DESCRIPTION
~~@tanmayv25 I fixed a smaller perf issue like earlier i.e. .find() in set is much faster than vector using the stl std::find~~
I also ran through most of the code base but no other places existed where indices were being compared as string instead of integers