### PR TITLE
Support multiple instances with TritonBackendThread. Fix dynamic sche…

### DIFF
--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -162,7 +162,6 @@ TritonModelInstance::SetBackendThread()
   // TODO: Currently each instance has a dedicated TritonBackendThread.
   // For device blocking execution policy we must share the
   // TritonBackendThread object with the instances on same device.
-  // FIXME: Get the nice value for the thread from config
   std::unique_ptr<TritonBackendThread> local_backend_thread;
   RETURN_IF_ERROR(TritonBackendThread::CreateBackendThread(
       Name(), 0 /* nice */, &local_backend_thread));

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -26,10 +26,16 @@
 
 #include "src/backends/backend/triton_model_instance.h"
 
+#ifndef _WIN32
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
 #include "model_config.pb.h"
 #include "src/backends/backend/triton_model.h"
 #include "src/core/logging.h"
 #include "src/core/metrics.h"
+#include "src/core/nvtx.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -69,6 +75,18 @@ Status
 TritonModelInstance::CreateInstances(
     TritonModel* model, const inference::ModelConfig& model_config)
 {
+  bool use_backend_threads = false;
+  size_t count = 0;
+  for (const auto& group : model_config.instance_group()) {
+    if (!group.passive()) {
+      count += group.count();
+      if (count > 1) {
+        use_backend_threads = true;
+        break;
+      }
+    }
+  }
+
   for (const auto& group : model_config.instance_group()) {
     std::vector<std::string> profile_names;
     for (const auto& profile_name : group.profile()) {
@@ -82,17 +100,20 @@ TritonModelInstance::CreateInstances(
       if (group.kind() == inference::ModelInstanceGroup::KIND_CPU) {
         RETURN_IF_ERROR(CreateInstance(
             model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_CPU,
-            0 /* device_id */, profile_names, passive, group.rate_limiter()));
+            0 /* device_id */, profile_names, passive, group.rate_limiter(),
+            use_backend_threads));
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_GPU) {
         for (const int32_t device_id : group.gpus()) {
           RETURN_IF_ERROR(CreateInstance(
               model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_GPU,
-              device_id, profile_names, passive, group.rate_limiter()));
+              device_id, profile_names, passive, group.rate_limiter(),
+              use_backend_threads));
         }
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_MODEL) {
         RETURN_IF_ERROR(CreateInstance(
             model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_MODEL,
-            0 /* device_id */, profile_names, passive, group.rate_limiter()));
+            0 /* device_id */, profile_names, passive, group.rate_limiter(),
+            use_backend_threads));
       } else {
         return Status(
             Status::Code::INVALID_ARG,
@@ -110,13 +131,18 @@ TritonModelInstance::CreateInstance(
     TritonModel* model, const std::string& name, const size_t index,
     const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
     const std::vector<std::string>& profile_names, const bool passive,
-    const inference::ModelRateLimiter& rate_limiter_config)
+    const inference::ModelRateLimiter& rate_limiter_config,
+    const bool use_backend_threads)
 {
   std::unique_ptr<TritonModelInstance> local_instance(new TritonModelInstance(
       model, name, index, kind, device_id, profile_names, passive));
 
   TRITONBACKEND_ModelInstance* triton_instance =
       reinterpret_cast<TRITONBACKEND_ModelInstance*>(local_instance.get());
+
+  if (use_backend_threads) {
+    local_instance->SetBackendThread();
+  }
 
   // Instance initialization is optional...
   if (model->Backend()->ModelInstanceInitFn() != nullptr) {
@@ -131,9 +157,69 @@ TritonModelInstance::CreateInstance(
 }
 
 Status
+TritonModelInstance::SetBackendThread()
+{
+  // TODO: Currently each instance has a dedicated TritonBackendThread.
+  // For device blocking execution policy we must share the
+  // TritonBackendThread object with the instances on same device.
+  // FIXME: Get the nice value for the thread from config
+  std::unique_ptr<TritonBackendThread> local_backend_thread;
+  RETURN_IF_ERROR(TritonBackendThread::CreateBackendThread(
+      Name(), 0 /* nice */, &local_backend_thread));
+  triton_backend_thread_ = std::move(local_backend_thread);
+
+  return Status::Success;
+}
+
+Status
+TritonModelInstance::Initialize()
+{
+  Status status;
+  if (triton_backend_thread_.get() != nullptr) {
+    auto payload = std::make_shared<TritonBackendThread::Payload>(
+        TritonBackendThread::Operation::INIT, this);
+    triton_backend_thread_->Enqueue(payload);
+    status = payload->Wait();
+  } else {
+    status = InitializeFunc();
+  }
+  return status;
+}
+
+Status
+TritonModelInstance::WarmUp()
+{
+  Status status;
+  if (triton_backend_thread_.get() != nullptr) {
+    auto payload = std::make_shared<TritonBackendThread::Payload>(
+        TritonBackendThread::Operation::WARM_UP, this);
+    triton_backend_thread_->Enqueue(payload);
+    status = payload->Wait();
+  } else {
+    status = WarmUpFunc();
+  }
+  return status;
+}
+
+void
 TritonModelInstance::Schedule(
     std::vector<std::unique_ptr<InferenceRequest>>&& requests,
-    std::function<void()> OnCompletion)
+    const std::function<void()>& OnCompletion)
+{
+  if (triton_backend_thread_.get() != nullptr) {
+    auto payload = std::make_shared<TritonBackendThread::Payload>(
+        TritonBackendThread::Operation::INFER_RUN, this, std::move(requests),
+        OnCompletion);
+    triton_backend_thread_->Enqueue(payload);
+  } else {
+    ScheduleFunc(std::move(requests), OnCompletion);
+  }
+}
+
+void
+TritonModelInstance::ScheduleFunc(
+    std::vector<std::unique_ptr<InferenceRequest>>&& requests,
+    const std::function<void()>& OnCompletion)
 {
   // Use a thread local vector to avoid needing to malloc each
   // time an inference is run.
@@ -167,234 +253,129 @@ TritonModelInstance::Schedule(
   }
 
   OnCompletion();
+}
 
+Status
+TritonModelInstance::WarmUpFunc()
+{
+  LOG_ERROR << "WarmUp is not yet supported";
   return Status::Success;
 }
 
 Status
-TritonModelInstance::WarmUp()
+TritonModelInstance::TritonBackendThread::CreateBackendThread(
+    const std::string name, const int nice,
+    std::unique_ptr<TritonBackendThread>* triton_backend_thread)
 {
-  LOG_ERROR << "WarmUp is not yet supported";
+  TritonBackendThread* raw_triton_backend_thread =
+      new TritonBackendThread(name);
+  std::unique_ptr<TritonBackendThread> runner(raw_triton_backend_thread);
+
+  runner->backend_thread_ = std::thread([raw_triton_backend_thread, nice]() {
+    raw_triton_backend_thread->BackendThread(nice);
+  });
+
+  triton_backend_thread->reset(runner.release());
+
   return Status::Success;
-  //  std::vector<TRITONBACKEND_Request*> triton_requests(1024);
-  //  triton_requests.clear();
-  //  for (auto& request : sample.requests_) {
-  //    // Capture timestamp before run to avoid incorrect accumulation from
-  //    // sequential warmup runs
-  //#ifdef TRITON_ENABLE_STATS
-  //    request->CaptureRequestStartNs();
-  //#endif  // TRITON_ENABLE_STATS
-  //    request->CaptureQueueStartNs();
-  //    triton_requests.push_back(
-  //        reinterpret_cast<TRITONBACKEND_Request*>(request.release()));
-  //  }
-  //  TRITONBACKEND_ModelInstance* triton_model_instance =
-  //      reinterpret_cast<TRITONBACKEND_ModelInstance*>(this);
-  //  TritonBackend::TritonModelInstanceExecFn_t inst_exec_fn =
-  //      backend_->ModelInstanceExecFn();
-  //
-  //  // If there is an error then we retain ownership of 'requests'
-  //  // and must send error responses.
-  //  TRITONSERVER_Error* err = inst_exec_fn(
-  //      triton_model_instance, &triton_requests[0], triton_requests.size());
-  //  if (err != nullptr) {
-  //    Status status = Status(
-  //        TritonCodeToStatusCode(TRITONSERVER_ErrorCode(err)),
-  //        TRITONSERVER_ErrorMessage(err));
-  //    for (TRITONBACKEND_Request* tr : triton_requests) {
-  //      std::unique_ptr<InferenceRequest> ur(
-  //          reinterpret_cast<InferenceRequest*>(tr));
-  //      InferenceRequest::RespondIfError(ur, status, true /* release_requests
-  //      */);
-  //    }
-  //
-  //    TRITONSERVER_ErrorDelete(err);
-  //  }
 }
 
+TritonModelInstance::TritonBackendThread::TritonBackendThread(
+    const std::string& name)
+    : name_(name)
+{
+}
 
-// Status
-// TritonModelInstance::GenerateWarmupData()
-//{
-//  samples_->clear();
-//  for (const auto& warmup_setting : model_->Config().model_warmup()) {
-//    if (warmup_setting.batch_size() == 0) {
-//      LOG_VERBOSE(1) << "Skipping batch 0 warmup sample '"
-//                     << warmup_setting.name() << "'";
-//      continue;
-//    }
-//    LOG_VERBOSE(1) << "Generating warmup sample data for '"
-//                   << warmup_setting.name() << "'";
-//
-//    // Two passes. First pass to get max byte size for synthetic
-//    // data. Second pass to add original inputs and override inputs
-//    // for control inputs.
-//    int64_t max_zero_byte_size = 0;
-//    int64_t max_random_byte_size = 0;
-//    for (const auto& input_meta : warmup_setting.inputs()) {
-//      auto element_count = GetElementCount(input_meta.second.dims());
-//      if (element_count == -1) {
-//        return Status(
-//            Status::Code::INVALID_ARG,
-//            "warmup setting expects all variable-size dimensions are specified
-//            " "for input '" +
-//                input_meta.first + "'");
-//      }
-//
-//      int64_t batch_byte_size =
-//          element_count * GetDataTypeByteSize(input_meta.second.data_type());
-//      if (batch_byte_size == 0) {
-//        batch_byte_size = element_count * sizeof(int32_t);
-//      }
-//
-//      switch (input_meta.second.input_data_type_case()) {
-//        case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
-//          max_zero_byte_size = std::max(batch_byte_size, max_zero_byte_size);
-//          break;
-//        case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
-//          if (input_meta.second.data_type() ==
-//              inference::DataType::TYPE_STRING) {
-//            max_zero_byte_size = std::max(batch_byte_size,
-//            max_zero_byte_size);
-//          } else {
-//            max_random_byte_size =
-//                std::max(batch_byte_size, max_random_byte_size);
-//          }
-//          break;
-//        }
-//        default:
-//          break;
-//      }
-//    }
-//
-//    samples_->emplace_back(warmup_setting.name());
-//    auto& warmup_data = samples_->back();
-//    // Create buffers for synthetic data
-//    TRITONSERVER_MemoryType type;
-//    int64_t type_id;
-//    warmup_data.zero_data_.reset(new AllocatedMemory(
-//        max_zero_byte_size, TRITONSERVER_MEMORY_CPU_PINNED /* memory_type */,
-//        0 /* memory_type_id */));
-//    char* zero_buffer = warmup_data.zero_data_->MutableBuffer(&type,
-//    &type_id); memset(zero_buffer, 0, max_zero_byte_size);
-//
-//    warmup_data.random_data_.reset(new AllocatedMemory(
-//        max_random_byte_size, TRITONSERVER_MEMORY_CPU_PINNED /* memory_type
-//        */, 0 /* memory_type_id */));
-//    char* random_buffer =
-//        warmup_data.random_data_->MutableBuffer(&type, &type_id);
-//    for (int64_t offset = 0; offset < max_random_byte_size; offset++) {
-//      random_buffer[offset] = rand();
-//    }
-//
-//    // Prepare the inference request for the specified sample.
-//    for (size_t cnt = 0; cnt < warmup_setting.batch_size(); cnt++) {
-//      warmup_data.requests_.emplace_back(new InferenceRequest(this,
-//      Version())); auto& lrequest = warmup_data.requests_.back();
-//
-//      // Second pass to prepare original inputs.
-//      std::vector<std::shared_ptr<InferenceRequest::Input>> input_sps;
-//      for (const auto& input_meta : warmup_setting.inputs()) {
-//        auto batch1_element_count = GetElementCount(input_meta.second.dims());
-//        auto batch_byte_size =
-//            batch1_element_count *
-//            GetDataTypeByteSize(input_meta.second.data_type());
-//        if (batch_byte_size == 0) {
-//          batch_byte_size = batch1_element_count * sizeof(int32_t);
-//        }
-//
-//        const char* allocated_ptr;
-//        switch (input_meta.second.input_data_type_case()) {
-//          case inference::ModelWarmup_Input::InputDataTypeCase::kZeroData:
-//            allocated_ptr = zero_buffer;
-//            break;
-//          case inference::ModelWarmup_Input::InputDataTypeCase::kRandomData: {
-//            if (input_meta.second.data_type() ==
-//                inference::DataType::TYPE_STRING) {
-//              allocated_ptr = zero_buffer;
-//            } else {
-//              allocated_ptr = random_buffer;
-//            }
-//            break;
-//          }
-//          case inference::ModelWarmup_Input::InputDataTypeCase::
-//              kInputDataFile: {
-//            // For data provided from file, we can set buffer in first pass
-//            warmup_data.provided_data_.emplace_back(new std::string());
-//            auto input_data = warmup_data.provided_data_.back().get();
-//            RETURN_IF_ERROR(ReadTextFile(
-//                JoinPath({model_dir_, kWarmupDataFolder,
-//                          input_meta.second.input_data_file()}),
-//                input_data));
-//            if (input_meta.second.data_type() ==
-//                inference::DataType::TYPE_STRING) {
-//              batch_byte_size = input_data->size();
-//            } else if (((size_t)batch_byte_size) > input_data->size()) {
-//              return Status(
-//                  Status::Code::INVALID_ARG,
-//                  "warmup setting expects " + std::to_string(batch_byte_size)
-//                  +
-//                      " bytes, but the data "
-//                      "provided from " +
-//                      input_meta.second.input_data_file() + "only has " +
-//                      std::to_string(input_data->size()) + " bytes");
-//            }
-//            allocated_ptr = input_data->data();
-//            break;
-//          }
-//          default:
-//            return Status(
-//                Status::Code::INVALID_ARG, "warmup setting expects input '" +
-//                                               input_meta.first +
-//                                               "' to have input_data_type
-//                                               set");
-//        }
-//
-//        const inference::ModelInput* input_config;
-//        bool is_original_input =
-//            GetInput(input_meta.first, &input_config).IsOk();
-//        InferenceRequest::Input* input = nullptr;
-//        std::vector<int64_t> input_meta_shape;
-//        // Append batch size only if the model supports batching
-//        // and not control inpt.
-//        if ((config_.max_batch_size() != 0) && is_original_input) {
-//          input_meta_shape.push_back(1);
-//        }
-//        for (auto d : input_meta.second.dims()) {
-//          input_meta_shape.push_back(d);
-//        }
-//        if (is_original_input) {
-//          RETURN_IF_ERROR(lrequest->AddOriginalInput(
-//              input_meta.first, input_meta.second.data_type(),
-//              input_meta_shape, &input));
-//        } else {
-//          input_sps.emplace_back();
-//          RETURN_IF_ERROR(lrequest->AddOverrideInput(
-//              input_meta.first, input_meta.second.data_type(),
-//              (config_.max_batch_size() != 0 ? 1 : 0), input_meta_shape,
-//              &input_sps.back()));
-//          input = input_sps.back().get();
-//        }
-//        RETURN_IF_ERROR(input->AppendData(
-//            allocated_ptr, batch_byte_size,
-//            TRITONSERVER_MEMORY_CPU /* memory_type */, 0 /* memory_type_id
-//            */));
-//      }
-//
-//      RETURN_IF_ERROR(lrequest->PrepareForInference());
-//      // Override inputs must be added after PrepareForInference() is called
-//      for (const auto& sp : input_sps) {
-//        RETURN_IF_ERROR(lrequest->AddOverrideInput(sp));
-//      }
-//
-//      RETURN_IF_ERROR(lrequest->SetResponseCallback(
-//          &warmup_allocator, nullptr, WarmupResponseComplete, nullptr));
-//    }
-//  }
-//
-//  return Status::Success;
-//}
+TritonModelInstance::TritonBackendThread::~TritonBackendThread()
+{
+  // Signal the backend thread to exit and then wait for it..
+  auto exit_payload = std::make_shared<Payload>(Operation::EXIT, nullptr);
+  queue_.Put(exit_payload);
+  if (backend_thread_.joinable()) {
+    backend_thread_.join();
+  }
+}
 
+TritonModelInstance::TritonBackendThread::Payload::Payload(
+    const Operation op_type, TritonModelInstance* instance)
+    : op_type_(op_type), instance_(instance),
+      requests_(std::vector<std::unique_ptr<InferenceRequest>>()),
+      OnCompletion_([]() {})
+{
+}
+
+TritonModelInstance::TritonBackendThread::Payload::Payload(
+    const Operation op_type, TritonModelInstance* instance,
+    std::vector<std::unique_ptr<InferenceRequest>>&& requests,
+    std::function<void()> OnCompletion)
+    : op_type_(op_type), instance_(instance), requests_(std::move(requests)),
+      OnCompletion_(OnCompletion)
+{
+}
+
+Status
+TritonModelInstance::TritonBackendThread::Payload::Wait()
+{
+  return status_.get_future().get();
+}
+
+void
+TritonModelInstance::TritonBackendThread::Payload::Execute(bool* should_exit)
+{
+  *should_exit = false;
+
+  Status status;
+  switch (op_type_) {
+    case Operation::INFER_RUN:
+      instance_->ScheduleFunc(std::move(requests_), OnCompletion_);
+
+      break;
+    case Operation::INIT:
+      status = instance_->InitializeFunc();
+      break;
+    case Operation::WARM_UP:
+      status = instance_->WarmUpFunc();
+      break;
+    case Operation::EXIT:
+      *should_exit = true;
+  }
+
+  status_.set_value(status);
+}
+
+void
+TritonModelInstance::TritonBackendThread::Enqueue(
+    std::shared_ptr<Payload> payload)
+{
+  queue_.Put(payload);
+}
+
+void
+TritonModelInstance::TritonBackendThread::BackendThread(const int nice)
+{
+#ifndef _WIN32
+  if (setpriority(PRIO_PROCESS, syscall(SYS_gettid), nice) == 0) {
+    LOG_VERBOSE(1) << "Starting backend thread for " << name_ << " at nice "
+                   << nice << "...";
+  } else {
+    LOG_VERBOSE(1) << "Starting backend thread for " << name_
+                   << " at default nice (requested nice " << nice
+                   << " failed)...";
+  }
+#else
+  LOG_VERBOSE(1) << "Starting backend thread for " << name_
+                 << " at default nice...";
+#endif
+
+  bool should_exit = false;
+  while (!should_exit) {
+    NVTX_RANGE(nvtx_, "BackendThread " + name_);
+    auto payload = queue_.Get();
+    payload->Execute(&should_exit);
+  }
+
+  LOG_VERBOSE(1) << "Stopping backend thread for " << name_ << "...";
+}
 
 extern "C" {
 
@@ -528,5 +509,4 @@ TRITONBACKEND_ModelInstanceReportBatchStatistics(
 }
 
 }  // extern C
-
 }}  // namespace nvidia::inferenceserver

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -263,7 +263,8 @@ DynamicBatchScheduler::SchedulerThread(
     RateLimiter::ModelInstance* allocated_instance = nullptr;
     state.store(SchedState::RETRIEVING_REQUEST);
 
-    while (state != READY_FOR_NEW_REQUESTS && !scheduler_thread_exit_.load()) {
+    while ((state != READY_FOR_NEW_REQUESTS) &&
+           (!scheduler_thread_exit_.load())) {
       switch (state.load()) {
         case SchedState::RETRIEVING_REQUEST: {
           uint64_t wait_microseconds = 0;

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -149,10 +149,7 @@ DynamicBatchScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
       request->QueueStartNs());
 
   Status enqueue_status;
-  // If dynamic batching is not enabled the schduler thread should be woken up
-  // with every request. Each request will be enqueued on the rate limiter to
-  // be scheduled whenever conditions are met.
-  bool wake_sched_thread = (!dynamic_batching_enabled_);
+  bool wake_sched_thread = false;
   {
     std::lock_guard<std::mutex> lock(mu_);
 
@@ -162,18 +159,16 @@ DynamicBatchScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
     // 'request' and so we can't use it after this point.
     RETURN_IF_ERROR(queue_.Enqueue(request->Priority(), request));
 
-    if (dynamic_batching_enabled_) {
-      // If there are any idle model instance and the queued batch size is
-      // greater or equal to next preferred batch size, then wake scheduler
-      // thread up to service this request. We do the actual wake outside of the
-      // lock to avoid having the woken thread immediately block on the lock
-      wake_sched_thread = (rate_limiter_->AvailableInstanceCount(model_) > 0);
+    // If there are any idle model instance and the queued batch size is
+    // greater or equal to next preferred batch size, then wake scheduler
+    // thread up to service this request. We do the actual wake outside of the
+    // lock to avoid having the woken thread immediately block on the lock
+    wake_sched_thread = (rate_limiter_->AvailableInstanceCount(model_) > 0);
 
-      // We may wake up scheduler thread less often if we don't enforce equal
-      // shape within a batch, otherwise must always wake up runner to check it
-      if (enforce_equal_shape_tensors_.empty()) {
-        wake_sched_thread &= (queued_batch_size_ >= next_preferred_batch_size_);
-      }
+    // We may wake up scheduler thread less often if we don't enforce equal
+    // shape within a batch, otherwise must always wake up runner to check it
+    if (enforce_equal_shape_tensors_.empty()) {
+      wake_sched_thread &= (queued_batch_size_ >= next_preferred_batch_size_);
     }
   }
 
@@ -251,7 +246,13 @@ DynamicBatchScheduler::SchedulerThread(
 
   const uint64_t default_wait_microseconds = 500 * 1000;
 
-  std::atomic<bool> pending_request_rate_limiter{false};
+  enum SchedState {
+    RETRIEVING_REQUEST = 0,
+    REQUESTED_MODEL_INSTANCE = 1,
+    RECEIVED_MODEL_INSTANCE = 2,
+    READY_FOR_NEW_REQUESTS = 3
+  };
+  std::atomic<SchedState> state{SchedState::RETRIEVING_REQUEST};
 
   while (!scheduler_thread_exit_.load()) {
     NVTX_RANGE(nvtx_, "DynamicBatchScheduler " + model_->Name());
@@ -259,161 +260,203 @@ DynamicBatchScheduler::SchedulerThread(
     std::vector<std::unique_ptr<InferenceRequest>> requests;
     std::shared_ptr<std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>
         rejected_requests;
-    uint64_t wait_microseconds = 0;
+    RateLimiter::ModelInstance* allocated_instance = nullptr;
+    state.store(SchedState::RETRIEVING_REQUEST);
 
-    // Hold the lock for as short a time as possible.
-    {
-      std::unique_lock<std::mutex> lock(mu_);
-      if (delay_cnt > 0) {
-        // Debugging/testing... wait until queue contains 'delay_cnt'
-        // items...
-        wait_microseconds = 10 * 1000;
-        if (queue_.Size() >= delay_cnt) {
-          delay_cnt = 0;
-        }
-        LOG_VERBOSE(1) << "Delaying scheduler thread for " << model_->Name()
-                       << " until " << delay_cnt
-                       << " queued requests, current total = " << queue_.Size();
-      } else if (queue_.Empty()) {
-        wait_microseconds = default_wait_microseconds;
-      } else if (dynamic_batching_enabled_) {
-        // TODO: This method of blocking the scheduler thread till last request
-        // is not scheduled by the rate limiter does not ensure the batched
-        // request is largest possible. There might be new requests queued on
-        // scheduler while rate limiter deferred the execution on model
-        // instance.
-        //
-        // For dynamic batching if there are no available model instance to
-        // allocate or there is already a request pending to be scheduled by the
-        // rate limiter then block the scheduler thread. This is done to allow
-        // dynamic batcher issue a request with largest batchsize.
-        auto ublock_scheduler = [this,
-                                 &pending_request_rate_limiter]() -> bool {
-          return !(
-              (this->rate_limiter_->AvailableInstanceCount(model_) == 0) ||
-              (pending_request_rate_limiter.load()));
-        };
-        cv_.wait(lock, ublock_scheduler);
-        // Use dynamic batching to get request(s) to execute.
-        wait_microseconds = GetDynamicBatch();
+    while (state != READY_FOR_NEW_REQUESTS && !scheduler_thread_exit_.load()) {
+      switch (state.load()) {
+        case SchedState::RETRIEVING_REQUEST: {
+          uint64_t wait_microseconds = 0;
 
-        // Get requests that are rejected from searching dynamic batch.
-        queue_.ReleaseRejectedRequests(&rejected_requests);
+          // Hold the lock for as short a time as possible.
+          {
+            std::unique_lock<std::mutex> lock(mu_);
+            if (delay_cnt > 0) {
+              // Debugging/testing... wait until queue contains 'delay_cnt'
+              // items...
+              wait_microseconds = 10 * 1000;
+              if (queue_.Size() >= delay_cnt) {
+                delay_cnt = 0;
+              }
+              LOG_VERBOSE(1)
+                  << "Delaying scheduler thread for " << model_->Name()
+                  << " until " << delay_cnt
+                  << " queued requests, current total = " << queue_.Size();
+            } else if (queue_.Empty()) {
+              wait_microseconds = default_wait_microseconds;
+            } else if (dynamic_batching_enabled_) {
+              // Blocking scheduler thread till there is an instance available
+              // with rate limiter. This is done to ensure the batch size of
+              // the request is as large as possible. Unfortunately, this
+              // does not ensure RateLimiter is able to allocate the instance
+              // right away.
+              auto instance_available = [this]() -> bool {
+                return !(
+                    this->scheduler_thread_exit_.load() ||
+                    (this->rate_limiter_->AvailableInstanceCount(model_) == 0));
+              };
+              cv_.wait(lock, instance_available);
+              // Use dynamic batching to get request(s) to execute.
+              wait_microseconds = GetDynamicBatch();
 
-        // Extract batch only if there is pending batch
-        auto pending_batch_queue_cnt = queue_.PendingBatchCount();
-        if ((wait_microseconds == 0) && (pending_batch_queue_cnt != 0)) {
-          requests.reserve(pending_batch_queue_cnt);
-          for (size_t idx = 0; idx < pending_batch_queue_cnt; ++idx) {
-            std::unique_ptr<InferenceRequest> request;
-            auto status = queue_.Dequeue(&request);
-            if (status.IsOk()) {
-              requests.emplace_back(std::move(request));
-            } else {
-              // The queue is empty which conflicts with pending batch count.
-              // Send the current batch if any and reset related variables.
-              LOG_ERROR << "Failed to retrieve request from scheduler queue: "
+              // Get requests that are rejected from searching dynamic batch.
+              queue_.ReleaseRejectedRequests(&rejected_requests);
+
+              // Extract batch only if there is pending batch
+              auto pending_batch_queue_cnt = queue_.PendingBatchCount();
+              if ((wait_microseconds == 0) && (pending_batch_queue_cnt != 0)) {
+                requests.reserve(pending_batch_queue_cnt);
+                for (size_t idx = 0; idx < pending_batch_queue_cnt; ++idx) {
+                  std::unique_ptr<InferenceRequest> request;
+                  auto status = queue_.Dequeue(&request);
+                  if (status.IsOk()) {
+                    requests.emplace_back(std::move(request));
+                  } else {
+                    // The queue is empty which conflicts with pending batch
+                    // count. Send the current batch if any and reset related
+                    // variables.
+                    LOG_ERROR
+                        << "Failed to retrieve request from scheduler queue: "
                         << status.Message();
-              queue_.ResetCursor();
-              queued_batch_size_ = 0;
-              pending_batch_size_ = 0;
-              break;
+                    queue_.ResetCursor();
+                    queued_batch_size_ = 0;
+                    pending_batch_size_ = 0;
+                    break;
+                  }
+                }
+                if (preserve_ordering_ && !requests.empty()) {
+                  std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+                  for (auto& request : requests) {
+                    completion_queue_.emplace_back();
+                    auto queue_slot = &completion_queue_.back();
+                    request->SetResponseDelegator(
+                        [this, queue_slot](
+                            std::unique_ptr<InferenceResponse>&& response,
+                            const uint32_t flags) {
+                          {
+                            std::lock_guard<std::mutex> lock(
+                                completion_queue_mtx_);
+                            queue_slot->emplace_back(
+                                std::move(response), flags);
+                          }
+                          FinalizeResponses();
+                        });
+                  }
+                }
+
+                queued_batch_size_ -= pending_batch_size_;
+                // Set next preferred to be 0 so that enqueue thread will wake
+                // up runners when new request arrives. In the case where the
+                // queue becomes empty, this helps the runners to set up proper
+                // wait time instead of waiting for the default timer or actual
+                // next preferred batch size is reached.
+                next_preferred_batch_size_ = 0;
+
+                pending_batch_size_ = 0;
+                required_equal_inputs_.clear();
+              }
+            } else {
+              // No batching... execute next request
+              std::unique_ptr<InferenceRequest> request;
+              auto status = queue_.Dequeue(&request);
+              if (status.IsOk()) {
+                requests.emplace_back(std::move(request));
+                if (preserve_ordering_) {
+                  std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+                  for (auto& request : requests) {
+                    completion_queue_.emplace_back();
+                    auto queue_slot = &completion_queue_.back();
+                    request->SetResponseDelegator(
+                        [this, queue_slot](
+                            std::unique_ptr<InferenceResponse>&& response,
+                            const uint32_t flags) {
+                          {
+                            std::lock_guard<std::mutex> lock(
+                                completion_queue_mtx_);
+                            queue_slot->emplace_back(
+                                std::move(response), flags);
+                          }
+                          FinalizeResponses();
+                        });
+                  }
+                }
+              } else {
+                LOG_ERROR << "Failed to retrieve request from scheduler queue: "
+                          << status.Message();
+              }
             }
-          }
-          if (preserve_ordering_ && !requests.empty()) {
-            std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-            for (auto& request : requests) {
-              completion_queue_.emplace_back();
-              auto queue_slot = &completion_queue_.back();
-              request->SetResponseDelegator(
-                  [this, queue_slot](
-                      std::unique_ptr<InferenceResponse>&& response,
-                      const uint32_t flags) {
-                    {
-                      std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-                      queue_slot->emplace_back(std::move(response), flags);
-                    }
-                    FinalizeResponses();
-                  });
+
+            // If no requests are to be handled, wait for notification or
+            // for the specified timeout before checking the queue again.
+            if (wait_microseconds > 0) {
+              std::chrono::microseconds wait_timeout(wait_microseconds);
+              cv_.wait_for(lock, wait_timeout);
             }
           }
 
-          queued_batch_size_ -= pending_batch_size_;
-          // Set next preferred to be 0 so that enqueue thread will wake up
-          // runners when new request arrives. In the case where the queue
-          // becomes empty, this helps the runners to set up proper wait time
-          // instead of waiting for the default timer or actual next preferred
-          // batch size is reached.
-          next_preferred_batch_size_ = 0;
+          if (!requests.empty()) {
+            auto sched_cb = [this, &state, &allocated_instance](
+                                RateLimiter::ModelInstance* mi) {
+              allocated_instance = mi;
+              state.store(SchedState::RECEIVED_MODEL_INSTANCE);
+              this->cv_.notify_all();
+            };
+            state.store(SchedState::REQUESTED_MODEL_INSTANCE);
+            rate_limiter_->RequestModelInstance(sched_cb, model_);
 
-          pending_batch_size_ = 0;
-          required_equal_inputs_.clear();
+            // FIXME: This should not be valid anymore.
+            // For testing we introduce a delay here to make the
+            // "DynamicBatchScheduler destroyed by this thread" case
+            // described in the comment below reproducible.
+            if (backend_release_wait_milliseconds > 0) {
+              std::this_thread::sleep_for(
+                  std::chrono::milliseconds(backend_release_wait_milliseconds));
+            }
+          }
+
+          // Finish rejected requests if any
+          if (rejected_requests != nullptr) {
+            static Status rejected_status =
+                Status(Status::Code::UNAVAILABLE, "Request timeout expired");
+            for (auto& rejected_queue : *rejected_requests) {
+              for (auto& rejected_request : rejected_queue) {
+                InferenceRequest::RespondIfError(
+                    rejected_request, rejected_status, true);
+              }
+            }
+          }
+          break;
         }
-      } else {
-        // No batching... execute next request
-        std::unique_ptr<InferenceRequest> request;
-        auto status = queue_.Dequeue(&request);
-        if (status.IsOk()) {
-          requests.emplace_back(std::move(request));
-          if (preserve_ordering_) {
-            std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-            for (auto& request : requests) {
-              completion_queue_.emplace_back();
-              auto queue_slot = &completion_queue_.back();
-              request->SetResponseDelegator(
-                  [this, queue_slot](
-                      std::unique_ptr<InferenceResponse>&& response,
-                      const uint32_t flags) {
-                    {
-                      std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-                      queue_slot->emplace_back(std::move(response), flags);
-                    }
-                    FinalizeResponses();
-                  });
-            }
+        case SchedState::REQUESTED_MODEL_INSTANCE: {
+          // The control will reach this block iff rate limiter could not
+          // allocate a model instance to run inference. In such cases we will
+          // block the scheduler thread till a model instance is received by
+          // rate limiter.
+          // TODO: This method of blocking scheduler thread is a nice
+          // approximation to improve the possibility of forming larger batch
+          // sizes for next requests, however a better approach will be to try
+          // to grow size of the current batch itself using any newly arrived
+          // requests. Also there might be some requests in the current deferred
+          // batch that must be rejected but currently isn't.
+          {
+            std::unique_lock<std::mutex> lock(mu_);
+            auto received_instance = [this, &state]() -> bool {
+              return (!this->scheduler_thread_exit_.load()) &&
+                     (state.load() == SchedState::RECEIVED_MODEL_INSTANCE);
+            };
+            cv_.wait(lock, received_instance);
           }
-        } else {
-          LOG_ERROR << "Failed to retrieve request from scheduler queue: "
-                    << status.Message();
+          break;
         }
-      }
-
-      // If no requests are to be handled, wait for notification or
-      // for the specified timeout before checking the queue again.
-      if (wait_microseconds > 0) {
-        std::chrono::microseconds wait_timeout(wait_microseconds);
-        cv_.wait_for(lock, wait_timeout);
-      }
-    }
-
-    if (!requests.empty()) {
-      auto sched_cb = [this, &requests, &pending_request_rate_limiter](
-                          RateLimiter::ModelInstance* mi) {
-        mi->ScheduleNow(std::move(requests));
-        pending_request_rate_limiter.store(false);
-        this->cv_.notify_all();
-      };
-      pending_request_rate_limiter.store(true);
-      rate_limiter_->RequestModelInstance(sched_cb, model_);
-
-      // FIXME: This should not be valid anymore.
-      // For testing we introduce a delay here to make the
-      // "DynamicBatchScheduler destroyed by this thread" case
-      // described in the comment below reproducible.
-      if (backend_release_wait_milliseconds > 0) {
-        std::this_thread::sleep_for(
-            std::chrono::milliseconds(backend_release_wait_milliseconds));
-      }
-    }
-
-    // Finish rejected requests if any
-    if (rejected_requests != nullptr) {
-      static Status rejected_status =
-          Status(Status::Code::UNAVAILABLE, "Request timeout expired");
-      for (auto& rejected_queue : *rejected_requests) {
-        for (auto& rejected_request : rejected_queue) {
-          InferenceRequest::RespondIfError(
-              rejected_request, rejected_status, true);
+        case SchedState::RECEIVED_MODEL_INSTANCE: {
+          // Schedule the request on allocated model instance
+          allocated_instance->ScheduleNow(std::move(requests));
+          allocated_instance = nullptr;
+          state.store(SchedState::READY_FOR_NEW_REQUESTS);
+          break;
+        }
+        case SchedState::READY_FOR_NEW_REQUESTS: {
+          break;
         }
       }
     }

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -103,7 +103,7 @@ class DynamicBatchScheduler : public Scheduler {
   std::thread scheduler_thread_;
   std::atomic<bool> scheduler_thread_exit_;
 
-  // Mutex and condvar for signalling scheduler thread
+  // Mutex and condvar for signaling scheduler thread
   std::mutex mu_;
   std::condition_variable cv_;
 

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -431,12 +431,7 @@ RateLimiter::ModelInstance::ScheduleNow(
 {
   executed_ = (!requests.empty());
   auto OnCompletion = [this]() { this->Release(); };
-  auto status =
-      triton_model_instance_->Schedule(std::move(requests), OnCompletion);
-  if (!status.IsOk()) {
-    LOG_ERROR << "Error encountered when scheduling request on model instance: "
-              << status.Message();
-  }
+  triton_model_instance_->Schedule(std::move(requests), OnCompletion);
 }
 
 void


### PR DESCRIPTION
…duler

Adds the TritonBackendThread implementation within TritonModelInstances. This does not implement DEVICE_BLOCKING yet. For instance_count > 1, the BackendThread corresponding to ModelInstance will be used to call model Initialize, WarmUp and Schedule.

Also fixed the dynamic batch scheduler to ensure the scheduler thread corresponding to the same TritonModel gets to run its inference everytime. I have successfully done some functional testing and am looking on the affect on performance of this new threading model on non-TRT backends.