### PR TITLE
Extend model repository API for config override

### DIFF
--- a/docs/protocol/extension_model_repository.md
+++ b/docs/protocol/extension_model_repository.md
@@ -137,7 +137,8 @@ The load API accepts the following parameters:
 
 - "config" : string parameter that contains a JSON representation of the model
 configuration, which must be able to be parsed into [ModelConfig message from
-model_config.proto](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto). This config will be used for loading the model instead of the one in
+model_config.proto](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto).
+This config will be used for loading the model instead of the one in
 the model directory.
 
 A failed load request must be indicated by an HTTP error status
@@ -305,7 +306,8 @@ The RepositoryModelLoad API accepts the following parameters:
 
 - "config" : string parameter that contains a JSON representation of the model
 configuration, which must be able to be parsed into [ModelConfig message from
-model_config.proto](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto). This config will be used for loading the model instead of the one in
+model_config.proto](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto).
+This config will be used for loading the model instead of the one in
 the model directory.
 
 ### Unload

--- a/docs/protocol/extension_model_repository.md
+++ b/docs/protocol/extension_model_repository.md
@@ -139,7 +139,9 @@ The load API accepts the following parameters:
 configuration, which must be able to be parsed into [ModelConfig message from
 model_config.proto](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto).
 This config will be used for loading the model instead of the one in
-the model directory.
+the model directory. If config is provided, the (re-)load will be triggered as
+the model metadata has been updated, and the same (re-)load behavior will be
+applied.
 
 A failed load request must be indicated by an HTTP error status
 (typically 400). The HTTP body must contain the
@@ -177,8 +179,8 @@ The unload API accepts the following parameters:
 
 - "unload_dependents" : boolean parameter indicating that in addition
   to unloading the requested model, also unload any dependent model
-  that was loaded along with the requested model (for example, the
-  models composing an ensemble).
+  that was loaded along with the requested model. For example, request to
+  unload the models composing an ensemble will unload the ensemble as well.
 
 A failed unload request must be indicated by an HTTP error status
 (typically 400). The HTTP body must contain the
@@ -308,7 +310,9 @@ The RepositoryModelLoad API accepts the following parameters:
 configuration, which must be able to be parsed into [ModelConfig message from
 model_config.proto](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto).
 This config will be used for loading the model instead of the one in
-the model directory.
+the model directory. If config is provided, the (re-)load will be triggered as
+the model metadata has been updated, and the same (re-)load behavior will be
+applied.
 
 ### Unload
 
@@ -341,5 +345,5 @@ The RepositoryModelUnload API accepts the following parameters:
 
 - "unload_dependents" : boolean parameter indicating that in addition
   to unloading the requested model, also unload any dependent model
-  that was loaded along with the requested model (for example, the
-  models composing an ensemble).
+  that was loaded along with the requested model. For example, request to
+  unload the models composing an ensemble will unload the ensemble as well.

--- a/docs/protocol/extension_model_repository.md
+++ b/docs/protocol/extension_model_repository.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/protocol/extension_model_repository.md
+++ b/docs/protocol/extension_model_repository.md
@@ -116,8 +116,29 @@ $repository_index_error_response =
 
 The load API requests that a model be loaded into Triton, or reloaded
 if the model is already loaded. A load request is made with an HTTP
-POST to a load endpoint. The HTTP body must be empty. A successful
-load request is indicated by a 200 HTTP status.
+POST to a load endpoint.  The HTTP body may be empty or may contain
+the load request object, identified as $repository_load_request.
+A successful load request is indicated by a 200 HTTP status.
+
+
+```
+$repository_load_request =
+{
+  "parameters" : $parameters #optional
+}
+```
+
+- "parameters" : An object containing zero or more parameters for this
+  request expressed as key/value pairs. See
+  [Parameters](https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/required_api.md#parameters)
+  for more information.
+
+The load API accepts the following parameters:
+
+- "config" : string parameter that contains a JSON representation of the model
+configuration, which must be able to be parsed into [ModelConfig message from
+model_config.proto](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto). This config will be used for loading the model instead of the one in
+the model directory.
 
 A failed load request must be indicated by an HTTP error status
 (typically 400). The HTTP body must contain the
@@ -270,12 +291,22 @@ message RepositoryModelLoadRequest
 
   // The name of the model to load, or reload.
   string model_name = 2;
+
+  // Optional parameters.
+  map<string, ModelRepositoryParameter> parameters = 3;
 }
 
 message RepositoryModelLoadResponse
 {
 }
 ```
+
+The RepositoryModelLoad API accepts the following parameters:
+
+- "config" : string parameter that contains a JSON representation of the model
+configuration, which must be able to be parsed into [ModelConfig message from
+model_config.proto](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto). This config will be used for loading the model instead of the one in
+the model directory.
 
 ### Unload
 
@@ -303,3 +334,10 @@ message RepositoryModelUnloadResponse
 {
 }
 ```
+
+The RepositoryModelUnload API accepts the following parameters:
+
+- "unload_dependents" : boolean parameter indicating that in addition
+  to unloading the requested model, also unload any dependent model
+  that was loaded along with the requested model (for example, the
+  models composing an ensemble).

--- a/docs/protocol/extension_model_repository.md
+++ b/docs/protocol/extension_model_repository.md
@@ -116,7 +116,7 @@ $repository_index_error_response =
 
 The load API requests that a model be loaded into Triton, or reloaded
 if the model is already loaded. A load request is made with an HTTP
-POST to a load endpoint.  The HTTP body may be empty or may contain
+POST to a load endpoint. The HTTP body may be empty or may contain
 the load request object, identified as $repository_load_request.
 A successful load request is indicated by a 200 HTTP status.
 

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -643,16 +643,6 @@ GetNormalizedModelConfig(
     const std::string& path, const bool autofill,
     const double min_compute_capability, inference::ModelConfig* config)
 {
-  // If 'autofill' then the configuration file can be empty.
-  const auto config_path = JoinPath({path, kModelConfigPbTxt});
-  bool model_config_exists;
-  RETURN_IF_ERROR(FileExists(config_path, &model_config_exists));
-  if (autofill && !model_config_exists) {
-    config->Clear();
-  } else {
-    RETURN_IF_ERROR(ReadTextProto(config_path, config));
-  }
-
   // If the model name is not given in the configuration, set if based
   // on the model path.
   const std::string model_name(BaseName(path));

--- a/src/core/model_config_utils.cc
+++ b/src/core/model_config_utils.cc
@@ -640,8 +640,8 @@ GetTypedSequenceControlProperties(
 
 Status
 GetNormalizedModelConfig(
-    const std::string& path, const bool autofill,
-    const double min_compute_capability, inference::ModelConfig* config)
+    const std::string& path, const double min_compute_capability,
+    inference::ModelConfig* config)
 {
   // If the model name is not given in the configuration, set if based
   // on the model path.

--- a/src/core/model_config_utils.h
+++ b/src/core/model_config_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -68,15 +68,13 @@ Status GetTypedSequenceControlProperties(
 /// Read a ModelConfig and normalize it as expected by model backends.
 /// \param path The full-path to the directory containing the
 /// model configuration.
-/// \param autofill If true attempt to determine any missing required
-/// configuration from the model definition.
 /// \param min_compute_capability The minimum support CUDA compute
 /// capability.
 /// \param config Returns the normalized model configuration.
 /// \return The error status.
 Status GetNormalizedModelConfig(
-    const std::string& path, const bool autofill,
-    const double min_compute_capability, inference::ModelConfig* config);
+    const std::string& path, const double min_compute_capability,
+    inference::ModelConfig* config);
 
 /// Auto-complete backend related fields (platform, backend and default model
 /// filename) if not set, note that only Triton recognized backends will be

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -1221,8 +1221,13 @@ ModelRepositoryManager::Create(
     // model loading / unloading error will be printed but ignored
     RETURN_IF_ERROR(local_manager->PollAndUpdateInternal(&all_models_polled));
   } else {
+    std::unordered_map<std::string, std::vector<const InferenceParameter*>>
+        models;
+    for (const auto& model_name : startup_models) {
+      models[model_name];
+    }
     RETURN_IF_ERROR(local_manager->LoadUnloadModels(
-        startup_models, ActionType::LOAD, false, &all_models_polled));
+        models, ActionType::LOAD, false, &all_models_polled));
   }
 
   *model_repository_manager = std::move(local_manager);
@@ -1277,7 +1282,8 @@ ModelRepositoryManager::PollAndUpdateInternal(bool* all_models_polled)
 
   // Each subdirectory of repository path is a model directory from
   // which we read the model configuration.
-  std::set<std::string> subdirs;
+  std::unordered_map<std::string, std::vector<const InferenceParameter*>>
+      subdirs;
   RETURN_IF_ERROR(Poll(
       subdirs, &added, &deleted, &modified, &unmodified, &new_infos,
       all_models_polled));
@@ -1377,8 +1383,9 @@ ModelRepositoryManager::LoadModelByDependency()
 
 Status
 ModelRepositoryManager::LoadUnloadModel(
-    const std::string& model_name, const ActionType type,
-    const bool unload_dependents)
+    const std::unordered_map<
+        std::string, std::vector<const InferenceParameter*>>& models,
+    const ActionType type, const bool unload_dependents)
 {
   if (!model_control_enabled_) {
     return Status(
@@ -1386,14 +1393,20 @@ ModelRepositoryManager::LoadUnloadModel(
         "explicit model load / unload is not allowed if polling is enabled");
   }
 
+  if (models.size() > 1) {
+    return Status(
+        Status::Code::UNSUPPORTED,
+        "explicit load / unload multiple models is not currently supported");
+  }
+
   // Serialize all operations that change model state
   std::lock_guard<std::mutex> lock(poll_mu_);
 
   bool polled = true;
-  RETURN_IF_ERROR(
-      LoadUnloadModels({model_name}, type, unload_dependents, &polled));
+  RETURN_IF_ERROR(LoadUnloadModels(models, type, unload_dependents, &polled));
 
   // Check if model is loaded / unloaded properly
+  const auto& model_name = models.begin()->first;
   const auto version_states = model_life_cycle_->VersionStates(model_name);
   if (type == ActionType::LOAD) {
     if (version_states.empty()) {
@@ -1430,8 +1443,10 @@ ModelRepositoryManager::LoadUnloadModel(
 
 Status
 ModelRepositoryManager::LoadUnloadModels(
-    const std::set<std::string>& model_names, const ActionType type,
-    const bool unload_dependents, bool* all_models_polled)
+    const std::unordered_map<
+        std::string, std::vector<const InferenceParameter*>>& models,
+    const ActionType type, const bool unload_dependents,
+    bool* all_models_polled)
 {
   auto status = Status::Success;
   *all_models_polled = true;
@@ -1439,12 +1454,15 @@ ModelRepositoryManager::LoadUnloadModels(
   std::set<std::string> added, deleted, modified, unmodified;
   {
     if (type == ActionType::UNLOAD) {
-      for (const auto& model_name : model_names) {
-        deleted.insert(model_name);
+      for (const auto& model : models) {
+        deleted.insert(model.first);
       }
     } else {
-      std::set<std::string> checked_modes = model_names;
-      std::set<std::string> models = model_names;
+      std::set<std::string> current_models, checked_models;
+      for (const auto& model : models) {
+        current_models.emplace(model.first);
+        checked_models.emplace(model.first);
+      }
 
       ModelInfoMap new_infos;
 #ifdef TRITON_ENABLE_ENSEMBLE
@@ -1460,7 +1478,7 @@ ModelRepositoryManager::LoadUnloadModels(
         // More models should be polled if the polled models are ensembles
         std::set<std::string> next_models;
 #ifdef TRITON_ENABLE_ENSEMBLE
-        for (const auto& model : models) {
+        for (const auto& model : current_models) {
           auto it = new_infos.find(model);
           // Some models may be marked as deleted and not in 'new_infos'
           if (it != new_infos.end()) {
@@ -1469,7 +1487,7 @@ ModelRepositoryManager::LoadUnloadModels(
             if (config.has_ensemble_scheduling()) {
               for (const auto& step : config.ensemble_scheduling().step()) {
                 bool need_poll =
-                    checked_modes.emplace(step.model_name()).second;
+                    checked_models.emplace(step.model_name()).second;
                 if (need_poll) {
                   next_models.emplace(step.model_name());
                 }
@@ -1479,7 +1497,7 @@ ModelRepositoryManager::LoadUnloadModels(
         }
         first_iteration = false;
 #endif  // TRITON_ENABLE_ENSEMBLE
-        models.swap(next_models);
+        current_models.swap(next_models);
       }
 
       // Only update the infos when all validation is completed
@@ -1514,13 +1532,13 @@ ModelRepositoryManager::LoadUnloadModels(
   const auto& load_status = LoadModelByDependency();
   if (status.IsOk() && (type == ActionType::LOAD)) {
     std::string load_error_message = "";
-    for (const auto& model_name : model_names) {
-      auto it = load_status.find(model_name);
-      // If 'model_name' not in load status, it means the (re-)load is not
+    for (const auto& model : models) {
+      auto it = load_status.find(model.first);
+      // If 'model.first' not in load status, it means the (re-)load is not
       // necessary because there is no change in the model's directory
       if ((it != load_status.end()) && !it->second.IsOk()) {
         load_error_message +=
-            ("load failed for model '" + model_name +
+            ("load failed for model '" + model.first +
              "': " + it->second.Message() + "\n");
       }
     }
@@ -1640,10 +1658,11 @@ ModelRepositoryManager::GetModel(
 
 Status
 ModelRepositoryManager::Poll(
-    const std::set<std::string>& models, std::set<std::string>* added,
-    std::set<std::string>* deleted, std::set<std::string>* modified,
-    std::set<std::string>* unmodified, ModelInfoMap* updated_infos,
-    bool* all_models_polled)
+    const std::unordered_map<
+        std::string, std::vector<const InferenceParameter*>>& models,
+    std::set<std::string>* added, std::set<std::string>* deleted,
+    std::set<std::string>* modified, std::set<std::string>* unmodified,
+    ModelInfoMap* updated_infos, bool* all_models_polled)
 {
   *all_models_polled = true;
   std::map<std::string, std::string> model_to_repository;
@@ -1676,24 +1695,27 @@ ModelRepositoryManager::Poll(
                 << "': not unique across all model repositories";
     }
   } else {
+    // [DLIS-3487] Model doesn't need to be in repository if model files
+    // are provided in flight.
     for (const auto& model : models) {
       bool exists = false;
       for (const auto repository_path : repository_paths_) {
         bool exists_in_this_repo = false;
-        const auto full_path = JoinPath({repository_path, model});
+        const auto full_path = JoinPath({repository_path, model.first});
         Status status = FileExists(full_path, &exists_in_this_repo);
         if (!status.IsOk()) {
           LOG_ERROR << "failed to poll model repository '" << repository_path
-                    << "' for model '" << model << "': " << status.Message();
+                    << "' for model '" << model.first
+                    << "': " << status.Message();
           *all_models_polled = false;
         } else if (exists_in_this_repo) {
-          auto res = model_to_repository.emplace(model, repository_path);
+          auto res = model_to_repository.emplace(model.first, repository_path);
           if (res.second) {
             exists = true;
           } else {
             exists = false;
             model_to_repository.erase(res.first);
-            LOG_ERROR << "failed to poll model '" << model
+            LOG_ERROR << "failed to poll model '" << model.first
                       << "': not unique across all model repositories";
             *all_models_polled = false;
             break;
@@ -1701,7 +1723,7 @@ ModelRepositoryManager::Poll(
         }
       }
       if (!exists) {
-        deleted->insert(model);
+        deleted->insert(model.first);
       }
     }
   }
@@ -1724,6 +1746,7 @@ ModelRepositoryManager::Poll(
     auto model_poll_state = STATE_UNMODIFIED;
     auto full_path = JoinPath({repository, child});
 
+    const auto& mit = models.find(child);
 
     std::unique_ptr<ModelInfo> model_info;
     const auto iitr = infos_.find(child);
@@ -1742,7 +1765,36 @@ ModelRepositoryManager::Poll(
     }
 
     Status status = Status::Success;
-    if (model_poll_state != STATE_UNMODIFIED) {
+
+    // Check if there is config override
+    std::string override_config;
+    if ((mit != models.end()) && (!mit->second.empty())) {
+      for (const auto& override_parameter : mit->second) {
+        if ((override_parameter->Name() == "config") &&
+            (override_parameter->Type() == TRITONSERVER_PARAMETER_STRING)) {
+          override_config = std::string(reinterpret_cast<const char*>(
+              override_parameter->ValuePointer()));
+          // When override happens, make modification time be less than
+          // the actual time in file system so that next load without override
+          // will trigger re-load to undo the override while the files may still
+          // be unchanged.
+          mtime_ns -= 1;
+          if (model_poll_state != STATE_ADDED) {
+            model_poll_state = STATE_MODIFIED;
+          }
+        } else {
+          status = Status(
+              Status::Code::INVALID_ARG,
+              "Unrecognized load parameter '" + override_parameter->Name() +
+                  "' with type '" +
+                  TRITONSERVER_ParameterTypeString(override_parameter->Type()) +
+                  "'");
+          break;
+        }
+      }
+    }
+
+    if (status.IsOk() && (model_poll_state != STATE_UNMODIFIED)) {
       model_info.reset(new ModelInfo(mtime_ns, repository));
       inference::ModelConfig& model_config = model_info->model_config_;
 
@@ -1750,8 +1802,18 @@ ModelRepositoryManager::Poll(
       // this must be done before normalizing model config as agents might
       // redirect to use the model config at a different location
       {
-        const auto config_path = JoinPath({full_path, kModelConfigPbTxt});
-        if (ReadTextProto(config_path, &model_config).IsOk()) {
+        bool parsed_config = false;
+        if (override_config.empty()) {
+          // ReadTextProto() is allowed to fail because model config may not be
+          // provided
+          const auto config_path = JoinPath({full_path, kModelConfigPbTxt});
+          parsed_config = ReadTextProto(config_path, &model_config).IsOk();
+        } else {
+          status = JsonToModelConfig(
+              override_config, 1 /* config_version */, &model_config);
+          parsed_config = status.IsOk();
+        }
+        if (parsed_config) {
           status = CreateAgentModelListWithLoadAction(
               model_config, full_path, &model_info->agent_model_list_);
           if (status.IsOk() && model_info->agent_model_list_ != nullptr) {
@@ -1809,13 +1871,13 @@ ModelRepositoryManager::Poll(
                   "', directory name must equal model name");
         }
       }
+    }
 
-      if (!status.IsOk()) {
-        if (model_poll_state == STATE_MODIFIED) {
-          model_poll_state = STATE_UNMODIFIED;
-        } else {
-          model_poll_state = STATE_INVALID;
-        }
+    if (!status.IsOk()) {
+      if (model_poll_state == STATE_MODIFIED) {
+        model_poll_state = STATE_UNMODIFIED;
+      } else {
+        model_poll_state = STATE_INVALID;
       }
     }
 
@@ -1873,7 +1935,7 @@ ModelRepositoryManager::UpdateDependencyGraph(
         // remove this node from its upstreams
         for (auto& upstream : it->second->upstreams_) {
           upstream.first->downstreams_.erase(it->second.get());
-          // Check if the upstream should be removed aas well
+          // Check if the upstream should be removed as well
           if ((deleted_dependents != nullptr) &&
               (upstream.first->downstreams_.empty()) &&
               (!upstream.first->explicitly_load_)) {

--- a/src/core/model_repository_manager.cc
+++ b/src/core/model_repository_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/model_repository_manager.h
+++ b/src/core/model_repository_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/server.cc
+++ b/src/core/server.cc
@@ -471,7 +471,9 @@ InferenceServer::InferAsync(std::unique_ptr<InferenceRequest>& request)
 }
 
 Status
-InferenceServer::LoadModel(const std::string& model_name)
+InferenceServer::LoadModel(
+    const std::unordered_map<
+        std::string, std::vector<const InferenceParameter*>>& models)
 {
   if (ready_state_ != ServerReadyState::SERVER_READY) {
     return Status(Status::Code::UNAVAILABLE, "Server not ready");
@@ -481,7 +483,7 @@ InferenceServer::LoadModel(const std::string& model_name)
 
   auto action_type = ModelRepositoryManager::ActionType::LOAD;
   return model_repository_manager_->LoadUnloadModel(
-      model_name, action_type, false /* unload_dependents */);
+      models, action_type, false /* unload_dependents */);
 }
 
 Status
@@ -496,7 +498,7 @@ InferenceServer::UnloadModel(
 
   auto action_type = ModelRepositoryManager::ActionType::UNLOAD;
   return model_repository_manager_->LoadUnloadModel(
-      model_name, action_type, unload_dependents);
+      {{model_name, {}}}, action_type, unload_dependents);
 }
 
 Status

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/core/server.h
+++ b/src/core/server.h
@@ -34,6 +34,7 @@
 #include <vector>
 
 #include "model_config.pb.h"
+#include "src/core/infer_parameter.h"
 #include "src/core/model_config.h"
 #include "src/core/model_repository_manager.h"
 #include "src/core/persistent_backend_manager.h"
@@ -118,7 +119,9 @@ class InferenceServer {
   Status InferAsync(std::unique_ptr<InferenceRequest>& request);
 
   // Load the corresponding model. Reload the model if it has been loaded.
-  Status LoadModel(const std::string& model_name);
+  Status LoadModel(
+      const std::unordered_map<
+          std::string, std::vector<const InferenceParameter*>>& models);
 
   // Unload the corresponding model.
   Status UnloadModel(

--- a/src/core/tritonserver.cc
+++ b/src/core/tritonserver.cc
@@ -523,7 +523,7 @@ TRITONSERVER_MemoryTypeString(TRITONSERVER_MemoryType memtype)
 }
 
 //
-// TRITONSERVER_ParameterType
+// TRITONSERVER_Parameter
 //
 const char*
 TRITONSERVER_ParameterTypeString(TRITONSERVER_ParameterType paramtype)
@@ -540,6 +540,36 @@ TRITONSERVER_ParameterTypeString(TRITONSERVER_ParameterType paramtype)
   }
 
   return "<invalid>";
+}
+
+TRITONSERVER_Parameter*
+TRITONSERVER_ParameterNew(
+    const char* name, const TRITONSERVER_ParameterType type, const void* value)
+{
+  std::unique_ptr<ni::InferenceParameter> lparam;
+  switch (type) {
+    case TRITONSERVER_PARAMETER_STRING:
+      lparam.reset(new ni::InferenceParameter(
+          name, reinterpret_cast<const char*>(value)));
+      break;
+    case TRITONSERVER_PARAMETER_INT:
+      lparam.reset(new ni::InferenceParameter(
+          name, *reinterpret_cast<const int64_t*>(value)));
+      break;
+    case TRITONSERVER_PARAMETER_BOOL:
+      lparam.reset(new ni::InferenceParameter(
+          name, *reinterpret_cast<const bool*>(value)));
+      break;
+    default:
+      break;
+  }
+  return reinterpret_cast<TRITONSERVER_Parameter*>(lparam.release());
+}
+
+void
+TRITONSERVER_ParameterDelete(TRITONSERVER_Parameter* parameter)
+{
+  delete reinterpret_cast<ni::InferenceParameter*>(parameter);
 }
 
 //
@@ -2197,7 +2227,7 @@ TRITONSERVER_ServerModelStatistics(
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
   auto model_name_string = std::string(model_name);
-  std::map<std::string, std::vector<int64_t> > ready_model_versions;
+  std::map<std::string, std::vector<int64_t>> ready_model_versions;
   if (model_name_string.empty()) {
     RETURN_IF_STATUS_ERROR(lserver->ModelReadyVersions(&ready_model_versions));
   } else {
@@ -2402,7 +2432,33 @@ TRITONSERVER_ServerLoadModel(
 {
   ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
 
-  RETURN_IF_STATUS_ERROR(lserver->LoadModel(std::string(model_name)));
+  RETURN_IF_STATUS_ERROR(lserver->LoadModel({{std::string(model_name), {}}}));
+
+  return nullptr;  // success
+}
+
+TRITONSERVER_Error*
+TRITONSERVER_ServerLoadModelWithParameters(
+    TRITONSERVER_Server* server, const char* model_name,
+    const TRITONSERVER_Parameter** parameters, const uint64_t parameter_count)
+{
+  if ((parameters == nullptr) && (parameter_count != 0)) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INVALID_ARG,
+        "load parameters are not provided while parameter count is non-zero");
+  }
+
+  ni::InferenceServer* lserver = reinterpret_cast<ni::InferenceServer*>(server);
+
+  std::unordered_map<std::string, std::vector<const ni::InferenceParameter*>>
+      models;
+  std::vector<const ni::InferenceParameter*> mp;
+  for (size_t i = 0; i < parameter_count; ++i) {
+    mp.emplace_back(
+        reinterpret_cast<const ni::InferenceParameter*>(parameters[i]));
+  }
+  models[model_name] = std::move(mp);
+  RETURN_IF_STATUS_ERROR(lserver->LoadModel(models));
 
   return nullptr;  // success
 }

--- a/src/servers/grpc_server.cc
+++ b/src/servers/grpc_server.cc
@@ -1741,8 +1741,8 @@ CommonHandler::SetUpAllRequests()
           grpc::Status* status) {
         TRITONSERVER_Error* err = nullptr;
         if (request.repository_name().empty()) {
-          err = TRITONSERVER_ServerLoadModel(
-              tritonserver_.get(), request.model_name().c_str());
+          err = TRITONSERVER_ServerLoadModelWithParameters(
+              tritonserver_.get(), request.model_name().c_str(), nullptr, 0);
         } else {
           err = TRITONSERVER_ErrorNew(
               TRITONSERVER_ERROR_UNSUPPORTED,

--- a/src/servers/http_server.cc
+++ b/src/servers/http_server.cc
@@ -1265,7 +1265,8 @@ HTTPAPIServer::HandleRepositoryControl(
         "'repository_name' specification is not supported");
   } else {
     if (action == "load") {
-      err = TRITONSERVER_ServerLoadModel(server_.get(), model_name.c_str());
+      err = TRITONSERVER_ServerLoadModelWithParameters(
+          server_.get(), model_name.c_str(), nullptr, 0);
     } else if (action == "unload") {
       // Check if the dependent models should be removed
       bool unload_dependents = false;


### PR DESCRIPTION
@deadeyegoodwin @tanmayv25 @CoderHam Look and feel of the extended API. In terms of GRPC API, I think we could `ModelRepositoryParameter` extend to have `ModelConfig` as one of the value option, but requiring JSON string for now to match the HTTP side.