### PR TITLE
sequence batcher Load nop_* identity model on GPU instead of CPU

### DIFF
--- a/qa/L0_sequence_batcher/sequence_batcher_test.py
+++ b/qa/L0_sequence_batcher/sequence_batcher_test.py
@@ -2266,8 +2266,7 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                             model_name,
                             dtype,
                             1001,
-                            # (4000, 3000), TODO: Investigate why earlier threshold requirements were lower
-                            (6000, 3000),
+                            (4000, 3000),
                             # (flag_str, value, pre_delay_ms)
                             (
                                 ("start", 1, None),),

--- a/qa/L0_sequence_batcher/test.sh
+++ b/qa/L0_sequence_batcher/test.sh
@@ -284,6 +284,10 @@ for model_trial in $MODEL_TRIALS; do
     if [ "$ENSEMBLES" == "1" ]; then
       cp -r $DATADIR/qa_ensemble_model_repository/qa_sequence_model_repository/nop_* `pwd`/$MODEL_PATH/.
         create_nop_version_dir `pwd`/$MODEL_PATH
+      # Must load identity backend on GPU to avoid cuda init delay during 1st run
+      for NOP_MODEL in `pwd`/$MODEL_PATH/nop_*; do
+        (cd $NOP_MODEL && sed -i "s/kind: KIND_CPU/kind: KIND_GPU/" config.pbtxt)
+      done
     fi
 
     # Need to launch the server for each test so that the model status


### PR DESCRIPTION
- Fix L0_sequence_batcher_valgrind failure caused by sequence timeout due to cuda init delay