### PR TITLE
Build Java jar in sdk and QA containers

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -1,4 +1,4 @@
-# Copyright 2018-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -321,6 +321,9 @@ RUN GO111MODULE=off go get github.com/golang/protobuf/protoc-gen-go && \
 # user.
 WORKDIR /opt/tritonserver
 COPY --chown=1000:1000 --from=sdk /workspace/qa/ qa/
+# Copy Java API jar
+COPY --from=sdk /workspace/install/java-api-bindings/tritonserver-java-bindings.jar qa/pkgs/.
+
 
 # Remove CI tests that are meant to run only on build image and
 # install the tritonserver/triton python client APIs.

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -246,7 +246,7 @@ RUN cp client/src/grpc_generated/go/*.go qa/L0_simple_go_client/. && \
     cp client/src/grpc_generated/javascript/*.json qa/L0_simple_nodejs_client/. && \
     cp -r client/src/grpc_generated/java qa/L0_client_java/.
 # Copy Java API jar
-RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         cp install/java-api-bindings/tritonserver-java-bindings.jar qa/pkgs/. ;\
     fi
 

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -246,7 +246,7 @@ RUN cp client/src/grpc_generated/go/*.go qa/L0_simple_go_client/. && \
     cp client/src/grpc_generated/javascript/*.json qa/L0_simple_nodejs_client/. && \
     cp -r client/src/grpc_generated/java qa/L0_client_java/.
 # Copy Java API jar
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
         cp install/java-api-bindings/tritonserver-java-bindings.jar qa/pkgs/. ;\
     fi
 

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -230,6 +230,7 @@ RUN mkdir -p qa/L0_passive_instance/models/distributed_int32_int32_int32/1 && \
 ## Copy artifacts from sdk container
 ############################################################################
 FROM ${SDK_IMAGE} AS sdk
+ARG TARGETPLATFORM
 
 WORKDIR /workspace
 COPY --from=build /workspace/qa/ qa/
@@ -244,6 +245,10 @@ RUN cp client/src/grpc_generated/go/*.go qa/L0_simple_go_client/. && \
     cp client/src/grpc_generated/javascript/*.js qa/L0_simple_nodejs_client/. && \
     cp client/src/grpc_generated/javascript/*.json qa/L0_simple_nodejs_client/. && \
     cp -r client/src/grpc_generated/java qa/L0_client_java/.
+# Copy Java API jar
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        cp install/java-api-bindings/tritonserver-java-bindings.jar qa/pkgs/. ;\
+    fi
 
 ############################################################################
 ## Create CI enabled image
@@ -321,9 +326,6 @@ RUN GO111MODULE=off go get github.com/golang/protobuf/protoc-gen-go && \
 # user.
 WORKDIR /opt/tritonserver
 COPY --chown=1000:1000 --from=sdk /workspace/qa/ qa/
-# Copy Java API jar
-COPY --from=sdk /workspace/install/java-api-bindings/tritonserver-java-bindings.jar qa/pkgs/.
-
 
 # Remove CI tests that are meant to run only on build image and
 # install the tritonserver/triton python client APIs.

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -199,4 +199,3 @@ ENV NVIDIA_BUILD_ID=${NVIDIA_BUILD_ID}
 
 ENV PATH /workspace/install/bin:${PATH}
 ENV LD_LIBRARY_PATH /workspace/install/lib:${LD_LIBRARY_PATH}
-

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -44,7 +44,7 @@ FROM ${JAVA_API_IMAGE} as java-api-image
 ARG TARGETPLATFORM
 WORKDIR /workspace
 # Copy Java API jar
-RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         mkdir -p install/java-api-bindings && \
         cp /opt/tritonserver/tritonserver-java-bindings.jar install/java-api-bindings/tritonserver-java-bindings.jar ;\
     fi

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -42,11 +42,11 @@ ARG NVIDIA_BUILD_ID=unknown
 
 FROM ${JAVA_API_IMAGE} as java-api-image
 ARG TARGETPLATFORM
-WORKDIR /workspace
+WORKDIR /workspace/install
 # Copy Java API jar
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
-        mkdir -p install/java-api-bindings && \
-        cp /opt/tritonserver/tritonserver-java-bindings.jar install/java-api-bindings/tritonserver-java-bindings.jar ;\
+        mkdir -p java-api-bindings && \
+        cp /opt/tritonserver/tritonserver-java-bindings.jar java-api-bindings/tritonserver-java-bindings.jar ;\
     fi
  
 FROM ${BASE_IMAGE}

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -35,10 +35,12 @@ ARG TRITON_THIRD_PARTY_REPO_TAG=main
 ARG TRITON_MODEL_ANALYZER_REPO_TAG=main
 ARG CMAKE_UBUNTU_VERSION=20.04
 ARG TRITON_ENABLE_GPU=ON
+ARG JAVA_API_IMAGE=java_api_build
 
 ARG NVIDIA_TRITON_SERVER_SDK_VERSION=unknown
 ARG NVIDIA_BUILD_ID=unknown
 
+FROM ${JAVA_API_IMAGE} AS java-api-build
 FROM ${BASE_IMAGE}
 
 ARG TARGETPLATFORM
@@ -186,3 +188,11 @@ ENV NVIDIA_BUILD_ID=${NVIDIA_BUILD_ID}
 
 ENV PATH /workspace/install/bin:${PATH}
 ENV LD_LIBRARY_PATH /workspace/install/lib:${LD_LIBRARY_PATH}
+
+############################################################################
+### COPY jar file from Java API Image build
+############################################################################
+WORKDIR /workspace/install/java-api-bindings
+ARG JAVA_API_IMAGE
+RUN echo $JAVA_API_IMAGE
+COPY --from=java-api-build /opt/tritonserver/tritonserver-java-bindings.jar .

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -40,7 +40,15 @@ ARG JAVA_API_IMAGE=java_api_build
 ARG NVIDIA_TRITON_SERVER_SDK_VERSION=unknown
 ARG NVIDIA_BUILD_ID=unknown
 
-FROM ${JAVA_API_IMAGE} AS java-api-build
+FROM ${JAVA_API_IMAGE} as java-api-image
+ARG TARGETPLATFORM
+WORKDIR /workspace
+# Copy Java API jar
+RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
+        mkdir -p install/java-api-bindings && \
+        cp /opt/tritonserver/tritonserver-java-bindings.jar install/java-api-bindings/tritonserver-java-bindings.jar ;\
+    fi
+ 
 FROM ${BASE_IMAGE}
 
 ARG TARGETPLATFORM
@@ -169,6 +177,9 @@ RUN if [ "$TRITON_ENABLE_GPU" = "ON" ]; then \
       fi \
     fi
 
+# Copy jar from multistage build
+COPY --from=java-api-image /workspace/install /workspace/install/
+
 # Install Model Analyzer
 ARG TRITON_MODEL_ANALYZER_REPO_TAG
 ARG TRITON_MODEL_ANALYZER_REPO="https://github.com/triton-inference-server/model_analyzer@${TRITON_MODEL_ANALYZER_REPO_TAG}"
@@ -189,14 +200,3 @@ ENV NVIDIA_BUILD_ID=${NVIDIA_BUILD_ID}
 ENV PATH /workspace/install/bin:${PATH}
 ENV LD_LIBRARY_PATH /workspace/install/lib:${LD_LIBRARY_PATH}
 
-############################################################################
-### COPY jar file from Java API Image build
-############################################################################
-FROM ${JAVA_API_IMAGE}
-ARG TARGETPLATFORM
-
-# Copy Java API jar
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        mkdir /workspace/install/java-api-bindings; && \
-        cp /opt/tritonserver/tritonserver-java-bindings.jar . ;\
-    fi

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -192,7 +192,11 @@ ENV LD_LIBRARY_PATH /workspace/install/lib:${LD_LIBRARY_PATH}
 ############################################################################
 ### COPY jar file from Java API Image build
 ############################################################################
-WORKDIR /workspace/install/java-api-bindings
-ARG JAVA_API_IMAGE
-RUN echo $JAVA_API_IMAGE
-COPY --from=java-api-build /opt/tritonserver/tritonserver-java-bindings.jar .
+FROM ${JAVA_API_IMAGE}
+ARG TARGETPLATFORM
+
+# Copy Java API jar
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        mkdir /workspace/install/java-api-bindings; && \
+        cp /opt/tritonserver/tritonserver-java-bindings.jar . ;\
+    fi


### PR DESCRIPTION
Multistage build to add Java bindings jar to SDK and QA container
Actual build in client repo: https://github.com/triton-inference-server/client/pull/68