### PR TITLE
Exposing port 8000 for Gitlab CI

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -41,7 +41,7 @@ ARG TRITON_BACKEND_REPO_TAG=main
 ## into QA area.
 ############################################################################
 FROM ${BUILD_IMAGE} AS build
-
+EXPOSE 9000
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -41,7 +41,7 @@ ARG TRITON_BACKEND_REPO_TAG=main
 ## into QA area.
 ############################################################################
 FROM ${BUILD_IMAGE} AS build
-EXPOSE 9000
+EXPOSE 8000
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Hey, working around with Triton, Gitlab CI end to end testing. Sadly I'm not able to access the container from Gitlab CI bcs no port is exposed in the dockerfile. Exposing the port should be a solution bcs Trition is running healthy in the container and there is just no way of accessing it. 