### PR TITLE
[New Threading Model] For Single Instance, Dynamic Batcher, Execution…

### DIFF
--- a/src/backends/backend/triton_model.h
+++ b/src/backends/backend/triton_model.h
@@ -65,12 +65,17 @@ class TritonModel : public InferenceBackend {
       const uint32_t config_version,
       TRITONSERVER_Message* updated_config_message);
   const std::shared_ptr<TritonBackend>& Backend() const { return backend_; }
+  const std::vector<std::unique_ptr<TritonModelInstance>>& Instances() const
+  {
+    return instances_;
+  }
   void* State() { return state_; }
   void SetState(void* state) { state_ = state; }
   void AddInstance(
       std::unique_ptr<TritonModelInstance>&& instance, const bool passive);
 
-  void WarmUp(uint32_t runner_idx, WarmupData& sample) override;
+  Status Initialize();
+  Status WarmUp();
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TritonModel);

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -171,222 +171,220 @@ TritonModelInstance::WarmUp()
 {
   LOG_ERROR << "WarmUp is not yet supported";
   return Status::Success;
-#if 0
-  std::vector<TRITONBACKEND_Request*> triton_requests(1024);
-  triton_requests.clear();
-  for (auto& request : sample.requests_) {
-    // Capture timestamp before run to avoid incorrect accumulation from
-    // sequential warmup runs
-#ifdef TRITON_ENABLE_STATS
-    request->CaptureRequestStartNs();
-#endif  // TRITON_ENABLE_STATS
-    request->CaptureQueueStartNs();
-    triton_requests.push_back(
-        reinterpret_cast<TRITONBACKEND_Request*>(request.release()));
-  }
-  TRITONBACKEND_ModelInstance* triton_model_instance =
-      reinterpret_cast<TRITONBACKEND_ModelInstance*>(this);
-  TritonBackend::TritonModelInstanceExecFn_t inst_exec_fn =
-      backend_->ModelInstanceExecFn();
-
-  // If there is an error then we retain ownership of 'requests'
-  // and must send error responses.
-  TRITONSERVER_Error* err = inst_exec_fn(
-      triton_model_instance, &triton_requests[0], triton_requests.size());
-  if (err != nullptr) {
-    Status status = Status(
-        TritonCodeToStatusCode(TRITONSERVER_ErrorCode(err)),
-        TRITONSERVER_ErrorMessage(err));
-    for (TRITONBACKEND_Request* tr : triton_requests) {
-      std::unique_ptr<InferenceRequest> ur(
-          reinterpret_cast<InferenceRequest*>(tr));
-      InferenceRequest::RespondIfError(ur, status, true /* release_requests */);
-    }
-
-    TRITONSERVER_ErrorDelete(err);
-  }
-#endif
+//  std::vector<TRITONBACKEND_Request*> triton_requests(1024);
+//  triton_requests.clear();
+//  for (auto& request : sample.requests_) {
+//    // Capture timestamp before run to avoid incorrect accumulation from
+//    // sequential warmup runs
+//#ifdef TRITON_ENABLE_STATS
+//    request->CaptureRequestStartNs();
+//#endif  // TRITON_ENABLE_STATS
+//    request->CaptureQueueStartNs();
+//    triton_requests.push_back(
+//        reinterpret_cast<TRITONBACKEND_Request*>(request.release()));
+//  }
+//  TRITONBACKEND_ModelInstance* triton_model_instance =
+//      reinterpret_cast<TRITONBACKEND_ModelInstance*>(this);
+//  TritonBackend::TritonModelInstanceExecFn_t inst_exec_fn =
+//      backend_->ModelInstanceExecFn();
+//
+//  // If there is an error then we retain ownership of 'requests'
+//  // and must send error responses.
+//  TRITONSERVER_Error* err = inst_exec_fn(
+//      triton_model_instance, &triton_requests[0], triton_requests.size());
+//  if (err != nullptr) {
+//    Status status = Status(
+//        TritonCodeToStatusCode(TRITONSERVER_ErrorCode(err)),
+//        TRITONSERVER_ErrorMessage(err));
+//    for (TRITONBACKEND_Request* tr : triton_requests) {
+//      std::unique_ptr<InferenceRequest> ur(
+//          reinterpret_cast<InferenceRequest*>(tr));
+//      InferenceRequest::RespondIfError(ur, status, true /* release_requests */);
+//    }
+//
+//    TRITONSERVER_ErrorDelete(err);
+//  }
 }
 
-#if 0
-Status
-TritonModelInstance::GenerateWarmupData()
-{
-  samples_->clear();
-  for (const auto& warmup_setting : model_->Config().model_warmup()) {
-    if (warmup_setting.batch_size() == 0) {
-      LOG_VERBOSE(1) << "Skipping batch 0 warmup sample '"
-                     << warmup_setting.name() << "'";
-      continue;
-    }
-    LOG_VERBOSE(1) << "Generating warmup sample data for '"
-                   << warmup_setting.name() << "'";
 
-    // Two passes. First pass to get max byte size for synthetic
-    // data. Second pass to add original inputs and override inputs
-    // for control inputs.
-    int64_t max_zero_byte_size = 0;
-    int64_t max_random_byte_size = 0;
-    for (const auto& input_meta : warmup_setting.inputs()) {
-      auto element_count = GetElementCount(input_meta.second.dims());
-      if (element_count == -1) {
-        return Status(
-            Status::Code::INVALID_ARG,
-            "warmup setting expects all variable-size dimensions are specified "
-            "for input '" +
-                input_meta.first + "'");
-      }
+//Status
+//TritonModelInstance::GenerateWarmupData()
+//{
+//  samples_->clear();
+//  for (const auto& warmup_setting : model_->Config().model_warmup()) {
+//    if (warmup_setting.batch_size() == 0) {
+//      LOG_VERBOSE(1) << "Skipping batch 0 warmup sample '"
+//                     << warmup_setting.name() << "'";
+//      continue;
+//    }
+//    LOG_VERBOSE(1) << "Generating warmup sample data for '"
+//                   << warmup_setting.name() << "'";
+//
+//    // Two passes. First pass to get max byte size for synthetic
+//    // data. Second pass to add original inputs and override inputs
+//    // for control inputs.
+//    int64_t max_zero_byte_size = 0;
+//    int64_t max_random_byte_size = 0;
+//    for (const auto& input_meta : warmup_setting.inputs()) {
+//      auto element_count = GetElementCount(input_meta.second.dims());
+//      if (element_count == -1) {
+//        return Status(
+//            Status::Code::INVALID_ARG,
+//            "warmup setting expects all variable-size dimensions are specified "
+//            "for input '" +
+//                input_meta.first + "'");
+//      }
+//
+//      int64_t batch_byte_size =
+//          element_count * GetDataTypeByteSize(input_meta.second.data_type());
+//      if (batch_byte_size == 0) {
+//        batch_byte_size = element_count * sizeof(int32_t);
+//      }
+//
+//      switch (input_meta.second.input_data_type_case()) {
+//        case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
+//          max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
+//          break;
+//        case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
+//          if (input_meta.second.data_type() ==
+//              inference::DataType::TYPE_STRING) {
+//            max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
+//          } else {
+//            max_random_byte_size =
+//                std::max(batch_byte_size, max_random_byte_size);
+//          }
+//          break;
+//        }
+//        default:
+//          break;
+//      }
+//    }
+//
+//    samples_->emplace_back(warmup_setting.name());
+//    auto& warmup_data = samples_->back();
+//    // Create buffers for synthetic data
+//    TRITONSERVER_MemoryType type;
+//    int64_t type_id;
+//    warmup_data.zero_data_.reset(new AllocatedMemory(
+//        max_zero_byte_size, TRITONSERVER_MEMORY_CPU_PINNED /* memory_type */,
+//        0 /* memory_type_id */));
+//    char* zero_buffer = warmup_data.zero_data_->MutableBuffer(&type, &type_id);
+//    memset(zero_buffer, 0, max_zero_byte_size);
+//
+//    warmup_data.random_data_.reset(new AllocatedMemory(
+//        max_random_byte_size, TRITONSERVER_MEMORY_CPU_PINNED /* memory_type */,
+//        0 /* memory_type_id */));
+//    char* random_buffer =
+//        warmup_data.random_data_->MutableBuffer(&type, &type_id);
+//    for (int64_t offset = 0; offset < max_random_byte_size; offset++) {
+//      random_buffer[offset] = rand();
+//    }
+//
+//    // Prepare the inference request for the specified sample.
+//    for (size_t cnt = 0; cnt < warmup_setting.batch_size(); cnt++) {
+//      warmup_data.requests_.emplace_back(new InferenceRequest(this, Version()));
+//      auto& lrequest = warmup_data.requests_.back();
+//
+//      // Second pass to prepare original inputs.
+//      std::vector<std::shared_ptr<InferenceRequest::Input>> input_sps;
+//      for (const auto& input_meta : warmup_setting.inputs()) {
+//        auto batch1_element_count = GetElementCount(input_meta.second.dims());
+//        auto batch_byte_size =
+//            batch1_element_count *
+//            GetDataTypeByteSize(input_meta.second.data_type());
+//        if (batch_byte_size == 0) {
+//          batch_byte_size = batch1_element_count * sizeof(int32_t);
+//        }
+//
+//        const char* allocated_ptr;
+//        switch (input_meta.second.input_data_type_case()) {
+//          case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
+//            allocated_ptr = zero_buffer;
+//            break;
+//          case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
+//            if (input_meta.second.data_type() ==
+//                inference::DataType::TYPE_STRING) {
+//              allocated_ptr = zero_buffer;
+//            } else {
+//              allocated_ptr = random_buffer;
+//            }
+//            break;
+//          }
+//          case inference::ModelWarmup_Input::InputDataTypeCase::
+//              kInputDataFile: {
+//            // For data provided from file, we can set buffer in first pass
+//            warmup_data.provided_data_.emplace_back(new std::string());
+//            auto input_data = warmup_data.provided_data_.back().get();
+//            RETURN_IF_ERROR(ReadTextFile(
+//                JoinPath({model_dir_, kWarmupDataFolder,
+//                          input_meta.second.input_data_file()}),
+//                input_data));
+//            if (input_meta.second.data_type() ==
+//                inference::DataType::TYPE_STRING) {
+//              batch_byte_size = input_data->size();
+//            } else if (((size_t)batch_byte_size) > input_data->size()) {
+//              return Status(
+//                  Status::Code::INVALID_ARG,
+//                  "warmup setting expects " + std::to_string(batch_byte_size) +
+//                      " bytes, but the data "
+//                      "provided from " +
+//                      input_meta.second.input_data_file() + "only has " +
+//                      std::to_string(input_data->size()) + " bytes");
+//            }
+//            allocated_ptr = input_data->data();
+//            break;
+//          }
+//          default:
+//            return Status(
+//                Status::Code::INVALID_ARG, "warmup setting expects input '" +
+//                                               input_meta.first +
+//                                               "' to have input_data_type set");
+//        }
+//
+//        const inference::ModelInput* input_config;
+//        bool is_original_input =
+//            GetInput(input_meta.first, &input_config).IsOk();
+//        InferenceRequest::Input* input = nullptr;
+//        std::vector<int64_t> input_meta_shape;
+//        // Append batch size only if the model supports batching
+//        // and not control inpt.
+//        if ((config_.max_batch_size() != 0) && is_original_input) {
+//          input_meta_shape.push_back(1);
+//        }
+//        for (auto d : input_meta.second.dims()) {
+//          input_meta_shape.push_back(d);
+//        }
+//        if (is_original_input) {
+//          RETURN_IF_ERROR(lrequest->AddOriginalInput(
+//              input_meta.first, input_meta.second.data_type(), input_meta_shape,
+//              &input));
+//        } else {
+//          input_sps.emplace_back();
+//          RETURN_IF_ERROR(lrequest->AddOverrideInput(
+//              input_meta.first, input_meta.second.data_type(),
+//              (config_.max_batch_size() != 0 ? 1 : 0), input_meta_shape,
+//              &input_sps.back()));
+//          input = input_sps.back().get();
+//        }
+//        RETURN_IF_ERROR(input->AppendData(
+//            allocated_ptr, batch_byte_size,
+//            TRITONSERVER_MEMORY_CPU /* memory_type */, 0 /* memory_type_id */));
+//      }
+//
+//      RETURN_IF_ERROR(lrequest->PrepareForInference());
+//      // Override inputs must be added after PrepareForInference() is called
+//      for (const auto& sp : input_sps) {
+//        RETURN_IF_ERROR(lrequest->AddOverrideInput(sp));
+//      }
+//
+//      RETURN_IF_ERROR(lrequest->SetResponseCallback(
+//          &warmup_allocator, nullptr, WarmupResponseComplete, nullptr));
+//    }
+//  }
+//
+//  return Status::Success;
+//}
 
-      int64_t batch_byte_size =
-          element_count * GetDataTypeByteSize(input_meta.second.data_type());
-      if (batch_byte_size == 0) {
-        batch_byte_size = element_count * sizeof(int32_t);
-      }
-
-      switch (input_meta.second.input_data_type_case()) {
-        case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
-          max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
-          break;
-        case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
-          if (input_meta.second.data_type() ==
-              inference::DataType::TYPE_STRING) {
-            max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
-          } else {
-            max_random_byte_size =
-                std::max(batch_byte_size, max_random_byte_size);
-          }
-          break;
-        }
-        default:
-          break;
-      }
-    }
-
-    samples_->emplace_back(warmup_setting.name());
-    auto& warmup_data = samples_->back();
-    // Create buffers for synthetic data
-    TRITONSERVER_MemoryType type;
-    int64_t type_id;
-    warmup_data.zero_data_.reset(new AllocatedMemory(
-        max_zero_byte_size, TRITONSERVER_MEMORY_CPU_PINNED /* memory_type */,
-        0 /* memory_type_id */));
-    char* zero_buffer = warmup_data.zero_data_->MutableBuffer(&type, &type_id);
-    memset(zero_buffer, 0, max_zero_byte_size);
-
-    warmup_data.random_data_.reset(new AllocatedMemory(
-        max_random_byte_size, TRITONSERVER_MEMORY_CPU_PINNED /* memory_type */,
-        0 /* memory_type_id */));
-    char* random_buffer =
-        warmup_data.random_data_->MutableBuffer(&type, &type_id);
-    for (int64_t offset = 0; offset < max_random_byte_size; offset++) {
-      random_buffer[offset] = rand();
-    }
-
-    // Prepare the inference request for the specified sample.
-    for (size_t cnt = 0; cnt < warmup_setting.batch_size(); cnt++) {
-      warmup_data.requests_.emplace_back(new InferenceRequest(this, Version()));
-      auto& lrequest = warmup_data.requests_.back();
-
-      // Second pass to prepare original inputs.
-      std::vector<std::shared_ptr<InferenceRequest::Input>> input_sps;
-      for (const auto& input_meta : warmup_setting.inputs()) {
-        auto batch1_element_count = GetElementCount(input_meta.second.dims());
-        auto batch_byte_size =
-            batch1_element_count *
-            GetDataTypeByteSize(input_meta.second.data_type());
-        if (batch_byte_size == 0) {
-          batch_byte_size = batch1_element_count * sizeof(int32_t);
-        }
-
-        const char* allocated_ptr;
-        switch (input_meta.second.input_data_type_case()) {
-          case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
-            allocated_ptr = zero_buffer;
-            break;
-          case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
-            if (input_meta.second.data_type() ==
-                inference::DataType::TYPE_STRING) {
-              allocated_ptr = zero_buffer;
-            } else {
-              allocated_ptr = random_buffer;
-            }
-            break;
-          }
-          case inference::ModelWarmup_Input::InputDataTypeCase::
-              kInputDataFile: {
-            // For data provided from file, we can set buffer in first pass
-            warmup_data.provided_data_.emplace_back(new std::string());
-            auto input_data = warmup_data.provided_data_.back().get();
-            RETURN_IF_ERROR(ReadTextFile(
-                JoinPath({model_dir_, kWarmupDataFolder,
-                          input_meta.second.input_data_file()}),
-                input_data));
-            if (input_meta.second.data_type() ==
-                inference::DataType::TYPE_STRING) {
-              batch_byte_size = input_data->size();
-            } else if (((size_t)batch_byte_size) > input_data->size()) {
-              return Status(
-                  Status::Code::INVALID_ARG,
-                  "warmup setting expects " + std::to_string(batch_byte_size) +
-                      " bytes, but the data "
-                      "provided from " +
-                      input_meta.second.input_data_file() + "only has " +
-                      std::to_string(input_data->size()) + " bytes");
-            }
-            allocated_ptr = input_data->data();
-            break;
-          }
-          default:
-            return Status(
-                Status::Code::INVALID_ARG, "warmup setting expects input '" +
-                                               input_meta.first +
-                                               "' to have input_data_type set");
-        }
-
-        const inference::ModelInput* input_config;
-        bool is_original_input =
-            GetInput(input_meta.first, &input_config).IsOk();
-        InferenceRequest::Input* input = nullptr;
-        std::vector<int64_t> input_meta_shape;
-        // Append batch size only if the model supports batching
-        // and not control inpt.
-        if ((config_.max_batch_size() != 0) && is_original_input) {
-          input_meta_shape.push_back(1);
-        }
-        for (auto d : input_meta.second.dims()) {
-          input_meta_shape.push_back(d);
-        }
-        if (is_original_input) {
-          RETURN_IF_ERROR(lrequest->AddOriginalInput(
-              input_meta.first, input_meta.second.data_type(), input_meta_shape,
-              &input));
-        } else {
-          input_sps.emplace_back();
-          RETURN_IF_ERROR(lrequest->AddOverrideInput(
-              input_meta.first, input_meta.second.data_type(),
-              (config_.max_batch_size() != 0 ? 1 : 0), input_meta_shape,
-              &input_sps.back()));
-          input = input_sps.back().get();
-        }
-        RETURN_IF_ERROR(input->AppendData(
-            allocated_ptr, batch_byte_size,
-            TRITONSERVER_MEMORY_CPU /* memory_type */, 0 /* memory_type_id */));
-      }
-
-      RETURN_IF_ERROR(lrequest->PrepareForInference());
-      // Override inputs must be added after PrepareForInference() is called
-      for (const auto& sp : input_sps) {
-        RETURN_IF_ERROR(lrequest->AddOverrideInput(sp));
-      }
-
-      RETURN_IF_ERROR(lrequest->SetResponseCallback(
-          &warmup_allocator, nullptr, WarmupResponseComplete, nullptr));
-    }
-  }
-
-  return Status::Success;
-}
-#endif
 
 extern "C" {
 

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -128,6 +128,266 @@ TritonModelInstance::CreateInstance(
   return Status::Success;
 }
 
+Status
+TritonModelInstance::Schedule(
+    std::vector<std::unique_ptr<InferenceRequest>>&& requests)
+{
+  // Use a thread local vector to avoid needing to malloc each
+  // time an inference is run.
+  thread_local std::vector<TRITONBACKEND_Request*> triton_requests(1024);
+  triton_requests.clear();
+  for (auto& r : requests) {
+    triton_requests.push_back(
+        reinterpret_cast<TRITONBACKEND_Request*>(r.release()));
+  }
+
+  TRITONBACKEND_ModelInstance* triton_model_instance =
+      reinterpret_cast<TRITONBACKEND_ModelInstance*>(this);
+  TritonBackend::TritonModelInstanceExecFn_t inst_exec_fn =
+      model_->Backend()->ModelInstanceExecFn();
+
+  // If there is an error then we retain ownership of 'requests'
+  // and must send error responses.
+  TRITONSERVER_Error* err = inst_exec_fn(
+      triton_model_instance, &triton_requests[0], triton_requests.size());
+  if (err != nullptr) {
+    Status status = Status(
+        TritonCodeToStatusCode(TRITONSERVER_ErrorCode(err)),
+        TRITONSERVER_ErrorMessage(err));
+    for (TRITONBACKEND_Request* tr : triton_requests) {
+      std::unique_ptr<InferenceRequest> ur(
+          reinterpret_cast<InferenceRequest*>(tr));
+      InferenceRequest::RespondIfError(ur, status, true /* release_requests */);
+    }
+
+    TRITONSERVER_ErrorDelete(err);
+  }
+
+  return Status::Success;
+}
+
+Status
+TritonModelInstance::WarmUp()
+{
+  LOG_ERROR << "WarmUp is not yet supported";
+  return Status::Success;
+#if 0
+  std::vector<TRITONBACKEND_Request*> triton_requests(1024);
+  triton_requests.clear();
+  for (auto& request : sample.requests_) {
+    // Capture timestamp before run to avoid incorrect accumulation from
+    // sequential warmup runs
+#ifdef TRITON_ENABLE_STATS
+    request->CaptureRequestStartNs();
+#endif  // TRITON_ENABLE_STATS
+    request->CaptureQueueStartNs();
+    triton_requests.push_back(
+        reinterpret_cast<TRITONBACKEND_Request*>(request.release()));
+  }
+  TRITONBACKEND_ModelInstance* triton_model_instance =
+      reinterpret_cast<TRITONBACKEND_ModelInstance*>(this);
+  TritonBackend::TritonModelInstanceExecFn_t inst_exec_fn =
+      backend_->ModelInstanceExecFn();
+
+  // If there is an error then we retain ownership of 'requests'
+  // and must send error responses.
+  TRITONSERVER_Error* err = inst_exec_fn(
+      triton_model_instance, &triton_requests[0], triton_requests.size());
+  if (err != nullptr) {
+    Status status = Status(
+        TritonCodeToStatusCode(TRITONSERVER_ErrorCode(err)),
+        TRITONSERVER_ErrorMessage(err));
+    for (TRITONBACKEND_Request* tr : triton_requests) {
+      std::unique_ptr<InferenceRequest> ur(
+          reinterpret_cast<InferenceRequest*>(tr));
+      InferenceRequest::RespondIfError(ur, status, true /* release_requests */);
+    }
+
+    TRITONSERVER_ErrorDelete(err);
+  }
+#endif
+}
+
+#if 0
+Status
+TritonModelInstance::GenerateWarmupData()
+{
+  samples_->clear();
+  for (const auto& warmup_setting : model_->Config().model_warmup()) {
+    if (warmup_setting.batch_size() == 0) {
+      LOG_VERBOSE(1) << "Skipping batch 0 warmup sample '"
+                     << warmup_setting.name() << "'";
+      continue;
+    }
+    LOG_VERBOSE(1) << "Generating warmup sample data for '"
+                   << warmup_setting.name() << "'";
+
+    // Two passes. First pass to get max byte size for synthetic
+    // data. Second pass to add original inputs and override inputs
+    // for control inputs.
+    int64_t max_zero_byte_size = 0;
+    int64_t max_random_byte_size = 0;
+    for (const auto& input_meta : warmup_setting.inputs()) {
+      auto element_count = GetElementCount(input_meta.second.dims());
+      if (element_count == -1) {
+        return Status(
+            Status::Code::INVALID_ARG,
+            "warmup setting expects all variable-size dimensions are specified "
+            "for input '" +
+                input_meta.first + "'");
+      }
+
+      int64_t batch_byte_size =
+          element_count * GetDataTypeByteSize(input_meta.second.data_type());
+      if (batch_byte_size == 0) {
+        batch_byte_size = element_count * sizeof(int32_t);
+      }
+
+      switch (input_meta.second.input_data_type_case()) {
+        case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
+          max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
+          break;
+        case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
+          if (input_meta.second.data_type() ==
+              inference::DataType::TYPE_STRING) {
+            max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
+          } else {
+            max_random_byte_size =
+                std::max(batch_byte_size, max_random_byte_size);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    samples_->emplace_back(warmup_setting.name());
+    auto& warmup_data = samples_->back();
+    // Create buffers for synthetic data
+    TRITONSERVER_MemoryType type;
+    int64_t type_id;
+    warmup_data.zero_data_.reset(new AllocatedMemory(
+        max_zero_byte_size, TRITONSERVER_MEMORY_CPU_PINNED /* memory_type */,
+        0 /* memory_type_id */));
+    char* zero_buffer = warmup_data.zero_data_->MutableBuffer(&type, &type_id);
+    memset(zero_buffer, 0, max_zero_byte_size);
+
+    warmup_data.random_data_.reset(new AllocatedMemory(
+        max_random_byte_size, TRITONSERVER_MEMORY_CPU_PINNED /* memory_type */,
+        0 /* memory_type_id */));
+    char* random_buffer =
+        warmup_data.random_data_->MutableBuffer(&type, &type_id);
+    for (int64_t offset = 0; offset < max_random_byte_size; offset++) {
+      random_buffer[offset] = rand();
+    }
+
+    // Prepare the inference request for the specified sample.
+    for (size_t cnt = 0; cnt < warmup_setting.batch_size(); cnt++) {
+      warmup_data.requests_.emplace_back(new InferenceRequest(this, Version()));
+      auto& lrequest = warmup_data.requests_.back();
+
+      // Second pass to prepare original inputs.
+      std::vector<std::shared_ptr<InferenceRequest::Input>> input_sps;
+      for (const auto& input_meta : warmup_setting.inputs()) {
+        auto batch1_element_count = GetElementCount(input_meta.second.dims());
+        auto batch_byte_size =
+            batch1_element_count *
+            GetDataTypeByteSize(input_meta.second.data_type());
+        if (batch_byte_size == 0) {
+          batch_byte_size = batch1_element_count * sizeof(int32_t);
+        }
+
+        const char* allocated_ptr;
+        switch (input_meta.second.input_data_type_case()) {
+          case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
+            allocated_ptr = zero_buffer;
+            break;
+          case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
+            if (input_meta.second.data_type() ==
+                inference::DataType::TYPE_STRING) {
+              allocated_ptr = zero_buffer;
+            } else {
+              allocated_ptr = random_buffer;
+            }
+            break;
+          }
+          case inference::ModelWarmup_Input::InputDataTypeCase::
+              kInputDataFile: {
+            // For data provided from file, we can set buffer in first pass
+            warmup_data.provided_data_.emplace_back(new std::string());
+            auto input_data = warmup_data.provided_data_.back().get();
+            RETURN_IF_ERROR(ReadTextFile(
+                JoinPath({model_dir_, kWarmupDataFolder,
+                          input_meta.second.input_data_file()}),
+                input_data));
+            if (input_meta.second.data_type() ==
+                inference::DataType::TYPE_STRING) {
+              batch_byte_size = input_data->size();
+            } else if (((size_t)batch_byte_size) > input_data->size()) {
+              return Status(
+                  Status::Code::INVALID_ARG,
+                  "warmup setting expects " + std::to_string(batch_byte_size) +
+                      " bytes, but the data "
+                      "provided from " +
+                      input_meta.second.input_data_file() + "only has " +
+                      std::to_string(input_data->size()) + " bytes");
+            }
+            allocated_ptr = input_data->data();
+            break;
+          }
+          default:
+            return Status(
+                Status::Code::INVALID_ARG, "warmup setting expects input '" +
+                                               input_meta.first +
+                                               "' to have input_data_type set");
+        }
+
+        const inference::ModelInput* input_config;
+        bool is_original_input =
+            GetInput(input_meta.first, &input_config).IsOk();
+        InferenceRequest::Input* input = nullptr;
+        std::vector<int64_t> input_meta_shape;
+        // Append batch size only if the model supports batching
+        // and not control inpt.
+        if ((config_.max_batch_size() != 0) && is_original_input) {
+          input_meta_shape.push_back(1);
+        }
+        for (auto d : input_meta.second.dims()) {
+          input_meta_shape.push_back(d);
+        }
+        if (is_original_input) {
+          RETURN_IF_ERROR(lrequest->AddOriginalInput(
+              input_meta.first, input_meta.second.data_type(), input_meta_shape,
+              &input));
+        } else {
+          input_sps.emplace_back();
+          RETURN_IF_ERROR(lrequest->AddOverrideInput(
+              input_meta.first, input_meta.second.data_type(),
+              (config_.max_batch_size() != 0 ? 1 : 0), input_meta_shape,
+              &input_sps.back()));
+          input = input_sps.back().get();
+        }
+        RETURN_IF_ERROR(input->AppendData(
+            allocated_ptr, batch_byte_size,
+            TRITONSERVER_MEMORY_CPU /* memory_type */, 0 /* memory_type_id */));
+      }
+
+      RETURN_IF_ERROR(lrequest->PrepareForInference());
+      // Override inputs must be added after PrepareForInference() is called
+      for (const auto& sp : input_sps) {
+        RETURN_IF_ERROR(lrequest->AddOverrideInput(sp));
+      }
+
+      RETURN_IF_ERROR(lrequest->SetResponseCallback(
+          &warmup_allocator, nullptr, WarmupResponseComplete, nullptr));
+    }
+  }
+
+  return Status::Success;
+}
+#endif
+
 extern "C" {
 
 TRITONSERVER_Error*

--- a/src/backends/backend/triton_model_instance.h
+++ b/src/backends/backend/triton_model_instance.h
@@ -93,7 +93,7 @@ class TritonModelInstance {
   std::vector<std::string> profile_names_;
   bool passive_;
 
-  // std::vector<WarmupData> sampels_;
+  // std::vector<WarmupData> samples_;
 
   // Reporter for metrics, or nullptr if no metrics should be reported
   std::shared_ptr<MetricModelReporter> reporter_;

--- a/src/backends/backend/triton_model_instance.h
+++ b/src/backends/backend/triton_model_instance.h
@@ -35,6 +35,7 @@
 namespace nvidia { namespace inferenceserver {
 
 class TritonModel;
+class InferenceRequest;
 
 //
 // Represents a model instance.
@@ -51,6 +52,12 @@ class TritonModelInstance {
   int32_t DeviceId() const { return device_id_; }
   bool IsPassive() const { return passive_; }
   const std::vector<std::string>& Profiles() const { return profile_names_; }
+
+  Status Initialize() { return Status::Success; }
+
+  Status WarmUp();
+
+  Status Schedule(std::vector<std::unique_ptr<InferenceRequest>>&& requests);
 
   TritonModel* Model() { return model_; }
   void* State() { return state_; }
@@ -85,6 +92,8 @@ class TritonModelInstance {
   int32_t device_id_;
   std::vector<std::string> profile_names_;
   bool passive_;
+
+  // std::vector<WarmupData> sampels_;
 
   // Reporter for metrics, or nullptr if no metrics should be reported
   std::shared_ptr<MetricModelReporter> reporter_;

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -90,20 +90,18 @@ WarmupResponseComplete(
 }
 
 // FIxME: Move the warmup logic into TritonModelInstance
-#if 0
-void
-WarmupRequestComplete(
-    TRITONSERVER_InferenceRequest* request, const uint32_t flags, void* userp)
-{
-  if ((flags & TRITONSERVER_REQUEST_RELEASE_ALL) != 0) {
-    TRITONSERVER_InferenceRequestDelete(request);
-    if (userp != nullptr) {
-      auto warmup_promise = reinterpret_cast<std::promise<void>*>(userp);
-      warmup_promise->set_value();
-    }
-  }
-}
-#endif
+//void
+//WarmupRequestComplete(
+//    TRITONSERVER_InferenceRequest* request, const uint32_t flags, void* userp)
+//{
+//  if ((flags & TRITONSERVER_REQUEST_RELEASE_ALL) != 0) {
+//    TRITONSERVER_InferenceRequestDelete(request);
+//    if (userp != nullptr) {
+//      auto warmup_promise = reinterpret_cast<std::promise<void>*>(userp);
+//      warmup_promise->set_value();
+//    }
+//  }
+//}
 
 }  // namespace
 

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -89,6 +89,8 @@ WarmupResponseComplete(
   }
 }
 
+// FIxME: Move the warmup logic into TritonModelInstance
+#if 0
 void
 WarmupRequestComplete(
     TRITONSERVER_InferenceRequest* request, const uint32_t flags, void* userp)
@@ -101,6 +103,7 @@ WarmupRequestComplete(
     }
   }
 }
+#endif
 
 }  // namespace
 
@@ -187,51 +190,9 @@ InferenceBackend::SetScheduler(std::unique_ptr<Scheduler> scheduler)
 }
 
 Status
-InferenceBackend::SetConfiguredScheduler(
-    const uint32_t runner_cnt, const Scheduler::StandardInitFunc& OnInit,
-    const Scheduler::StandardRunFunc& OnRun)
+InferenceBackend::SetConfiguredScheduler(void* model)
 {
   std::unique_ptr<Scheduler> scheduler;
-
-  // Create a warmup function for the scheduler thread to run the contexts
-  // in corresponding threads. Currently the warmup function can't be run
-  // asynchronously with respect to Scheduler::Create() as there is no way to
-  // change ModelReadyState, which is controlled by model manager, from within
-  // the scheduler.
-  // But running warmup synchronously allows us to use one set of warmup data
-  // for all contexts.
-  std::vector<std::vector<WarmupData>> samples{runner_cnt};
-  if (Config().model_warmup_size() != 0) {
-    // The ownership of InferenceRequest will be transferred on model execution,
-    // so must have unique set of samples for each runner
-    for (auto& runner_samples : samples) {
-      RETURN_IF_ERROR(GenerateWarmupData(&runner_samples));
-    }
-  }
-
-  auto OnWarmup = [this, &samples](uint32_t runner_idx) -> Status {
-    auto& runner_samples = samples[runner_idx];
-    for (auto& sample : runner_samples) {
-      LOG_VERBOSE(1) << "model '" << sample.requests_.back()->ModelName()
-                     << "' instance " << std::to_string(runner_idx)
-                     << " is running warmup sample '" << sample.sample_name_
-                     << "'";
-
-      std::promise<void> warmup_promise;
-      // only now we can set the proper request complete callback,
-      // only one request in the batch can set the promise.
-      sample.requests_[0]->SetReleaseCallback(
-          WarmupRequestComplete, &warmup_promise);
-      for (size_t idx = 1; idx < sample.requests_.size(); idx++) {
-        sample.requests_[idx]->SetReleaseCallback(
-            WarmupRequestComplete, nullptr);
-      }
-      WarmUp(runner_idx, sample);
-      warmup_promise.get_future().get();
-    }
-
-    return Status::Success;
-  };
 
   // Need to enforce equal shape batches (i.e. non-ragged batches) if
   // the model 1) allows one or more variable-size input tensors that
@@ -251,24 +212,26 @@ InferenceBackend::SetConfiguredScheduler(
   // If 'sequence_batching' is configured use the SequenceBatchScheduler,
   // otherwise use the default DynamicBatchScheduler.
   if (config_.has_sequence_batching()) {
+    return Status(
+        Status::Code::INTERNAL, "SequenceBatcher is not yet supported");
+    /*
     // Sequence batcher
     RETURN_IF_ERROR(SequenceBatchScheduler::Create(
         config_, runner_cnt, OnInit, OnWarmup, OnRun,
         enforce_equal_shape_tensors, &scheduler));
+    */
   } else if (config_.has_dynamic_batching()) {
     // Dynamic batcher
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
-        0 /* runner_id_start */, runner_cnt, GetCpuNiceLevel(config_), OnInit,
-        OnWarmup, OnRun, true /* dynamic_batching_enabled */,
-        config_.max_batch_size(), enforce_equal_shape_tensors,
-        config_.dynamic_batching(), &scheduler));
+        static_cast<TritonModel*>(model), GetCpuNiceLevel(config_),
+        true /* dynamic_batching_enabled */, config_.max_batch_size(),
+        enforce_equal_shape_tensors, config_.dynamic_batching(), &scheduler));
   } else {
     // Default scheduler. Use dynamic batch scheduler (with batching
     // disabled) as the default scheduler.
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
-        0 /* runner_id_start */, runner_cnt, GetCpuNiceLevel(config_), OnInit,
-        OnWarmup, OnRun, false /* dynamic_batching_enabled */,
-        1 /* max_batch_size */,
+        static_cast<TritonModel*>(model), GetCpuNiceLevel(config_),
+        false /* dynamic_batching_enabled */, 1 /* max_batch_size */,
         std::unordered_map<
             std::string, bool>() /* enforce_equal_shape_tensors */,
         false /* preserve_ordering */,

--- a/src/core/backend.h
+++ b/src/core/backend.h
@@ -25,10 +25,10 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include "model_config.pb.h"
 #include "src/core/backend_context.h"
 #include "src/core/infer_stats.h"
 #include "src/core/label_provider.h"
-#include "model_config.pb.h"
 #include "src/core/scheduler.h"
 #include "src/core/status.h"
 
@@ -179,9 +179,9 @@ class InferenceBackend {
 
   // Set the scheduler based on the model configuration. The scheduler
   // can only be set once for a backend.
-  Status SetConfiguredScheduler(
-      const uint32_t runner_cnt, const Scheduler::StandardInitFunc& OnInit,
-      const Scheduler::StandardRunFunc& OnRun);
+  // FIXME: The pointer is of TritonModel* type and is doen to keep ensemble
+  // happy
+  Status SetConfiguredScheduler(void* model);
 
   // Get the raw pointer to the scheduler of this backend.
   Scheduler* BackendScheduler() { return scheduler_.get(); }

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -34,8 +34,10 @@
 #include <queue>
 #include <set>
 #include <thread>
-#include "src/core/model_config.h"
 #include "model_config.pb.h"
+#include "src/backends/backend/triton_model.h"
+#include "src/backends/backend/triton_model_instance.h"
+#include "src/core/model_config.h"
 #include "src/core/scheduler.h"
 #include "src/core/scheduler_utils.h"
 #include "src/core/status.h"
@@ -48,9 +50,7 @@ class DynamicBatchScheduler : public Scheduler {
   // Create a scheduler to support a given number of runners and a run
   // function to call when a request is scheduled.
   static Status Create(
-      const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
-      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
+      TritonModel* model, const int nice, const bool dynamic_batching_enabled,
       const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
@@ -62,9 +62,7 @@ class DynamicBatchScheduler : public Scheduler {
   // function to call when a request is scheduled. And the scheduler also
   // supports different queue policies for different priority levels.
   static Status Create(
-      const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
-      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
+      TritonModel* model, const int nice, const bool dynamic_batching_enabled,
       const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const inference::ModelDynamicBatching& batcher_config,
@@ -77,10 +75,7 @@ class DynamicBatchScheduler : public Scheduler {
 
  private:
   DynamicBatchScheduler(
-      const uint32_t runner_id_start, const uint32_t runner_cnt,
-      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
-      const int32_t max_batch_size,
+      const bool dynamic_batching_enabled, const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
@@ -89,41 +84,24 @@ class DynamicBatchScheduler : public Scheduler {
       const uint32_t priority_levels,
       const ModelQueuePolicyMap& queue_policy_map);
   void SchedulerThread(
-      const uint32_t runner_id, const int nice,
-      const std::shared_ptr<std::atomic<bool>>& rthread_exit,
-      std::promise<bool>* is_initialized);
-  uint64_t GetDynamicBatch(const int64_t runner_id);
+      TritonModel* model, const int nice, std::promise<bool>* is_initialized);
+  uint64_t GetDynamicBatch();
   void FinalizeResponses();
-
-  // Function the scheduler will call to initialize a runner.
-  const StandardInitFunc OnInit_;
-
-  // Function the scheduler will call to warmup a runner.
-  const StandardWarmupFunc OnWarmup_;
-
-  // Function the scheduler will call to schedule a batch of requests.
-  const StandardRunFunc OnSchedule_;
 
   // True if dynamic batching is enabled.
   const bool dynamic_batching_enabled_;
-
-  // The number of scheduler threads.
-  const uint32_t scheduler_thread_cnt_;
-
-  // The number of scheduler threads currently idle.
-  uint32_t idle_scheduler_thread_cnt_;
-
-  // Mutex and condvar protecting the scheduling queue.
-  std::mutex mu_;
-  std::condition_variable cv_;
 
   // Map from priority level to queue holding inference requests for the model
   // represented by this scheduler. If priority queues are not supported by the
   // scheduler, then priority zero entry is used as the single queue.
   PriorityQueue queue_;
 
-  std::vector<std::unique_ptr<std::thread>> scheduler_threads_;
-  std::vector<std::shared_ptr<std::atomic<bool>>> scheduler_threads_exit_;
+  std::thread scheduler_thread_;
+  std::atomic<bool> scheduler_thread_exit_;
+
+  // Mutex and condvar for signalling scheduler thread
+  std::mutex mu_;
+  std::condition_variable cv_;
 
   size_t max_batch_size_;
   size_t max_preferred_batch_size_;

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -1270,6 +1270,8 @@ OldestSequenceBatch::OldestSequenceBatch(
           continue_input_overrides, notready_input_overrides),
       in_flight_(seq_slot_cnt, false), queues_(seq_slot_cnt)
 {
+// FIXME: Fix with sequence  batcher change
+#if 0
   // Initialize to handle CORRID control. If error just exit
   // now... that means the corresponding model instance will not have
   // any runner and so will not get used for execution.
@@ -1301,6 +1303,7 @@ OldestSequenceBatch::OldestSequenceBatch(
   }
 
   is_initialized->set_value(true);
+#endif
 }
 
 OldestSequenceBatch::~OldestSequenceBatch() {}

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -1270,40 +1270,39 @@ OldestSequenceBatch::OldestSequenceBatch(
           continue_input_overrides, notready_input_overrides),
       in_flight_(seq_slot_cnt, false), queues_(seq_slot_cnt)
 {
-// FIXME: Fix with sequence  batcher change
-#if 0
-  // Initialize to handle CORRID control. If error just exit
-  // now... that means the corresponding model instance will not have
-  // any runner and so will not get used for execution.
-  if (!CreateCorrelationIDControl(config)) {
-    is_initialized->set_value(false);
-    return;
-  }
+//// FIXME: Fix with sequence  batcher change
+//  // Initialize to handle CORRID control. If error just exit
+//  // now... that means the corresponding model instance will not have
+//  // any runner and so will not get used for execution.
+//  if (!CreateCorrelationIDControl(config)) {
+//    is_initialized->set_value(false);
+//    return;
+//  }
+//
+//  // Create a dynamic batcher use to batch together sequences for
+//  // inference.
+//  std::set<int32_t> preferred_batch_sizes;
+//  for (const auto size :
+//       config.sequence_batching().oldest().preferred_batch_size()) {
+//    preferred_batch_sizes.insert(size);
+//  }
+//
+//  Status status = DynamicBatchScheduler::Create(
+//      batcher_idx_, 1 /* runner_cnt */, GetCpuNiceLevel(config), OnInit,
+//      OnWarmup, OnSchedule, true /* dynamic_batching_enabled */,
+//      config.max_batch_size(), enforce_equal_shape_tensors_,
+//      true /* preserve_ordering */, preferred_batch_sizes,
+//      config.sequence_batching().oldest().max_queue_delay_microseconds(),
+//      &dynamic_batcher_);
+//  if (!status.IsOk()) {
+//    LOG_ERROR << "failed creating dynamic sequence batcher for OldestFirst "
+//              << batcher_idx_ << ": " << status.Message();
+//    is_initialized->set_value(false);
+//    return;
+//  }
+//
+//  is_initialized->set_value(true);
 
-  // Create a dynamic batcher use to batch together sequences for
-  // inference.
-  std::set<int32_t> preferred_batch_sizes;
-  for (const auto size :
-       config.sequence_batching().oldest().preferred_batch_size()) {
-    preferred_batch_sizes.insert(size);
-  }
-
-  Status status = DynamicBatchScheduler::Create(
-      batcher_idx_, 1 /* runner_cnt */, GetCpuNiceLevel(config), OnInit,
-      OnWarmup, OnSchedule, true /* dynamic_batching_enabled */,
-      config.max_batch_size(), enforce_equal_shape_tensors_,
-      true /* preserve_ordering */, preferred_batch_sizes,
-      config.sequence_batching().oldest().max_queue_delay_microseconds(),
-      &dynamic_batcher_);
-  if (!status.IsOk()) {
-    LOG_ERROR << "failed creating dynamic sequence batcher for OldestFirst "
-              << batcher_idx_ << ": " << status.Message();
-    is_initialized->set_value(false);
-    return;
-  }
-
-  is_initialized->set_value(true);
-#endif
 }
 
 OldestSequenceBatch::~OldestSequenceBatch() {}

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -33,8 +33,8 @@
 #include <queue>
 #include <thread>
 #include <unordered_map>
-#include "src/core/model_config.h"
 #include "model_config.pb.h"
+#include "src/core/model_config.h"
 #include "src/core/scheduler.h"
 #include "src/core/scheduler_utils.h"
 #include "src/core/status.h"


### PR DESCRIPTION
… Blocking

I will use `tanmayv-dev` for all the developments related to  TRT backend, new threading model and rate limiter.`*` 
This PR includes changes to be made in dynamic_batcher_scheduler and a brief idea of new organization.

 For multiple instances, all the remaining logic will be implemented in TritonModelInstance class which includes separate threads for executing inference. The warmup logic will also be moved to TritonModelInstance. Even after these future enhancements, the threading behavior for single instance will remain the same. i.e. for a single instance, scheduler thread itself will jump into backend for execution.
 
 Please ignore `#if 0 ... #endif ` and warmup related sections in the code. I will clean that up once I get to it. 
 
 These changes passes most of the tests working on TRT backend. 
 
 `*` Until and unless all these 3 features are implemented fully master will be in broken state.