### PR TITLE
Fix build_variants

### DIFF
--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -241,6 +241,8 @@ target_link_libraries(
   PRIVATE triton-common-error
   PRIVATE triton-core-serverapi
   PRIVATE tritonserver
+  PRIVATE pthread
+  PRIVATE dl
 )
 if (NOT WIN32)
 target_link_libraries(

--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -241,13 +241,12 @@ target_link_libraries(
   PRIVATE triton-common-error
   PRIVATE triton-core-serverapi
   PRIVATE tritonserver
-  PRIVATE pthread
-  PRIVATE dl
 )
 if (NOT WIN32)
 target_link_libraries(
   main
   PRIVATE rt
+  PRIVATE dl
 )
 endif()
 if(${TRITON_ENABLE_GPU})


### PR DESCRIPTION
Because the dl library is needed by boost::stacktrace, the dl library should be linked after the Boost stacktrace libraries are linked.