### PR TITLE
Adding logging options to sagemaker startup script

### DIFF
--- a/build/sagemaker/serve
+++ b/build/sagemaker/serve
@@ -39,6 +39,18 @@ fi
 if [ -n "$SAGEMAKER_TRITON_THREAD_COUNT" ]; then
     SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --sagemaker-thread-count=${SAGEMAKER_TRITON_THREAD_COUNT}"
 fi
+if [ -n "$SAGEMAKER_TRITON_LOG_VERBOSE" ]; then
+    SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --log-verbose=${SAGEMAKER_TRITON_LOG_VERBOSE}"
+fi
+if [ -n "$SAGEMAKER_TRITON_LOG_INFO" ]; then
+    SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --log-info=${SAGEMAKER_TRITON_LOG_INFO}"
+fi
+if [ -n "$SAGEMAKER_TRITON_LOG_WARNING" ]; then
+    SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --log-warning=${SAGEMAKER_TRITON_LOG_WARNING}"
+fi
+if [ -n "$SAGEMAKER_TRITON_LOG_ERROR" ]; then
+    SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --log-error=${SAGEMAKER_TRITON_LOG_ERROR}"
+fi
 
 if [ -f "${SAGEMAKER_SINGLE_MODEL_REPO}/config.pbtxt" ]; then
     echo "ERROR: Incorrect directory structure."


### PR DESCRIPTION
Adding logging options to sagemaker [serve](https://github.com/triton-inference-server/server/blob/043a95e911102571231fdfc8ed94ca1836e75c8e/build/sagemaker/serve#L75) script to make the log level configurable for Sagemaker inference endpoints

### Testing
```
import time
from sagemaker.predictor import Predictor
from sagemaker.model import Model

model_path='<s3_model_path>'
image_uri='<image_uri>'
role='<sagemaker_execution_role>'
model_name='resnet'
model = Model(model_data=model_path,
              image_uri=image_uri,
              role=role,
              env={'SAGEMAKER_TRITON_LOG_VERBOSE':'1'},
              predictor_cls=Predictor,name=model_name+time.strftime("-%Y-%m-%d-%H-%M-%S", time.gmtime()))
endpoint_name=model_name+time.strftime("-%Y-%m-%d-%H-%M-%S", time.gmtime())
predictor=model.deploy(endpoint_name=endpoint_name,
                    initial_instance_count=1,
                    instance_type='ml.g4dn.4xlarge')
```