### PR TITLE
Remove platform checks when the backend is present.

### DIFF
--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -998,7 +998,8 @@ ValidateModelConfig(
         "'max_batch_size' must be non-negative value for " + config.name());
   }
 
-  if (!config.platform().empty()) {
+  //If backend is  empty, validate the platform
+  if (!config.platform().empty() && config.backend().empty()) {
     if (!expected_platform.empty() &&
         (config.platform() != expected_platform)) {
       return Status(

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -998,7 +998,8 @@ ValidateModelConfig(
         "'max_batch_size' must be non-negative value for " + config.name());
   }
 
-  //If backend is  empty, validate the platform
+  // If backend is  empty, validate the platform.
+  // Otherwise, the platform validation should be performed by the backend, if necessary, as Triton may not know about the backend's requirements.
   if (!config.platform().empty() && config.backend().empty()) {
     if (!expected_platform.empty() &&
         (config.platform() != expected_platform)) {

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -998,8 +998,9 @@ ValidateModelConfig(
         "'max_batch_size' must be non-negative value for " + config.name());
   }
 
-  // If backend is  empty, validate the platform.
-  // Otherwise, the platform validation should be performed by the backend, if necessary, as Triton may not know about the backend's requirements.
+  // If backend is empty, validate the platform.
+  // Otherwise, the platform validation should be performed by the backend,
+  // as Triton may not know about the backend's requirements.
   if (!config.platform().empty() && config.backend().empty()) {
     if (!expected_platform.empty() &&
         (config.platform() != expected_platform)) {

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -998,9 +998,9 @@ ValidateModelConfig(
         "'max_batch_size' must be non-negative value for " + config.name());
   }
 
-  // If backend is empty, validate the platform.
-  // Otherwise, the platform validation should be performed by the backend,
-  // as Triton may not know about the backend's requirements.
+  // If backend is empty, validate the platform. Otherwise, the platform
+  // validation should be performed by the backend, as Triton may not know
+  // about the backend's requirements.
   if (!config.platform().empty() && config.backend().empty()) {
     if (!expected_platform.empty() &&
         (config.platform() != expected_platform)) {


### PR DESCRIPTION
Removing the platform checks when backend is present. This will allow people to put custom backends onto the server after building it, rather than building with the backend flags enabled.