### PR TITLE
Fix L0_backend_identity test

### DIFF
--- a/qa/L0_backend_identity/test.sh
+++ b/qa/L0_backend_identity/test.sh
@@ -83,7 +83,7 @@ for i in "byte_size = 0, 6", \
          "byte_size = 20, 2", \
          "byte_size = 160, 2" \
          ; do set -- $i; \
-    if [[ $(cat $SERVER_LOG | grep $1 | wc -l) -ne $2 ]]; then
+    if [[ $(cat $SERVER_LOG | grep -a $1 | wc -l) -ne $2 ]]; then
         echo -e "\n***\n*** Test Failed $1 $2\n***"
         RET=1
     fi

--- a/qa/L0_backend_identity/test.sh
+++ b/qa/L0_backend_identity/test.sh
@@ -83,6 +83,8 @@ for i in "byte_size = 0, 6", \
          "byte_size = 20, 2", \
          "byte_size = 160, 2" \
          ; do set -- $i; \
+    # $SERVER_LOG is recorded as a binary file. Using -a option
+    # to correctly grep the pattern in the server log.
     if [[ $(cat $SERVER_LOG | grep -a $1 | wc -l) -ne $2 ]]; then
         echo -e "\n***\n*** Test Failed $1 $2\n***"
         RET=1


### PR DESCRIPTION
The output log of the server is being returned as binary file. 
```
# file inference_server.log 
inference_server.log: data
```