### PR TITLE
Add the Optimization Profile APIs for TRT backend

### DIFF
--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -36,7 +36,7 @@ namespace nvidia { namespace inferenceserver {
 TritonModelInstance::TritonModelInstance(
     TritonModel* model, const std::string& name, const size_t index,
     const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
-    const std::set<std::string>& profile_names, const bool passive)
+    const std::vector<std::string>& profile_names, const bool passive)
     : model_(model), name_(name), index_(index), kind_(kind),
       device_id_(device_id), profile_names_(profile_names), passive_(passive),
       state_(nullptr)
@@ -70,9 +70,9 @@ TritonModelInstance::CreateInstances(
     TritonModel* model, const inference::ModelConfig& model_config)
 {
   for (const auto& group : model_config.instance_group()) {
-    std::set<std::string> profile_names;
+    std::vector<std::string> profile_names;
     for (const auto& profile_name : group.profile()) {
-      profile_names.insert(profile_name);
+      profile_names.push_back(profile_name);
     }
     for (int32_t c = 0; c < group.count(); ++c) {
       std::string instance_name{group.count() > 1
@@ -109,7 +109,7 @@ Status
 TritonModelInstance::CreateInstance(
     TritonModel* model, const std::string& name, const size_t index,
     const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
-    const std::set<std::string>& profile_names, const bool passive)
+    const std::vector<std::string>& profile_names, const bool passive)
 {
   std::unique_ptr<TritonModelInstance> local_instance(new TritonModelInstance(
       model, name, index, kind, device_id, profile_names, passive));
@@ -184,13 +184,8 @@ TRITONBACKEND_ModelInstanceProfileName(
             .c_str());
   }
 
-  uint32_t cnt = 0;
-  for (const auto& rprofile : rprofiles) {
-    if (cnt++ == index) {
-      *profile_name = rprofile.c_str();
-      break;
-    }
-  }
+  *profile_name = rprofiles[index].c_str();
+
   return nullptr;  // success
 }
 

--- a/src/backends/backend/triton_model_instance.h
+++ b/src/backends/backend/triton_model_instance.h
@@ -50,7 +50,7 @@ class TritonModelInstance {
   TRITONSERVER_InstanceGroupKind Kind() const { return kind_; }
   int32_t DeviceId() const { return device_id_; }
   bool IsPassive() const { return passive_; }
-  const std::set<std::string>& Profiles() const { return profile_names_; }
+  const std::vector<std::string>& Profiles() const { return profile_names_; }
 
   TritonModel* Model() { return model_; }
   void* State() { return state_; }
@@ -64,11 +64,11 @@ class TritonModelInstance {
   TritonModelInstance(
       TritonModel* model, const std::string& name, const size_t index,
       const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
-      const std::set<std::string>& profile_names, const bool passive);
+      const std::vector<std::string>& profile_names, const bool passive);
   static Status CreateInstance(
       TritonModel* model, const std::string& name, const size_t index,
       const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
-      const std::set<std::string>& profile_names, const bool passive);
+      const std::vector<std::string>& profile_names, const bool passive);
 
   // The TritonModel object that owns this instance. The instance
   // holds this as a raw pointer because the lifetime of the model is
@@ -83,7 +83,7 @@ class TritonModelInstance {
   // GPU device to be used by the instance.
   TRITONSERVER_InstanceGroupKind kind_;
   int32_t device_id_;
-  std::set<std::string> profile_names_;
+  std::vector<std::string> profile_names_;
   bool passive_;
 
   // Reporter for metrics, or nullptr if no metrics should be reported

--- a/src/backends/backend/triton_model_instance.h
+++ b/src/backends/backend/triton_model_instance.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -50,6 +50,7 @@ class TritonModelInstance {
   TRITONSERVER_InstanceGroupKind Kind() const { return kind_; }
   int32_t DeviceId() const { return device_id_; }
   bool IsPassive() const { return passive_; }
+  const std::set<std::string>& Profiles() const { return profile_names_; }
 
   TritonModel* Model() { return model_; }
   void* State() { return state_; }
@@ -63,11 +64,11 @@ class TritonModelInstance {
   TritonModelInstance(
       TritonModel* model, const std::string& name, const size_t index,
       const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
-      const bool passive);
+      const std::set<std::string>& profile_names, const bool passive);
   static Status CreateInstance(
       TritonModel* model, const std::string& name, const size_t index,
       const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
-      const bool passive);
+      const std::set<std::string>& profile_names, const bool passive);
 
   // The TritonModel object that owns this instance. The instance
   // holds this as a raw pointer because the lifetime of the model is
@@ -82,6 +83,7 @@ class TritonModelInstance {
   // GPU device to be used by the instance.
   TRITONSERVER_InstanceGroupKind kind_;
   int32_t device_id_;
+  std::set<std::string> profile_names_;
   bool passive_;
 
   // Reporter for metrics, or nullptr if no metrics should be reported


### PR DESCRIPTION
I have separated this change in a separate PR from tanmay-dev as it can go for now. I have tested it for TRT backend repo and it passes L0_infer_variable.
This will prevent frequent rebases.
Linked PR on core: https://github.com/triton-inference-server/core/pull/20