### PR TITLE
Make mali gpu flag non-dependent on armnn tflite backend

### DIFF
--- a/build.py
+++ b/build.py
@@ -253,11 +253,9 @@ def core_cmake_args(components, backends, install_dir):
         cmake_enable(FLAGS.enable_gpu)))
     cargs.append('-DTRITON_MIN_COMPUTE_CAPABILITY={}'.format(
         FLAGS.min_compute_capability))
-
-    # If building the ArmNN TFLite backend set enable MALI GPU
-    if 'armnn_tflite' in backends:
-        cargs.append('-DTRITON_ENABLE_MALI_GPU:BOOL={}'.format(
-            cmake_enable(FLAGS.enable_mali_gpu)))
+    
+    cargs.append('-DTRITON_ENABLE_MALI_GPU:BOOL={}'.format(
+        cmake_enable(FLAGS.enable_mali_gpu)))
 
     cargs.append('-DTRITON_ENABLE_GRPC:BOOL={}'.format(
         cmake_enable('grpc' in FLAGS.endpoint)))


### PR DESCRIPTION
When building the armnn_tflite_backend independently of the server with `build.py`, if mali gpu support is to be included in the triton components, then the cmake arg should be added. It's better if this is not conditional the inclusion of the armnn_tflite_backend in the build.

For reference a server build with no armnn_tflite_backend and mali gpu support would be done with:
```bash
./build.py --cmake-dir=/workspace/build --build-dir=/tmp/citritonbuild --image=base,arm64v8/ubuntu:20.04 --enable-logging --enable-stats --enable-tracing --enable-metrics --endpoint=http --endpoint=grpc --enable-mali-gpu
```