### PR TITLE
Bugfix: normalize a model path in MLFlow plugin script.

### DIFF
--- a/deploy/mlflow-triton-plugin/scripts/triton_flavor.py
+++ b/deploy/mlflow-triton-plugin/scripts/triton_flavor.py
@@ -66,6 +66,7 @@ def save_model(
         raise MlflowException(message="Path '{}' already exists".format(path),
                               error_code=RESOURCE_ALREADY_EXISTS)
     os.makedirs(path)
+    triton_model_path = os.path.normpath(triton_model_path)
     model_data_subpath = os.path.basename(triton_model_path)
     model_data_path = os.path.join(path, model_data_subpath)
 


### PR DESCRIPTION
This is a trivial bugfix. When users use [`deploy/mlflow-triton-plugin/scripts/publish_model_to_mlflow.py`](https://github.com/triton-inference-server/server/blob/main/deploy/mlflow-triton-plugin/scripts/publish_model_to_mlflow.py) with a model option, `--model_directory`, having slash (`/`) at the end of model path (e.g., `--model_directory <path-to-the-examples-directory>/onnx_float32_int32_int32/`), `FileExistsError` occurs like below.
(Note that this error never happens with a normalized path like `--model_directory <path-to-the-examples-directory>/onnx_float32_int32_int32`.)

```
Traceback (most recent call last):
  File "publish_model_to_mlflow.py", line 71, in <module>
    publish_to_mlflow()
  File "/usr/local/lib/python3.8/dist-packages/click-8.0.3-py3.8.egg/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click-8.0.3-py3.8.egg/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/click-8.0.3-py3.8.egg/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/dist-packages/click-8.0.3-py3.8.egg/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "publish_model_to_mlflow.py", line 56, in publish_to_mlflow
    triton_flavor.log_model(
  File "/ws/deploy/mlflow-triton-plugin/scripts/triton_flavor.py", line 100, in log_model
    Model.log(
  File "/usr/local/lib/python3.8/dist-packages/mlflow-1.23.0-py3.8.egg/mlflow/models/model.py", line 282, in log
    flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
  File "/ws/deploy/mlflow-triton-plugin/scripts/triton_flavor.py", line 73, in save_model
    shutil.copytree(triton_model_path, model_data_path)
  File "/usr/lib/python3.8/shutil.py", line 557, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.8/shutil.py", line 458, in _copytree
    os.makedirs(dst, exist_ok=dirs_exist_ok)
  File "/usr/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/tmp/tmpugrd_7sm/model/'
```

It looks like this is caused by inappropriate usage of `os.path.basename()`in [`deploy/mlflow-triton-plugin/scripts/triton_flavor.py#L69`](https://github.com/triton-inference-server/server/blob/043a95e911102571231fdfc8ed94ca1836e75c8e/deploy/mlflow-triton-plugin/scripts/triton_flavor.py#L69).
By adding `os.path.normpath()` before getting basename, this should be resolved.