### PR TITLE
CPU only build with only onnx runtime

### DIFF
--- a/build.py
+++ b/build.py
@@ -327,6 +327,7 @@ def backend_repo(be):
 def backend_cmake_args(images, components, be, install_dir, library_paths):
     if be == 'onnxruntime':
         args = onnxruntime_cmake_args(images, library_paths)
+        print(args)
     elif be == 'openvino':
         args = openvino_cmake_args()
     elif be == 'tensorflow1':
@@ -382,10 +383,13 @@ def pytorch_cmake_args(images):
 
 def onnxruntime_cmake_args(images, library_paths):
     cargs = [
-        '-DTRITON_ENABLE_ONNXRUNTIME_TENSORRT=ON',
         '-DTRITON_BUILD_ONNXRUNTIME_VERSION={}'.format(
             TRITON_VERSION_MAP[FLAGS.version][2])
     ]
+    if FLAGS.enable_gpu:
+        cargs.append('-DTRITON_ENABLE_ONNXRUNTIME_TENSORRT=ON')
+    else:
+        cargs.append('-DTRITON_ENABLE_GPU=OFF')
 
     # If platform is jetpack do not use docker based build
     if target_platform() == 'jetpack':
@@ -409,7 +413,8 @@ def onnxruntime_cmake_args(images, library_paths):
                 cargs.append('-DTRITON_BUILD_CONTAINER_VERSION={}'.format(
                     TRITON_VERSION_MAP[FLAGS.version][1]))
 
-            if TRITON_VERSION_MAP[FLAGS.version][3] is not None:
+            if TRITON_VERSION_MAP[
+                    FLAGS.version][3] is not None and FLAGS.enable_gpu:
                 cargs.append('-DTRITON_ENABLE_ONNXRUNTIME_OPENVINO=ON')
                 cargs.append(
                     '-DTRITON_BUILD_ONNXRUNTIME_OPENVINO_VERSION={}'.format(
@@ -602,7 +607,16 @@ RUN rm -fr *
 COPY . .
 ENTRYPOINT []
 '''
-        df += install_dcgm_libraries(argmap['DCGM_VERSION'])
+        if FLAGS.enable_gpu:
+            df += install_dcgm_libraries(argmap['DCGM_VERSION'])
+        else:
+            df += '''
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+            git \
+            libnuma-dev && \
+    rm -rf /var/lib/apt/lists/*
+'''
 
     df += '''
 ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
@@ -660,7 +674,7 @@ FROM ${{BASE_IMAGE}}
 '''.format(argmap['TRITON_VERSION'], argmap['TRITON_CONTAINER_VERSION'],
            argmap['BASE_IMAGE'])
 
-    df += dockerfile_prepare_container_linux(argmap, backends)
+    df += dockerfile_prepare_container_linux(argmap, backends, FLAGS.enable_gpu)
 
     df += '''
 WORKDIR /opt/tritonserver
@@ -698,7 +712,7 @@ COPY --chown=1000:1000 --from=tritonserver_build /workspace/build/sagemaker/serv
         dfile.write(df)
 
 
-def dockerfile_prepare_container_linux(argmap, backends):
+def dockerfile_prepare_container_linux(argmap, backends, enable_gpu):
     # Common steps to produce docker images shared by build.py and compose.py.
     # Sets enviroment variables, installs dependencies and adds entrypoint
     df = '''
@@ -740,7 +754,24 @@ RUN apt-get update && \
          libre2-5 && \
     rm -rf /var/lib/apt/lists/*
 '''
-    df += install_dcgm_libraries(argmap['DCGM_VERSION'])
+    if enable_gpu:
+        df += install_dcgm_libraries(argmap['DCGM_VERSION'])
+        df += '''
+# Extra defensive wiring for CUDA Compat lib
+RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \
+ && echo ${_CUDA_COMPAT_PATH}/lib > /etc/ld.so.conf.d/00-cuda-compat.conf \
+ && ldconfig \
+ && rm -f ${_CUDA_COMPAT_PATH}/lib 
+'''
+    else:
+        df += '''
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        dirmngr \ 
+        libnuma-dev && \
+    rm -rf /var/lib/apt/lists/*
+'''
     # Add dependencies needed for python backend
     if 'python' in backends:
         df += '''
@@ -755,12 +786,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 '''
     df += '''
-# Extra defensive wiring for CUDA Compat lib
-RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \
- && echo ${_CUDA_COMPAT_PATH}/lib > /etc/ld.so.conf.d/00-cuda-compat.conf \
- && ldconfig \
- && rm -f ${_CUDA_COMPAT_PATH}/lib
-
 WORKDIR /opt/tritonserver
 RUN rm -fr /opt/tritonserver/*
 COPY --chown=1000:1000 nvidia_entrypoint.sh .

--- a/build.py
+++ b/build.py
@@ -769,9 +769,18 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git \
         dirmngr \ 
-        libnuma-dev && \
+        libnuma-dev \
+        curl && \
     rm -rf /var/lib/apt/lists/*
 '''
+        if 'onnxruntime' in backends:
+            df += '''
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libgomp1 && \
+    rm -rf /var/lib/apt/lists
+'''
+
     # Add dependencies needed for python backend
     if 'python' in backends:
         df += '''

--- a/compose.py
+++ b/compose.py
@@ -71,7 +71,8 @@ FROM {}
            images["full"], images["min"])
 
     import build
-    df += build.dockerfile_prepare_container_linux(argmap, backends)
+    df += build.dockerfile_prepare_container_linux(argmap, backends,
+                                                   FLAGS.enable_gpu)
     # Copy over files
     df += '''
 WORKDIR /opt/tritonserver
@@ -91,7 +92,8 @@ def add_requested_backends(ddir, dockerfile_name, backends):
     for backend in backends:
         df += '''COPY --chown=1000:1000 --from=full /opt/tritonserver/backends/{} /opt/tritonserver/backends/{}    
 '''.format(backend, backend)
-    df += '''
+    if len(backends) > 0:
+        df += '''
 # Top-level /opt/tritonserver/backends not copied so need to explicitly set permissions here
 RUN chown triton-server:triton-server /opt/tritonserver/backends
 '''

--- a/qa/L0_infer/install_and_test.sh
+++ b/qa/L0_infer/install_and_test.sh
@@ -29,11 +29,13 @@
 # dependencies to run L0_infer tests
 apt-get update && \
     apt-get install -y --no-install-recommends \
+         curl \
+         jq \
          python3 \
          python3-pip && \
-pip3 install --upgrade pip
+pip3 install --upgrade pip && \
 # install client libraries
-pip3 install nvidia-pyindex
+pip3 install nvidia-pyindex && \
 pip3 install tritonclient[all]
 
 # Run the actual test


### PR DESCRIPTION
Changes to enable CPU only build with onnx runtime. 
Onnx Runtime PR: https://github.com/triton-inference-server/onnxruntime_backend/pull/54