### PR TITLE
Propagate build.py --enable-nvtx flag to CMake options

### DIFF
--- a/build.py
+++ b/build.py
@@ -233,6 +233,8 @@ def core_cmake_args(components, backends, install_dir):
         cmake_enable(FLAGS.enable_gpu_metrics)))
     cargs.append('-DTRITON_ENABLE_TRACING:BOOL={}'.format(
         cmake_enable(FLAGS.enable_tracing)))
+    cargs.append('-DTRITON_ENABLE_NVTX:BOOL={}'.format(
+        cmake_enable(FLAGS.enable_nvtx)))
 
     cargs.append('-DTRITON_ENABLE_GPU:BOOL={}'.format(
         cmake_enable(FLAGS.enable_gpu)))


### PR DESCRIPTION
The builld.py argument parser reads --enable-nvtx but did not pass the option to cmake
which created a false impression this option works.
It is fixed in this commit