### PR TITLE
Fix parsing of --override-backend-cmake-arg

### DIFF
--- a/build.py
+++ b/build.py
@@ -1830,7 +1830,6 @@ if __name__ == '__main__':
             len(parts) != 2,
             '--override-backend-cmake-arg must specify <backend>:<name>=<value>'
         )
-        parts = cf.split(':')
         fail_if(
             be not in backends,
             '--override-backend-cmake-arg specifies backend "{}" which is not included in build'


### PR DESCRIPTION
Prior to change:
Using `--override-backend-cmake-arg=python:TRITON_ENABLE_GPU=OFF` resulted in incorrect parsing
```
backend "python" CMake override "-Dpython=TRITON_ENABLE_GPU=OFF"
```

After change:

```
backend "python" CMake override "-DTRITON_ENABLE_GPU=OFF"
```