### PR TITLE
Remove nvidia from client namespace

### DIFF
--- a/qa/L0_sdk/grpc_test.cc
+++ b/qa/L0_sdk/grpc_test.cc
@@ -26,13 +26,15 @@
 
 #include "grpc_client.h"
 
+namespace tc = triton::client;
+
 int
 main(int argc, char* argv[])
 {
-  std::unique_ptr<triton::client::InferenceServerGrpcClient> client;
+  std::unique_ptr<tc::InferenceServerGrpcClient> client;
   // Add a symbol from protobufs to verify correct linking
   inference::ModelConfigResponse model_config;
-  triton::client::InferenceServerGrpcClient::Create(&client, "localhost:8001");
+  tc::InferenceServerGrpcClient::Create(&client, "localhost:8001");
   bool live;
   client->IsServerLive(&live);
 

--- a/qa/L0_sdk/grpc_test.cc
+++ b/qa/L0_sdk/grpc_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,15 +26,13 @@
 
 #include "grpc_client.h"
 
-namespace nvic = nvidia::inferenceserver::client;
-
 int
 main(int argc, char* argv[])
 {
-  std::unique_ptr<nvic::InferenceServerGrpcClient> client;
+  std::unique_ptr<triton::client::InferenceServerGrpcClient> client;
   // Add a symbol from protobufs to verify correct linking
   inference::ModelConfigResponse model_config;
-  nvic::InferenceServerGrpcClient::Create(&client, "localhost:8001");
+  triton::client::InferenceServerGrpcClient::Create(&client, "localhost:8001");
   bool live;
   client->IsServerLive(&live);
 

--- a/qa/L0_sdk/http_test.cc
+++ b/qa/L0_sdk/http_test.cc
@@ -26,11 +26,13 @@
 
 #include "http_client.h"
 
+namespace tc = triton::client;
+
 int
 main(int argc, char* argv[])
 {
-  std::unique_ptr<triton::client::InferenceServerHttpClient> client;
-  triton::client::InferenceServerHttpClient::Create(&client, "localhost:8001");
+  std::unique_ptr<tc::InferenceServerHttpClient> client;
+  tc::InferenceServerHttpClient::Create(&client, "localhost:8001");
   bool live;
   client->IsServerLive(&live);
 

--- a/qa/L0_sdk/http_test.cc
+++ b/qa/L0_sdk/http_test.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,13 +26,11 @@
 
 #include "http_client.h"
 
-namespace nvic = nvidia::inferenceserver::client;
-
 int
 main(int argc, char* argv[])
 {
-  std::unique_ptr<nvic::InferenceServerHttpClient> client;
-  nvic::InferenceServerHttpClient::Create(&client, "localhost:8001");
+  std::unique_ptr<triton::client::InferenceServerHttpClient> client;
+  triton::client::InferenceServerHttpClient::Create(&client, "localhost:8001");
   bool live;
   client->IsServerLive(&live);
 


### PR DESCRIPTION
Change unit test to reflect changes in the client

Changed code:
https://github.com/triton-inference-server/client/pull/14

