### PR TITLE
Build dynamic batches using BatcherThread

### DIFF
--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -198,7 +198,8 @@ TritonModelInstance::CreateInstance(
   std::unique_ptr<TritonModelInstance> local_instance(new TritonModelInstance(
       model, name, index, kind, device_id, profile_names, passive));
 
-  model->Server()->GetRateLimiter()->InitializePayloadQueues(local_instance.get());
+  model->Server()->GetRateLimiter()->InitializePayloadQueues(
+      local_instance.get());
   TRITONBACKEND_ModelInstance* triton_instance =
       reinterpret_cast<TRITONBACKEND_ModelInstance*>(local_instance.get());
   local_instance->SetBackendThread(

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -87,6 +87,7 @@ class DynamicBatchScheduler : public Scheduler {
       const ModelQueuePolicyMap& queue_policy_map);
 
   void BatcherThread(const int nice);
+  void NewPayload();
   uint64_t GetDynamicBatch();
   void DelegateResponse(std::unique_ptr<InferenceRequest>& request);
   void FinalizeResponses();
@@ -113,6 +114,9 @@ class DynamicBatchScheduler : public Scheduler {
   std::condition_variable instance_cv_;
 
   std::shared_ptr<RateLimiter> rate_limiter_;
+
+  std::shared_ptr<RateLimiter::Payload> curr_payload_;
+  bool payload_saturated_;
 
   size_t max_batch_size_;
   size_t max_preferred_batch_size_;

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -110,8 +110,7 @@ class DynamicBatchScheduler : public Scheduler {
   std::mutex mu_;
   std::condition_variable cv_;
 
-  std::mutex instance_mu_;
-  std::condition_variable instance_cv_;
+  std::condition_variable slot_cv_;
 
   std::shared_ptr<RateLimiter> rate_limiter_;
 

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -97,6 +97,7 @@ class RateLimiter {
 
   void InitializePayloadQueues(const TritonModelInstance* instance);
   size_t IdleInstanceCount(const TritonModel* model);
+  bool PayloadSlotAvailable(const TritonModel* model);
 
   Status EnqueuePayload(
       const TritonModel* model, std::shared_ptr<Payload> payload);
@@ -150,6 +151,8 @@ class RateLimiter {
     size_t BatchSize() { return requests_.size(); }
     void ReserveRequests(size_t size);
     void AddRequest(std::unique_ptr<InferenceRequest> request);
+    void SetCallback(std::function<void()> OnCallback);
+    void Callback();
     void SetInstance(TritonModelInstance* model_instance);
     TritonModelInstance* GetInstance() { return instance_; }
 
@@ -162,7 +165,7 @@ class RateLimiter {
    private:
     Operation op_type_;
     std::vector<std::unique_ptr<InferenceRequest>> requests_;
-    std::function<void()> OnCompletion_;
+    std::function<void()> OnCallback_;
     TritonModelInstance* instance_;
     State state_;
     std::unique_ptr<std::promise<Status>> status_;

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -96,7 +96,6 @@ class RateLimiter {
   Status UnregisterModel(const TritonModel* model);
 
   void InitializePayloadQueues(const TritonModelInstance* instance);
-  size_t IdleInstanceCount(const TritonModel* model);
   bool PayloadSlotAvailable(const TritonModel* model);
 
   Status EnqueuePayload(
@@ -334,13 +333,11 @@ class RateLimiter {
   std::vector<std::shared_ptr<Payload>> payload_bucket_;
 
   struct PayloadQueue {
-    PayloadQueue() : idle_count_(0) {}
     std::deque<std::shared_ptr<Payload>> queue_;
     std::map<
         const TritonModelInstance*,
         std::unique_ptr<std::deque<std::shared_ptr<Payload>>>>
         specific_queues_;
-    std::atomic<size_t> idle_count_;
     std::mutex mu_;
     std::condition_variable cv_;
   };


### PR DESCRIPTION
This enables the dynamic batches to the models. I have fixed the perf difference for most of the cases. There are few cases performance of this DB still lags. The reason is now the batcher thread acquires the lock to the priority queue more frequently. I have to do some more tuning and believe after which the performance might actually improve.

UPDATE: I have done some of the tune ups to batcher. Take a look at the performance analysis and further scope with DLIS-2534.