### PR TITLE
Don't use GIT_SHALLOW to pull common,core and backend 

### DIFF
--- a/build/server/CMakeLists.txt
+++ b/build/server/CMakeLists.txt
@@ -59,19 +59,16 @@ FetchContent_Declare(
   repo-common
   GIT_REPOSITORY https://github.com/triton-inference-server/common.git
   GIT_TAG ${TRITON_COMMON_REPO_TAG}
-  GIT_SHALLOW ON
 )
 FetchContent_Declare(
   repo-core
   GIT_REPOSITORY https://github.com/triton-inference-server/core.git
   GIT_TAG ${TRITON_CORE_REPO_TAG}
-  GIT_SHALLOW ON
 )
 FetchContent_Declare(
   repo-backend
   GIT_REPOSITORY https://github.com/triton-inference-server/backend.git
   GIT_TAG ${TRITON_BACKEND_REPO_TAG}
-  GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(repo-common repo-core repo-backend)
 


### PR DESCRIPTION
User might be using an untagged older commit for the dependency repos. In those cases, user might see a fetch content failure as the older commit is not pulled.