### PR TITLE
Fix an old broken link to a model config protobuf.

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -305,7 +305,7 @@ optimization { execution_accelerators {
 ```
 
 The options are described in detail in the
-[ModelOptimizationPolicy](../src/core/model_configuration.proto)
+[ModelOptimizationPolicy](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto)
 section of the model configuration protobuf.
 
 As an example of TensorRT optimization applied to a TensorFlow model,


### PR DESCRIPTION
This is a trivial fix.
It looks like one link to a model config protobuf is still old and 404 error happens. This PR replaces it with a newer correct link.