### PR TITLE
Fix cuda memory manager destructor when not initialized

### DIFF
--- a/src/core/cuda_memory_manager.cc
+++ b/src/core/cuda_memory_manager.cc
@@ -61,10 +61,12 @@ std::mutex CudaMemoryManager::instance_mu_;
 
 CudaMemoryManager::~CudaMemoryManager()
 {
-  auto status = cnmemFinalize();
-  if (status != CNMEM_STATUS_SUCCESS) {
-    LOG_ERROR << "Failed to finalize CUDA memory manager: [" << status << "] "
-              << cnmemGetErrorString(status);
+  if (has_allocation_) {
+    auto status = cnmemFinalize();
+    if (status != CNMEM_STATUS_SUCCESS) {
+      LOG_ERROR << "Failed to finalize CUDA memory manager: [" << status << "] "
+                << cnmemGetErrorString(status);
+    }
   }
 }
 


### PR DESCRIPTION
- cnmem is not initialized when memory pool sizes are 0