### PR TITLE
Add cache metrics docs

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -56,8 +56,8 @@ The following table describes the available metrics.
 |              |GPU Used Memory |Used GPU memory, in bytes              |Per GPU    |Per second   |
 |Count         |Success Count   |Number of successful inference requests received by Triton (each request is counted as 1, even if the request contains a batch) |Per model  |Per request  |
 |              |Failure Count   |Number of failed inference requests received by Triton (each request is counted as 1, even if the request contains a batch) |Per model  |Per request  |
-|              |Inference Count |Number of inferences performed (a batch of "n" is counted as "n" inferences)|Per model|Per request|
-|              |Execution Count |Number of inference batch executions (see [Count Metrics](#count-metrics))|Per model|Per request|
+|              |Inference Count |Number of inferences performed (a batch of "n" is counted as "n" inferences, does not include cached requests)|Per model|Per request|
+|              |Execution Count |Number of inference batch executions (see [Count Metrics](#count-metrics), does not include cached requests)|Per model|Per request|
 |Latency       |Request Time    |Cumulative end-to-end inference request handling time (includes cached requests) |Per model  |Per request  |
 |              |Queue Time      |Cumulative time requests spend waiting in the scheduling queue (includes cached requests) |Per model  |Per request  |
 |              |Compute Input Time|Cumulative time requests spend processing inference inputs (in the framework backend, does not include cached requests)     |Per model  |Per request  |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,14 +54,37 @@ The following table describes the available metrics.
 |              |GPU Utilization |GPU utilization rate (0.0 - 1.0)       |Per GPU    |Per second   |
 |GPU Memory    |GPU Total Memory|Total GPU memory, in bytes             |Per GPU    |Per second   |
 |              |GPU Used Memory |Used GPU memory, in bytes              |Per GPU    |Per second   |
-|Count         |Request Count   |Number of inference requests received by Triton (each request is counted as 1, even if the request contains a batch) |Per model  |Per request  |
+|Count         |Success Count   |Number of successful inference requests received by Triton (each request is counted as 1, even if the request contains a batch) |Per model  |Per request  |
+|              |Failure Count   |Number of failed inference requests received by Triton (each request is counted as 1, even if the request contains a batch) |Per model  |Per request  |
 |              |Inference Count |Number of inferences performed (a batch of "n" is counted as "n" inferences)|Per model|Per request|
 |              |Execution Count |Number of inference batch executions (see [Count Metrics](#count-metrics))|Per model|Per request|
-|Latency       |Request Time    |Cumulative end-to-end inference request handling time    |Per model  |Per request  |
-|              |Queue Time      |Cumulative time requests spend waiting in the scheduling queue     |Per model  |Per request  |
-|              |Compute Input Time|Cumulative time requests spend processing inference inputs (in the framework backend)     |Per model  |Per request  |
-|              |Compute Time    |Cumulative time requests spend executing the inference model (in the framework backend)     |Per model  |Per request  |
-|              |Compute Output Time|Cumulative time requests spend processing inference outputs (in the framework backend)     |Per model  |Per request  |
+|Latency       |Request Time    |Cumulative end-to-end inference request handling time (includes cached requests) |Per model  |Per request  |
+|              |Queue Time      |Cumulative time requests spend waiting in the scheduling queue (includes cached requests) |Per model  |Per request  |
+|              |Compute Input Time|Cumulative time requests spend processing inference inputs (in the framework backend, does not include cached requests)     |Per model  |Per request  |
+|              |Compute Time    |Cumulative time requests spend executing the inference model (in the framework backend, does not include cached requests)     |Per model  |Per request  |
+|              |Compute Output Time|Cumulative time requests spend processing inference outputs (in the framework backend, does not include cached requests)     |Per model  |Per request  |
+|Response Cache|Total Cache Entry Count |Number of responses currently stored in response cache |Server-wide |Per second |
+|              |Total Cache Lookup Count |Number of response cache lookups done by Triton |Server-wide |Per second |
+|              |Total Cache Hit Count |Number of response cache hits |Server-wide |Per second |
+|              |Total Cache Miss Count |Number of response cache misses |Server-wide |Per second |
+|              |Total Cache Eviction Count |Number of response cache evictions |Server-wide |Per second |
+|              |Total Cache Lookup Time |Cumulative time requests spend checking for a cached response (microseconds) |Server-wide |Per second |
+|              |Total Cache Utilization |Response Cache utilization rate (0.0 - 1.0) |Server-wide |Per second |
+|              |Cache Hit Count |Number of response cache hits per model |Per model |Per request |
+|              |Cache Hit Lookup Time |Cumulative time requests spend checking for a cached response (microseconds) per model |Per model |Per request |
+
+## Response Cache
+
+Compute latency metrics in the table above are calculated for the
+time spent in model inference backends. If the response cache is enabled for a
+given model (and a non-zero `--response-cache-byte-size` is defined for the
+server), total inference times may be affected by response cache lookup times.
+
+On cache hits, the cached response will be used instead of going through the
+inference backend, so compute times will not be recorded.
+
+On cache misses, the request will still go through to the inference backend and
+update compute time metrics accordingly.
 
 ## Count Metrics
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -65,13 +65,13 @@ The following table describes the available metrics.
 |              |Compute Output Time|Cumulative time requests spend processing inference outputs (in the framework backend, does not include cached requests)     |Per model  |Per request  |
 |Response Cache|Total Cache Entry Count |Number of responses currently stored in response cache |Server-wide |Per second |
 |              |Total Cache Lookup Count |Number of response cache lookups done by Triton |Server-wide |Per second |
-|              |Total Cache Hit Count |Number of response cache hits |Server-wide |Per second |
-|              |Total Cache Miss Count |Number of response cache misses |Server-wide |Per second |
-|              |Total Cache Eviction Count |Number of response cache evictions |Server-wide |Per second |
-|              |Total Cache Lookup Time |Cumulative time requests spend checking for a cached response (microseconds) |Server-wide |Per second |
+|              |Total Cache Hit Count |Total number of response cache hits across all models |Server-wide |Per second |
+|              |Total Cache Miss Count |Total number of response cache misses across all models |Server-wide |Per second |
+|              |Total Cache Eviction Count |Total number of response cache evictions across all models |Server-wide |Per second |
+|              |Total Cache Lookup Time |Cumulative time requests spend checking for a cached response across all models (microseconds) |Server-wide |Per second |
 |              |Total Cache Utilization |Response Cache utilization rate (0.0 - 1.0) |Server-wide |Per second |
 |              |Cache Hit Count |Number of response cache hits per model |Per model |Per request |
-|              |Cache Hit Lookup Time |Cumulative time requests spend checking for a cached response (microseconds) per model |Per model |Per request |
+|              |Cache Hit Lookup Time |Cumulative time requests spend retrieving a cached response per-model on cache hits, does not include cache misses (microseconds) |Per model |Per request |
 
 ## Response Cache
 
@@ -83,7 +83,7 @@ server), total inference times may be affected by response cache lookup times.
 On cache hits, the cached response will be used instead of going through the
 inference backend, so compute times will not be recorded.
 
-On cache misses, the request will still go through to the inference backend and
+On cache misses, the request will fallback to the inference backend and
 update compute time metrics accordingly.
 
 ## Count Metrics

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -69,9 +69,9 @@ The following table describes the available metrics.
 |              |Total Cache Miss Count |Total number of response cache misses across all models |Server-wide |Per second |
 |              |Total Cache Eviction Count |Total number of response cache evictions across all models |Server-wide |Per second |
 |              |Total Cache Lookup Time |Cumulative time requests spend checking for a cached response across all models (microseconds) |Server-wide |Per second |
-|              |Total Cache Utilization |Response Cache utilization rate (0.0 - 1.0) |Server-wide |Per second |
+|              |Total Cache Utilization |Total Response Cache utilization rate (0.0 - 1.0) |Server-wide |Per second |
 |              |Cache Hit Count |Number of response cache hits per model |Per model |Per request |
-|              |Cache Hit Lookup Time |Cumulative time requests spend retrieving a cached response per-model on cache hits, does not include cache misses (microseconds) |Per model |Per request |
+|              |Cache Hit Lookup Time |Cumulative time requests spend retrieving a cached response per model on cache hits, does not include cache misses (microseconds) |Per model |Per request |
 
 ## Response Cache
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -77,14 +77,17 @@ The following table describes the available metrics.
 
 Compute latency metrics in the table above are calculated for the
 time spent in model inference backends. If the response cache is enabled for a
-given model (and a non-zero `--response-cache-byte-size` is defined for the
-server), total inference times may be affected by response cache lookup times.
+given model (see [Response Cache](https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md)
+docs for more info), total inference times may be affected by response cache
+lookup times.
 
-On cache hits, the cached response will be used instead of going through the
-inference backend, so compute times will not be recorded.
+On cache hits, "Cache Hit Lookup Time" indicates the time spent looking up the
+response, and "Compute Input Time" /  "Compute Time" / "Compute Output Time"
+are not recorded.
 
-On cache misses, the request will fallback to the inference backend and
-update compute time metrics accordingly.
+On cache misses, "Cache Hit Lookup Time" will not be recorded, and
+"Compute Input Time" /  "Compute Time" / "Compute Output Time" will be
+recorded as usual.
 
 ## Count Metrics
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -63,8 +63,8 @@ The following table describes the available metrics.
 |              |Compute Input Time|Cumulative time requests spend processing inference inputs (in the framework backend, does not include cached requests)     |Per model  |Per request  |
 |              |Compute Time    |Cumulative time requests spend executing the inference model (in the framework backend, does not include cached requests)     |Per model  |Per request  |
 |              |Compute Output Time|Cumulative time requests spend processing inference outputs (in the framework backend, does not include cached requests)     |Per model  |Per request  |
-|Response Cache|Total Cache Entry Count |Number of responses currently stored in response cache |Server-wide |Per second |
-|              |Total Cache Lookup Count |Number of response cache lookups done by Triton |Server-wide |Per second |
+|Response Cache|Total Cache Entry Count |Total number of responses stored in response cache across all models |Server-wide |Per second |
+|              |Total Cache Lookup Count |Total number of response cache lookups done by Triton across all models |Server-wide |Per second |
 |              |Total Cache Hit Count |Total number of response cache hits across all models |Server-wide |Per second |
 |              |Total Cache Miss Count |Total number of response cache misses across all models |Server-wide |Per second |
 |              |Total Cache Eviction Count |Total number of response cache evictions across all models |Server-wide |Per second |


### PR DESCRIPTION
Documentation on new cache metrics/stats introduced in https://github.com/triton-inference-server/server/pull/3569