### PR TITLE
Fix for optional secrets.token in deploy/fleetcommand helm chart

### DIFF
--- a/deploy/fleetcommand/Chart.yaml
+++ b/deploy/fleetcommand/Chart.yaml
@@ -25,9 +25,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 apiVersion: v1
-# appVersion is the Triton version; update when changing release
+# appVersion is the Triton version; update when changing release (i.e. updating container image in values.yaml)
 appVersion: "2.17.0"
 description: Triton Inference Server (Fleet Command)
 name: triton-inference-server
-# version is the Chart version; update when changing anything in the chart (semver)
-version: 1.3.0
+# version is the Chart version; update when changing anything in the chart
+# This follows semantic versioning, i.e.:
+#   Given version X.Y.Z
+#   When making fixes to the chart, increment Z
+#   When making functional changes to the chart (including updating the Triton version, above), increment Y and reset Z to 0
+#   When making breaking changes to the chart (e.g. user must take action before deploying), increment X and reset Y and Z to 0
+version: 1.3.1

--- a/deploy/fleetcommand/templates/deployment.yaml
+++ b/deploy/fleetcommand/templates/deployment.yaml
@@ -80,11 +80,13 @@ spec:
               secretKeyRef:
                 name: aws-credentials
                 key: AWS_SECRET_ACCESS_KEY
+{{- if .Values.secret.token }}
           - name: AWS_SESSION_TOKEN
             valueFrom:
               secretKeyRef:
                 name: aws-credentials
                 key: AWS_SESSION_TOKEN
+{{- end }}
 {{- end }}
 
           ports:

--- a/deploy/fleetcommand/templates/secrets.yaml
+++ b/deploy/fleetcommand/templates/secrets.yaml
@@ -34,5 +34,7 @@ data:
   AWS_DEFAULT_REGION: {{ .Values.secret.region }}
   AWS_ACCESS_KEY_ID: {{ .Values.secret.id }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.secret.key }}
+{{- if .Values.secret.token }}
   AWS_SESSION_TOKEN: {{ .Values.secret.token }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
With this PR, an issue were the `secrets.token` value in the deploy/fleetcommand helm chart was required, when it is supposed to be optional.  This PR also adds in some inline comments for how to update the chart version.