### PR TITLE
convert Millis to Nanoseconds for correct comparison.

### DIFF
--- a/src/core/filesystem.cc
+++ b/src/core/filesystem.cc
@@ -1470,7 +1470,7 @@ S3FileSystem::FileModificationTime(const std::string& path, int64_t* mtime_ns)
   // If request succeeds, copy over the modification time
   auto head_object_outcome = client_.HeadObject(head_request);
   if (head_object_outcome.IsSuccess()) {
-    *mtime_ns = head_object_outcome.GetResult().GetLastModified().Millis();
+    *mtime_ns = head_object_outcome.GetResult().GetLastModified().Millis()*1000000;
   } else {
     return Status(
         Status::Code::INTERNAL,


### PR DESCRIPTION
Fixes [issue #2853](https://github.com/triton-inference-server/server/issues/2853) which was prematurely closed 