### PR TITLE
Register more infer requests to improve concurrency

### DIFF
--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -2188,7 +2188,10 @@ InferHandler<
   auto barrier = std::make_shared<Barrier>(2);
 
   thread_.reset(new std::thread([this, barrier] {
-    StartNewRequest();
+    size_t registered_infer_request_count = 2;
+    for (size_t i = 0; i < registered_infer_request_count; ++i) {
+      StartNewRequest();
+    }
     barrier->Wait();
 
     void* tag;

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -61,6 +61,8 @@
 #include "src/servers/tracer.h"
 #endif  // TRITON_ENABLE_TRACING
 
+#define REGISTER_GRPC_INFER_REQUEST_COUNT 2
+
 namespace nvidia { namespace inferenceserver {
 namespace {
 
@@ -2188,8 +2190,7 @@ InferHandler<
   auto barrier = std::make_shared<Barrier>(2);
 
   thread_.reset(new std::thread([this, barrier] {
-    size_t registered_infer_request_count = 2;
-    for (size_t i = 0; i < registered_infer_request_count; ++i) {
+    for (int i = 0; i < REGISTER_GRPC_INFER_REQUEST_COUNT; ++i) {
       StartNewRequest();
     }
     barrier->Wait();

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -61,7 +61,7 @@
 #include "src/servers/tracer.h"
 #endif  // TRITON_ENABLE_TRACING
 
-#define REGISTER_GRPC_INFER_REQUEST_COUNT 2
+#define REGISTER_GRPC_INFER_THREAD_COUNT 2
 
 namespace nvidia { namespace inferenceserver {
 namespace {
@@ -2190,9 +2190,7 @@ InferHandler<
   auto barrier = std::make_shared<Barrier>(2);
 
   thread_.reset(new std::thread([this, barrier] {
-    for (int i = 0; i < REGISTER_GRPC_INFER_REQUEST_COUNT; ++i) {
-      StartNewRequest();
-    }
+    StartNewRequest();
     barrier->Wait();
 
     void* tag;
@@ -4173,22 +4171,24 @@ GRPCServer::Start()
   common_handler_.reset(hcommon);
 
   // Handler for model inference requests.
-  ModelInferHandler* hmodelinfer = new ModelInferHandler(
-      "ModelInferHandler", server_, trace_manager_, shm_manager_, &service_,
-      model_infer_cq_.get(),
-      infer_allocation_pool_size_ /* max_state_bucket_count */,
-      compression_level_);
-  hmodelinfer->Start();
-  model_infer_handler_.reset(hmodelinfer);
+  for (int i = 0; i < REGISTER_GRPC_INFER_THREAD_COUNT; ++i) {
+    ModelInferHandler* hmodelinfer = new ModelInferHandler(
+        "ModelInferHandler", server_, trace_manager_, shm_manager_, &service_,
+        model_infer_cq_.get(),
+        infer_allocation_pool_size_ /* max_state_bucket_count */,
+        compression_level_);
+    hmodelinfer->Start();
+    model_infer_handlers_.emplace_back(hmodelinfer);
 
-  // Handler for streaming inference requests.
-  ModelStreamInferHandler* hmodelstreaminfer = new ModelStreamInferHandler(
-      "ModelStreamInferHandler", server_, trace_manager_, shm_manager_,
-      &service_, model_stream_infer_cq_.get(),
-      infer_allocation_pool_size_ /* max_state_bucket_count */,
-      compression_level_);
-  hmodelstreaminfer->Start();
-  model_stream_infer_handler_.reset(hmodelstreaminfer);
+    // Handler for streaming inference requests.
+    ModelStreamInferHandler* hmodelstreaminfer = new ModelStreamInferHandler(
+        "ModelStreamInferHandler", server_, trace_manager_, shm_manager_,
+        &service_, model_stream_infer_cq_.get(),
+        infer_allocation_pool_size_ /* max_state_bucket_count */,
+        compression_level_);
+    hmodelstreaminfer->Start();
+    model_stream_infer_handlers_.emplace_back(hmodelstreaminfer);
+  }
 
   running_ = true;
   LOG_INFO << "Started GRPCInferenceService at " << server_addr_;
@@ -4213,9 +4213,13 @@ GRPCServer::Stop()
   // Must stop all handlers explicitly to wait for all the handler
   // threads to join since they are referencing completion queue, etc.
   dynamic_cast<CommonHandler*>(common_handler_.get())->Stop();
-  dynamic_cast<ModelInferHandler*>(model_infer_handler_.get())->Stop();
-  dynamic_cast<ModelStreamInferHandler*>(model_stream_infer_handler_.get())
-      ->Stop();
+  for (const auto& model_infer_handler : model_infer_handlers_) {
+    dynamic_cast<ModelInferHandler*>(model_infer_handler.get())->Stop();
+  }
+  for (const auto& model_stream_infer_handler : model_stream_infer_handlers_) {
+    dynamic_cast<ModelStreamInferHandler*>(model_stream_infer_handler.get())
+        ->Stop();
+  }
 
   running_ = false;
   return nullptr;  // success

--- a/src/servers/grpc_server.h
+++ b/src/servers/grpc_server.h
@@ -122,8 +122,8 @@ class GRPCServer {
   std::unique_ptr<grpc::Server> grpc_server_;
 
   std::unique_ptr<HandlerBase> common_handler_;
-  std::unique_ptr<HandlerBase> model_infer_handler_;
-  std::unique_ptr<HandlerBase> model_stream_infer_handler_;
+  std::vector<std::unique_ptr<HandlerBase>> model_infer_handlers_;
+  std::vector<std::unique_ptr<HandlerBase>> model_stream_infer_handlers_;
 
   inference::GRPCInferenceService::AsyncService service_;
   bool running_;


### PR DESCRIPTION
This PR is in conjunction with https://github.com/triton-inference-server/client/pull/55 to improve single process GRPC throughput. After the change, the single perf analyzer performance is comparable with two perf analyzer sending requests to the same server (total of ~6300 infer / sec). Note that there is still abnormal grpc time compare to server-side latency which suggests long network overhead, networking analysis is needed to determine if it can be further improved

before:
```
install/bin/perf_analyzer -m batching --concurrency-range=1024 -i grpc -a -v -p 10000
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 10000 msec
  Using asynchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1024
  Pass [1] throughput: 4315.2 infer/sec. Avg latency: 236408 usec (std 65277 usec)
  Pass [2] throughput: 4466.6 infer/sec. Avg latency: 229143 usec (std 58849 usec)
  Pass [3] throughput: 4572.1 infer/sec. Avg latency: 223281 usec (std 78012 usec)
  Client: 
    Request count: 45721
    Throughput: 4572.1 infer/sec
    Avg latency: 223281 usec (standard deviation 78012 usec)
    p50 latency: 243031 usec
    p90 latency: 267150 usec
    p95 latency: 275639 usec
    p99 latency: 435332 usec
    Avg gRPC time: 223703 usec (marshal 119 usec + response wait 223583 usec + unmarshal 1 usec)
  Server: 
    Inference count: 55845
    Execution count: 54387
    Successful request count: 54387
    Avg request latency: 111 usec (overhead 41 usec + queue 63 usec + compute input 3 usec + compute infer 0 usec + compute output 4 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1024, throughput: 4572.1 infer/sec, latency 223281 usec
```

after:
```
../install/bin/perf_analyzer -m batching --concurrency-range=1024 -i grpc -a -v -p 10000
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 10000 msec
  Using asynchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1024
  Pass [1] throughput: 6331.6 infer/sec. Avg latency: 160157 usec (std 38960 usec)
  Pass [2] throughput: 6351.6 infer/sec. Avg latency: 159802 usec (std 29872 usec)
  Pass [3] throughput: 6304.6 infer/sec. Avg latency: 160978 usec (std 32013 usec)
  Client: 
    Request count: 63046
    Throughput: 6304.6 infer/sec
    Avg latency: 160978 usec (standard deviation 32013 usec)
    p50 latency: 159044 usec
    p90 latency: 197871 usec
    p95 latency: 215177 usec
    p99 latency: 250667 usec
    Avg gRPC time: 161364 usec (marshal 86 usec + response wait 161277 usec + unmarshal 1 usec)
  Server: 
    Inference count: 75572
    Execution count: 68081
    Successful request count: 68081
    Avg request latency: 251 usec (overhead 75 usec + queue 165 usec + compute input 5 usec + compute infer 0 usec + compute output 6 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1024, throughput: 6304.6 infer/sec, latency 160978 usec
```