### PR TITLE
Add CPU only to compose script

### DIFF
--- a/build.py
+++ b/build.py
@@ -761,7 +761,7 @@ ENV TF_ADJUST_HUE_FUSED         1
 ENV TF_ADJUST_SATURATION_FUSED  1
 ENV TF_ENABLE_WINOGRAD_NONFUSED 1
 ENV TF_AUTOTUNE_THRESHOLD       2
-ENV TRITON_GPU_ENABLED_BUILD    {gpu_enabled}        
+ENV TRITON_SERVER_GPU_ENABLED    {gpu_enabled}        
 
 # Create a user that can be used to run triton as
 # non-root. Make sure that this user to given ID 1000. All server

--- a/build.py
+++ b/build.py
@@ -742,7 +742,7 @@ COPY --chown=1000:1000 --from=tritonserver_build /workspace/build/sagemaker/serv
 
 
 def dockerfile_prepare_container_linux(argmap, backends, enable_gpu):
-    gpu_enabled = 1 if not enable_gpu else 0
+    gpu_enabled = 1 if enable_gpu else 0
     # Common steps to produce docker images shared by build.py and compose.py.
     # Sets enviroment variables, installs dependencies and adds entrypoint
     df = '''

--- a/build.py
+++ b/build.py
@@ -742,6 +742,7 @@ COPY --chown=1000:1000 --from=tritonserver_build /workspace/build/sagemaker/serv
 
 
 def dockerfile_prepare_container_linux(argmap, backends, enable_gpu):
+    gpu_enabled = 1 if not enable_gpu else 0
     # Common steps to produce docker images shared by build.py and compose.py.
     # Sets enviroment variables, installs dependencies and adds entrypoint
     df = '''
@@ -760,6 +761,7 @@ ENV TF_ADJUST_HUE_FUSED         1
 ENV TF_ADJUST_SATURATION_FUSED  1
 ENV TF_ENABLE_WINOGRAD_NONFUSED 1
 ENV TF_AUTOTUNE_THRESHOLD       2
+ENV TRITON_GPU_ENABLED_BUILD    {gpu_enabled}        
 
 # Create a user that can be used to run triton as
 # non-root. Make sure that this user to given ID 1000. All server
@@ -788,7 +790,7 @@ RUN apt-get update && \
             curl \
             {ort_dependencies} && \
     rm -rf /var/lib/apt/lists/*
-'''.format(ort_dependencies=ort_dependencies)
+'''.format(gpu_enabled=gpu_enabled, ort_dependencies=ort_dependencies)
 
     if enable_gpu:
         df += install_dcgm_libraries(argmap['DCGM_VERSION'])

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -41,9 +41,18 @@ from source to get more exact customization.
 
 ## Use the compose.py script
 
-The `compose.py` script can be found in the [server repository](https://github.com/triton-inference-server/server). Simply clone the repository and run `compose.py` to create a custom container. Note created container version will depend on the branch that was cloned. For example branch [r21.06](https://github.com/triton-inference-server/server/tree/r21.06) should be used to create a image based on the NGC 21.06 Triton release. 
+The `compose.py` script can be found in the [server repository](https://github.com/triton-inference-server/server).
+Simply clone the repository and run `compose.py` to create a custom container. 
+Note created container version will depend on the branch that was cloned. 
+For example branch [r21.08](https://github.com/triton-inference-server/server/tree/r21.08) 
+should be used to create a image based on the NGC 21.08 Triton release. 
 
-`compose.py` provides `--backend`, `--repoagent` options that allow you to specify which backends and repository agents to include in the custom image. The `--enable-gpu` flag indicates that you want to create an image that supports NVIDIA GPUs. For example, the following creates a new docker image that contains only the TensorFlow 1 and TensorFlow 2 backends and the checksum repository agent.
+`compose.py` provides `--backend`, `--repoagent` options that allow you to 
+specify which backends and repository agents to include in the custom image. 
+The `--enable-gpu` flag indicates that you want to create an image that supports
+ NVIDIA GPUs. For example, the following creates a new docker image that 
+contains only the TensorFlow 1 and TensorFlow 2 backends and the checksum 
+repository agent.
 
 Example:
 ```
@@ -54,11 +63,44 @@ will provide a container `tritonserver` locally. You can access the container wi
 $ docker run -it tritonserver:latest
 ```
 
-Note: If `compose.py` is run on release versions `r21.08` and older, the resulting container will have DCGM version 2.2.3 installed. This may result in different GPU statistic reporting behavior.
+Note: If `compose.py` is run on release versions `r21.08` and older, 
+the resulting container will have DCGM version 2.2.3 installed. 
+This may result in different GPU statistic reporting behavior.
+
+### Compose a specific version of Triton
+
+`compose.py` requires two containers to build, a `min` container which is the 
+base the compose container is build from and a `full` container where the script
+will extract components from. The version of the `min` and `full` container 
+is determined by the branch of Triton `compose.py` is on. 
+For example, running
+```
+python3 compose.py --backend tensorflow1 --repoagent checksum --enable-gpu
+```
+on branch [r21.08](https://github.com/triton-inference-server/server/tree/r21.08) pulls:
+-  `min` container `nvcr.io/nvidia/tritonserver:21.08-py3-min` 
+- `full` container `nvcr.io/nvidia/tritonserver:21.08-py3`
+
+Alternatively, users can specify the version of Triton container to pull from any branch by either:
+1. Adding flag `--container-version <container version>` to branch
+```
+python3 compose.py --backend tensorflow1 --repoagent checksum --container-version 21.08 --enable-gpu
+```
+2. Specifying `--image min,<min container image name> --image full,<full container image name>`. The user is responsible for specifying compatible `min` and `full` containers. 
+```
+python3 compose.py --backend tensorflow1 --repoagent checksum --image min,nvcr.io/nvidia/tritonserver:21.08-py3-min --image full,nvcr.io/nvidia/tritonserver:21.08-py3 --enable-gpu
+```
+Method 1 and 2 will result in the same composed container. Furthermore, `--image` flag overrides the `--container-version` flag when both are specified.
 
 ### CPU only container composition
 
-To compose a container that is build for only cpu usage, simply remove the `--enable-gpu` flag when running `compose.py`. This will build a container from `ubuntu:20.04` docker and use backends/repoagents from `nvcr.io/nvidia/tritonserver:<upstream-container-version>-cpu-only-py3`.
+To compose a container that is build for only cpu usage, simply remove the 
+`--enable-gpu` flag when running `compose.py`. 
+This will build a container from `ubuntu:20.04` docker and use 
+backends/repoagents from `nvcr.io/nvidia/tritonserver:<upstream-container-version>-cpu-only-py3`.
+Note: 
+1. If composing a CPU only container, both `min` and `full` containers should be built for CPU only and not have CUDA installed.
+2. CPU only containers are only available for Triton versions > `21.09` 
 
 ## Build it yourself
 

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -43,14 +43,14 @@ from source to get more exact customization.
 
 The `compose.py` script can be found in the [server repository](https://github.com/triton-inference-server/server).
 Simply clone the repository and run `compose.py` to create a custom container. 
-Note created container version will depend on the branch that was cloned. 
+Note: Created container version will depend on the branch that was cloned. 
 For example branch [r21.08](https://github.com/triton-inference-server/server/tree/r21.08) 
 should be used to create a image based on the NGC 21.08 Triton release. 
 
 `compose.py` provides `--backend`, `--repoagent` options that allow you to 
 specify which backends and repository agents to include in the custom image. 
 The `--enable-gpu` flag indicates that you want to create an image that supports
- NVIDIA GPUs. For example, the following creates a new docker image that 
+NVIDIA GPUs. For example, the following creates a new docker image that 
 contains only the TensorFlow 1 and TensorFlow 2 backends and the checksum 
 repository agent.
 
@@ -63,22 +63,22 @@ will provide a container `tritonserver` locally. You can access the container wi
 $ docker run -it tritonserver:latest
 ```
 
-Note: If `compose.py` is run on release versions `r21.08` and older, 
+Note: If `compose.py` is run on release versions `r21.08` and earlier, 
 the resulting container will have DCGM version 2.2.3 installed. 
 This may result in different GPU statistic reporting behavior.
 
 ### Compose a specific version of Triton
 
-`compose.py` requires two containers to build, a `min` container which is the 
-base the compose container is build from and a `full` container where the script
-will extract components from. The version of the `min` and `full` container 
+`compose.py` requires two containers: a `min` container which is the 
+base the compose container is built from and a `full` container from which the 
+script will extract components. The version of the `min` and `full` container 
 is determined by the branch of Triton `compose.py` is on. 
 For example, running
 ```
 python3 compose.py --backend tensorflow1 --repoagent checksum --enable-gpu
 ```
 on branch [r21.08](https://github.com/triton-inference-server/server/tree/r21.08) pulls:
--  `min` container `nvcr.io/nvidia/tritonserver:21.08-py3-min` 
+- `min` container `nvcr.io/nvidia/tritonserver:21.08-py3-min` 
 - `full` container `nvcr.io/nvidia/tritonserver:21.08-py3`
 
 Alternatively, users can specify the version of Triton container to pull from any branch by either:
@@ -86,7 +86,8 @@ Alternatively, users can specify the version of Triton container to pull from an
 ```
 python3 compose.py --backend tensorflow1 --repoagent checksum --container-version 21.08 --enable-gpu
 ```
-2. Specifying `--image min,<min container image name> --image full,<full container image name>`. The user is responsible for specifying compatible `min` and `full` containers. 
+2. Specifying `--image min,<min container image name> --image full,<full container image name>`. 
+   The user is responsible for specifying compatible `min` and `full` containers. 
 ```
 python3 compose.py --backend tensorflow1 --repoagent checksum --image min,nvcr.io/nvidia/tritonserver:21.08-py3-min --image full,nvcr.io/nvidia/tritonserver:21.08-py3 --enable-gpu
 ```
@@ -94,13 +95,15 @@ Method 1 and 2 will result in the same composed container. Furthermore, `--image
 
 ### CPU only container composition
 
-To compose a container that is build for only cpu usage, simply remove the 
+To compose a container that is built for only cpu usage, simply remove the 
 `--enable-gpu` flag when running `compose.py`. 
-This will build a container from `ubuntu:20.04` docker and use 
-backends/repoagents from `nvcr.io/nvidia/tritonserver:<upstream-container-version>-cpu-only-py3`.
+
+This will build a container using `ubuntu:20.04` docker as the `min` container 
+and `nvcr.io/nvidia/tritonserver:<upstream-container-version>-cpu-only-py3` as the `full` container.
 Note: 
-1. If composing a CPU only container, both `min` and `full` containers should be built for CPU only and not have CUDA installed.
+1. When composing a CPU only container, both `min` and `full` containers should be built for CPU only and not have CUDA installed.
 2. CPU only containers are only available for Triton versions > `21.09` 
+3. CPU only "full" containers are build with less backends then the GPU enabled containers. Currently supported backends are `onnxruntime`, `openvino` and `python`.
 
 ## Build it yourself
 

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -56,6 +56,10 @@ $ docker run -it tritonserver:latest
 
 Note: If `compose.py` is run on release versions `r21.08` and older, the resulting container will have DCGM version 2.2.3 installed. This may result in different GPU statistic reporting behavior.
 
+### CPU only container composition
+
+To compose a container that is build for only cpu usage, simply remove the `--enable-gpu` flag when running `compose.py`. This will build a container from `ubuntu:20.04` docker and use backends/repoagents from `nvcr.io/nvidia/tritonserver:<upstream-container-version>-cpu-only-py3`.
+
 ## Build it yourself
 
 If you would like to do what `compose.py` is doing under the hood yourself, you can run `compose.py` with the `--dry-run` option and then modify the `Dockerfile.compose` file to satisfy your needs. 


### PR DESCRIPTION
Enable compose script to compose cpu-only containers. Fixed upstream-version confusion to ensure compose script works for all branches