### PR TITLE
Fix classification label error

### DIFF
--- a/src/servers/classification.cc
+++ b/src/servers/classification.cc
@@ -56,7 +56,7 @@ AddClassResults(
 
     const char* label;
     RETURN_IF_ERR(TRITONSERVER_InferenceResponseOutputClassificationLabel(
-        response, output_idx, idx[k], &label));
+        response, output_idx, k, &label));
     if (label != nullptr) {
       class_strs->back() += ":";
       class_strs->back().append(label);


### PR DESCRIPTION
I believe the class name lookup should be indexed by class instead of the global index in the probabilities file.

Change-Id: I508892dda626a024dda8ffe589f321de0523a55b