### PR TITLE
Replace magic numbers for MetricModelReporter device_id with constants

### DIFF
--- a/src/backends/backend/triton_model_instance.cc
+++ b/src/backends/backend/triton_model_instance.cc
@@ -122,9 +122,11 @@ TritonModelInstance::TritonModelInstance(
 #ifdef TRITON_ENABLE_METRICS
   if (Metrics::Enabled()) {
     // Use an ID in the metric only for GPU instances. Otherwise use
-    // -1 to indicate no device should be reported in the metric.
-    const int id =
-        (kind_ == TRITONSERVER_INSTANCEGROUPKIND_GPU) ? device_id_ : -1;
+    // METRIC_REPORTER_ID_CPU to indicate no device should be reported in the
+    // metric.
+    const int id = (kind_ == TRITONSERVER_INSTANCEGROUPKIND_GPU)
+                       ? device_id_
+                       : METRIC_REPORTER_ID_CPU;
     MetricModelReporter::Create(
         model_->Name(), model_->Version(), id, model_->Config().metric_tags(),
         &reporter_);

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -88,6 +88,13 @@ constexpr int SCHEDULER_DEFAULT_NICE = 5;
 constexpr uint64_t SEQUENCE_IDLE_DEFAULT_MICROSECONDS = 1000 * 1000;
 constexpr size_t STRING_CORRELATION_ID_MAX_LENGTH_BYTES = 128;
 
+#ifdef TRITON_ENABLE_METRICS
+// MetricModelReporter expects a device ID for GPUs, but we reuse this device
+// ID for other metrics as well such as for CPU and Response Cache metrics
+constexpr int METRIC_REPORTER_ID_CPU = -1;
+constexpr int METRIC_REPORTER_ID_RESPONSE_CACHE = -2;
+#endif
+
 #define TIMESPEC_TO_NANOS(TS) \
   ((TS).tv_sec * nvidia::inferenceserver::NANOS_PER_SECOND + (TS).tv_nsec)
 #define TIMESPEC_TO_MILLIS(TS) \

--- a/src/core/dynamic_batch_scheduler.cc
+++ b/src/core/dynamic_batch_scheduler.cc
@@ -75,13 +75,9 @@ DynamicBatchScheduler::DynamicBatchScheduler(
 #ifdef TRITON_ENABLE_METRICS
   // Initialize metric reporter for cache statistics if cache enabled
   if (response_cache_enabled_) {
-    // The cache isn't tied to any specific model instance or GPU device,
-    // so we use device=-2 to indicate caching for now. -1 is currently
-    // used for CPU
-    const int id = -2;
     MetricModelReporter::Create(
-        model_->Name(), model_->Version(), id, model_->Config().metric_tags(),
-        &reporter_);
+        model_->Name(), model_->Version(), METRIC_REPORTER_ID_RESPONSE_CACHE,
+        model_->Config().metric_tags(), &reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS
   max_preferred_batch_size_ = 0;

--- a/src/core/ensemble_scheduler.cc
+++ b/src/core/ensemble_scheduler.cc
@@ -1286,7 +1286,8 @@ EnsembleScheduler::EnsembleScheduler(
 #ifdef TRITON_ENABLE_METRICS
   if (Metrics::Enabled()) {
     MetricModelReporter::Create(
-        config.name(), 1, -1, config.metric_tags(), &metric_reporter_);
+        config.name(), 1, METRIC_REPORTER_ID_CPU, config.metric_tags(),
+        &metric_reporter_);
   }
 #endif  // TRITON_ENABLE_METRICS
 

--- a/src/core/metric_model_reporter.cc
+++ b/src/core/metric_model_reporter.cc
@@ -135,7 +135,7 @@ MetricModelReporter::GetMetricLabels(
         "_" + tag.first, tag.second));
   }
 
-  // 'device' can be -1 to indicate that the GPU is not known. In
+  // 'device' can be < 0 to indicate that the GPU is not known. In
   // that case use a metric that doesn't have the gpu_uuid label.
   if (device >= 0) {
     std::string uuid;


### PR DESCRIPTION
Follow-up to https://github.com/triton-inference-server/server/pull/3569/files/752abbe7f07f3cc1ab787033d982a9d2aa8fde34#r802145062