### PR TITLE
Add support for Helm3 (helm2 still supported) 

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -53,10 +53,21 @@ metrics reported by the inference server.
 
 ## Installing Helm
 
+### Helm v3
+
 If you do not already have Helm installed in your Kubernetes cluster,
 executing the following steps from the [official helm install
 guide](https://helm.sh/docs/intro/install/) will
 give you a quick setup.
+
+If you're currently using Helm v2 and would like to migrate to Helm v3,
+please see the [official migration guide](https://helm.sh/docs/topics/v2_v3_migration/).
+
+### Helm v2
+
+> **NOTE**: Moving forward this chart will only be tested and maintained for Helm v3.
+
+Below are example instructions for installing Helm v2. 
 
 ```
 $ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
@@ -65,6 +76,8 @@ serviceaccount/tiller created
 $ kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
 $ helm init --service-account tiller --wait
 ```
+
+If you run into any issues, you can refer to the official installation guide [here](https://v2.helm.sh/docs/install/).
 
 ## Model Repository
 

--- a/deploy/aws/templates/deployment.yaml
+++ b/deploy/aws/templates/deployment.yaml
@@ -95,6 +95,6 @@ spec:
               path: /v2/health/ready
               port: http
               
-          securityContext:
-            runAsUser: 1000
-            fsGroup: 1000
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -55,12 +55,24 @@ launch the inference server, and then send inference requests to the
 running server. You can access a Grafana endpoint to see real-time
 metrics reported by the inference server.
 
+
 ## Installing Helm
+
+### Helm v3
 
 If you do not already have Helm installed in your Kubernetes cluster,
 executing the following steps from the [official helm install
 guide](https://helm.sh/docs/intro/install/) will
 give you a quick setup.
+
+If you're currently using Helm v2 and would like to migrate to Helm v3,
+please see the [official migration guide](https://helm.sh/docs/topics/v2_v3_migration/).
+
+### Helm v2
+
+> **NOTE**: Moving forward this chart will only be tested and maintained for Helm v3.
+
+Below are example instructions for installing Helm v2. 
 
 ```
 $ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
@@ -69,6 +81,8 @@ serviceaccount/tiller created
 $ kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
 $ helm init --service-account tiller --wait
 ```
+
+If you run into any issues, you can refer to the official installation guide [here](https://v2.helm.sh/docs/install/).
 
 ## Model Repository
 

--- a/deploy/gcp/templates/deployment.yaml
+++ b/deploy/gcp/templates/deployment.yaml
@@ -76,6 +76,6 @@ spec:
               path: /v2/health/ready
               port: http
 
-          securityContext:
-            runAsUser: 1000
-            fsGroup: 1000
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000


### PR DESCRIPTION
- Move `securityContext` from container scope to pod scope to support Helm3 in addition to Helm2. 
- Update `gcp/README.md` and `aws/README.md` with instructions on Helm3 and Helm2 installation.

### Before

#### Helm3

Helm3 fails with this error described here: https://github.com/zammad/zammad-helm/issues/40

Fix is to move `securityContext` up one level from container scope to pod scope.

```bash
$ helm3 install local-helm3 . 
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].securityContext): unknown field "fsGroup" in io.k8s.api.core.v1.SecurityContext
```

#### Helm2
```
$ helm2 install --name local-helm2 .
NAME:   local-helm2
LAST DEPLOYED: Fri Jun 25 15:40:34 2021
NAMESPACE: default
STATUS: DEPLOYED
```

### After

#### Helm3:
```
$ helm3 install local-helm3 .
--
NAME: local-helm3
LAST DEPLOYED: Fri Jun 25 15:12:41 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

Can query server status:
```
$ curl "${TRITON_IP}:${TRITON_HTTP_PORT_HELM3}/v2"
{"name":"triton","version":"2.10.0","extensions":["classification","sequence","model_repository","model_repository(unload_dependents)","schedule_policy","model_configuration","system_shared_memory","cuda_shared_memory","binary_tensor_data","statistics"]}
```

#### Helm2:
```
$ helm2 install --name local-helm2 .
--
NAME: local-helm2
LAST DEPLOYED: Fri Jun 25 15:13:06 2021
NAMESPACE: default
STATUS: DEPLOYED
```

Can query server status:
```
$ curl "${TRITON_IP}:${TRITON_HTTP_PORT_HELM2}/v2"
{"name":"triton","version":"2.10.0","extensions":["classification","sequence","model_repository","model_repository(unload_dependents)","schedule_policy","model_configuration","system_shared_memory","cuda_shared_memory","binary_tensor_data","statistics"]}
```