### PR TITLE
Remove np.bool deprecation warnings

### DIFF
--- a/qa/L0_sequence_batcher/sequence_batcher_test.py
+++ b/qa/L0_sequence_batcher/sequence_batcher_test.py
@@ -124,10 +124,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
         if ("custom" in trial):
             return (np.int32,)
         if ("savedmodel" in trial):
-            return (np.float32, np.bool)
+            return (np.float32, np.bool_)
         if ("graphdef" in trial):
-            return (np.dtype(object), np.bool)
-        return (np.int32, np.bool)
+            return (np.dtype(object), np.bool_)
+        return (np.int32, np.bool_)
 
     def get_expected_result(self, expected_result, value, trial, flag_str=None):
         # Adjust the expected_result for models that
@@ -167,10 +167,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                     model_name = tu.get_sequence_model_name(trial, dtype)
                     # Skip bool type ensemble models
                     if (any(word in trial for word in ENSEMBLE_PREFIXES)) and (
-                            dtype == np.bool):
+                            dtype == np.bool_):
                         continue
                     # For bool type control models, use int32 as I/O types
-                    if dtype == np.bool:
+                    if dtype == np.bool_:
                         dtype = np.int32
 
                     self.clear_deferred_exceptions()
@@ -220,10 +220,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                     model_name = tu.get_sequence_model_name(trial, dtype)
                     # Skip bool type ensemble models
                     if (any(word in trial for word in ENSEMBLE_PREFIXES)) and (
-                            dtype == np.bool):
+                            dtype == np.bool_):
                         continue
                     # For bool type control models, use int32 as I/O types
-                    if dtype == np.bool:
+                    if dtype == np.bool_:
                         dtype = np.int32
 
                     self.clear_deferred_exceptions()
@@ -276,10 +276,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                     model_name = tu.get_sequence_model_name(trial, dtype)
                     # Skip bool type ensemble models
                     if (any(word in trial for word in ENSEMBLE_PREFIXES)) and (
-                            dtype == np.bool):
+                            dtype == np.bool_):
                         continue
                     # For bool type control models, use int32 as I/O types
-                    if dtype == np.bool:
+                    if dtype == np.bool_:
                         dtype = np.int32
 
                     self.clear_deferred_exceptions()
@@ -338,10 +338,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                     model_name = tu.get_sequence_model_name(trial, dtype)
                     # Skip bool type ensemble models
                     if (any(word in trial for word in ENSEMBLE_PREFIXES)) and (
-                            dtype == np.bool):
+                            dtype == np.bool_):
                         continue
                     # For bool type control models, use int32 as I/O types
-                    if dtype == np.bool:
+                    if dtype == np.bool_:
                         dtype = np.int32
 
                     self.clear_deferred_exceptions()
@@ -398,10 +398,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                     model_name = tu.get_sequence_model_name(trial, dtype)
                     # Skip bool type ensemble models
                     if (any(word in trial for word in ENSEMBLE_PREFIXES)) and (
-                            dtype == np.bool):
+                            dtype == np.bool_):
                         continue
                     # For bool type control models, use int32 as I/O types
-                    if dtype == np.bool:
+                    if dtype == np.bool_:
                         dtype = np.int32
 
                     self.clear_deferred_exceptions()
@@ -463,10 +463,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                     model_name = tu.get_sequence_model_name(trial, dtype)
                     # Skip bool type ensemble models
                     if (any(word in trial for word in ENSEMBLE_PREFIXES)) and (
-                            dtype == np.bool):
+                            dtype == np.bool_):
                         continue
                     # For bool type control models, use int32 as I/O types
-                    if dtype == np.bool:
+                    if dtype == np.bool_:
                         dtype = np.int32
 
                     self.clear_deferred_exceptions()
@@ -529,10 +529,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                     model_name = tu.get_sequence_model_name(trial, dtype)
                     # Skip bool type ensemble models
                     if (any(word in trial for word in ENSEMBLE_PREFIXES)) and (
-                            dtype == np.bool):
+                            dtype == np.bool_):
                         continue
                     # For bool type control models, use int32 as I/O types
-                    if dtype == np.bool:
+                    if dtype == np.bool_:
                         dtype = np.int32
 
                     self.clear_deferred_exceptions()
@@ -578,10 +578,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -686,10 +686,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -850,10 +850,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -1013,10 +1013,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -1180,10 +1180,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -1338,10 +1338,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -1529,10 +1529,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -1743,10 +1743,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -1959,10 +1959,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -2158,10 +2158,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -2347,10 +2347,10 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # Skip bool type ensemble models
                 if (any(word in trial
-                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool):
+                        for word in ENSEMBLE_PREFIXES)) and (dtype == np.bool_):
                     continue
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -2552,7 +2552,7 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
             for dtype in dtypes:
                 model_name = tu.get_sequence_model_name(trial, dtype)
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -2659,7 +2659,7 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
             for dtype in dtypes:
                 model_name = tu.get_sequence_model_name(trial, dtype) + "_half"
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()
@@ -2766,7 +2766,7 @@ class SequenceBatcherTest(su.SequenceBatcherTestUtil):
             for dtype in dtypes:
                 model_name = tu.get_sequence_model_name(trial, dtype) + "_full"
                 # For bool type control models, use int32 as I/O types
-                if dtype == np.bool:
+                if dtype == np.bool_:
                     dtype = np.int32
 
                 self.clear_deferred_exceptions()

--- a/qa/common/gen_qa_dyna_sequence_implicit_models.py
+++ b/qa/common/gen_qa_dyna_sequence_implicit_models.py
@@ -642,7 +642,7 @@ def create_models(models_dir, dtype, shape, no_batch=True):
             create_onnx_modelfile(models_dir, model_version, 0, dtype, shape)
 
     if FLAGS.tensorrt:
-        if dtype == np.bool:
+        if dtype == np.bool_:
             return
 
         create_plan_modelconfig(models_dir, model_version, 8, dtype, shape)

--- a/qa/common/gen_qa_implicit_models.py
+++ b/qa/common/gen_qa_implicit_models.py
@@ -370,7 +370,7 @@ def create_onnx_modelconfig(models_dir, model_version, max_batch, dtype, shape, 
 
     if dtype == np.float32:
         control_type = "fp32"
-    elif dtype == np.bool:
+    elif dtype == np.bool_:
         control_type = "bool"
         dtype = np.int32
     else:
@@ -764,7 +764,7 @@ def create_models(models_dir, dtype, shape, initial_state, no_batch=True):
             create_onnx_modelfile(models_dir, model_version, 0, dtype, shape, initial_state)
 
     if FLAGS.tensorrt:
-        if dtype == np.bool:
+        if dtype == np.bool_:
             return
         suffix = []
         if dtype == np.int8:
@@ -857,7 +857,7 @@ if __name__ == '__main__':
         create_models(FLAGS.models_dir, np_dtype_string, [
             1,
         ], FLAGS.initial_state)
-        create_models(FLAGS.models_dir, np.bool, [
+        create_models(FLAGS.models_dir, np.bool_, [
             1,
         ], FLAGS.initial_state)
 
@@ -872,6 +872,6 @@ if __name__ == '__main__':
         create_models(FLAGS.models_dir, np_dtype_string, [
             -1,
         ], FLAGS.initial_state, False)
-        create_models(FLAGS.models_dir, np.bool, [
+        create_models(FLAGS.models_dir, np.bool_, [
             -1,
         ], FLAGS.initial_state, False)

--- a/qa/common/gen_qa_sequence_models.py
+++ b/qa/common/gen_qa_sequence_models.py
@@ -292,7 +292,7 @@ def create_tf_modelconfig(create_savedmodel, models_dir, model_version,
 
     if dtype == np.float32:
         control_type = "fp32"
-    elif dtype == np.bool:
+    elif dtype == np.bool_:
         control_type = "bool"
         dtype = np.int32
     else:
@@ -1046,7 +1046,7 @@ def create_onnx_modelconfig(models_dir, model_version, max_batch, dtype, shape):
 
     if dtype == np.float32:
         control_type = "fp32"
-    elif dtype == np.bool:
+    elif dtype == np.bool_:
         control_type = "bool"
         dtype = np.int32
     else:
@@ -1169,7 +1169,7 @@ def create_libtorch_modelconfig(models_dir, model_version, max_batch, dtype,
 
     if dtype == np.float32:
         control_type = "fp32"
-    elif dtype == np.bool:
+    elif dtype == np.bool_:
         control_type = "bool"
         dtype = np.int32
     else:
@@ -1376,7 +1376,7 @@ def create_models(models_dir, dtype, shape, no_batch=True):
                                 shape)
 
     if FLAGS.tensorrt:
-        if dtype == np.bool:
+        if dtype == np.bool_:
             return
         suffix = []
         if dtype == np.int8:
@@ -1418,7 +1418,7 @@ def create_models(models_dir, dtype, shape, no_batch=True):
                                       shape)
 
     if FLAGS.ensemble:
-        if dtype == np.bool:
+        if dtype == np.bool_:
             return
         for pair in emu.platform_types_and_validation():
             config_shape = shape
@@ -1527,7 +1527,7 @@ if __name__ == '__main__':
             create_models(FLAGS.models_dir, np_dtype_string, [
                 1,
             ])
-            create_models(FLAGS.models_dir, np.bool, [
+            create_models(FLAGS.models_dir, np.bool_, [
                 1,
             ])
 
@@ -1542,7 +1542,7 @@ if __name__ == '__main__':
             create_models(FLAGS.models_dir, np_dtype_string, [
                 -1,
             ], False)
-            create_models(FLAGS.models_dir, np.bool, [
+            create_models(FLAGS.models_dir, np.bool_, [
                 -1,
             ], False)
 

--- a/qa/python_models/dlpack_add_sub/model.py
+++ b/qa/python_models/dlpack_add_sub/model.py
@@ -46,7 +46,7 @@ class TritonPythonModel:
         self.output1_dtype = pb_utils.triton_string_to_numpy(
             output1_config['data_type'])
         self.numpy_to_pytorch_dtype = {
-            np.bool: torch.bool,
+            np.bool_: torch.bool,
             np.uint8: torch.uint8,
             np.int8: torch.int8,
             np.int16: torch.int16,

--- a/qa/python_models/dlpack_sub_add/model.py
+++ b/qa/python_models/dlpack_sub_add/model.py
@@ -46,7 +46,7 @@ class TritonPythonModel:
         self.output1_dtype = pb_utils.triton_string_to_numpy(
             output1_config['data_type'])
         self.numpy_to_pytorch_dtype = {
-            np.bool: torch.bool,
+            np.bool_: torch.bool,
             np.uint8: torch.uint8,
             np.int8: torch.int8,
             np.int16: torch.int16,


### PR DESCRIPTION
Removes the following deprecation warning
```
DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
```