### PR TITLE
Fix compose script by tagging openvino backend dir name before trying to copy it out

### DIFF
--- a/compose.py
+++ b/compose.py
@@ -92,6 +92,10 @@ COPY --chown=1000:1000 --from=full /opt/tritonserver/include include/
 def add_requested_backends(ddir, dockerfile_name, backends):
     df = "# Copying over backends \n"
     for backend in backends:
+        if backend == 'openvino':
+            import build
+            ver = next(iter(build.TRITON_VERSION_MAP.values()))
+            backend = build.get_tagged_backend(backend, ver[4][0])
         df += '''COPY --chown=1000:1000 --from=full /opt/tritonserver/backends/{} /opt/tritonserver/backends/{}    
 '''.format(backend, backend)
     if len(backends) > 0:


### PR DESCRIPTION
openvino backend directory name is now tagged to reflect the version. In order to compose image with mulitple openvino backends user must explicitly specify `--backend openvino_<vers_str>`. To support --backend openvino, we tag the name with default ov version from the build.py. 