### PR TITLE
Block the DirectSequenceBatcher thread to form larger batches

### DIFF
--- a/src/core/payload.h
+++ b/src/core/payload.h
@@ -66,8 +66,8 @@ class Payload {
   uint64_t BatcherStartNs() { return batcher_start_ns_; }
   void SetCallback(std::function<void()> OnCallback);
   void Callback();
-  void SetSecondaryCallback(std::function<void()> OnRelease);
-  void SecondaryCallback();
+  void AddInternalReleaseCallback(std::function<void()>&& callback);
+  void OnRelease();
   void SetInstance(TritonModelInstance* model_instance);
   TritonModelInstance* GetInstance() { return instance_; }
   void MarkSaturated();
@@ -84,7 +84,7 @@ class Payload {
   Operation op_type_;
   std::vector<std::unique_ptr<InferenceRequest>> requests_;
   std::function<void()> OnCallback_;
-  std::function<void()> OnSecondaryCallback_;
+  std::vector<std::function<void()>> release_callbacks_;
   TritonModelInstance* instance_;
   State state_;
   std::unique_ptr<std::promise<Status>> status_;

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -156,7 +156,7 @@ RateLimiter::EnqueuePayload(
         this->SchedulePayload(mi->RawInstance(), payload_queue, payload);
       }
       auto cb = [mi]() { mi->Release(); };
-      payload->SetSecondaryCallback(cb);
+      payload->AddInternalReleaseCallback(cb);
       if (mi->RawInstance() == nullptr) {
         payload_queue->cv_.notify_one();
       } else {
@@ -253,7 +253,7 @@ RateLimiter::GetPayload(
 void
 RateLimiter::PayloadRelease(std::shared_ptr<Payload>& payload)
 {
-  payload->SecondaryCallback();
+  payload->OnRelease();
   if (max_payload_bucket_count_ > 0) {
     std::lock_guard<std::mutex> lock(alloc_mu_);
 

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -1202,7 +1202,7 @@ DirectSequenceBatch::BatcherThread(const int nice)
   while (!scheduler_thread_exit_) {
     uint64_t wait_microseconds = default_wait_microseconds;
 
-    // Wait till execution of the last enqueued payload is not
+    // Wait till execution of the last enqueued payload is
     // complete.
     {
       std::unique_lock<std::mutex> lk(payload_mu_);

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -1193,6 +1193,7 @@ DirectSequenceBatch::BatcherThread(const int nice)
   const uint64_t default_wait_microseconds = 500 * 1000;
 
   NewPayload();
+  exec_complete_ = true;
 
   // When there is optional input or input shape must be enforced,
   // the inputs in the requests must be examined for forming a batch
@@ -1200,6 +1201,13 @@ DirectSequenceBatch::BatcherThread(const int nice)
       !enforce_equal_shape_tensors_.empty() || has_optional_input_;
   while (!scheduler_thread_exit_) {
     uint64_t wait_microseconds = default_wait_microseconds;
+
+    // Wait till execution of the last enqueued payload is not
+    // complete.
+    {
+      std::unique_lock<std::mutex> lk(payload_mu_);
+      payload_cv_.wait(lk, [this] { return exec_complete_; });
+    }
 
     // Hold the lock for as short a time as possible.
     {
@@ -1459,7 +1467,18 @@ DirectSequenceBatch::BatcherThread(const int nice)
     }
 
     if (curr_payload_->GetState() == Payload::State::READY) {
-      // Run the model...
+      // Add callback to signal the execution completion
+      exec_complete_ = false;
+      auto callback = [this]() {
+        {
+          std::unique_lock<std::mutex> lk(payload_mu_);
+          exec_complete_ = true;
+        }
+        payload_cv_.notify_one();
+      };
+      curr_payload_->SetSecondaryCallback(callback);
+
+      // Enqueue the payload to RateLimiter
       model_instance_->Model()->Server()->GetRateLimiter()->EnqueuePayload(
           model_instance_->Model(), curr_payload_);
       NewPayload();

--- a/src/core/sequence_batch_scheduler.cc
+++ b/src/core/sequence_batch_scheduler.cc
@@ -1476,7 +1476,7 @@ DirectSequenceBatch::BatcherThread(const int nice)
         }
         payload_cv_.notify_one();
       };
-      curr_payload_->SetSecondaryCallback(callback);
+      curr_payload_->AddInternalReleaseCallback(callback);
 
       // Enqueue the payload to RateLimiter
       model_instance_->Model()->Server()->GetRateLimiter()->EnqueuePayload(

--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -309,6 +309,13 @@ class DirectSequenceBatch : public SequenceBatch {
   std::mutex mu_;
   std::condition_variable cv_;
 
+  // Execution state of the last enqueued payload
+  bool exec_complete_;
+
+  // Mutex protecting execution state of payload
+  std::mutex payload_mu_;
+  std::condition_variable payload_cv_;
+
   // Queues holding inference requests. There are 'seq_slot_cnt'
   // queues, one for each sequence slot where requests assigned to
   // that slot are enqueued to wait for inferencing.


### PR DESCRIPTION
This change improves performance of DirectSequenceBatcher and brings it at par with r21.08.

### Benchmarking parameters:
perf_analyzer -u localhost:8001 --streaming -i gRPC -m citrinet-1024-en-US-asr-streaming-throughput -b 1 --input-data ensemble_chunk800/ --shape=AUDIO_SIGNAL:12800 --shape=CUSTOM_CONFIGURATION:1,2 --sequence-length=4  --concurrency-range=128:128:1 -p 1000

### Model Configuration:
`citrinet-1024-en-US-asr-streaming-throughput` is an ensemble model with 5 composing sequence models. Only 1 of these five  uses DirectSequenceBatcher, others use Oldest scheme.

### With Fix

```
Inferences/Second vs. Client Average Batch Latency
Concurrency: 128, throughput: 983 infer/sec, latency 136770 usec
```

### Without fix

```
Inferences/Second vs. Client Average Batch Latency
Concurrency: 128, throughput: 644 infer/sec, latency 199690 usec
```

### 21.08

```
*** Measurement Settings ***
Inferences/Second vs. Client Average Batch Latency
Concurrency: 128, throughput: 846 infer/sec, latency 147019 usec
```