### PR TITLE
Add support for DLA in TensorRT backend

### DIFF
--- a/qa/L0_trt_dla/test.sh
+++ b/qa/L0_trt_dla/test.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
+if [ "$#" -ge 1 ]; then
+    REPO_VERSION=$1
+fi
+if [ -z "$REPO_VERSION" ]; then
+    echo -e "Repository version must be specified"
+    echo -e "\n***\n*** Test Failed\n***"
+    exit 1
+fi
+
+export CUDA_VISIBLE_DEVICES=0
+
+# Need to run on only one device since only creating a single
+# PLAN. Without this test will fail on a heterogeneous system.
+export CUDA_VISIBLE_DEVICES=0
+
+IMAGE_CLIENT=../clients/image_client
+IMAGE=../images/vulture.jpeg
+
+CAFFE2PLAN=../common/caffe2plan
+
+DATADIR=${DATADIR:="/data/inferenceserver/${REPO_VERSION}"}
+OPTDIR=${OPTDIR:="/opt"}
+SERVER=${OPTDIR}/tritonserver/bin/tritonserver
+BACKEND_DIR=${OPTDIR}/tritonserver/backends
+
+SERVER_ARGS="--model-repository=`pwd`/models --exit-timeout-secs=120 --backend-directory=${BACKEND_DIR}"
+SERVER_LOG="./inference_server.log"
+source ../common/util.sh
+
+rm -fr models && mkdir models 
+cp -r $DATADIR/caffe_models/trt_model_store/resnet50_plan models/.
+rm -f *.log
+
+set +e
+
+# Create the PLAN file
+mkdir -p models/resnet50_plan/1 && rm -f models/resnet50_plan/1/model.plan && \
+    $CAFFE2PLAN -b32 -n prob -o models/resnet50_plan/1/model.plan \
+                $DATADIR/caffe_models/resnet50_dla.prototxt $DATADIR/caffe_models/resnet50.caffemodel
+if [ $? -ne 0 ]; then
+    echo -e "\n***\n*** Failed to generate resnet50 DLA compatible PLAN\n***"
+    exit 1
+fi
+
+set -e
+
+# Enable NVDLA by specifying secondary devices in instance group
+echo "instance_group [{" >> models/resnet50_plan/config.pbtxt
+echo "    kind: KIND_GPU" >> models/resnet50_plan/config.pbtxt
+echo "    secondary_devices [{" >> models/resnet50_plan/config.pbtxt
+echo "          kind: KIND_NVDLA " >> models/resnet50_plan/config.pbtxt
+echo "          device_id: 0" >> models/resnet50_plan/config.pbtxt
+echo "    }]" >> models/resnet50_plan/config.pbtxt
+echo "}]" >> models/resnet50_plan/config.pbtxt
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+RET=0
+
+set +e
+
+CLIENT_LOG=${IMAGE_CLIENT##*/}.log
+
+echo "Model: resnet50_plan" >> $CLIENT_LOG
+$IMAGE_CLIENT $EXTRA_ARGS -m resnet50_plan -s VGG -c 1 -b 1 $IMAGE >> $CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    RET=1
+fi
+
+if [ `grep -c VULTURE $CLIENT_LOG` != "1" ]; then
+    echo -e "\n***\n*** Failed. Expected 1 VULTURE results\n***"
+    RET=1
+fi
+
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+rm -rf models
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/qa/L0_trt_dla/test.sh
+++ b/qa/L0_trt_dla/test.sh
@@ -56,30 +56,10 @@ SERVER_LOG="./inference_server.log"
 source ../common/util.sh
 
 rm -fr models && mkdir models 
-cp -r $DATADIR/caffe_models/trt_model_store/resnet50_plan models/.
+cp -r $DATADIR/trt_dla_model_store/resnet50_plan models/.
 rm -f *.log
 
 set +e
-
-# Create the PLAN file
-mkdir -p models/resnet50_plan/1 && rm -f models/resnet50_plan/1/model.plan && \
-    $CAFFE2PLAN -b32 -n prob -o models/resnet50_plan/1/model.plan \
-                $DATADIR/caffe_models/resnet50_dla.prototxt $DATADIR/caffe_models/resnet50.caffemodel
-if [ $? -ne 0 ]; then
-    echo -e "\n***\n*** Failed to generate resnet50 DLA compatible PLAN\n***"
-    exit 1
-fi
-
-set -e
-
-# Enable NVDLA by specifying secondary devices in instance group
-echo "instance_group [{" >> models/resnet50_plan/config.pbtxt
-echo "    kind: KIND_GPU" >> models/resnet50_plan/config.pbtxt
-echo "    secondary_devices [{" >> models/resnet50_plan/config.pbtxt
-echo "          kind: KIND_NVDLA " >> models/resnet50_plan/config.pbtxt
-echo "          device_id: 0" >> models/resnet50_plan/config.pbtxt
-echo "    }]" >> models/resnet50_plan/config.pbtxt
-echo "}]" >> models/resnet50_plan/config.pbtxt
 
 run_server
 if [ "$SERVER_PID" == "0" ]; then

--- a/src/backends/tensorrt/autofill.cc
+++ b/src/backends/tensorrt/autofill.cc
@@ -471,7 +471,7 @@ AutoFillPlan::Create(
     }
     std::vector<char> plan_data(plan_data_str.begin(), plan_data_str.end());
 
-    if (!LoadPlan(plan_data, &runtime, &engine).IsOk()) {
+    if (!LoadPlan(plan_data, -1 /* dla_core_id */, &runtime, &engine).IsOk()) {
       if (engine != nullptr) {
         engine->destroy();
         engine = nullptr;

--- a/src/backends/tensorrt/loader.cc
+++ b/src/backends/tensorrt/loader.cc
@@ -45,18 +45,18 @@ LoadPlan(
       return Status(
           Status::Code::INTERNAL, "unable to create TensorRT runtime");
     }
-  }
 
-  // If there are no DLA cores or dla_core_id < number of DLA cores report error
-  if (dla_core_id != -1) {
-    if (dla_core_id < (*runtime)->getNbDLACores()) {
-      (*runtime)->setDLACore(dla_core_id);
-    } else {
-      return Status(
-          Status::Code::INVALID_ARG,
-          ("unable to create TensorRT runtime with DLA Core ID: " +
-           std::to_string(dla_core_id))
-              .c_str());
+    // Report error if 'dla_core_id' >= number of DLA cores
+    if (dla_core_id != -1) {
+      if (dla_core_id < (*runtime)->getNbDLACores()) {
+        (*runtime)->setDLACore(dla_core_id);
+      } else {
+        return Status(
+            Status::Code::INVALID_ARG,
+            ("unable to create TensorRT runtime with DLA Core ID: " +
+             std::to_string(dla_core_id))
+                .c_str());
+      }
     }
   }
 

--- a/src/backends/tensorrt/loader.cc
+++ b/src/backends/tensorrt/loader.cc
@@ -35,8 +35,8 @@ namespace nvidia { namespace inferenceserver {
 
 Status
 LoadPlan(
-    const std::vector<char>& model_data, nvinfer1::IRuntime** runtime,
-    nvinfer1::ICudaEngine** engine, int32_t dla_core_id)
+    const std::vector<char>& model_data, int64_t dla_core_id,
+    nvinfer1::IRuntime** runtime, nvinfer1::ICudaEngine** engine)
 {
   // Create runtime only if it is not provided
   if (*runtime == nullptr) {

--- a/src/backends/tensorrt/loader.cc
+++ b/src/backends/tensorrt/loader.cc
@@ -51,9 +51,10 @@ LoadPlan(
   if (dla_core_id != -1) {
     if (dla_core_id < (*runtime)->getNbDLACores()) {
       (*runtime)->setDLACore(dla_core_id);
+    } else {
       return Status(
           Status::Code::INTERNAL,
-          ("unable to create TensorRT runtime with invalid DLA Core Id: " +
+          ("unable to create TensorRT runtime with DLA Core ID: " +
            std::to_string(dla_core_id))
               .c_str());
     }

--- a/src/backends/tensorrt/loader.cc
+++ b/src/backends/tensorrt/loader.cc
@@ -53,7 +53,7 @@ LoadPlan(
       (*runtime)->setDLACore(dla_core_id);
     } else {
       return Status(
-          Status::Code::INTERNAL,
+          Status::Code::INVALID_ARG,
           ("unable to create TensorRT runtime with DLA Core ID: " +
            std::to_string(dla_core_id))
               .c_str());

--- a/src/backends/tensorrt/loader.h
+++ b/src/backends/tensorrt/loader.h
@@ -41,9 +41,11 @@ namespace nvidia { namespace inferenceserver {
 /// to create
 /// \param engine Returns the ICudaEngine object, or nullptr if failed
 /// to create
+/// \param dla_core_id The DLA core to use for this runtime. Defaults to -1
+/// and does not use DLA when set to -1.
 /// \return Error status.
 Status LoadPlan(
     const std::vector<char>& model_data, nvinfer1::IRuntime** runtime,
-    nvinfer1::ICudaEngine** engine);
+    nvinfer1::ICudaEngine** engine, int32_t dla_core_id = -1);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/backends/tensorrt/loader.h
+++ b/src/backends/tensorrt/loader.h
@@ -36,16 +36,16 @@ namespace nvidia { namespace inferenceserver {
 /// responsibility to destroy any returned runtime or engine object
 /// even if an error is returned.
 ///
-/// \param model_data The binary blob of the plan data
+/// \param model_data The binary blob of the plan data.
+/// \param dla_core_id The DLA core to use for this runtime. Does not
+/// use DLA when set to -1.
 /// \param runtime Returns the IRuntime object, or nullptr if failed
-/// to create
+/// to create.
 /// \param engine Returns the ICudaEngine object, or nullptr if failed
-/// to create
-/// \param dla_core_id The DLA core to use for this runtime. Defaults to -1
-/// and does not use DLA when set to -1.
+/// to create.
 /// \return Error status.
 Status LoadPlan(
-    const std::vector<char>& model_data, nvinfer1::IRuntime** runtime,
-    nvinfer1::ICudaEngine** engine, int32_t dla_core_id = -1);
+    const std::vector<char>& model_data, int64_t dla_core_id,
+    nvinfer1::IRuntime** runtime, nvinfer1::ICudaEngine** engine);
 
 }}  // namespace nvidia::inferenceserver

--- a/src/backends/tensorrt/plan_backend.cc
+++ b/src/backends/tensorrt/plan_backend.cc
@@ -291,7 +291,7 @@ PlanBackend::CreateExecutionContexts(
     }
 
     // Use DLA core id or GPU id from config based on instance group type
-    int32_t dla_core_id = -1;
+    int64_t dla_core_id = -1;
     uint32_t secondary_device_count = group.secondary_devices().size();
     if (secondary_device_count != 0) {
       if (secondary_device_count != 1) {
@@ -392,7 +392,8 @@ PlanBackend::CreateExecutionContexts(
           }
 
           RETURN_IF_ERROR(LoadPlan(
-              mn_itr->second, &eit->second.first, &eit->second.second));
+              mn_itr->second, dla_core_id, &eit->second.first,
+              &eit->second.second));
 
           // Validate whether the engine can be shared
           bool is_dynamic = false;
@@ -585,7 +586,7 @@ PlanBackend::Context::InitOptimizationProfiles(
 Status
 PlanBackend::CreateExecutionContext(
     const std::string& instance_name, const int gpu_device,
-    const int dla_core_id, const std::vector<char>& model,
+    const int64_t dla_core_id, const std::vector<char>& model,
     const ::google::protobuf::RepeatedPtrField<std::string>& profile_names,
     const std::shared_ptr<triton::common::SyncQueue<size_t>>& context_queue)
 {
@@ -649,7 +650,8 @@ PlanBackend::CreateExecutionContext(
   auto eit = device_engines_.find(device_pair);
   if (eit->second.second == nullptr) {
     context->is_shared_engine_ = false;
-    RETURN_IF_ERROR(LoadPlan(model, &eit->second.first, &context->engine_));
+    RETURN_IF_ERROR(
+        LoadPlan(model, dla_core_id, &eit->second.first, &context->engine_));
   } else {
     context->engine_ = eit->second.second;
   }

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -60,7 +60,7 @@ class PlanBackend : public InferenceBackend {
       const std::unordered_map<std::string, std::vector<char>>& models);
   Status CreateExecutionContext(
       const std::string& instance_name, const int gpu_device,
-      const int dla_core_id, const std::vector<char>& models,
+      const int64_t dla_core_id, const std::vector<char>& models,
       const ::google::protobuf::RepeatedPtrField<std::string>& profile_names,
       const std::shared_ptr<triton::common::SyncQueue<size_t>>& context_queue);
 
@@ -430,10 +430,11 @@ class PlanBackend : public InferenceBackend {
     bool eager_batching_;
   };
 
-  // CUDA engine shared across all model instances using the same DLA core on
-  // same GPU.
+  // CUDA engine shared across all model instances using the same (or no) DLA
+  // core on same GPU. The first element in the key pair is the GPU ID, the
+  // second is the DLA core ID.
   std::map<
-      std::pair<int, int>,
+      std::pair<int, int64_t>,
       std::pair<nvinfer1::IRuntime*, nvinfer1::ICudaEngine*>>
       device_engines_;
 

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -28,10 +28,10 @@
 #include <NvInfer.h>
 #include <cuda_runtime_api.h>
 #include <thread>
+#include "model_config.pb.h"
 #include "src/core/backend.h"
 #include "src/core/backend_context.h"
 #include "src/core/metric_model_reporter.h"
-#include "model_config.pb.h"
 #include "src/core/scheduler.h"
 #include "src/core/status.h"
 #include "triton/common/sync_queue.h"
@@ -60,7 +60,7 @@ class PlanBackend : public InferenceBackend {
       const std::unordered_map<std::string, std::vector<char>>& models);
   Status CreateExecutionContext(
       const std::string& instance_name, const int gpu_device,
-      const std::vector<char>& models,
+      const int dla_core_id, const std::vector<char>& models,
       const ::google::protobuf::RepeatedPtrField<std::string>& profile_names,
       const std::shared_ptr<triton::common::SyncQueue<size_t>>& context_queue);
 
@@ -430,9 +430,16 @@ class PlanBackend : public InferenceBackend {
     bool eager_batching_;
   };
 
-  // CUDA engine shared across all model instances on the same device.
+  // CUDA engine shared across all model instances on the same GPU.
   std::map<int, std::pair<nvinfer1::IRuntime*, nvinfer1::ICudaEngine*>>
-      device_engines_;
+      gpu_engines_;
+
+  // CUDA engine shared across all model instances using the same DLA core on
+  // same GPU.
+  std::map<
+      std::pair<int, int>,
+      std::pair<nvinfer1::IRuntime*, nvinfer1::ICudaEngine*>>
+      dla_engines_;
 
   // vector for storing available context queue associated with a runner
   std::vector<std::shared_ptr<triton::common::SyncQueue<size_t>>>

--- a/src/backends/tensorrt/plan_backend.h
+++ b/src/backends/tensorrt/plan_backend.h
@@ -430,16 +430,12 @@ class PlanBackend : public InferenceBackend {
     bool eager_batching_;
   };
 
-  // CUDA engine shared across all model instances on the same GPU.
-  std::map<int, std::pair<nvinfer1::IRuntime*, nvinfer1::ICudaEngine*>>
-      gpu_engines_;
-
   // CUDA engine shared across all model instances using the same DLA core on
   // same GPU.
   std::map<
       std::pair<int, int>,
       std::pair<nvinfer1::IRuntime*, nvinfer1::ICudaEngine*>>
-      dla_engines_;
+      device_engines_;
 
   // vector for storing available context queue associated with a runner
   std::vector<std::shared_ptr<triton::common::SyncQueue<size_t>>>

--- a/src/backends/tensorrt/plan_backend_factory.cc
+++ b/src/backends/tensorrt/plan_backend_factory.cc
@@ -31,11 +31,11 @@
 #include <vector>
 
 #include <NvInferPlugin.h>
+#include "model_config.pb.h"
 #include "src/backends/tensorrt/logging.h"
 #include "src/core/constants.h"
 #include "src/core/filesystem.h"
 #include "src/core/logging.h"
-#include "model_config.pb.h"
 #include "src/core/model_config_utils.h"
 
 namespace nvidia { namespace inferenceserver {

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -1544,7 +1544,8 @@ ValidateModelConfigInt64()
       "ModelConfig::model_warmup::inputs::value::dims",
       "ModelConfig::optimization::cuda::graph_spec::input::value::dim",
       "ModelConfig::optimization::cuda::graph_spec::graph_lower_bound::input::"
-      "value::dim"};
+      "value::dim",
+      "ModelConfig::instance_group::secondary_devices::device_id"};
 
   if (int64_fields != expected) {
     return Status(


### PR DESCRIPTION
TODO: When moving to separate repo and new Backend API the parallel changes need also to be made

Must add secondary devices to model config to specify that the model should use DLA as shown below:
```
instance_group [
  {
    kind: KIND_GPU
    secondary_devices [
      {
          kind: KIND_NVDLA 
          device_id: 1
      }
    ]
  }
]
```

When launched on a machine with no DLA cores, Triton reports the following error
```
+----------------+---------+--------------------------------------------------------------------------------------+
| Model          | Version | Status                                                                               |
+----------------+---------+--------------------------------------------------------------------------------------+
| resnet50_plan  | 1       | UNAVAILABLE: Internal: unable to create TensorRT runtime with DLA Core ID: 1         |
+----------------+---------+--------------------------------------------------------------------------------------+
```
