### PR TITLE
Remove NVML linking from entrypoint script

### DIFF
--- a/nvidia_entrypoint.sh
+++ b/nvidia_entrypoint.sh
@@ -34,7 +34,7 @@ cat <<EOF
 
 NVIDIA Release ${NVIDIA_TRITON_SERVER_VERSION} (build ${NVIDIA_BUILD_ID})
 
-Copyright (c) 2018-21, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+Copyright (c) 2018-2021, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 
 Various files include modifications (c) NVIDIA CORPORATION.  All rights reserved.
 

--- a/nvidia_entrypoint.sh
+++ b/nvidia_entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/nvidia_entrypoint.sh
+++ b/nvidia_entrypoint.sh
@@ -34,7 +34,7 @@ cat <<EOF
 
 NVIDIA Release ${NVIDIA_TRITON_SERVER_VERSION} (build ${NVIDIA_BUILD_ID})
 
-Copyright (c) 2018-2021, NVIDIA CORPORATION.  All rights reserved.
+Copyright (c) 2018-21, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 
 Various files include modifications (c) NVIDIA CORPORATION.  All rights reserved.
 
@@ -48,7 +48,6 @@ if [[ "$(find -L /usr -name libcuda.so.1 | grep -v "compat") " == " " || "$(ls /
   echo "WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available."
   echo "   Use Docker with NVIDIA Container Toolkit to start this container; see"
   echo "   https://github.com/NVIDIA/nvidia-docker."
-  ln -s `find / -name libnvidia-ml.so -print -quit` /opt/tritonserver/lib/libnvidia-ml.so.1
   export TRITON_SERVER_CPU_ONLY=1
 else
   ( /usr/local/bin/checkSMVER.sh )


### PR DESCRIPTION
Remove NVM linking. Since we have moved off of NVML to DCGM, we do not need 
special linking in entry script. 
This PR should merge after https://github.com/triton-inference-server/server/pull/2924
Solves https://github.com/triton-inference-server/server/issues/2600