### PR TITLE
Update Lifecycle Tests to Check Specific Errors

### DIFF
--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -288,12 +288,6 @@ class LifeCycleTest(tu.TestResultCollector):
                 self.assertIn(
                     "Request for unknown model: 'graphdef_float32_float32_float32' is not found",
                     ex.message())
-                with open(os.environ["SERVER_LOG"]) as log:
-                    log_text = log.read()
-                    self.assertIn("failed to open text file for read", log_text)
-                    self.assertIn(
-                        "{}/config.pbtxt: No such file or directory".format(
-                            model_name), log_text)
 
         # And other models should be loaded successfully
         try:
@@ -611,8 +605,8 @@ class LifeCycleTest(tu.TestResultCollector):
                 "expected error for unavailable model " + savedmodel_name)
         except Exception as ex:
             self.assertIn(
-                "Request for unknown model: 'savedmodel_float32_float32_float32' has no available versions",
-                ex.message())
+                "Request for unknown model: '{}' has no available versions".
+                format(savedmodel_name), ex.message())
 
         # Add back the same model. The status/stats should be reset.
         try:
@@ -1862,10 +1856,6 @@ class LifeCycleTest(tu.TestResultCollector):
         except Exception as ex:
             self.assertIn("version 2: Internal: GPU instances not supported",
                           ex.message())
-            with open(os.environ["SERVER_LOG"]) as log:
-                self.assertIn(
-                    "failed to load '{}' version 2: Internal: GPU instances not supported"
-                    .format(model_name), log.read())
 
         # Make sure version 1 of the model is available, and version 2 is not
         try:

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -25,6 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
+
 sys.path.append("../common")
 
 from builtins import range
@@ -178,9 +179,9 @@ class LifeCycleTest(tu.TestResultCollector):
             self.assertTrue(
                 False, "expected error for unavailable model " + model_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "Request for unknown model: 'graphdef_float32_float32_float32' has no available versions"
-            ))
+            self.assertIn(
+                "Request for unknown model: 'graphdef_float32_float32_float32' has no available versions",
+                ex.message())
 
         # And other models should be loaded successfully
         try:
@@ -235,9 +236,9 @@ class LifeCycleTest(tu.TestResultCollector):
             self.assertTrue(
                 False, "expected error for unavailable model " + model_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "Request for unknown model: 'graphdef_float32_float32_float32' has no available versions"
-            ))
+            self.assertIn(
+                "Request for unknown model: 'graphdef_float32_float32_float32' has no available versions",
+                ex.message())
 
         # And other models should be loaded successfully
         try:
@@ -284,9 +285,15 @@ class LifeCycleTest(tu.TestResultCollector):
                     "' to be ignored due to polling failure")
 
             except Exception as ex:
-                self.assertTrue(ex.message().startswith(
-                    "Request for unknown model: 'graphdef_float32_float32_float32' is not found"
-                ))
+                self.assertIn(
+                    "Request for unknown model: 'graphdef_float32_float32_float32' is not found",
+                    ex.message())
+                with open(os.environ["SERVER_LOG"]) as log:
+                    log_text = log.read()
+                    self.assertIn("failed to open text file for read", log_text)
+                    self.assertIn(
+                        "{}/config.pbtxt: No such file or directory".format(
+                            model_name), log_text)
 
         # And other models should be loaded successfully
         try:
@@ -411,9 +418,9 @@ class LifeCycleTest(tu.TestResultCollector):
             self.assertTrue(
                 False, "expected error for unavailable model " + model_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "Request for unknown model: 'graphdef_float32_float32_float32' has no available versions"
-            ))
+            self.assertIn(
+                "Request for unknown model: 'graphdef_float32_float32_float32' has no available versions",
+                ex.message())
 
     def test_parse_ignore_zero_prefixed_version(self):
         tensor_shape = (1, 16)
@@ -603,9 +610,9 @@ class LifeCycleTest(tu.TestResultCollector):
                 False,
                 "expected error for unavailable model " + savedmodel_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "Request for unknown model: 'savedmodel_float32_float32_float32' has no available versions"
-            ))
+            self.assertIn(
+                "Request for unknown model: 'savedmodel_float32_float32_float32' has no available versions",
+                ex.message())
 
         # Add back the same model. The status/stats should be reset.
         try:
@@ -684,9 +691,9 @@ class LifeCycleTest(tu.TestResultCollector):
             self.assertTrue(False,
                             "expected error for unavailable model " + onnx_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "Request for unknown model: 'onnx_float32_float32_float32' has no available versions"
-            ))
+            self.assertIn(
+                "Request for unknown model: 'onnx_float32_float32_float32' has no available versions",
+                ex.message())
 
     def test_dynamic_model_load_unload_disabled(self):
         tensor_shape = (1, 16)
@@ -747,9 +754,9 @@ class LifeCycleTest(tu.TestResultCollector):
                 False,
                 "expected error for unavailable model " + savedmodel_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "Request for unknown model: 'savedmodel_float32_float32_float32' is not found"
-            ))
+            self.assertIn(
+                "Request for unknown model: 'savedmodel_float32_float32_float32' is not found",
+                ex.message())
 
         # Remove one of the original models from the model repository.
         # Unloading is disabled so it should remain available in the status.
@@ -890,9 +897,9 @@ class LifeCycleTest(tu.TestResultCollector):
             self.assertTrue(
                 False, "expected error for unavailable model " + graphdef_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "Request for unknown model: 'graphdef_int32_int32_int32' version 1 is not at ready state"
-            ))
+            self.assertIn(
+                "Request for unknown model: 'graphdef_int32_int32_int32' version 1 is not at ready state",
+                ex.message())
 
         # Add another version to the model repository.
         try:
@@ -1087,8 +1094,7 @@ class LifeCycleTest(tu.TestResultCollector):
                 self.assertTrue(
                     False, "expected error for unavailable model " + model_name)
             except Exception as ex:
-                self.assertTrue(
-                    ex.message().startswith("Request for unknown model"))
+                self.assertIn("Request for unknown model", ex.message())
 
         # Version 3 should continue to work...
         for model_name, model_shape in zip(models_base, models_shape):
@@ -1197,8 +1203,7 @@ class LifeCycleTest(tu.TestResultCollector):
                     False,
                     "expected error for unavailable model " + graphdef_name)
             except Exception as ex:
-                self.assertTrue(
-                    ex.message().startswith("Request for unknown model"))
+                self.assertIn("Request for unknown model", ex.message())
 
     def test_multiple_model_repository_polling(self):
         model_shape = (1, 16)
@@ -1301,8 +1306,8 @@ class LifeCycleTest(tu.TestResultCollector):
                                                              verbose=True)
             triton_client.load_model(savedmodel_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "failed to load '{}'".format(savedmodel_name)))
+            self.assertIn("failed to load '{}'".format(savedmodel_name),
+                          ex.message())
 
         try:
             for triton_client in (httpclient.InferenceServerClient(
@@ -1330,8 +1335,8 @@ class LifeCycleTest(tu.TestResultCollector):
                                                              verbose=True)
             triton_client.load_model(savedmodel_name)
         except Exception as ex:
-            self.assertTrue(ex.message().startswith(
-                "failed to load '{}'".format(savedmodel_name)))
+            self.assertIn("failed to load '{}'".format(savedmodel_name),
+                          ex.message())
 
         self._infer_success_models(['savedmodel', 'graphdef', 'onnx'], (1, 3),
                                    model_shape)
@@ -1369,8 +1374,9 @@ class LifeCycleTest(tu.TestResultCollector):
                 triton_client.load_model("unknown_model")
                 self.assertTrue(False, "expected unknown model failure")
             except Exception as ex:
-                self.assertTrue(ex.message().startswith(
-                    "failed to load 'unknown_model', no version is available"))
+                self.assertIn(
+                    "failed to load 'unknown_model', no version is available",
+                    ex.message())
 
         # Load ensemble model, the dependent model should be polled and loaded
         try:
@@ -1854,7 +1860,12 @@ class LifeCycleTest(tu.TestResultCollector):
             triton_client.load_model(model_name)
             self.assertTrue(False, "expecting load failure")
         except Exception as ex:
-            pass
+            self.assertIn("version 2: Internal: GPU instances not supported",
+                          ex.message())
+            with open(os.environ["SERVER_LOG"]) as log:
+                self.assertIn(
+                    "failed to load '{}' version 2: Internal: GPU instances not supported"
+                    .format(model_name), log.read())
 
         # Make sure version 1 of the model is available, and version 2 is not
         try:
@@ -1919,8 +1930,9 @@ class LifeCycleTest(tu.TestResultCollector):
                 triton_client.load_model("unknown_model")
                 self.assertTrue(False, "expected unknown model failure")
             except Exception as ex:
-                self.assertTrue(ex.message().startswith(
-                    "failed to load 'unknown_model', no version is available"))
+                self.assertIn(
+                    "failed to load 'unknown_model', no version is available",
+                    ex.message())
 
         # Load plan ensemble model, the dependent model is already
         # loaded via command-line

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -1406,6 +1406,8 @@ fi
 kill $SERVER_PID
 wait $SERVER_PID
 
+rm -f $CLIENT_LOG
+
 if [ $RET -eq 0 ]; then
   echo -e "\n***\n*** Test Passed\n***"
 fi

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -280,7 +280,7 @@ rm models/graphdef_float32_float32_float32/config.pbtxt
 
 SERVER_ARGS="--model-repository=`pwd`/models --model-repository=`pwd`/models_0 \
              --exit-on-error=false --exit-timeout-secs=5"
-SERVER_LOG="./inference_server_$LOG_IDX.log"
+export SERVER_LOG="./inference_server_$LOG_IDX.log"
 run_server_tolive
 if [ "$SERVER_PID" == "0" ]; then
     echo -e "\n***\n*** Failed to start $SERVER\n***"
@@ -1151,7 +1151,7 @@ SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit \
              --exit-timeout-secs=5 --strict-model-config=false \
              --load-model=identity_zero_1_int32 \
              --strict-readiness=false"
-SERVER_LOG="./inference_server_$LOG_IDX.log"
+export SERVER_LOG="./inference_server_$LOG_IDX.log"
 run_server
 if [ "$SERVER_PID" == "0" ]; then
     echo -e "\n***\n*** Failed to start $SERVER\n***"

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -66,9 +66,11 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 sleep 10
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_noexit >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -98,10 +100,12 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 sleep 10
 
+
 rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_noexit >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -133,10 +137,12 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 sleep 10
 
+
 rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_noexit >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -168,17 +174,19 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 sleep 10
 
+
 rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_noexit >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
     check_test_results $TEST_RESULT_FILE 1
     if [ $? -ne 0 ]; then
         cat $CLIENT_LOG
-        echo -e "\n***\n*** Test Failed\n***"
+        echo -e "\n***\n*** Test Result Verification Failed\n***"
         RET=1
     fi
 fi
@@ -213,9 +221,11 @@ fi
 # give plenty of time for model to load (and fail to load)
 wait_for_model_stable $SERVER_TIMEOUT
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_modelfail >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -247,9 +257,11 @@ fi
 # give plenty of time for model to load (and fail to load)
 wait_for_model_stable $SERVER_TIMEOUT
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_modelfail_nostrict >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -280,7 +292,7 @@ rm models/graphdef_float32_float32_float32/config.pbtxt
 
 SERVER_ARGS="--model-repository=`pwd`/models --model-repository=`pwd`/models_0 \
              --exit-on-error=false --exit-timeout-secs=5"
-export SERVER_LOG="./inference_server_$LOG_IDX.log"
+SERVER_LOG="./inference_server_$LOG_IDX.log"
 run_server_tolive
 if [ "$SERVER_PID" == "0" ]; then
     echo -e "\n***\n*** Failed to start $SERVER\n***"
@@ -291,16 +303,18 @@ fi
 # give plenty of time for model to load (and fail to load)
 wait_for_model_stable $SERVER_TIMEOUT
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_no_model_config >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
     check_test_results $TEST_RESULT_FILE 1
     if [ $? -ne 0 ]; then
         cat $CLIENT_LOG
-        echo -e "\n***\n*** Test Failed\n***"
+        echo -e "\n***\n*** Test Result Verification Failed\n***"
         RET=1
     fi
 fi
@@ -308,6 +322,13 @@ set -e
 
 kill $SERVER_PID
 wait $SERVER_PID
+
+# check server log for the warning messages
+if [ `grep -c "failed to open text file for read" $SERVER_LOG` == "0" ] || [ `grep -c "graphdef_float32_float32_float32/config.pbtxt: No such file or directory" $SERVER_LOG` == "0" ]; then
+    echo -e "\n***\n*** Server log ${SERVER_LOG} did not print model load failure\n***"
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
 
 LOG_IDX=$((LOG_IDX+1))
 
@@ -338,9 +359,11 @@ fi
 # give plenty of time for model to load (and fail to load)
 wait_for_model_stable $SERVER_TIMEOUT
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_init_error_modelfail >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -381,9 +404,11 @@ fi
 # give plenty of time for model to load (and fail to load)
 wait_for_model_stable $SERVER_TIMEOUT
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_error_model_no_version >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -419,9 +444,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_ignore_zero_prefixed_version >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -463,9 +490,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_parse_ignore_non_intergral_version >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -507,9 +536,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_dynamic_model_load_unload >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -545,9 +576,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_dynamic_model_load_unload_disabled >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -582,9 +615,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_dynamic_version_load_unload >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -620,9 +655,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_dynamic_version_load_unload_disabled >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -664,9 +701,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_dynamic_model_modify >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -701,9 +740,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_dynamic_file_delete >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -744,9 +785,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_multiple_model_repository_polling >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -789,9 +832,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_multiple_model_repository_control >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -830,9 +875,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_model_control >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -871,9 +918,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_model_control_ensemble >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -923,9 +972,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_multiple_model_repository_control_startup_models >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -973,9 +1024,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_model_repository_index >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -1014,9 +1067,11 @@ for protocol in grpc http; do
         exit 1
     fi
 
+    rm -f $CLIENT_LOG
     set +e
     python $LC_TEST LifeCycleTest.test_model_availability_on_reload >>$CLIENT_LOG 2>&1
     if [ $? -ne 0 ]; then
+        cat $CLIENT_LOG
         echo -e "\n***\n*** Test Failed\n***"
         RET=1
     else
@@ -1063,9 +1118,12 @@ for protocol in grpc http; do
         exit 1
     fi
 
+    rm -f $CLIENT_LOG
     set +e
     python $LC_TEST LifeCycleTest.test_model_availability_on_reload_2 >>$CLIENT_LOG 2>&1
     if [ $? -ne 0 ]; then
+        cat $CLIENT_LOG
+            cat $CLIENT_LOG
         echo -e "\n***\n*** Test Failed\n***"
         RET=1
     else
@@ -1111,9 +1169,11 @@ for protocol in grpc http; do
         exit 1
     fi
 
+    rm -f $CLIENT_LOG
     set +e
     python $LC_TEST LifeCycleTest.test_model_availability_on_reload_3 >>$CLIENT_LOG 2>&1
     if [ $? -ne 0 ]; then
+        cat $CLIENT_LOG
         echo -e "\n***\n*** Test Failed\n***"
         RET=1
     else
@@ -1151,7 +1211,7 @@ SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit \
              --exit-timeout-secs=5 --strict-model-config=false \
              --load-model=identity_zero_1_int32 \
              --strict-readiness=false"
-export SERVER_LOG="./inference_server_$LOG_IDX.log"
+SERVER_LOG="./inference_server_$LOG_IDX.log"
 run_server
 if [ "$SERVER_PID" == "0" ]; then
     echo -e "\n***\n*** Failed to start $SERVER\n***"
@@ -1159,9 +1219,11 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
+rm -f $CLIENT_LOG
 set +e
 python $LC_TEST LifeCycleTest.test_model_reload_fail >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"
     RET=1
 else
@@ -1176,6 +1238,13 @@ set -e
 
 kill $SERVER_PID
 wait $SERVER_PID
+
+# check server log for the warning messages
+if [ `grep -c "failed to load 'identity_zero_1_int32' version 2: Internal: GPU instances not supported" $SERVER_LOG` == "0" ]; then
+    echo -e "\n***\n*** Server log ${SERVER_LOG} did not print model load failure\n***"
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
 
 LOG_IDX=$((LOG_IDX+1))
 
@@ -1203,9 +1272,11 @@ for protocol in grpc http; do
         exit 1
     fi
 
+    rm -f $CLIENT_LOG
     set +e
     python $LC_TEST LifeCycleTest.test_load_same_model_different_platform >>$CLIENT_LOG 2>&1
     if [ $? -ne 0 ]; then
+        cat $CLIENT_LOG
         echo -e "\n***\n*** Test Failed\n***"
         RET=1
     else


### PR DESCRIPTION
This updates the lifecycle tests to check specific errors are returned when a model load fails. The tests check for errors in the server logs for model control modes NONE and EXPLICIT.

I am not seeing errors returned for the tests in POLL mode (which load the models successfully, then modify the models to fail reloading). If we expect those to return errors too, the tests can be updated.