### PR TITLE
Fixes a memory leak during model unloading 

### DIFF
--- a/src/backends/backend/triton_model.cc
+++ b/src/backends/backend/triton_model.cc
@@ -312,7 +312,10 @@ TritonModel::~TritonModel()
   instances_.clear();
   passive_instances_.clear();
 
-  // Unregister itself from the rate limiter
+  // Unregister itself from the rate limiter. Note this should happen
+  // after all instances are destructed. Destrucing instances ensures
+  // there are no instance threads waiting on rate limiter for
+  // receiving their payloads.
   server_->GetRateLimiter()->UnregisterModel(this);
 
   // Model finalization is optional... The TRITONBACKEND_Model

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -546,10 +546,9 @@ RateLimiter::ModelInstanceContext::ModelInstanceContext(
     RateLimiter::StandardStageFunc OnStage,
     RateLimiter::StandardReleaseFunc OnRelease)
     : triton_model_instance_(triton_model_instance),
-      index_(triton_model_instance->Index()),
-      model_context_(model_context), rate_limiter_config_(rate_limiter_config),
-      OnStage_(OnStage), OnRelease_(OnRelease), exec_count_(0),
-      state_(AVAILABLE)
+      index_(triton_model_instance->Index()), model_context_(model_context),
+      rate_limiter_config_(rate_limiter_config), OnStage_(OnStage),
+      OnRelease_(OnRelease), exec_count_(0), state_(AVAILABLE)
 {
 }
 
@@ -647,7 +646,8 @@ RateLimiter::ModelInstanceContext::RequestRemoval()
 {
   std::lock_guard<std::mutex> lk(state_mtx_);
 
-  if ((state_ == AVAILABLE) && (!model_context_->ContainsPendingRequests(index_))) {
+  if ((state_ == AVAILABLE) &&
+      (!model_context_->ContainsPendingRequests(index_))) {
     state_ = REMOVED;
   }
 }

--- a/src/core/rate_limiter.cc
+++ b/src/core/rate_limiter.cc
@@ -546,6 +546,7 @@ RateLimiter::ModelInstanceContext::ModelInstanceContext(
     RateLimiter::StandardStageFunc OnStage,
     RateLimiter::StandardReleaseFunc OnRelease)
     : triton_model_instance_(triton_model_instance),
+      index_(triton_model_instance->Index()),
       model_context_(model_context), rate_limiter_config_(rate_limiter_config),
       OnStage_(OnStage), OnRelease_(OnRelease), exec_count_(0),
       state_(AVAILABLE)
@@ -631,8 +632,7 @@ RateLimiter::ModelInstanceContext::Release()
   {
     std::lock_guard<std::mutex> lk(state_mtx_);
     if ((model_context_->isRemovalInProgress()) && (state_ == AVAILABLE) &&
-        (!model_context_->ContainsPendingRequests(
-            triton_model_instance_->Index()))) {
+        (!model_context_->ContainsPendingRequests(index_))) {
       state_ = REMOVED;
     }
   }
@@ -647,8 +647,7 @@ RateLimiter::ModelInstanceContext::RequestRemoval()
 {
   std::lock_guard<std::mutex> lk(state_mtx_);
 
-  if ((state_ == AVAILABLE) && (!model_context_->ContainsPendingRequests(
-                                   triton_model_instance_->Index()))) {
+  if ((state_ == AVAILABLE) && (!model_context_->ContainsPendingRequests(index_))) {
     state_ = REMOVED;
   }
 }

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/rate_limiter.h
+++ b/src/core/rate_limiter.h
@@ -160,6 +160,7 @@ class RateLimiter {
     void WaitForRemoval();
 
     TritonModelInstance* triton_model_instance_;
+    size_t index_;
     ModelContext* model_context_;
     RateLimiterConfig rate_limiter_config_;
     StandardStageFunc OnStage_;


### PR DESCRIPTION

### Before

```
 ==21418== Thread 32:
==21418== Invalid read of size 8
==21418== at 0x4CCA20F: nvidia::inferenceserver::RateLimiter::ModelInstanceContext::RequestRemoval() (in\
/opt/tritonserver/lib/libtritonserver.so)
==21418== by 0x4CCA285: nvidia::inferenceserver::RateLimiter::ModelInstanceContext::WaitForRemoval() (in\
/opt/tritonserver/lib/libtritonserver.so)
==21418== by 0x4CD1480: nvidia::inferenceserver::RateLimiter::UnregisterModel(nvidia::inferenceserver::T\
ritonModel const*) (in /opt/tritonserver/lib/libtritonserver.so)
==21418== by 0x4DC498A: nvidia::inferenceserver::TritonModel::~TritonModel() (in /opt/tritonserver/lib/l\
ibtritonserver.so)
==21418== by 0x4DC504C: nvidia::inferenceserver::TritonModel::~TritonModel() (in /opt/tritonserver/lib/l\
ibtritonserver.so)
==21418== by 0x4C61E46: std::thread::_State_impl<std::thread::_Invoker<std::tuple<nvidia::inferenceserve\
r::(anonymous namespace)::ModelDeleter::operator()(nvidia::inferenceserver::Model*)::{lambda()#1}> > >::M\
run() (in /opt/tritonserver/lib/libtritonserver.so)
==21418== by 0x5BE3DE3: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==21418== by 0x578A608: start_thread (pthread_create.c:477)
==21418== by 0x5F7D292: clone (clone.S:95)
==21418== Address 0xf3d5d650 is 80 bytes inside a block of size 312 free'd
==21418== at 0x483F651: operator delete(void*) (vg_replace_malloc.c:923)
==21418== by 0x4DC48F0: nvidia::inferenceserver::TritonModel::~TritonModel() (in /opt/tritonserver/lib/l\
ibtritonserver.so)
==21418== by 0x4DC504C: nvidia::inferenceserver::TritonModel::~TritonModel() (in /opt/tritonserver/lib/l\
ibtritonserver.so)
==21418== by 0x4C61E46: std::thread::_State_impl<std::thread::_Invoker<std::tuple<nvidia::inferenceserve\
r::(anonymous namespace)::ModelDeleter::operator()(nvidia::inferenceserver::Model*)::{lambda()#1}> > >::M\
run() (in /opt/tritonserver/lib/libtritonserver.so)
==21418== by 0x5BE3DE3: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28)
==21418== by 0x578A608: start_thread (pthread_create.c:477)
==21418== by 0x5F7D292: clone (clone.S:95)
```