### PR TITLE
Fix setuptools version to WAR azure cli error

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -282,7 +282,7 @@ RUN rm -f /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip3 install --upgrade wheel setuptools && \
-    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil awscli six grpcio-channelz azure-cli
+    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil awscli six grpcio-channelz
 
 # L0_http_fuzz is hitting similar issue with boofuzz with latest version (0.4.0):
 # https://github.com/jtpereyda/boofuzz/issues/529

--- a/qa/L0_storage_azure/test.sh
+++ b/qa/L0_storage_azure/test.sh
@@ -61,6 +61,12 @@ CONTAINER_NAME="tritonqatest${timestamp}"
 # container path (Point to the container when testing cloud storage)
 AS_URL="as://${ACCOUNT_NAME}/${CONTAINER_NAME}"
 
+# Must use setuptools version before 58.0.0 due to https://github.com/Azure/azure-cli/issues/19468
+python -m pip install -U setuptools==57.5.0
+
+# Can now install latest azure-cli (instead of 2.0.73)
+python -m pip install azure-cli
+
 # create test container
 az storage container create --name ${CONTAINER_NAME} --account-name ${ACCOUNT_NAME} --account-key ${ACCOUNT_KEY}
 sleep 10


### PR DESCRIPTION
Fixes L0_storage_azure failure:
```
  File "/usr/local/lib/python3.8/dist-packages/azure/cli/core/_session.py", line 46, in load
    if st.st_mtime + max_age < time.clock():
AttributeError: module 'time' has no attribute 'clock'
```