### PR TITLE
Avoid overwriting queue timer in the case of oldest sequence batcher

### DIFF
--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -535,9 +535,11 @@ class InferenceRequest {
   uint64_t QueueStartNs() const { return queue_start_ns_; }
   uint64_t CaptureQueueStartNs()
   {
-    queue_start_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                          std::chrono::steady_clock::now().time_since_epoch())
-                          .count();
+    if (queue_start_ns_ == 0) {
+      queue_start_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch())
+                            .count();
+    }
     return queue_start_ns_;
   }
 


### PR DESCRIPTION
When enqueuing to the dynamic batcher, the function will be called again and results in recording incorrect queue start time