### PR TITLE
Integrate SequenceBatcher with new threading abstraction

### DIFF
--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -143,25 +143,21 @@ InferenceBackend::SetConfiguredScheduler(void* model)
   // If 'sequence_batching' is configured use the SequenceBatchScheduler,
   // otherwise use the default DynamicBatchScheduler.
   if (config_.has_sequence_batching()) {
-    return Status(
-        Status::Code::INTERNAL, "SequenceBatcher is not yet supported");
-    /*
     // Sequence batcher
     RETURN_IF_ERROR(SequenceBatchScheduler::Create(
-        config_, runner_cnt, OnInit, OnWarmup, OnRun,
-        enforce_equal_shape_tensors, &scheduler));
-    */
+        static_cast<TritonModel*>(model), enforce_equal_shape_tensors,
+        &scheduler));
   } else if (config_.has_dynamic_batching()) {
     // Dynamic batcher
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
-        static_cast<TritonModel*>(model), GetCpuNiceLevel(config_),
+        static_cast<TritonModel*>(model), nullptr, GetCpuNiceLevel(config_),
         true /* dynamic_batching_enabled */, config_.max_batch_size(),
         enforce_equal_shape_tensors, config_.dynamic_batching(), &scheduler));
   } else {
     // Default scheduler. Use dynamic batch scheduler (with batching
     // disabled) as the default scheduler.
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
-        static_cast<TritonModel*>(model), GetCpuNiceLevel(config_),
+        static_cast<TritonModel*>(model), nullptr, GetCpuNiceLevel(config_),
         false /* dynamic_batching_enabled */, 1 /* max_batch_size */,
         std::unordered_map<
             std::string, bool>() /* enforce_equal_shape_tensors */,

--- a/src/core/backend.cc
+++ b/src/core/backend.cc
@@ -150,14 +150,14 @@ InferenceBackend::SetConfiguredScheduler(void* model)
   } else if (config_.has_dynamic_batching()) {
     // Dynamic batcher
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
-        static_cast<TritonModel*>(model), nullptr, GetCpuNiceLevel(config_),
+        static_cast<TritonModel*>(model), nullptr, 0 /*nice*/,
         true /* dynamic_batching_enabled */, config_.max_batch_size(),
         enforce_equal_shape_tensors, config_.dynamic_batching(), &scheduler));
   } else {
     // Default scheduler. Use dynamic batch scheduler (with batching
     // disabled) as the default scheduler.
     RETURN_IF_ERROR(DynamicBatchScheduler::Create(
-        static_cast<TritonModel*>(model), nullptr, GetCpuNiceLevel(config_),
+        static_cast<TritonModel*>(model), nullptr, 0 /*nice*/,
         false /* dynamic_batching_enabled */, 1 /* max_batch_size */,
         std::unordered_map<
             std::string, bool>() /* enforce_equal_shape_tensors */,

--- a/src/core/dynamic_batch_scheduler.h
+++ b/src/core/dynamic_batch_scheduler.h
@@ -51,8 +51,8 @@ class DynamicBatchScheduler : public Scheduler {
   // Create a scheduler to support a given number of runners and a run
   // function to call when a request is scheduled.
   static Status Create(
-      TritonModel* model, const int nice, const bool dynamic_batching_enabled,
-      const int32_t max_batch_size,
+      TritonModel* model, TritonModelInstance* model_instance, const int nice,
+      const bool dynamic_batching_enabled, const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
@@ -63,8 +63,8 @@ class DynamicBatchScheduler : public Scheduler {
   // function to call when a request is scheduled. And the scheduler also
   // supports different queue policies for different priority levels.
   static Status Create(
-      TritonModel* model, const int nice, const bool dynamic_batching_enabled,
-      const int32_t max_batch_size,
+      TritonModel* model, TritonModelInstance* model_instance, const int nice,
+      const bool dynamic_batching_enabled, const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const inference::ModelDynamicBatching& batcher_config,
       std::unique_ptr<Scheduler>* scheduler);
@@ -76,8 +76,8 @@ class DynamicBatchScheduler : public Scheduler {
 
  private:
   DynamicBatchScheduler(
-      TritonModel* model, const bool dynamic_batching_enabled,
-      const int32_t max_batch_size,
+      TritonModel* model, TritonModelInstance* model_instance,
+      const bool dynamic_batching_enabled, const int32_t max_batch_size,
       const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
       const bool preserve_ordering,
       const std::set<int32_t>& preferred_batch_sizes,
@@ -94,6 +94,7 @@ class DynamicBatchScheduler : public Scheduler {
 
   // FIXME: Use shared_ptr for model once InferenceBackend class is cleaned up.
   TritonModel* model_;
+  TritonModelInstance* model_instance_;
 
   // True if dynamic batching is enabled.
   const bool dynamic_batching_enabled_;

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -326,6 +326,13 @@ SequenceBatchScheduler::CreateBooleanControlTensors(
 Status
 SequenceBatchScheduler::Enqueue(std::unique_ptr<InferenceRequest>& irequest)
 {
+  // Queue timer starts at the beginning of the queueing and
+  // scheduling process
+  irequest->CaptureQueueStartNs();
+  INFER_TRACE_ACTIVITY(
+      irequest->Trace(), TRITONSERVER_TRACE_QUEUE_START,
+      irequest->QueueStartNs());
+
   // For now the request must have batch-size 1 since the sequence
   // batcher does not yet support requests that are statically
   // batched.

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -35,14 +35,13 @@
 #include "src/core/dynamic_batch_scheduler.h"
 #include "src/core/logging.h"
 #include "src/core/model_config_utils.h"
+#include "src/core/server.h"
 
 namespace nvidia { namespace inferenceserver {
 
 Status
 SequenceBatchScheduler::Create(
-    const inference::ModelConfig& config, const uint32_t runner_cnt,
-    const StandardInitFunc& OnInit, const StandardWarmupFunc& OnWarmup,
-    const StandardRunFunc& OnSchedule,
+    TritonModel* model,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
     std::unique_ptr<Scheduler>* scheduler)
 {
@@ -56,7 +55,11 @@ SequenceBatchScheduler::Create(
     LOG_INFO << "Delaying scheduler until " << sched->backlog_delay_cnt_
              << " backlog queued requests...";
   }
-  sched->queue_request_cnts_.resize(runner_cnt, 0);
+
+  auto instance_count = model->Instances().size();
+  sched->queue_request_cnts_.resize(instance_count, 0);
+
+  auto config = model->Config();
 
   // Max sequence idle...
   sched->max_sequence_idle_microseconds_ =
@@ -86,33 +89,36 @@ SequenceBatchScheduler::Create(
   // Create one SequenceBatch object for each requested runner. The
   // SequenceBatch object has a thread that manages the batch of
   // requests.
-  for (uint32_t c = 0; c < runner_cnt; ++c) {
-    std::promise<bool> init_state;
+  const auto& instances = model->Instances();
+  uint32_t index = 0;
+  for (const auto& instance : instances) {
+    bool init_state;
     std::shared_ptr<SequenceBatch> sb;
 
     // Create the SequenceBatch derivative that handles the requested
     // scheduling strategy.
     if (config.sequence_batching().has_oldest()) {
       sb.reset(new OldestSequenceBatch(
-          sched.get(), c, seq_slot_cnt, config, OnInit, OnWarmup, OnSchedule,
+          sched.get(), index, seq_slot_cnt, instance.get(),
           enforce_equal_shape_tensors, start, end, startend, cont, notready,
           &init_state));
     } else {
       sb.reset(new DirectSequenceBatch(
-          sched.get(), c, seq_slot_cnt, config, OnInit, OnWarmup, OnSchedule,
+          sched.get(), index, seq_slot_cnt, instance.get(),
           enforce_equal_shape_tensors, start, end, startend, cont, notready,
           &init_state));
     }
 
-    if (init_state.get_future().get()) {
+    if (init_state) {
       sched->batchers_.push_back(sb);
       // All sequence slots in the batcher are initially ready for a
       // new sequence.
       for (size_t b = 0; b < seq_slot_cnt; ++b) {
         sched->ready_batcher_seq_slots_.push(
-            SequenceBatchScheduler::BatcherSequenceSlot(c, b));
+            SequenceBatchScheduler::BatcherSequenceSlot(index, b));
       }
     }
+    ++index;
   }
   if (sched->batchers_.empty()) {
     return Status(
@@ -812,10 +818,7 @@ SequenceBatch::SetControlTensors(
 
 DirectSequenceBatch::DirectSequenceBatch(
     SequenceBatchScheduler* base, const uint32_t batcher_idx,
-    const size_t seq_slot_cnt, const inference::ModelConfig& config,
-    const Scheduler::StandardInitFunc& OnInit,
-    const Scheduler::StandardWarmupFunc& OnWarmup,
-    const Scheduler::StandardRunFunc& OnSchedule,
+    const size_t seq_slot_cnt, TritonModelInstance* model_instance,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
     const std::shared_ptr<SequenceBatchScheduler::ControlInputs>&
         start_input_overrides,
@@ -827,21 +830,21 @@ DirectSequenceBatch::DirectSequenceBatch(
         continue_input_overrides,
     const std::shared_ptr<SequenceBatchScheduler::ControlInputs>&
         notready_input_overrides,
-    std::promise<bool>* is_initialized)
+    bool* is_initialized)
     : SequenceBatch(
           base, batcher_idx, seq_slot_cnt, enforce_equal_shape_tensors,
           start_input_overrides, end_input_overrides, startend_input_overrides,
           continue_input_overrides, notready_input_overrides),
-      OnInit_(OnInit), OnWarmup_(OnWarmup), OnSchedule_(OnSchedule),
-      scheduler_thread_exit_(false), scheduler_idle_(false),
-      queues_(seq_slot_cnt), seq_slot_correlation_ids_(seq_slot_cnt, 0),
-      max_active_seq_slot_(-1)
+      model_instance_(model_instance), scheduler_thread_exit_(false),
+      scheduler_idle_(false), queues_(seq_slot_cnt),
+      seq_slot_correlation_ids_(seq_slot_cnt, 0), max_active_seq_slot_(-1)
 {
   // Initialize to handle CORRID control. If error just exit
   // now... that means the corresponding model instance will not have
   // any runner and so will not get used for execution.
+  const auto& config = model_instance_->Model()->Config();
   if (!CreateCorrelationIDControl(config)) {
-    is_initialized->set_value(false);
+    *is_initialized = false;
     return;
   }
 
@@ -854,9 +857,10 @@ DirectSequenceBatch::DirectSequenceBatch(
   // Create a scheduler thread associated with 'batcher_idx' that
   // executes the queued requests.
   const int nice = GetCpuNiceLevel(config);
-  scheduler_thread_.reset(new std::thread([this, nice, is_initialized]() {
-    SchedulerThread(nice, is_initialized);
-  }));
+  scheduler_thread_.reset(
+      new std::thread([this, nice]() { SchedulerThread(nice); }));
+
+  *is_initialized = true;
 }
 
 DirectSequenceBatch::~DirectSequenceBatch()
@@ -876,10 +880,8 @@ DirectSequenceBatch::~DirectSequenceBatch()
   // scheduler thread does not join it against itself and instead
   // detach it so there is not a problem when its thread object is
   // destroyed.
-  if (scheduler_thread_->get_id() != std::this_thread::get_id()) {
+  if (scheduler_thread_->joinable()) {
     scheduler_thread_->join();
-  } else {
-    scheduler_thread_->detach();
   }
 }
 
@@ -911,8 +913,15 @@ DirectSequenceBatch::Enqueue(
 }
 
 void
-DirectSequenceBatch::SchedulerThread(
-    const int nice, std::promise<bool>* is_initialized)
+DirectSequenceBatch::NewPayload()
+{
+  curr_payload_ =
+      model_instance_->Model()->Server()->GetRateLimiter()->GetPayload(
+          RateLimiter::Payload::Operation::INFER_RUN, model_instance_);
+}
+
+void
+DirectSequenceBatch::BatcherThread(const int nice)
 {
 #ifndef _WIN32
   if (setpriority(PRIO_PROCESS, syscall(SYS_gettid), nice) == 0) {
@@ -928,25 +937,6 @@ DirectSequenceBatch::SchedulerThread(
                  << batcher_idx_ << " at default nice...";
 #endif
 
-  // Initialize using the thread. If error then just exit this thread
-  // now... that means the corresponding model instance will not have
-  // any runner and so will not get used for execution.
-  Status startup_status = OnInit_(batcher_idx_);
-
-  // Run warmup function if initialization succeed.
-  if (startup_status.IsOk()) {
-    startup_status = OnWarmup_(batcher_idx_);
-  }
-  if (!startup_status.IsOk()) {
-    LOG_ERROR
-        << "Initialization failed for Direct sequence-batch scheduler thread "
-        << batcher_idx_ << ": " << startup_status.Message();
-    is_initialized->set_value(false);
-    return;
-  } else {
-    is_initialized->set_value(true);
-  }
-
   // For debugging and testing, delay start of thread until queues
   // contain the specified number of entries (across all
   // SequenceBatchs in the scheduler).
@@ -958,23 +948,11 @@ DirectSequenceBatch::SchedulerThread(
                    << delay_cnt << " queued requests...";
   }
 
-  // For testing this scheduler thread to be the last to release the
-  // backend object.
-  uint64_t backend_release_wait_milliseconds = 0;
-  {
-    const char* dstr = getenv("TRITONSERVER_DELAY_SCHEDULER_BACKEND_RELEASE");
-    if (dstr != nullptr) {
-      backend_release_wait_milliseconds = atoi(dstr);
-      LOG_VERBOSE(1) << "Delaying scheduler backend release for "
-                     << batcher_idx_ << ": "
-                     << backend_release_wait_milliseconds << "ms";
-    }
-  }
-
   const uint64_t default_wait_microseconds = 500 * 1000;
 
+  NewPayload();
+
   while (!scheduler_thread_exit_) {
-    std::vector<std::unique_ptr<InferenceRequest>> requests;
     uint64_t wait_microseconds = default_wait_microseconds;
 
     // Hold the lock for as short a time as possible.
@@ -1150,7 +1128,7 @@ DirectSequenceBatch::SchedulerThread(
             // just use zero for that.
             SetControlTensors(
                 ni, seq_slot, 0 /* corrid */, true /* not_ready */);
-            requests.emplace_back(std::move(ni));
+            curr_payload_->AddRequest(std::move(ni));
           } else {
             std::unique_ptr<InferenceRequest>& irequest = queue.front();
 
@@ -1163,9 +1141,14 @@ DirectSequenceBatch::SchedulerThread(
               end_of_sequence = true;
             }
 
-            requests.emplace_back(std::move(irequest));
+            curr_payload_->AddRequest(std::move(irequest));
 
             queue.pop_front();
+          }
+
+          if (curr_payload_->GetState() ==
+              RateLimiter::Payload::State::UNINITIALIZED) {
+            curr_payload_->SetState(RateLimiter::Payload::State::READY);
           }
 
           // If the sequence has ended then attempt to refill the
@@ -1213,33 +1196,12 @@ DirectSequenceBatch::SchedulerThread(
       }
     }
 
-    if (!requests.empty()) {
+    if (curr_payload_->GetState() == RateLimiter::Payload::State::READY) {
       // Run the backend...
-      OnSchedule_(batcher_idx_, std::move(requests));
-
-      // For testing we introduce a delay here to make the
-      // "SequenceBatchScheduler destroyed by this thread" case
-      // described in the comment below reproducible.
-      if (backend_release_wait_milliseconds > 0) {
-        std::this_thread::sleep_for(
-            std::chrono::milliseconds(backend_release_wait_milliseconds));
-      }
+      model_instance_->Model()->Server()->GetRateLimiter()->EnqueuePayload(
+          model_instance_->Model(), curr_payload_);
+      NewPayload();
     }
-
-    // FIXME, this isn't really true anymore so needs to be revisited.
-    //
-    // At the end of this scope 'requests' will be destroyed.  A
-    // handle to the backend is held by the request. If the server is
-    // exiting or the backend is unloaded, it could be that this
-    // handle is the last one for the backend and so destroying
-    // 'requests' will cause the backend to be deleted which in turn
-    // will call this thread's DynamicBatchScheduler to be destroyed
-    // by this thread itself. In that case it is important that this
-    // thread not reference the object after this point since the
-    // object will be invalid. The while statement above uses a local
-    // atomic which is set to false by the destructor (and so the
-    // while loop will exit) and the logging below uses only local
-    // variables... so this code is ok.
   }  // end runner loop
 
   LOG_VERBOSE(1) << "Stopping Direct sequence-batch scheduler thread "
@@ -1248,10 +1210,7 @@ DirectSequenceBatch::SchedulerThread(
 
 OldestSequenceBatch::OldestSequenceBatch(
     SequenceBatchScheduler* base, const uint32_t batcher_idx,
-    const size_t seq_slot_cnt, const inference::ModelConfig& config,
-    const Scheduler::StandardInitFunc& OnInit,
-    const Scheduler::StandardWarmupFunc& OnWarmup,
-    const Scheduler::StandardRunFunc& OnSchedule,
+    const size_t seq_slot_cnt, TritonModelInstance* model_instance,
     const std::unordered_map<std::string, bool>& enforce_equal_shape_tensors,
     const std::shared_ptr<SequenceBatchScheduler::ControlInputs>&
         start_input_overrides,
@@ -1263,48 +1222,46 @@ OldestSequenceBatch::OldestSequenceBatch(
         continue_input_overrides,
     const std::shared_ptr<SequenceBatchScheduler::ControlInputs>&
         notready_input_overrides,
-    std::promise<bool>* is_initialized)
+    bool* is_initialized)
     : SequenceBatch(
           base, batcher_idx, seq_slot_cnt, enforce_equal_shape_tensors,
           start_input_overrides, end_input_overrides, startend_input_overrides,
           continue_input_overrides, notready_input_overrides),
       in_flight_(seq_slot_cnt, false), queues_(seq_slot_cnt)
 {
-//// FIXME: Fix with sequence  batcher change
-//  // Initialize to handle CORRID control. If error just exit
-//  // now... that means the corresponding model instance will not have
-//  // any runner and so will not get used for execution.
-//  if (!CreateCorrelationIDControl(config)) {
-//    is_initialized->set_value(false);
-//    return;
-//  }
-//
-//  // Create a dynamic batcher use to batch together sequences for
-//  // inference.
-//  std::set<int32_t> preferred_batch_sizes;
-//  for (const auto size :
-//       config.sequence_batching().oldest().preferred_batch_size()) {
-//    preferred_batch_sizes.insert(size);
-//  }
-//
-//  Status status = DynamicBatchScheduler::Create(
-//      batcher_idx_, 1 /* runner_cnt */, GetCpuNiceLevel(config), OnInit,
-//      OnWarmup, OnSchedule, true /* dynamic_batching_enabled */,
-//      config.max_batch_size(), enforce_equal_shape_tensors_,
-//      true /* preserve_ordering */, preferred_batch_sizes,
-//      config.sequence_batching().oldest().max_queue_delay_microseconds(),
-//      &dynamic_batcher_);
-//  if (!status.IsOk()) {
-//    LOG_ERROR << "failed creating dynamic sequence batcher for OldestFirst "
-//              << batcher_idx_ << ": " << status.Message();
-//    is_initialized->set_value(false);
-//    return;
-//  }
-//
-//  is_initialized->set_value(true);
+  // Initialize to handle CORRID control. If error just exit
+  // now... that means the corresponding model instance will not have
+  // any runner and so will not get used for execution.
+  const auto& config = model_instance->Model()->Config();
+  if (!CreateCorrelationIDControl(config)) {
+    *is_initialized = false;
+    return;
+  }
 
+  // Create a dynamic batcher use to batch together sequences for
+  // inference.
+  std::set<int32_t> preferred_batch_sizes;
+  for (const auto size :
+       config.sequence_batching().oldest().preferred_batch_size()) {
+    preferred_batch_sizes.insert(size);
+  }
+
+  Status status = DynamicBatchScheduler::Create(
+      model_instance->Model(), model_instance, GetCpuNiceLevel(config),
+      true /* dynamic_batching_enabled */, config.max_batch_size(),
+      enforce_equal_shape_tensors_, true /* preserve_ordering */,
+      preferred_batch_sizes,
+      config.sequence_batching().oldest().max_queue_delay_microseconds(),
+      &dynamic_batcher_);
+  if (!status.IsOk()) {
+    LOG_ERROR << "failed creating dynamic sequence batcher for OldestFirst "
+              << batcher_idx_ << ": " << status.Message();
+    *is_initialized = false;
+    return;
+  }
+
+  *is_initialized = true;
 }
-
 OldestSequenceBatch::~OldestSequenceBatch() {}
 
 void

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -326,13 +326,6 @@ SequenceBatchScheduler::CreateBooleanControlTensors(
 Status
 SequenceBatchScheduler::Enqueue(std::unique_ptr<InferenceRequest>& irequest)
 {
-  // Queue timer starts at the beginning of the queueing and
-  // scheduling process
-  irequest->CaptureQueueStartNs();
-  INFER_TRACE_ACTIVITY(
-      irequest->Trace(), TRITONSERVER_TRACE_QUEUE_START,
-      irequest->QueueStartNs());
-
   // For now the request must have batch-size 1 since the sequence
   // batcher does not yet support requests that are statically
   // batched.
@@ -856,9 +849,9 @@ DirectSequenceBatch::DirectSequenceBatch(
 
   // Create a scheduler thread associated with 'batcher_idx' that
   // executes the queued requests.
-  const int nice = GetCpuNiceLevel(config);
+  const int nice = 0;
   scheduler_thread_.reset(
-      new std::thread([this, nice]() { SchedulerThread(nice); }));
+      new std::thread([this, nice]() { BatcherThread(nice); }));
 
   *is_initialized = true;
 }


### PR DESCRIPTION
There is a big performance slump.

**Config:**
model: simple_savedmodel_sequence_object
instance count: 1
max_batch_size: 8
sequence_batching {
  max_sequence_idle_microseconds: 5000000
}
concurrent sequences: 4
request concurrencies: 5


**New SequenceBatcher:**
Concurrency: 5, throughput: 1830 infer/sec, latency 2701 usec
Avg request latency: 2543 usec (overhead 91 usec + **queue 2008 usec** + compute input 32 usec + compute infer 403 usec + compute output 9 usec)

**Current SequenceBatcher**
Concurrency: 5, throughput: 3619 infer/sec, latency 1348 usec
Avg request latency: 1171 usec (overhead 178 usec + **queue 512 usec** + compute input 37 usec + compute infer 431 usec + compute output 13 usec)

The nsight traces  show some serious missed notification. I will address the perf slump as a part of another ticket. Let me know if something looks seriously flawed. 