### PR TITLE
Add RTLD_DEEPBIND to prefer symbol defined in shared library

### DIFF
--- a/src/core/shared_library.cc
+++ b/src/core/shared_library.cc
@@ -136,7 +136,7 @@ SharedLibrary::OpenLibraryHandle(const std::string& path, void** handle)
         Status::Code::NOT_FOUND, "unable to load backend library: " + errstr);
   }
 #else
-  *handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
+  *handle = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_DEEPBIND);
   if (*handle == nullptr) {
     return Status(
         Status::Code::NOT_FOUND,


### PR DESCRIPTION
This place lookup scope of the symbols in the shared library ahead of the global scope, in the case where the shared library (backend) has symbols conflicted with global symbols, the local one will be used.