### PR TITLE
Fix wrong rendered README

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -127,9 +127,9 @@ typically applies when perf_analyzer is running on the same system as
 Triton. The first rule is that for minimum latency set the request
 concurrency to 1 and disable the dynamic batcher and use only 1 [model
 instance](#model-instances). The second rule is that for maximum
-throughput set the request concurrency to be `2 * <maximum batch size>
-* <model instance count>`. We will discuss model instances
-[below](#model-instances), for now we are working with one model
+throughput set the request concurrency to be 
+`2 * <maximum batch size> * <model instance count>`. We will discuss model 
+instances [below](#model-instances), for now we are working with one model
 instance. So for maximum-batch-size 4 we want to run perf_analyzer
 with request concurrency of `2 * 4 * 1 = 8`.
 


### PR DESCRIPTION
When rendered, the equation is off and can confuse readers