### PR TITLE
Solve windows docker build issues

### DIFF
--- a/Dockerfile.win10.min
+++ b/Dockerfile.win10.min
@@ -58,7 +58,7 @@ WORKDIR /tmp
 
 # Be aware that pip can interact badly with VS cmd shell so need to pip install before
 # vsdevcmd.bat (see https://bugs.python.org/issue38989)
-RUN powershell.exe -ExecutionPolicy RemoteSigned iex (new-object net.webclient).downloadstring('https://get.scoop.sh')
+RUN powershell.exe [Net.ServicePointManager]::Expect100Continue = $true; [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls12, [Net.SecurityProtocolType]::Ssl3; Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
 RUN scoop install python git docker unzip
 RUN pip3 install --upgrade wheel setuptools docker
 RUN pip3 install grpcio-tools


### PR DESCRIPTION
This solves the docker build issue in Windows 10

Error `The request was aborted: Could not create SSL/TLS secure channel.` is eliminated with this changes.