### PR TITLE
Add batcher timestamp to report queue time properly and to maintain batcher functionality

### DIFF
--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -166,7 +166,11 @@ DynamicBatchScheduler::Enqueue(std::unique_ptr<InferenceRequest>& request)
         request->QueueStartNs());
   }
 
-  // Record time at the beginning of the batcher queueing
+  // Record time at the beginning of the batcher queueing. In the case of
+  // oldest sequence batcher, this will overwrite the value that was previously
+  // set by sequence batcher, which is okay as by this point, the previous
+  // batcher won't be needing this value and it can be safely reused by
+  // the dynamic batcher.
   request->CaptureBatcherStartNs();
 
   std::unique_ptr<InferenceResponse> cached_response;

--- a/src/core/infer_request.cc
+++ b/src/core/infer_request.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -559,6 +559,7 @@ InferenceRequest::PrepareForInference()
 
   // Clear the timestamps
   queue_start_ns_ = 0;
+  batcher_start_ns_ = 0;
 #ifdef TRITON_ENABLE_STATS
   request_start_ns_ = 0;
 #endif  // TRITON_ENABLE_STATS

--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -541,6 +541,15 @@ class InferenceRequest {
     return queue_start_ns_;
   }
 
+  uint64_t BatcherStartNs() const { return batcher_start_ns_; }
+  uint64_t CaptureBatcherStartNs()
+  {
+    batcher_start_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::steady_clock::now().time_since_epoch())
+                            .count();
+    return batcher_start_ns_;
+  }
+
 #ifdef TRITON_ENABLE_STATS
   uint64_t RequestStartNs() const { return request_start_ns_; }
   uint64_t CaptureRequestStartNs()
@@ -640,6 +649,11 @@ class InferenceRequest {
   // Request timestamps. Queue start is needed for schedulers even
   // when statistics are not being collected.
   uint64_t queue_start_ns_;
+
+  // Dedicated timestamp for batcher internal which can diverge from
+  // queue start timestamp to provide accurate queue time without affecting
+  // batcher functionalities.
+  uint64_t batcher_start_ns_;
 
   // Whether the stats of the request should be collected.
   bool collect_stats_;

--- a/src/core/instance_queue.cc
+++ b/src/core/instance_queue.cc
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -75,7 +75,7 @@ InstanceQueue::Dequeue(
         size_t batch_size = (*payload)->BatchSize();
         if ((!payload_queue_.empty()) &&
             (!payload_queue_.front()->IsSaturated()) &&
-            (now_ns - payload_queue_.front()->QueueStartNs()) >
+            (now_ns - payload_queue_.front()->BatcherStartNs()) >
                 max_queue_delay_ns_) {
           std::lock_guard<std::mutex> exec_lock(
               *(payload_queue_.front()->GetExecMutex()));

--- a/src/core/payload.h
+++ b/src/core/payload.h
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -63,7 +63,7 @@ class Payload {
   {
     return requests_;
   }
-  uint64_t QueueStartNs() { return queue_start_ns_; }
+  uint64_t BatcherStartNs() { return batcher_start_ns_; }
   void SetCallback(std::function<void()> OnCallback);
   void Callback();
   void SetSecondaryCallback(std::function<void()> OnRelease);
@@ -89,7 +89,7 @@ class Payload {
   State state_;
   std::unique_ptr<std::promise<Status>> status_;
   std::unique_ptr<std::mutex> exec_mu_;
-  uint64_t queue_start_ns_;
+  uint64_t batcher_start_ns_;
 
   bool saturated_;
 };

--- a/src/core/scheduler_utils.cc
+++ b/src/core/scheduler_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -397,7 +397,7 @@ PriorityQueue::AdvanceCursor()
 
   uint64_t curr_enqueue_time_ns =
       pending_cursor_.curr_it_->second.At(pending_cursor_.queue_idx_)
-          ->QueueStartNs();
+          ->BatcherStartNs();
   if (pending_cursor_.pending_batch_oldest_enqueue_time_ns_ != 0) {
     pending_cursor_.pending_batch_oldest_enqueue_time_ns_ = std::min(
         pending_cursor_.pending_batch_oldest_enqueue_time_ns_,

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -512,6 +512,9 @@ SequenceBatchScheduler::Enqueue(std::unique_ptr<InferenceRequest>& irequest)
   INFER_TRACE_ACTIVITY(
       irequest->Trace(), TRITONSERVER_TRACE_QUEUE_START,
       irequest->QueueStartNs());
+
+  // Record time at the beginning of the batcher queueing
+  irequest->CaptureBatcherStartNs();
 
   // For now the request must have batch-size 1 since the sequence
   // batcher does not yet support requests that are statically
@@ -1286,7 +1289,7 @@ DirectSequenceBatch::BatcherThread(const int nice)
             }
 
             earliest_enqueue_time_ns = std::min(
-                earliest_enqueue_time_ns, queue.front()->QueueStartNs());
+                earliest_enqueue_time_ns, queue.front()->BatcherStartNs());
             ready_cnt++;
             max_seq_slot = seq_slot;
           }


### PR DESCRIPTION
Now in the case of oldest sequence batcher, the queue time is tracked (not counting towards overhead)
Before:
```
...
Avg request latency: 68538 usec (overhead 60622 usec + queue 2080 usec + compute input 172 usec + compute infer 5525 usec + compute output 139 usec)
...
```
After:
```
...
Avg request latency: 69777 usec (overhead 168 usec + queue 63749 usec + compute input 168 usec + compute infer 5554 usec + compute output 138 usec)
...
```