### PR TITLE
Revert "Avoid overwriting queue timer if it has been set (#3778)"

### DIFF
--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -535,11 +535,9 @@ class InferenceRequest {
   uint64_t QueueStartNs() const { return queue_start_ns_; }
   uint64_t CaptureQueueStartNs()
   {
-    if (queue_start_ns_ == 0) {
-      queue_start_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                            std::chrono::steady_clock::now().time_since_epoch())
-                            .count();
-    }
+    queue_start_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          std::chrono::steady_clock::now().time_since_epoch())
+                          .count();
     return queue_start_ns_;
   }
 


### PR DESCRIPTION
This reverts commit b0f1b33bc550274f474996cba1e4ce5602c46f68.

@deadeyegoodwin we may need to think about how to collect timestamp properly for oldest sequence batcher. The issue is that dynamic batcher also uses "queue start" timestamp to determine if its max queue delay is exceeded, so "queue start" timestamp should be recorded when the request reaches the dynamic batcher, which then doesn't reflect the actual queue time (start from when the request arrives oldest sequence batcher).