### PR TITLE
New design for better performance of no batching case with multiple i…

### DIFF
--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -158,11 +158,13 @@ TritonModel::Create(
   local_model->initialized_ = true;
 
   // FIXME: Should we use device blocking even for the sequential models?
-  const bool device_blocking = (local_model->backend_->ExecutionPolicy() == TRITONBACKEND_EXECUTION_DEVICE_BLOCKING);
+  const bool device_blocking =
+      (local_model->backend_->ExecutionPolicy() ==
+       TRITONBACKEND_EXECUTION_DEVICE_BLOCKING);
 
   // Create and initialize the model instances for this model.
-  RETURN_IF_ERROR(
-      TritonModelInstance::CreateInstances(raw_local_model, model_config, device_blocking));
+  RETURN_IF_ERROR(TritonModelInstance::CreateInstances(
+      raw_local_model, model_config, device_blocking));
 
   RETURN_IF_ERROR(
       local_model->SetConfiguredScheduler(static_cast<void*>(raw_local_model)));
@@ -259,13 +261,13 @@ TritonModel::~TritonModel()
   // TritonModel.
   scheduler_.reset();
 
-  // Unregister itself from the rate limiter
-  server_->GetRateLimiter()->UnregisterModel(this);
-
   // Explicitly delete/finalize all model instances before finalizing
   // the model itself.
   instances_.clear();
   passive_instances_.clear();
+
+  // Unregister itself from the rate limiter
+  server_->GetRateLimiter()->UnregisterModel(this);
 
   // Model finalization is optional... The TRITONBACKEND_Model
   // object is this TritonModel object.

--- a/src/backends/backend/triton_model.h
+++ b/src/backends/backend/triton_model.h
@@ -75,9 +75,6 @@ class TritonModel : public InferenceBackend {
       std::unique_ptr<TritonModelInstance>&& instance, const bool passive,
       const inference::ModelRateLimiter& rate_limiter_config);
 
-  Status Initialize();
-  Status WarmUp();
-
  private:
   DISALLOW_COPY_AND_ASSIGN(TritonModel);
 
@@ -86,6 +83,9 @@ class TritonModel : public InferenceBackend {
       const std::shared_ptr<LocalizedDirectory>& localized_model_dir,
       const std::shared_ptr<TritonBackend>& backend,
       const double min_compute_capability, const bool auto_complete_config);
+
+  Status Initialize();
+  Status WarmUp();
 
   // The server object that owns this model. The model holds this as a
   // raw pointer because the lifetime of the server is guaranteed to

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -36,6 +36,7 @@
 #include "src/core/logging.h"
 #include "src/core/metrics.h"
 #include "src/core/nvtx.h"
+#include "src/core/server.h"
 
 namespace nvidia { namespace inferenceserver {
 
@@ -141,17 +142,6 @@ TritonModelInstance::CreateInstances(
     TritonModel* model, const inference::ModelConfig& model_config,
     const bool device_blocking)
 {
-  bool use_backend_threads = false;
-  size_t count = 0;
-  for (const auto& group : model_config.instance_group()) {
-    if (!group.passive()) {
-      count += group.count();
-      if (count > 1) {
-        use_backend_threads = true;
-        break;
-      }
-    }
-  }
   // This structure is used to allocate TritonBackendThread to instances on same
   // device for device blocking execution policy.
   std::map<uint32_t, std::shared_ptr<TritonBackendThread>> device_to_thread_map;
@@ -170,19 +160,19 @@ TritonModelInstance::CreateInstances(
         RETURN_IF_ERROR(CreateInstance(
             model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_CPU,
             0 /* device_id */, profile_names, passive, group.rate_limiter(),
-            use_backend_threads, device_blocking, &device_to_thread_map));
+            device_blocking, &device_to_thread_map));
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_GPU) {
         for (const int32_t device_id : group.gpus()) {
           RETURN_IF_ERROR(CreateInstance(
               model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_GPU,
               device_id, profile_names, passive, group.rate_limiter(),
-              use_backend_threads, device_blocking, &device_to_thread_map));
+              device_blocking, &device_to_thread_map));
         }
       } else if (group.kind() == inference::ModelInstanceGroup::KIND_MODEL) {
         RETURN_IF_ERROR(CreateInstance(
             model, instance_name, c, TRITONSERVER_INSTANCEGROUPKIND_MODEL,
             0 /* device_id */, profile_names, passive, group.rate_limiter(),
-            use_backend_threads, device_blocking, &device_to_thread_map));
+            device_blocking, &device_to_thread_map));
       } else {
         return Status(
             Status::Code::INVALID_ARG,
@@ -201,7 +191,7 @@ TritonModelInstance::CreateInstance(
     const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
     const std::vector<std::string>& profile_names, const bool passive,
     const inference::ModelRateLimiter& rate_limiter_config,
-    const bool use_backend_threads, const bool device_blocking,
+    const bool device_blocking,
     std::map<uint32_t, std::shared_ptr<TritonBackendThread>>*
         device_to_thread_map)
 {
@@ -210,11 +200,8 @@ TritonModelInstance::CreateInstance(
 
   TRITONBACKEND_ModelInstance* triton_instance =
       reinterpret_cast<TRITONBACKEND_ModelInstance*>(local_instance.get());
-
-  if (use_backend_threads) {
-    local_instance->SetBackendThread(
-        device_id, device_blocking, device_to_thread_map);
-  }
+  local_instance->SetBackendThread(
+      kind, device_id, device_blocking, device_to_thread_map);
   RETURN_IF_ERROR(local_instance->GenerateWarmupData());
 
   // Instance initialization is optional...
@@ -231,11 +218,12 @@ TritonModelInstance::CreateInstance(
 
 Status
 TritonModelInstance::SetBackendThread(
-    const int32_t device_id, const bool device_blocking,
+    const TRITONSERVER_InstanceGroupKind kind, const int32_t device_id,
+    const bool device_blocking,
     std::map<uint32_t, std::shared_ptr<TritonBackendThread>>*
         device_to_thread_map)
 {
-  if (device_blocking) {
+  if (device_blocking && kind == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
     auto thread_it = device_to_thread_map->find(device_id);
     if (thread_it != device_to_thread_map->end()) {
       LOG_VERBOSE(1) << "Using already started backend thread for " << Name()
@@ -246,10 +234,13 @@ TritonModelInstance::SetBackendThread(
   if (triton_backend_thread_.get() == nullptr) {
     std::unique_ptr<TritonBackendThread> local_backend_thread;
     RETURN_IF_ERROR(TritonBackendThread::CreateBackendThread(
-        Name(), 5 /* nice */, device_id, &local_backend_thread));
+        Name(), model_, 5 /* nice */, device_id, &local_backend_thread));
     triton_backend_thread_ = std::move(local_backend_thread);
     device_to_thread_map->insert({device_id, triton_backend_thread_});
   }
+
+  triton_backend_thread_->AddModelInstance(this);
+
   return Status::Success;
 }
 
@@ -432,53 +423,8 @@ TritonModelInstance::GenerateWarmupData()
   return Status::Success;
 }
 
-Status
-TritonModelInstance::Initialize()
-{
-  Status status;
-  if (triton_backend_thread_.get() != nullptr) {
-    auto payload = std::make_shared<TritonBackendThread::Payload>(
-        TritonBackendThread::Operation::INIT, this);
-    triton_backend_thread_->Enqueue(payload);
-    status = payload->Wait();
-  } else {
-    status = InitializeFunc();
-  }
-  return status;
-}
-
-Status
-TritonModelInstance::WarmUp()
-{
-  Status status;
-  if (triton_backend_thread_.get() != nullptr) {
-    auto payload = std::make_shared<TritonBackendThread::Payload>(
-        TritonBackendThread::Operation::WARM_UP, this);
-    triton_backend_thread_->Enqueue(payload);
-    status = payload->Wait();
-  } else {
-    status = WarmUpFunc();
-  }
-  return status;
-}
-
 void
 TritonModelInstance::Schedule(
-    std::vector<std::unique_ptr<InferenceRequest>>&& requests,
-    const std::function<void()>& OnCompletion)
-{
-  if (triton_backend_thread_.get() != nullptr) {
-    auto payload = std::make_shared<TritonBackendThread::Payload>(
-        TritonBackendThread::Operation::INFER_RUN, this, std::move(requests),
-        OnCompletion);
-    triton_backend_thread_->Enqueue(payload);
-  } else {
-    ScheduleFunc(std::move(requests), OnCompletion);
-  }
-}
-
-void
-TritonModelInstance::ScheduleFunc(
     std::vector<std::unique_ptr<InferenceRequest>>&& requests,
     const std::function<void()>& OnCompletion)
 {
@@ -497,7 +443,7 @@ TritonModelInstance::ScheduleFunc(
 }
 
 Status
-TritonModelInstance::WarmUpFunc()
+TritonModelInstance::WarmUp()
 {
   for (auto& sample : warmup_samples_) {
     LOG_VERBOSE(1) << "model '" << sample.requests_.back()->ModelName()
@@ -560,11 +506,12 @@ TritonModelInstance::Execute(
 
 Status
 TritonModelInstance::TritonBackendThread::CreateBackendThread(
-    const std::string name, const int nice, const int32_t device_id,
+    const std::string name, TritonModel* model, const int nice,
+    const int32_t device_id,
     std::unique_ptr<TritonBackendThread>* triton_backend_thread)
 {
   TritonBackendThread* raw_triton_backend_thread =
-      new TritonBackendThread(name);
+      new TritonBackendThread(name, model);
   std::unique_ptr<TritonBackendThread> runner(raw_triton_backend_thread);
 
   runner->backend_thread_ =
@@ -577,73 +524,49 @@ TritonModelInstance::TritonBackendThread::CreateBackendThread(
   return Status::Success;
 }
 
+Status
+TritonModelInstance::TritonBackendThread::AddModelInstance(
+    TritonModelInstance* model_instance)
+{
+  model_instances_.push_back(model_instance);
+
+  /*
+  // Initialize the instance on the backend thread
+  auto init_payload = model_->Server()->GetRateLimiter()->GetPayload(
+      RateLimiter::Payload::Operation::INIT, model_instances_.back());
+  RETURN_IF_ERROR(
+      model_->Server()->GetRateLimiter()->EnqueuePayload(model_, init_payload));
+  RETURN_IF_ERROR(init_payload->Wait());
+
+  // Warm-up the instance on the backend thread
+  auto warmup_payload = model_->Server()->GetRateLimiter()->GetPayload(
+      RateLimiter::Payload::Operation::WARM_UP, model_instances_.back());
+  RETURN_IF_ERROR(model_->Server()->GetRateLimiter()->EnqueuePayload(
+      model_, warmup_payload));
+  RETURN_IF_ERROR(warmup_payload->Wait());
+  */
+
+  return Status::Success;
+}
+
 TritonModelInstance::TritonBackendThread::TritonBackendThread(
-    const std::string& name)
-    : name_(name)
+    const std::string& name, TritonModel* model)
+    : name_(name), model_(model)
 {
 }
 
 TritonModelInstance::TritonBackendThread::~TritonBackendThread()
 {
   // Signal the backend thread to exit and then wait for it..
-  auto exit_payload = std::make_shared<Payload>(Operation::EXIT, nullptr);
-  queue_.Put(exit_payload);
+  // FIXME: Currently, the logic to use specific instance for the execution
+  // is not available within rate limiter. The destruction will fix with
+  // accurate thread control within rate limiter.
+  auto exit_payload = model_->Server()->GetRateLimiter()->GetPayload(
+      RateLimiter::Payload::Operation::EXIT, model_instances_.back());
+  model_->Server()->GetRateLimiter()->EnqueuePayload(model_, exit_payload);
   if (backend_thread_.joinable()) {
     backend_thread_.join();
   }
-}
-
-TritonModelInstance::TritonBackendThread::Payload::Payload(
-    const Operation op_type, TritonModelInstance* instance)
-    : op_type_(op_type), instance_(instance),
-      requests_(std::vector<std::unique_ptr<InferenceRequest>>()),
-      OnCompletion_([]() {})
-{
-}
-
-TritonModelInstance::TritonBackendThread::Payload::Payload(
-    const Operation op_type, TritonModelInstance* instance,
-    std::vector<std::unique_ptr<InferenceRequest>>&& requests,
-    std::function<void()> OnCompletion)
-    : op_type_(op_type), instance_(instance), requests_(std::move(requests)),
-      OnCompletion_(OnCompletion)
-{
-}
-
-Status
-TritonModelInstance::TritonBackendThread::Payload::Wait()
-{
-  return status_.get_future().get();
-}
-
-void
-TritonModelInstance::TritonBackendThread::Payload::Execute(bool* should_exit)
-{
-  *should_exit = false;
-
-  Status status;
-  switch (op_type_) {
-    case Operation::INFER_RUN:
-      instance_->ScheduleFunc(std::move(requests_), OnCompletion_);
-      break;
-    case Operation::INIT:
-      status = instance_->InitializeFunc();
-      break;
-    case Operation::WARM_UP:
-      status = instance_->WarmUpFunc();
-      break;
-    case Operation::EXIT:
-      *should_exit = true;
-  }
-
-  status_.set_value(status);
-}
-
-void
-TritonModelInstance::TritonBackendThread::Enqueue(
-    std::shared_ptr<Payload> payload)
-{
-  queue_.Put(payload);
 }
 
 void
@@ -666,11 +589,16 @@ TritonModelInstance::TritonBackendThread::BackendThread(
 
   bool should_exit = false;
   while (!should_exit) {
-    auto payload = queue_.Get();
+    std::shared_ptr<RateLimiter::Payload> payload;
+    // TODO: For device blocking there can be multiple model instances being
+    // managed by this thread.
+    model_->Server()->GetRateLimiter()->DequeuePayload(
+        model_instances_[0], &payload);
     NVTX_RANGE(nvtx_, "BackendThread " + name_);
     payload->Execute(&should_exit);
+    // Release the payload to the RateLimiter
+    model_->Server()->GetRateLimiter()->PayloadRelease(payload);
   }
-
   LOG_VERBOSE(1) << "Stopping backend thread for " << name_ << "...";
 }
 

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -223,7 +223,7 @@ TritonModelInstance::SetBackendThread(
     std::map<uint32_t, std::shared_ptr<TritonBackendThread>>*
         device_to_thread_map)
 {
-  if (device_blocking && kind == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
+  if (device_blocking && (kind == TRITONSERVER_INSTANCEGROUPKIND_GPU)) {
     auto thread_it = device_to_thread_map->find(device_id);
     if (thread_it != device_to_thread_map->end()) {
       LOG_VERBOSE(1) << "Using already started backend thread for " << Name()
@@ -234,7 +234,7 @@ TritonModelInstance::SetBackendThread(
   if (triton_backend_thread_.get() == nullptr) {
     std::unique_ptr<TritonBackendThread> local_backend_thread;
     RETURN_IF_ERROR(TritonBackendThread::CreateBackendThread(
-        Name(), model_, 5 /* nice */, device_id, &local_backend_thread));
+        Name(), model_, 0 /* nice */, device_id, &local_backend_thread));
     triton_backend_thread_ = std::move(local_backend_thread);
     device_to_thread_map->insert({device_id, triton_backend_thread_});
   }

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -198,6 +198,7 @@ TritonModelInstance::CreateInstance(
   std::unique_ptr<TritonModelInstance> local_instance(new TritonModelInstance(
       model, name, index, kind, device_id, profile_names, passive));
 
+  model->Server()->GetRateLimiter()->InitializePayloadQueues(local_instance.get());
   TRITONBACKEND_ModelInstance* triton_instance =
       reinterpret_cast<TRITONBACKEND_ModelInstance*>(local_instance.get());
   local_instance->SetBackendThread(
@@ -530,7 +531,6 @@ TritonModelInstance::TritonBackendThread::AddModelInstance(
 {
   model_instances_.push_back(model_instance);
 
-  /*
   // Initialize the instance on the backend thread
   auto init_payload = model_->Server()->GetRateLimiter()->GetPayload(
       RateLimiter::Payload::Operation::INIT, model_instances_.back());
@@ -544,7 +544,6 @@ TritonModelInstance::TritonBackendThread::AddModelInstance(
   RETURN_IF_ERROR(model_->Server()->GetRateLimiter()->EnqueuePayload(
       model_, warmup_payload));
   RETURN_IF_ERROR(warmup_payload->Wait());
-  */
 
   return Status::Success;
 }

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -35,13 +35,12 @@
 #include "src/core/logging.h"
 #include "src/core/model_config.h"
 #include "src/core/nvtx.h"
+#include "src/core/server.h"
 
 namespace nvidia { namespace inferenceserver {
 
 DynamicBatchScheduler::DynamicBatchScheduler(
-    const uint32_t runner_id_start, const uint32_t runner_cnt,
-    const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-    const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
+    TritonModel* model, const bool dynamic_batching_enabled,
     const int32_t max_batch_size,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
     const bool preserve_ordering,
@@ -49,9 +48,7 @@ DynamicBatchScheduler::DynamicBatchScheduler(
     const uint64_t max_queue_delay_microseconds,
     const inference::ModelQueuePolicy& default_queue_policy,
     const uint32_t priority_levels, const ModelQueuePolicyMap& queue_policy_map)
-    : OnInit_(OnInit), OnWarmup_(OnWarmup), OnSchedule_(OnSchedule),
-      dynamic_batching_enabled_(dynamic_batching_enabled),
-      scheduler_thread_cnt_(runner_cnt), idle_scheduler_thread_cnt_(0),
+    : model_(model), dynamic_batching_enabled_(dynamic_batching_enabled),
       queue_(default_queue_policy, priority_levels, queue_policy_map),
       max_batch_size_((size_t)std::max(1, max_batch_size)),
       preferred_batch_sizes_(preferred_batch_sizes),
@@ -61,6 +58,7 @@ DynamicBatchScheduler::DynamicBatchScheduler(
       enforce_equal_shape_tensors_(enforce_equal_shape_tensors),
       preserve_ordering_(preserve_ordering)
 {
+  rate_limiter_ = model_->Server()->GetRateLimiter();
   max_preferred_batch_size_ = 0;
   for (const auto size : preferred_batch_sizes_) {
     max_preferred_batch_size_ =
@@ -70,9 +68,7 @@ DynamicBatchScheduler::DynamicBatchScheduler(
 
 Status
 DynamicBatchScheduler::Create(
-    const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
-    const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-    const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
+    TritonModel* model, const int nice, const bool dynamic_batching_enabled,
     const int32_t max_batch_size,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
     const bool preserve_ordering,
@@ -88,16 +84,13 @@ DynamicBatchScheduler::Create(
   batcher_config.set_max_queue_delay_microseconds(max_queue_delay_microseconds);
 
   return Create(
-      runner_id_start, runner_cnt, nice, OnInit, OnWarmup, OnSchedule,
-      dynamic_batching_enabled, max_batch_size, enforce_equal_shape_tensors,
-      batcher_config, scheduler);
+      model, nice, dynamic_batching_enabled, max_batch_size,
+      enforce_equal_shape_tensors, batcher_config, scheduler);
 }
 
 Status
 DynamicBatchScheduler::Create(
-    const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
-    const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-    const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
+    TritonModel* model, const int nice, const bool dynamic_batching_enabled,
     const int32_t max_batch_size,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
     const inference::ModelDynamicBatching& batcher_config,
@@ -109,39 +102,17 @@ DynamicBatchScheduler::Create(
   }
 
   DynamicBatchScheduler* dyna_sched = new DynamicBatchScheduler(
-      runner_id_start, runner_cnt, OnInit, OnWarmup, OnSchedule,
-      dynamic_batching_enabled, max_batch_size, enforce_equal_shape_tensors,
-      batcher_config.preserve_ordering(), preferred_batch_sizes,
-      batcher_config.max_queue_delay_microseconds(),
+      model, dynamic_batching_enabled, max_batch_size,
+      enforce_equal_shape_tensors, batcher_config.preserve_ordering(),
+      preferred_batch_sizes, batcher_config.max_queue_delay_microseconds(),
       batcher_config.default_queue_policy(), batcher_config.priority_levels(),
       batcher_config.priority_queue_policy());
   std::unique_ptr<DynamicBatchScheduler> sched(dyna_sched);
 
-  // Create one scheduler thread for each requested runner. Associate
-  // each scheduler thread with a runner.
-  for (uint32_t c = 0; c < sched->scheduler_thread_cnt_; ++c) {
-    const uint32_t runner_id = runner_id_start + c;
-    std::promise<bool> init_state;
-    auto thread_exit = std::make_shared<std::atomic<bool>>(false);
-    sched->scheduler_threads_exit_.emplace_back(thread_exit);
-    sched->scheduler_threads_.emplace_back(new std::thread(
-        [dyna_sched, runner_id, nice, thread_exit, &init_state]() {
-          dyna_sched->SchedulerThread(
-              runner_id, nice, thread_exit, &init_state);
-        }));
-    if (!init_state.get_future().get()) {
-      if (sched->scheduler_threads_.back()->joinable()) {
-        sched->scheduler_threads_.back()->join();
-      }
-      sched->scheduler_threads_exit_.pop_back();
-      sched->scheduler_threads_.pop_back();
-    }
-  }
-
-  if (sched->scheduler_threads_.empty()) {
-    return Status(
-        Status::Code::INTERNAL,
-        "Initialization failed for all dynamic-batch scheduler threads");
+  sched->scheduler_thread_exit_.store(false);
+  if (dynamic_batching_enabled) {
+    sched->scheduler_thread_ =
+        std::thread([dyna_sched, nice]() { dyna_sched->BatcherThread(nice); });
   }
 
   scheduler->reset(sched.release());
@@ -151,30 +122,11 @@ DynamicBatchScheduler::Create(
 
 DynamicBatchScheduler::~DynamicBatchScheduler()
 {
-  // Signal the scheduler threads to exit and then wait for them...
-  {
-    std::unique_lock<std::mutex> lock(mu_);
-    for (auto& ex : scheduler_threads_exit_) {
-      ex->store(true);
-    }
-
-    cv_.notify_all();
-  }
-
-  // It is possible for (one of) the scheduler threads to be the last
-  // holder of a backend object, and when that scheduler thread
-  // releases the object the scheduler thread itself will destroy the
-  // DynamicBatchScheduler object. So we need to check for a scheduler
-  // thread and not join it against itself. Instead we detach it so
-  // there is not a problem when its thread object is destroyed.
-  for (auto& thd : scheduler_threads_) {
-    if (thd->get_id() != std::this_thread::get_id()) {
-      if (thd->joinable()) {
-        thd->join();
-      }
-    } else {
-      thd->detach();
-    }
+  // Signal the scheduler thread to exit and then wait for it..
+  scheduler_thread_exit_.store(true);
+  cv_.notify_one();
+  if (scheduler_thread_.joinable()) {
+    scheduler_thread_.join();
   }
 }
 
@@ -188,286 +140,224 @@ DynamicBatchScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
       request->Trace(), TRITONSERVER_TRACE_QUEUE_START,
       request->QueueStartNs());
 
-  Status enqueue_status;
-  bool wake_runner = false;
-  {
-    std::lock_guard<std::mutex> lock(mu_);
-
-    queued_batch_size_ += std::max(1U, request->BatchSize());
-
-    // Assuming no error is returned, this call takes ownership of
-    // 'request' and so we can't use it after this point.
-    RETURN_IF_ERROR(queue_.Enqueue(request->Priority(), request));
-
-    // If there are any idle runners and the queued batch size is greater or
-    // equal to next preferred batch size, then wake one up to service this
-    // request. We do the actual wake outside of the lock to avoid having the
-    // woken thread immediately block on the lock
-    wake_runner = (idle_scheduler_thread_cnt_ > 0);
-
-    // We may wake up runner less often if we don't enforce equal shape within
-    // a batch, otherwise must always wake up runner to check it
-    if (enforce_equal_shape_tensors_.empty()) {
-      wake_runner &= (queued_batch_size_ >= next_preferred_batch_size_);
-    }
-  }
-
-  if (wake_runner) {
-    cv_.notify_one();
+  if (!dynamic_batching_enabled_) {
+    // If not using dynamic batching, directly enqueue the
+    // request to model for execution
+    auto payload = model_->Server()->GetRateLimiter()->GetPayload(
+        RateLimiter::Payload::Operation::INFER_RUN,
+        nullptr /* TritonModelInstance*/);
+    payload->AddRequest(std::move(request));
+    RETURN_IF_ERROR(
+        model_->Server()->GetRateLimiter()->EnqueuePayload(model_, payload));
+  } else {
+    return Status(
+        Status::Code::INVALID_ARG, "Dynamic batching is not yet supported");
+    //    bool wake_runner = false;
+    //    {
+    //      std::lock_guard<std::mutex> lock(mu_);
+    //
+    //      queued_batch_size_ += std::max(1U, request->BatchSize());
+    //
+    //      // Assuming no error is returned, this call takes ownership of
+    //      // 'request' and so we can't use it after this point.
+    //      RETURN_IF_ERROR(queue_.Enqueue(request->Priority(), request));
+    //
+    //      // If there are any idle runners and the queued batch size is
+    //      greater or
+    //      // equal to next preferred batch size, then wake batcher up to
+    //      service
+    //      // this request. We do the actual wake outside of the lock to avoid
+    //      having
+    //      // the woken thread immediately block on the lock
+    //      wake_runner = (model_->IdleInstanceCount() > 0);
+    //
+    //      // We may wake up runner less often if we don't enforce equal shape
+    //      within
+    //      // a batch, otherwise must always wake up runner to check it
+    //      if (enforce_equal_shape_tensors_.empty()) {
+    //        wake_runner &= (queued_batch_size_ >= next_preferred_batch_size_);
+    //      }
+    //    }
+    //
+    //    if (wake_runner) {
+    //      cv_.notify_one();
+    //    }
   }
 
   return Status::Success;
 }
 
 void
-DynamicBatchScheduler::SchedulerThread(
-    const uint32_t runner_id, const int nice,
-    const std::shared_ptr<std::atomic<bool>>& rthread_exit,
-    std::promise<bool>* is_initialized)
+DynamicBatchScheduler::BatcherThread(const int nice)
 {
-#ifndef _WIN32
-  if (setpriority(PRIO_PROCESS, syscall(SYS_gettid), nice) == 0) {
-    LOG_VERBOSE(1) << "Starting dynamic-batch scheduler thread " << runner_id
-                   << " at nice " << nice << "...";
-  } else {
-    LOG_VERBOSE(1) << "Starting dynamic-batch scheduler thread " << runner_id
-                   << " at default nice (requested nice " << nice
-                   << " failed)...";
-  }
-#else
-  LOG_VERBOSE(1) << "Starting dynamic-batch scheduler thread " << runner_id
-                 << " at default nice...";
-#endif
-
-  // Initialize using the thread. If error then just exit this thread
-  // now... that means the corresponding model instance will not have
-  // any runner and so will not get used for execution.
-  Status startup_status = OnInit_(runner_id);
-
-  // Run warmup function if initialization succeed.
-  if (startup_status.IsOk()) {
-    startup_status = OnWarmup_(runner_id);
-  }
-
-  if (!startup_status.IsOk()) {
-    LOG_ERROR << "Initialization failed for dynamic-batch scheduler thread "
-              << runner_id << ": " << startup_status.Message();
-    is_initialized->set_value(false);
-    return;
-  } else {
-    is_initialized->set_value(true);
-  }
-
-  // For testing this scheduler thread to be the last to release the
-  // backend object.
-  uint64_t backend_release_wait_milliseconds = 0;
-  {
-    const char* dstr = getenv("TRITONSERVER_DELAY_SCHEDULER_BACKEND_RELEASE");
-    if (dstr != nullptr) {
-      backend_release_wait_milliseconds = atoi(dstr);
-      LOG_VERBOSE(1) << "Delaying scheduler backend release for " << runner_id
-                     << ": " << backend_release_wait_milliseconds << "ms";
-    }
-  }
-
-  // For debugging/testing, delay start of threads until the queue
-  // contains the specified number of entries.
-  size_t delay_cnt = 0;
-  {
-    const char* dstr = getenv("TRITONSERVER_DELAY_SCHEDULER");
-    if (dstr != nullptr) {
-      delay_cnt = atoi(dstr);
-      LOG_VERBOSE(1) << "Delaying scheduler thread " << runner_id << " until "
-                     << delay_cnt << " queued requests...";
-    }
-  }
-
-  // Make a local copy of the atomic used to signal the thread to
-  // exit. See comment at end of function for explanation.
-  std::shared_ptr<std::atomic<bool>> thread_exit = rthread_exit;
-
-  const uint64_t default_wait_microseconds = 500 * 1000;
-
-  while (!thread_exit->load()) {
-    NVTX_RANGE(nvtx_, "DynamicBatchScheduler " + runner_id);
-
-    std::vector<std::unique_ptr<InferenceRequest>> requests;
-    std::shared_ptr<std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>
-        rejected_requests;
-    bool wake_thread = false;
-    uint64_t wait_microseconds = 0;
-
-    // Hold the lock for as short a time as possible.
-    {
-      std::unique_lock<std::mutex> lock(mu_);
-      if (delay_cnt > 0) {
-        // Debugging/testing... wait until queue contains 'delay_cnt'
-        // items...
-        wait_microseconds = 10 * 1000;
-        if (queue_.Size() >= delay_cnt) {
-          delay_cnt = 0;
-        }
-        LOG_VERBOSE(1) << "Delaying scheduler thread " << runner_id << " until "
-                       << delay_cnt
-                       << " queued requests, current total = " << queue_.Size();
-      } else if (queue_.Empty()) {
-        wait_microseconds = default_wait_microseconds;
-      } else if (dynamic_batching_enabled_) {
-        // Use dynamic batching to get request(s) to execute.
-        wait_microseconds = GetDynamicBatch(runner_id);
-
-        // Get requests that are rejected from searching dynamic batch.
-        queue_.ReleaseRejectedRequests(&rejected_requests);
-
-        // Extract batch only if there is pending batch
-        auto pending_batch_queue_cnt = queue_.PendingBatchCount();
-        if ((wait_microseconds == 0) && (pending_batch_queue_cnt != 0)) {
-          requests.reserve(pending_batch_queue_cnt);
-          for (size_t idx = 0; idx < pending_batch_queue_cnt; ++idx) {
-            std::unique_ptr<InferenceRequest> request;
-            auto status = queue_.Dequeue(&request);
-            if (status.IsOk()) {
-              requests.emplace_back(std::move(request));
-            } else {
-              // The queue is empty which conflicts with pending batch count.
-              // Send the current batch if any and reset related variables.
-              LOG_ERROR << "Failed to retrieve request from scheduler queue: "
-                        << status.Message();
-              queue_.ResetCursor();
-              queued_batch_size_ = 0;
-              pending_batch_size_ = 0;
-              break;
-            }
-          }
-          if (preserve_ordering_ && !requests.empty()) {
-            std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-            for (auto& request : requests) {
-              completion_queue_.emplace_back();
-              auto queue_slot = &completion_queue_.back();
-              request->SetResponseDelegator(
-                  [this, queue_slot](
-                      std::unique_ptr<InferenceResponse>&& response,
-                      const uint32_t flags) {
-                    {
-                      std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-                      queue_slot->emplace_back(std::move(response), flags);
-                    }
-                    FinalizeResponses();
-                  });
-            }
-          }
-
-          queued_batch_size_ -= pending_batch_size_;
-          // Set next preferred to be 0 so that enqueue thread will wake up
-          // runners when new request arrives. In the case where the queue
-          // becomes empty, this helps the runners to set up proper wait time
-          // instead of waiting for the default timer or actual next preferred
-          // batch size is reached.
-          next_preferred_batch_size_ = 0;
-
-          pending_batch_size_ = 0;
-          required_equal_inputs_.clear();
-
-          // If there are still requests in the queue after removing
-          // the pending batch and if there are any idle threads then
-          // wake one up to service the requests remaining in the
-          // queue. We need this special wake logic for the dynamic
-          // batching case because we may delay handling requests in
-          // the queue and so idle the threads that would normally be
-          // handling those requests. We do the actual wake outside of
-          // the lock to avoid having the woken thread immediately
-          // block on the lock.
-          wake_thread = !queue_.Empty() && (idle_scheduler_thread_cnt_ > 0);
-        }
-      } else {
-        // No batching... execute next request
-        std::unique_ptr<InferenceRequest> request;
-        auto status = queue_.Dequeue(&request);
-        if (status.IsOk()) {
-          requests.emplace_back(std::move(request));
-          if (preserve_ordering_) {
-            std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-            for (auto& request : requests) {
-              completion_queue_.emplace_back();
-              auto queue_slot = &completion_queue_.back();
-              request->SetResponseDelegator(
-                  [this, queue_slot](
-                      std::unique_ptr<InferenceResponse>&& response,
-                      const uint32_t flags) {
-                    {
-                      std::lock_guard<std::mutex> lock(completion_queue_mtx_);
-                      queue_slot->emplace_back(std::move(response), flags);
-                    }
-                    FinalizeResponses();
-                  });
-            }
-          }
-        } else {
-          LOG_ERROR << "Failed to retrieve request from scheduler queue: "
-                    << status.Message();
-        }
-      }
-
-      // If no requests are to be handled, wait for notification or
-      // for the specified timeout before checking the queue again.
-      if (wait_microseconds > 0) {
-        idle_scheduler_thread_cnt_++;
-        std::chrono::microseconds wait_timeout(wait_microseconds);
-        cv_.wait_for(lock, wait_timeout);
-        idle_scheduler_thread_cnt_--;
-      }
-    }
-
-    if (wake_thread) {
-      cv_.notify_one();
-    }
-
-    if (!requests.empty()) {
-      OnSchedule_(runner_id, std::move(requests));
-
-      // For testing we introduce a delay here to make the
-      // "DynamicBatchScheduler destroyed by this thread" case
-      // described in the comment below reproducible.
-      if (backend_release_wait_milliseconds > 0) {
-        std::this_thread::sleep_for(
-            std::chrono::milliseconds(backend_release_wait_milliseconds));
-      }
-    }
-
-    // Finish rejected requests if any
-    if (rejected_requests != nullptr) {
-      static Status rejected_status =
-          Status(Status::Code::UNAVAILABLE, "Request timeout expired");
-      for (auto& rejected_queue : *rejected_requests) {
-        for (auto& rejected_request : rejected_queue) {
-          InferenceRequest::RespondIfError(
-              rejected_request, rejected_status, true);
-        }
-      }
-    }
-
-    // FIXME, this isn't really true anymore so needs to be revisited.
-    //
-    // At the end of this scope 'requests' will be destroyed.  A
-    // handle to the backend is held by the request. If the server is
-    // exiting or the backend is unloaded, it could be that this
-    // handle is the last one for the backend and so destroying
-    // 'requests' will cause the backend to be deleted which in turn
-    // will call this thread's DynamicBatchScheduler to be destroyed
-    // by this thread itself. In that case it is important that this
-    // thread not reference the object after this point since the
-    // object will be invalid. The while statement above uses a local
-    // atomic which is set to false by the destructor (and so the
-    // while loop will exit) and the logging below uses only local
-    // variables... so this code is ok.
-  }  // end runner loop
-
-  LOG_VERBOSE(1) << "Stopping dynamic-batch scheduler thread " << runner_id
-                 << "...";
+  //#ifndef _WIN32
+  //  if (setpriority(PRIO_PROCESS, syscall(SYS_gettid), nice) == 0) {
+  //    LOG_VERBOSE(1) << "Starting dynamic-batcher thread for "
+  //                   << model_->Name() << " at nice " << nice << "...";
+  //  } else {
+  //    LOG_VERBOSE(1) << "Starting dynamic-batcher thread for "
+  //                   << model_->Name() << " at default nice (requested nice "
+  //                   << nice << " failed)...";
+  //  }
+  //#else
+  //  LOG_VERBOSE(1) << "Starting dynamic-batcher thread for "
+  //                 << model_->Name() << " at default nice...";
+  //#endif
+  //  // For debugging/testing, delay start of threads until the queue
+  //  // contains the specified number of entries.
+  //  size_t delay_cnt = 0;
+  //  {
+  //    const char* dstr = getenv("TRITONSERVER_DELAY_SCHEDULER");
+  //    if (dstr != nullptr) {
+  //      delay_cnt = atoi(dstr);
+  //      LOG_VERBOSE(1) << "Delaying scheduler thread for " << model_->Name()
+  //                     << " until " << delay_cnt << " queued requests...";
+  //    }
+  //  }
+  //
+  //   while (!scheduler_thread_exit_.load()) {
+  //     NVTX_RANGE(nvtx_, "DynamicBatcher " + model_->Name());
+  //
+  //     std::vector<std::unique_ptr<InferenceRequest>> requests;
+  //     std::shared_ptr<std::vector<std::deque<std::unique_ptr<InferenceRequest>>>>
+  //         rejected_requests;
+  //     bool wake_thread = false;
+  //     uint64_t wait_microseconds = 0;
+  //
+  //     // Hold the lock for as short a time as possible.
+  //     {
+  //       std::unique_lock<std::mutex> lock(mu_);
+  //       if (delay_cnt > 0) {
+  //         // Debugging/testing... wait until queue contains 'delay_cnt'
+  //         // items...
+  //         wait_microseconds = 10 * 1000;
+  //         if (queue_.Size() >= delay_cnt) {
+  //           delay_cnt = 0;
+  //         }
+  //         LOG_VERBOSE(1) << "Delaying scheduler thread " << runner_id << "
+  //         until "
+  //                        << delay_cnt
+  //                        << " queued requests, current total = " <<
+  //                        queue_.Size();
+  //       } else if (queue_.Empty()) {
+  //         wait_microseconds = default_wait_microseconds;
+  //       } else {
+  //         // Use dynamic batching to get request(s) to execute.
+  //         wait_microseconds = GetDynamicBatch(runner_id);
+  //
+  //         // Get requests that are rejected from searching dynamic batch.
+  //         queue_.ReleaseRejectedRequests(&rejected_requests);
+  //
+  //         // Extract batch only if there is pending batch
+  //         auto pending_batch_queue_cnt = queue_.PendingBatchCount();
+  //         if ((wait_microseconds == 0) && (pending_batch_queue_cnt != 0)) {
+  //           requests.reserve(pending_batch_queue_cnt);
+  //           for (size_t idx = 0; idx < pending_batch_queue_cnt; ++idx) {
+  //             std::unique_ptr<InferenceRequest> request;
+  //             auto status = queue_.Dequeue(&request);
+  //             if (status.IsOk()) {
+  //               requests.emplace_back(std::move(request));
+  //             } else {
+  //               // The queue is empty which conflicts with pending batch
+  //               count.
+  //               // Send the current batch if any and reset related variables.
+  //               LOG_ERROR << "Failed to retrieve request from scheduler
+  //               queue: "
+  //                         << status.Message();
+  //               queue_.ResetCursor();
+  //               queued_batch_size_ = 0;
+  //               pending_batch_size_ = 0;
+  //               break;
+  //             }
+  //           }
+  //           if (preserve_ordering_ && !requests.empty()) {
+  //             std::lock_guard<std::mutex> lock(completion_queue_mtx_);
+  //             for (auto& request : requests) {
+  //               completion_queue_.emplace_back();
+  //               auto queue_slot = &completion_queue_.back();
+  //               request->SetResponseDelegator(
+  //                   [this, queue_slot](
+  //                       std::unique_ptr<InferenceResponse>&& response,
+  //                       const uint32_t flags) {
+  //                     {
+  //                       std::lock_guard<std::mutex>
+  //                       lock(completion_queue_mtx_);
+  //                       queue_slot->emplace_back(std::move(response), flags);
+  //                     }
+  //                     FinalizeResponses();
+  //                   });
+  //             }
+  //           }
+  //
+  //           queued_batch_size_ -= pending_batch_size_;
+  //           // Set next preferred to be 0 so that enqueue thread will wake up
+  //           // runners when new request arrives. In the case where the queue
+  //           // becomes empty, this helps the runners to set up proper wait
+  //           time
+  //           // instead of waiting for the default timer or actual next
+  //           preferred
+  //           // batch size is reached.
+  //           next_preferred_batch_size_ = 0;
+  //
+  //           pending_batch_size_ = 0;
+  //           required_equal_inputs_.clear();
+  //         }
+  //       }
+  //
+  //       // If no requests are to be handled, wait for notification or
+  //       // for the specified timeout before checking the queue again.
+  //       if (wait_microseconds > 0) {
+  //         std::chrono::microseconds wait_timeout(wait_microseconds);
+  //         cv_.wait_for(lock, wait_timeout);
+  //       }
+  //     }
+  //
+  //     if (!requests.empty()) {
+  //       OnSchedule_(runner_id, std::move(requests));
+  //
+  //       // For testing we introduce a delay here to make the
+  //       // "DynamicBatchScheduler destroyed by this thread" case
+  //       // described in the comment below reproducible.
+  //       if (backend_release_wait_milliseconds > 0) {
+  //         std::this_thread::sleep_for(
+  //             std::chrono::milliseconds(backend_release_wait_milliseconds));
+  //       }
+  //     }
+  //
+  //     // Finish rejected requests if any
+  //     if (rejected_requests != nullptr) {
+  //       static Status rejected_status =
+  //           Status(Status::Code::UNAVAILABLE, "Request timeout expired");
+  //       for (auto& rejected_queue : *rejected_requests) {
+  //         for (auto& rejected_request : rejected_queue) {
+  //           InferenceRequest::RespondIfError(
+  //               rejected_request, rejected_status, true);
+  //         }
+  //       }
+  //     }
+  //
+  //     // FIXME, this isn't really true anymore so needs to be revisited.
+  //     //
+  //     // At the end of this scope 'requests' will be destroyed.  A
+  //     // handle to the backend is held by the request. If the server is
+  //     // exiting or the backend is unloaded, it could be that this
+  //     // handle is the last one for the backend and so destroying
+  //     // 'requests' will cause the backend to be deleted which in turn
+  //     // will call this thread's DynamicBatchScheduler to be destroyed
+  //     // by this thread itself. In that case it is important that this
+  //     // thread not reference the object after this point since the
+  //     // object will be invalid. The while statement above uses a local
+  //     // atomic which is set to false by the destructor (and so the
+  //     // while loop will exit) and the logging below uses only local
+  //     // variables... so this code is ok.
+  //   }  // end runner loop
+  //
+  //  LOG_VERBOSE(1) << "Stopping dynamic-batch scheduler thread for "
+  //                 << model_->Name() << "...";
 }
 
 uint64_t
-DynamicBatchScheduler::GetDynamicBatch(const int64_t runner_id)
+DynamicBatchScheduler::GetDynamicBatch()
 {
   // 'mu_' mutex must be held when this function is called. queue_
   // must not be empty.
@@ -503,8 +393,8 @@ DynamicBatchScheduler::GetDynamicBatch(const int64_t runner_id)
     } else {
       // There is a pending batch and adding this request would make
       // the batch size larger than all of the preferred batch sizes,
-      // so mark the cursor at this point. Not sending the pending batch so that
-      // we can examine the queue delay of requests that fits in a batch.
+      // so mark the cursor at this point. Not sending the pending batch so
+      // that we can examine the queue delay of requests that fits in a batch.
       if (((pending_batch_size_ + batch_size) > max_preferred_batch_size_) &&
           (best_preferred_batch_size == 0)) {
         best_preferred_batch_size = pending_batch_size_;
@@ -592,9 +482,9 @@ DynamicBatchScheduler::GetDynamicBatch(const int64_t runner_id)
 
   // Return non-zero wait microseconds to cause this thread to wait
   // until the queue delay or the closest timeout has expired.
-  // Another thread may be awaken due to incoming request to handle the pending
-  // batch before this thread wakes and that is ok. But if no other request
-  // comes in then this thread will wake and revisit the pending batch
+  // Another thread may be awaken due to incoming request to handle the
+  // pending batch before this thread wakes and that is ok. But if no other
+  // request comes in then this thread will wake and revisit the pending batch
   // (and at that time will then see the delay has been exceeded and will send
   // the batch).
   return wait_ns / 1000;

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -85,8 +85,10 @@ class DynamicBatchScheduler : public Scheduler {
       const inference::ModelQueuePolicy& default_queue_policy,
       const uint32_t priority_levels,
       const ModelQueuePolicyMap& queue_policy_map);
+
   void BatcherThread(const int nice);
   uint64_t GetDynamicBatch();
+  void DelegateResponse(std::unique_ptr<InferenceRequest>& request);
   void FinalizeResponses();
 
   // FIXME: Use shared_ptr for model once InferenceBackend class is cleaned up.

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -35,7 +35,10 @@
 #include <set>
 #include <thread>
 #include "model_config.pb.h"
+#include "src/backends/backend/triton_model.h"
+#include "src/backends/backend/triton_model_instance.h"
 #include "src/core/model_config.h"
+#include "src/core/rate_limiter.h"
 #include "src/core/scheduler.h"
 #include "src/core/scheduler_utils.h"
 #include "src/core/status.h"
@@ -48,9 +51,7 @@ class DynamicBatchScheduler : public Scheduler {
   // Create a scheduler to support a given number of runners and a run
   // function to call when a request is scheduled.
   static Status Create(
-      const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
-      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
+      TritonModel* model, const int nice, const bool dynamic_batching_enabled,
       const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
@@ -62,9 +63,7 @@ class DynamicBatchScheduler : public Scheduler {
   // function to call when a request is scheduled. And the scheduler also
   // supports different queue policies for different priority levels.
   static Status Create(
-      const uint32_t runner_id_start, const uint32_t runner_cnt, const int nice,
-      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
+      TritonModel* model, const int nice, const bool dynamic_batching_enabled,
       const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const inference::ModelDynamicBatching& batcher_config,
@@ -77,9 +76,7 @@ class DynamicBatchScheduler : public Scheduler {
 
  private:
   DynamicBatchScheduler(
-      const uint32_t runner_id_start, const uint32_t runner_cnt,
-      const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-      const StandardRunFunc& OnSchedule, const bool dynamic_batching_enabled,
+      TritonModel* model, const bool dynamic_batching_enabled,
       const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
@@ -88,42 +85,32 @@ class DynamicBatchScheduler : public Scheduler {
       const inference::ModelQueuePolicy& default_queue_policy,
       const uint32_t priority_levels,
       const ModelQueuePolicyMap& queue_policy_map);
-  void SchedulerThread(
-      const uint32_t runner_id, const int nice,
-      const std::shared_ptr<std::atomic<bool>>& rthread_exit,
-      std::promise<bool>* is_initialized);
-  uint64_t GetDynamicBatch(const int64_t runner_id);
+  void BatcherThread(const int nice);
+  uint64_t GetDynamicBatch();
   void FinalizeResponses();
 
-  // Function the scheduler will call to initialize a runner.
-  const StandardInitFunc OnInit_;
-
-  // Function the scheduler will call to warmup a runner.
-  const StandardWarmupFunc OnWarmup_;
-
-  // Function the scheduler will call to schedule a batch of requests.
-  const StandardRunFunc OnSchedule_;
+  // FIXME: Use shared_ptr for model once InferenceBackend class is cleaned up.
+  TritonModel* model_;
 
   // True if dynamic batching is enabled.
   const bool dynamic_batching_enabled_;
-
-  // The number of scheduler threads.
-  const uint32_t scheduler_thread_cnt_;
-
-  // The number of scheduler threads currently idle.
-  uint32_t idle_scheduler_thread_cnt_;
-
-  // Mutex and condvar protecting the scheduling queue.
-  std::mutex mu_;
-  std::condition_variable cv_;
 
   // Map from priority level to queue holding inference requests for the model
   // represented by this scheduler. If priority queues are not supported by the
   // scheduler, then priority zero entry is used as the single queue.
   PriorityQueue queue_;
 
-  std::vector<std::unique_ptr<std::thread>> scheduler_threads_;
-  std::vector<std::shared_ptr<std::atomic<bool>>> scheduler_threads_exit_;
+  std::thread scheduler_thread_;
+  std::atomic<bool> scheduler_thread_exit_;
+
+  // Mutex and condvar for signaling scheduler thread
+  std::mutex mu_;
+  std::condition_variable cv_;
+
+  std::mutex instance_mu_;
+  std::condition_variable instance_cv_;
+
+  std::shared_ptr<RateLimiter> rate_limiter_;
 
   size_t max_batch_size_;
   size_t max_preferred_batch_size_;

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -148,8 +148,8 @@ RateLimiter::DequeuePayload(
       std::unique_lock<std::mutex> lk(payload_queue->mu_);
       payload_queue->cv_.wait(
           lk, [payload_queue]() { return !(payload_queue->queue_.empty()); });
-      *payload = payload_queue->queue_.back();
-      payload_queue->queue_.pop_back();
+      *payload = payload_queue->queue_.front();
+      payload_queue->queue_.pop_front();
     }
     // FIXME: Fix when instance specific queues are added.
     (*payload)->SetInstance(instance);

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -30,6 +30,8 @@
 
 namespace nvidia { namespace inferenceserver {
 
+constexpr size_t MAX_PAYLOAD_BUCKET_COUNT = 1000;
+
 //=========================================================================
 //  Core Implementation
 //=========================================================================
@@ -100,8 +102,70 @@ RateLimiter::UnregisterModel(const TritonModel* model)
     RETURN_IF_ERROR(resource_manager_->UpdateResourceLimits());
   }
 
+  if (payload_queues_.find(model) != payload_queues_.end()) {
+    payload_queues_.erase(model);
+  }
+
   return Status::Success;
 }
+
+Status
+RateLimiter::EnqueuePayload(
+    const TritonModel* model, std::shared_ptr<Payload> payload)
+{
+  if (payload_queues_.find(model) == payload_queues_.end()) {
+    LOG_INFO << "Should not print this";
+  }
+  PayloadQueue* payload_queue = payload_queues_[model].get();
+  {
+    std::lock_guard<std::mutex> lk(payload_queue->mu_);
+    payload->SetState(Payload::State::REQUESTED);
+    payload_queue->queue_.push_back(payload);
+  }
+
+  if (ignore_resources_and_priority_) {
+    // Directly wake up any one of the waiting threadto process the payload.
+    // TODO: If payload includes a specific TritonModelInstance
+    payload->SetState(Payload::State::SCHEDULED);
+    payload_queue->cv_.notify_one();
+  } else {
+    // TODO: Implement the RateLimiting pipeline here that will schedule when
+    // an ExecuteThread gets to run.
+  }
+  return Status::Success;
+}
+
+void
+RateLimiter::DequeuePayload(
+    TritonModelInstance* instance, std::shared_ptr<Payload>* payload)
+{
+  if (payload_queues_.find(instance->Model()) == payload_queues_.end()) {
+    payload_queues_.emplace(instance->Model(), new PayloadQueue());
+  }
+  PayloadQueue* payload_queue = payload_queues_[instance->Model()].get();
+  if (ignore_resources_and_priority_) {
+    {
+      std::unique_lock<std::mutex> lk(payload_queue->mu_);
+      payload_queue->cv_.wait(
+          lk, [payload_queue]() { return !(payload_queue->queue_.empty()); });
+      *payload = payload_queue->queue_.back();
+      payload_queue->queue_.pop_back();
+    }
+    // FIXME: Fix when instance specific queues are added.
+    (*payload)->SetInstance(instance);
+    /*
+    if ((*payload)->GetInstance() == nullptr) {
+      (*payload)->SetInstance(instance);
+    } else if ((*payload)->GetInstance() != instance) {
+      LOG_ERROR << "Got mismatching instance in the payload to execute";
+    }
+    */
+    (*payload)->SetState(Payload::State::EXECUTING);
+  } else {
+    // TODO: Wait till RateLimiting pipeline notifies the thread
+  }
+}
+
 
 Status
 RateLimiter::RequestModelInstance(
@@ -136,23 +200,125 @@ RateLimiter::RequestModelInstance(
   return Status::Success;
 }
 
-size_t
-RateLimiter::AvailableInstanceCount(const TritonModel* model)
+RateLimiter::Payload::Payload()
+    : op_type_(Operation::INFER_RUN),
+      requests_(std::vector<std::unique_ptr<InferenceRequest>>()),
+      OnCompletion_([]() {}), instance_(nullptr), state_(State::UNINITIALIZED)
 {
-  std::lock_guard<std::mutex> lk(model_contexts_mtx_);
-  size_t count = 0;
-  auto itr = model_contexts_.find(model);
-  if (itr != model_contexts_.end()) {
-    count = itr->second.AvailableInstanceCount();
-  }
-
-  return count;
 }
 
+void
+RateLimiter::Payload::Reset(
+    const Operation op_type, TritonModelInstance* instance)
+{
+  op_type_ = op_type;
+  requests_.clear();
+  OnCompletion_ = []() {};
+  instance_ = instance;
+  state_ = State::UNINITIALIZED;
+  OnCompletion_ = []() {};
+  status_.reset(new std::promise<Status>());
+}
+
+void
+RateLimiter::Payload::Release()
+{
+  op_type_ = Operation::INFER_RUN;
+  requests_.clear();
+  OnCompletion_ = []() {};
+  instance_ = nullptr;
+  state_ = State::UNINITIALIZED;
+  OnCompletion_ = []() {};
+}
+
+void
+RateLimiter::Payload::AddRequest(std::unique_ptr<InferenceRequest> request)
+{
+  requests_.push_back(std::move(request));
+}
+
+void
+RateLimiter::Payload::SetInstance(TritonModelInstance* model_instance)
+{
+  instance_ = model_instance;
+}
+
+void
+RateLimiter::Payload::SetState(RateLimiter::Payload::State state)
+{
+  state_ = state;
+}
+
+Status
+RateLimiter::Payload::Wait()
+{
+  return status_->get_future().get();
+}
+
+void
+RateLimiter::Payload::Execute(bool* should_exit)
+{
+  *should_exit = false;
+
+  Status status;
+  switch (op_type_) {
+    case Operation::INFER_RUN:
+      instance_->Schedule(std::move(requests_), OnCompletion_);
+      break;
+    case Operation::INIT:
+      status = instance_->Initialize();
+      break;
+    case Operation::WARM_UP:
+      status = instance_->WarmUp();
+      break;
+    case Operation::EXIT:
+      *should_exit = true;
+  }
+
+  status_->set_value(status);
+}
+
+std::shared_ptr<RateLimiter::Payload>
+RateLimiter::GetPayload(
+    const Payload::Operation op_type, TritonModelInstance* instance)
+{
+  std::shared_ptr<RateLimiter::Payload> payload;
+
+  if (max_payload_bucket_count_ > 0) {
+    std::lock_guard<std::mutex> lock(alloc_mu_);
+
+    if (!payload_bucket_.empty()) {
+      payload = payload_bucket_.back();
+      payload_bucket_.pop_back();
+    }
+  }
+
+  if (payload.get() == nullptr) {
+    payload.reset(new RateLimiter::Payload());
+  }
+
+  payload->Reset(op_type, instance);
+  return payload;
+}
+
+void
+RateLimiter::PayloadRelease(std::shared_ptr<RateLimiter::Payload>& payload)
+{
+  if (max_payload_bucket_count_ > 0) {
+    std::lock_guard<std::mutex> lock(alloc_mu_);
+
+    if (payload_bucket_.size() < max_payload_bucket_count_) {
+      payload->Release();
+      payload_bucket_.push_back(std::move(payload));
+      return;
+    }
+  }
+}
 
 RateLimiter::RateLimiter(
     const bool ignore_resources_and_priority, const ResourceMap& resource_map)
-    : ignore_resources_and_priority_(ignore_resources_and_priority)
+    : ignore_resources_and_priority_(ignore_resources_and_priority),
+      max_payload_bucket_count_(MAX_PAYLOAD_BUCKET_COUNT)
 {
   ResourceManager::Create(resource_map, &resource_manager_);
 }
@@ -239,12 +405,6 @@ RateLimiter::ModelContext::AddAvailableInstance(ModelInstance* instance)
   instance->MarkAvailable();
 }
 
-size_t
-RateLimiter::ModelContext::AvailableInstanceCount()
-{
-  std::lock_guard<std::recursive_mutex> lk(avbl_instances_mtx_);
-  return avbl_instances_.size();
-}
 
 void
 RateLimiter::ModelContext::StageInstanceIfAvailable()
@@ -423,15 +583,6 @@ RateLimiter::ModelInstance::DirectAllocate(StandardScheduleFunc OnSchedule)
   OnSchedule(this);
 
   return Status::Success;
-}
-
-void
-RateLimiter::ModelInstance::ScheduleNow(
-    std::vector<std::unique_ptr<InferenceRequest>>&& requests)
-{
-  executed_ = (!requests.empty());
-  auto OnCompletion = [this]() { this->Release(); };
-  triton_model_instance_->Schedule(std::move(requests), OnCompletion);
 }
 
 void

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -45,6 +45,8 @@ class RateLimiter {
 
  public:
   class ModelInstance;
+  class Payload;
+
 
   using StandardReleaseFunc = std::function<void(ModelInstance*)>;
   using StandardScheduleFunc = std::function<void(ModelInstance*)>;
@@ -93,6 +95,11 @@ class RateLimiter {
   /// \return Status object indicating success or failure.
   Status UnregisterModel(const TritonModel* model);
 
+  Status EnqueuePayload(const TritonModel* model, std::shared_ptr<Payload> payload);
+
+  // TODO: Fix it for device blocking as a thread can accept requests for multiple instance
+  void DequeuePayload(TritonModelInstance* instance, std::shared_ptr<Payload>* payload);
+
   /// Requests one of the available model instance. In future, when the
   /// conditions are met, the callback will be invoked and a pointer to
   /// allocated RateLimiter::ModelInstance object will be exposed as a
@@ -113,12 +120,40 @@ class RateLimiter {
       const StandardScheduleFunc& OnSchedule, const TritonModel* model,
       TritonModelInstance* instance = nullptr);
 
-  /// Gets the number of instance available to run inferences.
-  size_t AvailableInstanceCount(const TritonModel* model);
-
   /// Whether or not to ignore the resource configurations and priority settings
   /// for the rate limiter.
   bool IgnoreResourcesAndPriority() { return ignore_resources_and_priority_; }
+
+  class Payload {
+   public:
+    enum Operation { INFER_RUN = 0, INIT = 1, WARM_UP = 2, EXIT = 3 };
+    enum State { UNINITIALIZED = 0, REQUESTED = 1, SCHEDULED = 3, EXECUTING = 4 };
+  
+    Payload();
+    void Reset(
+        const Operation op_type, TritonModelInstance* instance = nullptr);
+    Operation GetOpType(){return op_type_;}
+    void AddRequest(std::unique_ptr<InferenceRequest> request);
+    void SetInstance(TritonModelInstance* model_instance);
+    TritonModelInstance* GetInstance() { return instance_;}
+
+    State GetState() { return state_; }
+    void SetState(State state);
+    void Execute(bool* should_exit);
+    Status Wait();
+    void Release();
+   private:
+    Operation op_type_;
+    std::vector<std::unique_ptr<InferenceRequest>> requests_;
+    std::function<void()> OnCompletion_;
+    TritonModelInstance* instance_;
+    State state_;
+    std::unique_ptr<std::promise<Status>> status_;
+  };
+
+
+  std::shared_ptr<Payload> GetPayload(const Payload::Operation op_type, TritonModelInstance* instance = nullptr);
+  void PayloadRelease(std::shared_ptr<Payload>& payload);
 
   // Holds the state of the model instance.
   class ModelInstance {
@@ -126,8 +161,6 @@ class RateLimiter {
     friend class RateLimiter;
     friend class ResourceManager;
     enum State { AVAILABLE, STAGED, ALLOCATED, REMOVED };
-
-    void ScheduleNow(std::vector<std::unique_ptr<InferenceRequest>>&& requests);
 
     /// Should be called when the request on the model instance is
     /// complete. This function releases the resources allocated to
@@ -202,7 +235,6 @@ class RateLimiter {
         const StandardScheduleFunc& OnSchedule,
         TritonModelInstance* triton_model_instance);
     void AddAvailableInstance(ModelInstance* instance);
-    size_t AvailableInstanceCount();
     void StageInstanceIfAvailable();
     void AllocateInstanceIfAvailable();
     void AddSpecificRequestQueue();
@@ -269,6 +301,21 @@ class RateLimiter {
 
   // Manager to keep track of the resource allocations
   std::unique_ptr<ResourceManager> resource_manager_;
+
+  // Mutex to serialize Payload allocation
+  std::mutex alloc_mu_;
+
+  // Keep some number of Payload objects for reuse to avoid the overhead
+  // of creating a Payload for every new request.
+  const size_t max_payload_bucket_count_;
+  std::vector<std::shared_ptr<Payload>> payload_bucket_;
+
+  struct PayloadQueue { 
+    std::deque<std::shared_ptr<Payload>> queue_;
+    std::mutex mu_;
+    std::condition_variable cv_;
+  };
+  std::map<const TritonModel*, std::unique_ptr<PayloadQueue>> payload_queues_;
 };
 
 }}  // namespace nvidia::inferenceserver

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -153,8 +153,15 @@ InferenceServer::Init()
   std::unique_ptr<RateLimiter> local_rate_limiter;
   bool ignore_resources_and_priority =
       (rate_limit_mode_ == RateLimitMode::RL_OFF);
+  if (!ignore_resources_and_priority) {
+    return Status(
+        Status::Code::INVALID_ARG,
+        "rate limiter implementation is not complete. Please use "
+        "--rate-limit=OFF");
+  }
   status = RateLimiter::Create(
-      ignore_resources_and_priority, rate_limit_resource_map_, &local_rate_limiter);
+      ignore_resources_and_priority, rate_limit_resource_map_,
+      &local_rate_limiter);
   rate_limiter_ = std::move(local_rate_limiter);
 
   if (!status.IsOk()) {


### PR DESCRIPTION
…nstances

So, in this re-design we have modified the interface of rate limiter quite a bit. Instead of earlier callback based signaling, we will use the Enqueue and Dequeue methods to control when each instance gets to run inference.

The current implementation is just a proposal for a simple no batching case. I have verified that it keeps the same performance as our current threading model when the RL is disabled. However, there are some weirdness that I can not yet explain. More on this at the end.

Following are some points about this design:
1. The scheduler threads will just be batcher threads and will come into the picture only when a batching is enabled.
2. The request queue is maintained by RateLimiter. This will be replaced with PriorityQueue from scheduler_utils in the future to include functionalities like timeouts and priorities.
3. BackendThreads will wait on RL to receive a payload to use for inference. In case of the high load and no rate limiting, this reduces to just a pop out of the queue.
4. Payload infrastructure is kept because later for device blocking case the same thread can be used to intialize and warmup the multiple model instances whenever required.
5. In order to interact with the BackendThread, user must request for a payload oobject from RL, configure the object and then enqueue to the RL. The RL will then pass it to the waiting BackendThread whenever scheduling for inference.
