### PR TITLE
Remove instance group setting from identity model config

### DIFF
--- a/qa/python_models/identity_fp32/config.pbtxt
+++ b/qa/python_models/identity_fp32/config.pbtxt
@@ -44,9 +44,3 @@ output [
   }
 ]
 
-instance_group [
-  {
-    count: 1
-    kind : KIND_CPU
-  }
-]


### PR DESCRIPTION
Looks like the `L0_perf_no_model` tests for Python backend were running with 3 instances instead of 2 instances because the model configuration looked like below:

```
instance_group [
  {
    count: 1
    kind : KIND_CPU
  }
]
instance_group [ { kind: KIND_CPU, count: 2 }]
```

