### PR TITLE
Use decoupled gRPC streaming in preserve ordering testing

### DIFF
--- a/qa/L0_batcher/batcher_test.py
+++ b/qa/L0_batcher/batcher_test.py
@@ -38,7 +38,7 @@ import test_util as tu
 from functools import partial
 
 import tritonclient.grpc as grpcclient
-from tritonclient.utils import *
+from tritonclient.utils import np_to_triton_dtype
 
 if sys.version_info >= (3, 0):
     import queue

--- a/qa/L0_batcher/test.sh
+++ b/qa/L0_batcher/test.sh
@@ -559,10 +559,13 @@ if [[ "$(< /proc/sys/kernel/osrelease)" != *microsoft* ]]; then
 
     # Two instances will be created for the custom model, one delays 100 ms while
     # the other delays 400 ms
+    # Using decoupled mode as the non-decoupled streaming adds preserve ordering
+    # of its own.
     (cd custom_models/custom_zero_1_float32 && \
             sed -i "s/dims:.*\[.*\]/dims: \[ -1 \]/g" config.pbtxt && \
             sed -i "s/max_batch_size:.*/max_batch_size: 4/g" config.pbtxt && \
             echo "dynamic_batching { preferred_batch_size: [ 4 ] }" >> config.pbtxt && \
+            echo "model_transaction_policy { decoupled: True }" >> config.pbtxt && \
             echo "instance_group [ { kind: KIND_GPU count: 2 }]" >> config.pbtxt && \
             echo "parameters [" >> config.pbtxt && \
             echo "{ key: \"execute_delay_ms\"; value: { string_value: \"100\" }}," >> config.pbtxt && \

--- a/qa/L0_batcher/test.sh
+++ b/qa/L0_batcher/test.sh
@@ -559,8 +559,6 @@ if [[ "$(< /proc/sys/kernel/osrelease)" != *microsoft* ]]; then
 
     # Two instances will be created for the custom model, one delays 100 ms while
     # the other delays 400 ms
-    # Using decoupled mode as the non-decoupled streaming adds preserve ordering
-    # of its own.
     (cd custom_models/custom_zero_1_float32 && \
             sed -i "s/dims:.*\[.*\]/dims: \[ -1 \]/g" config.pbtxt && \
             sed -i "s/max_batch_size:.*/max_batch_size: 4/g" config.pbtxt && \

--- a/qa/L0_batcher/test.sh
+++ b/qa/L0_batcher/test.sh
@@ -563,7 +563,6 @@ if [[ "$(< /proc/sys/kernel/osrelease)" != *microsoft* ]]; then
             sed -i "s/dims:.*\[.*\]/dims: \[ -1 \]/g" config.pbtxt && \
             sed -i "s/max_batch_size:.*/max_batch_size: 4/g" config.pbtxt && \
             echo "dynamic_batching { preferred_batch_size: [ 4 ] }" >> config.pbtxt && \
-            echo "model_transaction_policy { decoupled: True }" >> config.pbtxt && \
             echo "instance_group [ { kind: KIND_GPU count: 2 }]" >> config.pbtxt && \
             echo "parameters [" >> config.pbtxt && \
             echo "{ key: \"execute_delay_ms\"; value: { string_value: \"100\" }}," >> config.pbtxt && \

--- a/qa/L0_batcher/verify_timestamps.py
+++ b/qa/L0_batcher/verify_timestamps.py
@@ -37,22 +37,9 @@ def verify_timestamps(traces, preserve):
 
     # Filter the trace that is not meaningful and group them by 'id'
     filtered_traces = dict()
-    grpc_id_offset = 0
     for trace in traces:
         if "id" not in trace:
             continue
-        # Skip GRPC traces as actual traces are not genarated via GRPC,
-        # thus GRPC traces are ill-formed
-        if "timestamps" in trace:
-            is_grpc = False
-            for ts in trace["timestamps"]:
-                if "GRPC" in ts["name"]:
-                    is_grpc = True
-                    break
-            if is_grpc:
-                grpc_id_offset += 1
-                continue
-
         if (trace['id'] in filtered_traces.keys()):
             rep_trace = filtered_traces[trace['id']]
             # Apend the timestamp to the trace representing this 'id'
@@ -75,9 +62,8 @@ def verify_timestamps(traces, preserve):
         compute_span = timestamps["COMPUTE_END"] - timestamps["COMPUTE_START"]
         # If the 3rd batch is also processed by large delay instance, we don't
         # want to use its responses as baseline
-        if trace["id"] <= (
-                8 + grpc_id_offset) and compute_span >= 400 * 1000 * 1000:
-            send_end = timestamps["HTTP_SEND_END"]
+        if trace["id"] <= 8 and compute_span >= 400 * 1000 * 1000:
+            send_end = timestamps["GRPC_SEND_END"]
             large_delay_send_end = max(large_delay_send_end, send_end)
         else:
             small_delay_traces.append(trace)
@@ -87,7 +73,7 @@ def verify_timestamps(traces, preserve):
         timestamps = dict()
         for ts in trace["timestamps"]:
             timestamps[ts["name"]] = ts["ns"]
-        send_end = timestamps["HTTP_SEND_END"]
+        send_end = timestamps["GRPC_SEND_END"]
         if send_end > large_delay_send_end:
             response_request_after_large_delay_count += 1
 
@@ -102,128 +88,6 @@ def verify_timestamps(traces, preserve):
         # If not preserve ordering, the small delay batches should all be done
         # before large delay batch regardless of the ordering in scheduler
         return 0 if response_request_after_large_delay_count == 0 else 1
-
-
-def summarize(protocol, traces):
-    for trace in filtered_traces:
-        timestamps = dict()
-        for ts in trace["timestamps"]:
-            timestamps[ts["name"]] = ts["ns"]
-
-        if ("REQUEST_START" in timestamps) and ("REQUEST_END" in timestamps):
-            key = (trace["model_name"], trace["model_version"])
-            if key not in model_count_map:
-                model_count_map[key] = 0
-                model_span_map[key] = dict()
-
-            model_count_map[key] += 1
-            if ("HTTP_RECV_START" in timestamps) and ("HTTP_SEND_END"
-                                                      in timestamps):
-                add_span(model_span_map[key], timestamps, "http infer",
-                         "HTTP_RECV_START", "HTTP_SEND_END")
-                add_span(model_span_map[key], timestamps, "http recv",
-                         "HTTP_RECV_START", "HTTP_RECV_END")
-                add_span(model_span_map[key], timestamps, "http send",
-                         "HTTP_SEND_START", "HTTP_SEND_END")
-            elif ("GRPC_WAITREAD_START" in timestamps) and ("GRPC_SEND_END"
-                                                            in timestamps):
-                add_span(model_span_map[key], timestamps, "grpc infer",
-                         "GRPC_WAITREAD_START", "GRPC_SEND_END")
-                add_span(model_span_map[key], timestamps, "grpc wait/read",
-                         "GRPC_WAITREAD_START", "GRPC_WAITREAD_END")
-                add_span(model_span_map[key], timestamps, "grpc send",
-                         "GRPC_SEND_START", "GRPC_SEND_END")
-
-            add_span(model_span_map[key], timestamps, "request handler",
-                     "REQUEST_START", "REQUEST_END")
-
-            # The tags below will be missing for ensemble model
-            if ("QUEUE_START" in timestamps) and ("COMPUTE_START"
-                                                  in timestamps):
-                add_span(model_span_map[key], timestamps, "queue",
-                         "QUEUE_START", "COMPUTE_START")
-            if ("COMPUTE_START" in timestamps) and ("COMPUTE_END"
-                                                    in timestamps):
-                add_span(model_span_map[key], timestamps, "compute",
-                         "COMPUTE_START", "COMPUTE_END")
-            if ("COMPUTE_INPUT_END" in timestamps) and ("COMPUTE_OUTPUT_START"
-                                                        in timestamps):
-                add_span(model_span_map[key], timestamps, "compute input",
-                         "COMPUTE_START", "COMPUTE_INPUT_END")
-                add_span(model_span_map[key], timestamps, "compute infer",
-                         "COMPUTE_INPUT_END", "COMPUTE_OUTPUT_START")
-                add_span(model_span_map[key], timestamps, "compute output",
-                         "COMPUTE_OUTPUT_START", "COMPUTE_END")
-
-            if FLAGS.show_trace:
-                print("{} ({}):".format(trace["model_name"],
-                                        trace["model_version"]))
-                print("\tid: {}".format(trace["id"]))
-                if "parent_id" in trace:
-                    print("\tparent id: {}".format(trace["parent_id"]))
-                ordered_timestamps = list()
-                for ts in trace["timestamps"]:
-                    ordered_timestamps.append((ts["name"], ts["ns"]))
-                ordered_timestamps.sort(key=lambda tup: tup[1])
-
-                now = None
-                for ts in ordered_timestamps:
-                    if now is not None:
-                        print("\t\t{}us".format((ts[1] - now) / 1000))
-                    print("\t{}".format(ts[0]))
-                    now = ts[1]
-
-    for key, cnt in model_count_map.items():
-        model_name, model_value = key
-        print("Summary for {} ({}): trace count = {}".format(
-            model_name, model_value, cnt))
-
-        if "http infer" in model_span_map[key]:
-            print("HTTP infer request (avg): {}us".format(
-                model_span_map[key]["http infer"] / (cnt * 1000)))
-            print("\tReceive (avg): {}us".format(
-                model_span_map[key]["http recv"] / (cnt * 1000)))
-            print("\tSend (avg): {}us".format(model_span_map[key]["http send"] /
-                                              (cnt * 1000)))
-            print("\tOverhead (avg): {}us".format(
-                (model_span_map[key]["http infer"] -
-                 model_span_map[key]["request handler"] -
-                 model_span_map[key]["http recv"] -
-                 model_span_map[key]["http send"]) / (cnt * 1000)))
-        elif "grpc infer" in model_span_map[key]:
-            print("GRPC infer request (avg): {}us".format(
-                model_span_map[key]["grpc infer"] / (cnt * 1000)))
-            print("\tWait/Read (avg): {}us".format(
-                model_span_map[key]["grpc wait/read"] / (cnt * 1000)))
-            print("\tSend (avg): {}us".format(model_span_map[key]["grpc send"] /
-                                              (cnt * 1000)))
-            print("\tOverhead (avg): {}us".format(
-                (model_span_map[key]["grpc infer"] -
-                 model_span_map[key]["request handler"] -
-                 model_span_map[key]["grpc wait/read"] -
-                 model_span_map[key]["grpc send"]) / (cnt * 1000)))
-
-        print("\tHandler (avg): {}us".format(
-            model_span_map[key]["request handler"] / (cnt * 1000)))
-        if ("queue"
-                in model_span_map[key]) and "compute" in model_span_map[key]:
-            print("\t\tOverhead (avg): {}us".format(
-                (model_span_map[key]["request handler"] -
-                 model_span_map[key]["queue"] - model_span_map[key]["compute"])
-                / (cnt * 1000)))
-            print("\t\tQueue (avg): {}us".format(model_span_map[key]["queue"] /
-                                                 (cnt * 1000)))
-            print("\t\tCompute (avg): {}us".format(
-                model_span_map[key]["compute"] / (cnt * 1000)))
-        if ("compute input" in model_span_map[key]
-           ) and "compute output" in model_span_map[key]:
-            print("\t\t\tInput (avg): {}us".format(
-                model_span_map[key]["compute input"] / (cnt * 1000)))
-            print("\t\t\tInfer (avg): {}us".format(
-                model_span_map[key]["compute infer"] / (cnt * 1000)))
-            print("\t\t\tOutput (avg): {}us".format(
-                model_span_map[key]["compute output"] / (cnt * 1000)))
-
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
The libevhtp event loop does not ensure the defered actions are performed exactly in the same order. 
~~Using the decoupled streaming API ensures that we test preserve ordering functionality in dynamic batcher accurately.~~
(Decoupled streaming + config.pbtxt preserve_ordering) frontend can also not ensure the responses are delivered in the exact order as invoked in the callbacks in Triton core. 
Using the async GRPC non-streaming is robust as the responses are written in the callback itself ensuring the correct order.  