### PR TITLE
Connects the rate limiter to the scheduling pipeline

### DIFF
--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -186,16 +186,12 @@ TritonModel::Create(
 
 Status
 TritonModel::AddInstance(
-    std::unique_ptr<TritonModelInstance>&& instance, const bool passive,
-    const inference::ModelRateLimiter& rate_limiter_config)
+    std::unique_ptr<TritonModelInstance>&& instance, const bool passive)
 {
   if (passive) {
     passive_instances_.emplace_back(std::move(instance));
   } else {
-    TritonModelInstance* raw_instance = instance.get();
     instances_.emplace_back(std::move(instance));
-    RETURN_IF_ERROR(server_->GetRateLimiter()->RegisterModelInstance(
-        raw_instance, rate_limiter_config));
   }
 
   return Status::Success;

--- a/src/backends/backend/triton_model.h
+++ b/src/backends/backend/triton_model.h
@@ -73,8 +73,7 @@ class TritonModel : public InferenceBackend {
   void* State() { return state_; }
   void SetState(void* state) { state_ = state; }
   Status AddInstance(
-      std::unique_ptr<TritonModelInstance>&& instance, const bool passive,
-      const inference::ModelRateLimiter& rate_limiter_config);
+      std::unique_ptr<TritonModelInstance>&& instance, const bool passive);
 
  private:
   DISALLOW_COPY_AND_ASSIGN(TritonModel);

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -258,8 +258,6 @@ TritonModelInstance::CreateInstance(
       model, name, index, kind, device_id, profile_names, passive, host_policy,
       host_policy_message, secondary_devices));
 
-  // model->Server()->GetRateLimiter()->InitializePayloadQueues(
-  //    local_instance.get());
   TRITONBACKEND_ModelInstance* triton_instance =
       reinterpret_cast<TRITONBACKEND_ModelInstance*>(local_instance.get());
 

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -280,12 +280,13 @@ TritonModelInstance::CreateInstance(
 
   if (!passive) {
     RETURN_IF_ERROR(local_instance->GenerateWarmupData());
+    RETURN_IF_ERROR(model->Server()->GetRateLimiter()->RegisterModelInstance(
+        local_instance.get(), rate_limiter_config));
     local_instance->SetBackendThread(
         kind, device_id, device_blocking, device_to_thread_map);
   }
 
-  RETURN_IF_ERROR(model->AddInstance(
-      std::move(local_instance), passive, rate_limiter_config));
+  RETURN_IF_ERROR(model->AddInstance(std::move(local_instance), passive));
 
   return Status::Success;
 }

--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -258,8 +258,8 @@ TritonModelInstance::CreateInstance(
       model, name, index, kind, device_id, profile_names, passive, host_policy,
       host_policy_message, secondary_devices));
 
-  model->Server()->GetRateLimiter()->InitializePayloadQueues(
-      local_instance.get());
+  // model->Server()->GetRateLimiter()->InitializePayloadQueues(
+  //    local_instance.get());
   TRITONBACKEND_ModelInstance* triton_instance =
       reinterpret_cast<TRITONBACKEND_ModelInstance*>(local_instance.get());
 

--- a/src/core/instance_queue.cc
+++ b/src/core/instance_queue.cc
@@ -48,7 +48,7 @@ InstanceQueue::Empty()
 }
 
 void
-InstanceQueue::Enqueue(std::shared_ptr<Payload>& payload)
+InstanceQueue::Enqueue(const std::shared_ptr<Payload>& payload)
 {
   payload_queue_.push_back(payload);
 }

--- a/src/core/instance_queue.h
+++ b/src/core/instance_queue.h
@@ -40,7 +40,7 @@ class InstanceQueue {
 
   size_t Size();
   bool Empty();
-  void Enqueue(std::shared_ptr<Payload>& payload);
+  void Enqueue(const std::shared_ptr<Payload>& payload);
   void Dequeue(
       std::shared_ptr<Payload>* payload,
       std::vector<std::shared_ptr<Payload>>* merged_payloads);

--- a/src/core/payload.h
+++ b/src/core/payload.h
@@ -66,6 +66,8 @@ class Payload {
   uint64_t QueueStartNs() { return queue_start_ns_; }
   void SetCallback(std::function<void()> OnCallback);
   void Callback();
+  void SetSecondaryCallback(std::function<void()> OnRelease);
+  void SecondaryCallback();
   void SetInstance(TritonModelInstance* model_instance);
   TritonModelInstance* GetInstance() { return instance_; }
 
@@ -79,6 +81,7 @@ class Payload {
   Operation op_type_;
   std::vector<std::unique_ptr<InferenceRequest>> requests_;
   std::function<void()> OnCallback_;
+  std::function<void()> OnSecondaryCallback_;
   TritonModelInstance* instance_;
   State state_;
   std::unique_ptr<std::promise<Status>> status_;

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -40,20 +40,10 @@
 
 namespace nvidia { namespace inferenceserver {
 
-// Limits the rate at which requests are dispatched from the scheduler
+// Limits the rate at which requests are dispatched to the model instances
 class RateLimiter {
- private:
-  class ModelContext;
-  class PayloadQueue;
-
  public:
-  class ModelInstance;
-
-  using StandardReleaseFunc = std::function<void(ModelInstance*)>;
-  using StandardScheduleFunc = std::function<void(ModelInstance*)>;
-  using StandardStageFunc = std::function<void(ModelInstance*)>;
   using RateLimiterConfig = inference::ModelRateLimiter;
-
   using ResourceMap = std::map<int, std::map<std::string, size_t>>;
   enum RESOURCE_KIND_KEY {
     // Key for holding global resources
@@ -86,6 +76,7 @@ class RateLimiter {
   /// with the rate limiter.
   /// \param rate_limiter_config The rate limiter configuration associated with
   /// the model instance.
+  /// \return Status object indicating success or failure.
   Status RegisterModelInstance(
       TritonModelInstance* instance,
       const RateLimiterConfig& rate_limiter_config);
@@ -95,43 +86,63 @@ class RateLimiter {
   /// \return Status object indicating success or failure.
   Status UnregisterModel(const TritonModel* model);
 
-  void InitializePayloadQueues(const TritonModelInstance* instance);
+  /// Returns true if there is a payload slot available for the given model.
+  /// \param model The pointer to TritonModel object to be removed.
+  /// \return slot availability in boolean.
   bool PayloadSlotAvailable(const TritonModel* model);
 
+  /// Enqueues the payload to rate limiter for scheduling on the given model.
+  /// \param model The pointer to TritonModel object to be removed.
+  /// \param payload The shared pointer to the payload object.
+  /// \return Status object indicating success or failure.
   Status EnqueuePayload(
       const TritonModel* model, std::shared_ptr<Payload> payload);
 
+  /// Returns the payload that has been scheduled for the given set of model
+  /// instances. Note that this call is blocking and depends upon the
+  /// availability of payloads in the rate limiter for the triton model
+  /// instance.
+  /// \param instance The pointers to TritonModelInstance objects whose
+  /// payload is being requested.
+  /// \param payload The shared pointer to the payload object.
   void DequeuePayload(
       std::deque<TritonModelInstance*>& instance,
       std::shared_ptr<Payload>* payload);
 
-  /// Whether or not to ignore the resource configurations and priority settings
-  /// for the rate limiter.
-  bool IgnoreResourcesAndPriority() { return ignore_resources_and_priority_; }
-
+  /// Returns a new payload object.
+  /// \param op_type The operation type for the payload.
+  /// \param instance Optional field that providess the model instance that must
+  /// be used for the execution of the payload. Default is nullptr which allows
+  /// any model instance to execute the payload.
+  /// \return The shared pointer to a new payload object.
   std::shared_ptr<Payload> GetPayload(
       const Payload::Operation op_type,
       TritonModelInstance* instance = nullptr);
+
+  /// Releases the given payload object back to the rate limiter.
+  /// \param payload The payload to release.
   void PayloadRelease(std::shared_ptr<Payload>& payload);
 
+ private:
+  class ModelInstanceContext;
+  class ModelContext;
+  struct PayloadQueue;
+  using StandardReleaseFunc = std::function<void(ModelInstanceContext*)>;
+  using StandardScheduleFunc = std::function<void(ModelInstanceContext*)>;
+  using StandardStageFunc = std::function<void(ModelInstanceContext*)>;
+
   // Holds the state of the model instance.
-  class ModelInstance {
+  class ModelInstanceContext {
    public:
     friend class RateLimiter;
     friend class ResourceManager;
     enum State { AVAILABLE, STAGED, ALLOCATED, REMOVED };
 
-    /// Should be called when the request on the model instance is
-    /// complete. This function releases the resources allocated to
-    /// the model instance and sends the instance into the available
-    /// pool so that it can serve other requests.
     void Release();
-
-    /// Returns the raw triton instance
     TritonModelInstance* RawInstance() const { return triton_model_instance_; }
 
    private:
-    ModelInstance(
+    ModelInstanceContext(
         TritonModelInstance* triton_model_instance, ModelContext* model_context,
         const RateLimiterConfig& rate_limiter_config, StandardStageFunc OnStage,
         StandardReleaseFunc OnRelease);
@@ -165,47 +176,17 @@ class RateLimiter {
     std::condition_variable cv_;
   };
 
- private:
-  RateLimiter(
-      const bool ignore_resources_and_priority,
-      const ResourceMap& resource_map);
-
-  /// Requests one of the available model instance. In future, when the
-  /// conditions are met, the callback will be invoked and a pointer to
-  /// allocated RateLimiter::ModelInstance object will be exposed as a
-  /// parameter. The user must ensure RateLimiter::ModelInstance::Release
-  /// gets called on the instance once the inference request is complete
-  /// so that the instance and its resources are returned to the available
-  /// pool. Also, note the callback should be a light-weight call and
-  /// must not itself invoke the inference execution but just be used
-  /// as a signal to proceed with the execution.
-  /// \param OnSchedule The callback function to be called when scheduling.
-  /// \param model The TritonModel object pointer to be used for running the
-  /// inference.
-  /// \param instance The TritonModelInstance object pointer to be used for
-  /// running the inference. The default value is nullptr which means that an
-  /// instance with highest priority will be selected for the execution.
-  /// \return Status object indicating success or failure.
-  Status DeferPayloadSchedule(
-      const StandardScheduleFunc& OnSchedule, const TritonModel* model,
-      TritonModelInstance* instance = nullptr);
-  void SchedulePayload(
-      TritonModelInstance* tmi, PayloadQueue* payload_queue,
-      const std::shared_ptr<Payload>& payload);
-  void OnStage(ModelInstance* instance_ptr);
-  void OnRelease(ModelInstance* instance_ptr);
-  void AttemptAllocation();
-
   class ScaledPriorityComparator {
    public:
-    bool operator()(ModelInstance* a, ModelInstance* b)
+    bool operator()(ModelInstanceContext* a, ModelInstanceContext* b)
     {
       return a->ScaledPriority() > b->ScaledPriority();
     }
   };
 
   using PriorityQueue = std::priority_queue<
-      ModelInstance*, std::vector<ModelInstance*>, ScaledPriorityComparator>;
+      ModelInstanceContext*, std::vector<ModelInstanceContext*>,
+      ScaledPriorityComparator>;
 
   // Holds the active context to a model
   class ModelContext {
@@ -215,7 +196,7 @@ class RateLimiter {
     Status EnqueueModelInstanceRequest(
         const StandardScheduleFunc& OnSchedule,
         TritonModelInstance* triton_model_instance);
-    void AddAvailableInstance(ModelInstance* instance);
+    void AddAvailableInstance(ModelInstanceContext* instance);
     void StageInstanceIfAvailable();
     void AllocateInstanceIfAvailable();
     void AddSpecificRequestQueue();
@@ -227,9 +208,10 @@ class RateLimiter {
     bool removal_in_progress_;
 
     // Queue holding pending scheduling request
-    std::queue<StandardScheduleFunc> generic_request_queue_;
-    std::vector<std::queue<StandardScheduleFunc>> specific_request_queues_;
-    std::recursive_mutex request_queue_mtx_;
+    std::queue<StandardScheduleFunc> generic_sched_request_queue_;
+    std::vector<std::queue<StandardScheduleFunc>>
+        specific_sched_request_queues_;
+    std::recursive_mutex sched_request_queue_mtx_;
 
     // The set of instances that are available at the moment
     PriorityQueue avbl_instances_;
@@ -242,11 +224,11 @@ class RateLimiter {
     static Status Create(
         const ResourceMap& resource_map,
         std::unique_ptr<ResourceManager>* resource_manager);
-    void AddModelInstance(const RateLimiter::ModelInstance* instance);
-    Status RemoveModelInstance(const RateLimiter::ModelInstance* instance);
+    void AddModelInstance(const ModelInstanceContext* instance);
+    Status RemoveModelInstance(const ModelInstanceContext* instance);
     Status UpdateResourceLimits();
-    bool AllocateResources(const RateLimiter::ModelInstance* instance);
-    Status ReleaseResources(const RateLimiter::ModelInstance* instance);
+    bool AllocateResources(const ModelInstanceContext* instance);
+    Status ReleaseResources(const ModelInstanceContext* instance);
 
    private:
     ResourceManager(const ResourceMap& resource_map);
@@ -255,7 +237,7 @@ class RateLimiter {
 
     ResourceMap explicit_max_resources_;
 
-    std::map<const RateLimiter::ModelInstance*, ResourceMap> model_resources_;
+    std::map<const ModelInstanceContext*, ResourceMap> model_resources_;
     std::mutex model_resources_mtx_;
 
     ResourceMap max_resources_;
@@ -265,16 +247,32 @@ class RateLimiter {
     std::mutex allocated_resources_mtx_;
   };
 
+  RateLimiter(
+      const bool ignore_resources_and_priority,
+      const ResourceMap& resource_map);
+
+  void InitializePayloadQueues(const TritonModelInstance* instance);
+  Status DeferPayloadSchedule(
+      const StandardScheduleFunc& OnSchedule, const TritonModel* model,
+      TritonModelInstance* instance = nullptr);
+  void OnStage(ModelInstanceContext* instance_ptr);
+  void OnRelease(ModelInstanceContext* instance_ptr);
+  void AttemptAllocation();
+  void SchedulePayload(
+      TritonModelInstance* tmi, PayloadQueue* payload_queue,
+      const std::shared_ptr<Payload>& payload);
+
   bool ignore_resources_and_priority_;
 
-  // Instances for the models
-  std::map<const TritonModel*, std::vector<std::shared_ptr<ModelInstance>>>
-      model_instances_;
-  std::mutex model_instances_mtx_;
+  // Instance context for the models
+  std::map<
+      const TritonModel*, std::vector<std::shared_ptr<ModelInstanceContext>>>
+      model_instance_ctxs_;
+  std::mutex model_instance_ctx_mtx_;
 
   // Running context of the models
   std::map<const TritonModel*, ModelContext> model_contexts_;
-  std::mutex model_contexts_mtx_;
+  std::mutex model_ctx_mtx_;
 
   // Holds the model instances that have been staged
   PriorityQueue staged_instances_;

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -153,12 +153,7 @@ InferenceServer::Init()
   std::unique_ptr<RateLimiter> local_rate_limiter;
   bool ignore_resources_and_priority =
       (rate_limit_mode_ == RateLimitMode::RL_OFF);
-  if (!ignore_resources_and_priority) {
-    return Status(
-        Status::Code::INVALID_ARG,
-        "rate limiter implementation is not complete. Please disable "
-        "rate limiter");
-  }
+
   status = RateLimiter::Create(
       ignore_resources_and_priority, rate_limit_resource_map_,
       &local_rate_limiter);


### PR DESCRIPTION
**Model:** resnet50v1.5_savedmodel;  **Instance Count**: 2

### Case 1:  --rate-limit = off:
Avg request latency: 16645 usec (overhead 47 usec + **queue 7450 usec** + compute input 136 usec + compute infer 8994 usec + compute output 18 usec)

### Case 2: --rate-limit=execution_count, sufficient resources to run two instances concurrently:
Avg request latency: 15629 usec (overhead 47 usec + **queue 6979 usec** + compute input 137 usec + compute infer 8448 usec + compute output 18 usec)

### Case 3: --rate-limit=execution_count, available resources support only one instance at a time:
Avg request latency: 25244 usec (overhead 50 usec + **queue 18561 usec** + compute input 163 usec + compute infer 6452 usec + compute output 18 usec)

Rate limiter seems to be working. 

There is some overhead in the rate limiting logic. For an efficient rate limiting implementation, I would assume the following: 

`queue time for case 3 = queue time of Case 2 + compute time of Case 2.`

which comes out to be 15582us. However. we see the queue time of 18561us, which is an additional overhead of **2.97ms**.  
I will add testing and perform tuning as a separate ticket.
