### PR TITLE
Fix mismatch between the override correlation ID and request correlation ID

### DIFF
--- a/src/core/sequence_batch_scheduler.h
+++ b/src/core/sequence_batch_scheduler.h
@@ -256,11 +256,9 @@ class SequenceBatch {
   std::shared_ptr<SequenceBatchScheduler::ControlInputs>
       notready_input_overrides_;
 
-  // For each sequence slot the correlation ID input for that
-  // slot. Empty if model does not specify the CONTROL_SEQUENCE_CORRID
-  // control.
-  std::vector<std::shared_ptr<InferenceRequest::Input>>
-      seq_slot_corrid_overrides_;
+  // The correlation ID override. Empty if model does not specify the
+  // CONTROL_SEQUENCE_CORRID control.
+  std::shared_ptr<InferenceRequest::Input> seq_slot_corrid_override_;
 
   // For each sequence slot store the optional state i/o tensors.
   std::vector<std::shared_ptr<SequenceStates>> sequence_states_;


### PR DESCRIPTION
The root cause was that we were reusing the same override input for all the sequence slots. If the sequence ended but the request was not executed yet, the slot will belong to a new sequence and override the correlation id of the previous sequence which has not been executed which lead to mismatch between the request correlation ID and input override correlation ID.

