### PR TITLE
Add NodeJs grpc generated client in CI test

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -77,6 +77,8 @@ RUN mkdir -p qa/common && \
     cp -r docs/examples/model_repository/simple qa/L0_simple_go_client/models/. && \
     mkdir qa/L0_backend_release/simple_models && \
     cp -r docs/examples/model_repository/simple qa/L0_backend_release/simple_models/. && \
+    mkdir qa/L0_simple_nodejs_client/models && \
+    cp -r docs/examples/model_repository/simple qa/L0_simple_nodejs_client/models/. && \
     mkdir qa/L0_backend_release/simple_seq_models && \
     cp -r /workspace/docs/examples/model_repository/simple_sequence qa/L0_backend_release/simple_seq_models/. && \
     mkdir qa/L0_shared_memory/models && \
@@ -236,6 +238,8 @@ RUN mkdir -p qa/clients && mkdir -p qa/pkgs && \
     cp install/python/triton*.whl qa/pkgs/. && \
     cp install/java/examples/*.jar qa/clients/.
 RUN cp client/src/grpc_generated/go/*.go qa/L0_simple_go_client/. && \
+    cp client/src/grpc_generated/javascript/*.js qa/L0_simple_nodejs_client/. && \
+    cp client/src/grpc_generated/javascript/*.json qa/L0_simple_nodejs_client/. && \
     cp -r client/src/grpc_generated/java qa/L0_client_java/.
 
 ############################################################################
@@ -270,14 +274,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                               libarchive-dev \
                               libopencv-core-dev \
                               libzmq3-dev \
+                              maven \
+                              nginx \
+                              npm \
+                              protobuf-compiler \
                               python3-dev \
                               python3-pip \
                               python3-protobuf \
                               python3-setuptools \
                               swig \
-                              nginx \
-                              protobuf-compiler \
-                              maven \
                               valgrind && \
     rm -rf /var/lib/apt/lists/*
 

--- a/qa/L0_simple_nodejs_client/test.sh
+++ b/qa/L0_simple_nodejs_client/test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+export CUDA_VISIBLE_DEVICES=0
+
+TRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG:="main"}
+
+SIMPLE_NODEJS_CLIENT=client.js
+
+SERVER=/opt/tritonserver/bin/tritonserver
+SERVER_ARGS=--model-repository=`pwd`/models
+SERVER_LOG="./inference_server.log"
+source ../common/util.sh
+
+rm -f *.log
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+RET=0
+
+# Get the proto files from the common repo
+rm -fr common
+git clone --single-branch --depth=1 -b $TRITON_COMMON_REPO_TAG \
+    https://github.com/triton-inference-server/common.git
+mkdir proto && cp common/protobuf/*.proto proto/.
+
+npm install
+
+set +e
+
+# Runs test for GRPC variant of nodejs client
+node $SIMPLE_NODEJS_CLIENT >> client.log 2>&1
+if [ $? -ne 0 ]; then
+    RET=1
+fi
+
+if [ `grep -c "Checking Inference Output" client.log` != "1" ]; then
+    echo -e "\n***\n*** Failed. Unable to run inference.\n***"
+    RET=1
+fi
+
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/qa/L0_simple_nodejs_client/test.sh
+++ b/qa/L0_simple_nodejs_client/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions


### PR DESCRIPTION
The NodeJS grpc generated client is being developed in this PR: https://github.com/triton-inference-server/client/pull/52