### PR TITLE
Bugfix: wrong URL scheme check in MLFlow plugin deployment.

### DIFF
--- a/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
+++ b/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
@@ -59,10 +59,10 @@ class TritonPlugin(BaseDeploymentClient):
         self.supported_flavors = ['triton', 'onnx']  # need to add other flavors
         # URL cleaning for constructing Triton client
         ssl = False
-        if triton_url.startswith("http:#"):
-            triton_url = triton_url[len("http:#"):]
-        elif triton_url.startswith("https:#"):
-            triton_url = triton_url[len("https:#"):]
+        if triton_url.startswith("http://"):
+            triton_url = triton_url[len("http://"):]
+        elif triton_url.startswith("https://"):
+            triton_url = triton_url[len("https://"):]
             ssl = True
         self.triton_client = tritonhttpclient.InferenceServerClient(
             url=triton_url, ssl=ssl)


### PR DESCRIPTION
This is a trivial bugfix.

If `TRITON_URL` contains a full URL like `http://...`, `mlflow deployment ...` should be failed. Although [`deploy/mlflow-triton-plugin/mlflow_triton/deployments.py`](https://github.com/triton-inference-server/server/blob/main/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py) is checking if a given URL has URL scheme or not and removing URL scheme, the check and removal don't work well. Therefore, creating a Triton client instance (at [`deploy/mlflow-triton-plugin/mlflow_triton/deployments.py#L67`](https://github.com/triton-inference-server/server/blob/043a95e911102571231fdfc8ed94ca1836e75c8e/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py#L67)) causes an error, and overall command also fails.