### PR TITLE
Add test coverage for pytorch too few inputs/outputs

### DIFF
--- a/qa/L0_model_config/autofill_noplatform/pytorch/too_few_inputs/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/pytorch/too_few_inputs/config.pbtxt
@@ -1,0 +1,14 @@
+max_batch_size: 1
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_INT8
+    dims: [ 16 ]
+  },
+  {
+    name: "OUTPUT1"
+    data_type: TYPE_INT8
+    dims: [ 16 ]
+  }
+]
+backend: "pytorch"

--- a/qa/L0_model_config/autofill_noplatform/pytorch/too_few_inputs/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/pytorch/too_few_inputs/config.pbtxt
@@ -1,12 +1,12 @@
 max_batch_size: 1
 output [
   {
-    name: "OUTPUT0"
+    name: "OUTPUT__0"
     data_type: TYPE_INT8
     dims: [ 16 ]
   },
   {
-    name: "OUTPUT1"
+    name: "OUTPUT__1"
     data_type: TYPE_INT8
     dims: [ 16 ]
   }

--- a/qa/L0_model_config/autofill_noplatform/pytorch/too_few_inputs/expected
+++ b/qa/L0_model_config/autofill_noplatform/pytorch/too_few_inputs/expected
@@ -1,1 +1,1 @@
-unable to load model 'too_few_inputs', model configuration must contain at least one input, none were specified
+model configuration must contain at least one input, none were specified

--- a/qa/L0_model_config/autofill_noplatform/pytorch/too_few_inputs/expected
+++ b/qa/L0_model_config/autofill_noplatform/pytorch/too_few_inputs/expected
@@ -1,0 +1,1 @@
+unable to load model 'too_few_inputs', model configuration must contain at least one input, none were specified

--- a/qa/L0_model_config/autofill_noplatform/pytorch/too_few_outputs/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/pytorch/too_few_outputs/config.pbtxt
@@ -1,7 +1,7 @@
 max_batch_size: 1
 input [
   {
-    name: "INPUT1"
+    name: "INPUT__0"
     data_type: TYPE_INT32
     dims: [ 16 ]
   }

--- a/qa/L0_model_config/autofill_noplatform/pytorch/too_few_outputs/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/pytorch/too_few_outputs/config.pbtxt
@@ -1,0 +1,9 @@
+max_batch_size: 1
+input [
+  {
+    name: "INPUT1"
+    data_type: TYPE_INT32
+    dims: [ 16 ]
+  }
+]
+backend: "pytorch"

--- a/qa/L0_model_config/autofill_noplatform/pytorch/too_few_outputs/expected
+++ b/qa/L0_model_config/autofill_noplatform/pytorch/too_few_outputs/expected
@@ -1,0 +1,1 @@
+unable to load model 'too_few_outputs', model configuration must contain at least one output, none were specified

--- a/qa/L0_model_config/autofill_noplatform/pytorch/too_few_outputs/expected
+++ b/qa/L0_model_config/autofill_noplatform/pytorch/too_few_outputs/expected
@@ -1,1 +1,1 @@
-unable to load model 'too_few_outputs', model configuration must contain at least one output, none were specified
+model configuration must contain at least one output, none were specified

--- a/qa/L0_model_config/test.sh
+++ b/qa/L0_model_config/test.sh
@@ -177,8 +177,9 @@ for modelpath in \
         autofill_noplatform/pytorch/too_few_inputs/1 \
         autofill_noplatform/pytorch/too_few_outputs/1 ; do
     mkdir -p $modelpath
-    cp /data/inferenceserver/${REPO_VERSION}/qa_model_repository/pytorch_float32_float32_float32/1/model.pt \
+    cp /data/inferenceserver/${REPO_VERSION}/qa_model_repository/libtorch_float32_float32_float32/1/model.pt \
        $modelpath/.
+done
 
 # Copy other required models
 mkdir -p special_cases/invalid_platform/1

--- a/qa/L0_model_config/test.sh
+++ b/qa/L0_model_config/test.sh
@@ -172,7 +172,13 @@ for modelpath in \
     cp ./libtriton_repeat.so $modelpath/libtriton_repeat.so
 done
 
-
+# Copy PyTorch models into the test model repositories.
+for modelpath in \
+        autofill_noplatform/pytorch/too_few_inputs/1 \
+        autofill_noplatform/pytorch/too_few_outputs/1 ; do
+    mkdir -p $modelpath
+    cp /data/inferenceserver/${REPO_VERSION}/qa_model_repository/pytorch_float32_float32_float32/1/model.pt \
+       $modelpath/.
 
 # Copy other required models
 mkdir -p special_cases/invalid_platform/1


### PR DESCRIPTION
Autofill should return error if no inputs / outputs are provided in model config
