### PR TITLE
Add back instance_group to python identity model and handle in perf_n…

### DIFF
--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -134,11 +134,20 @@ for BACKEND in $BACKENDS; do
     rm -fr models && mkdir -p models && \
         cp -r $REPO_DIR/$MODEL_NAME models/. && \
         (cd models/$MODEL_NAME && \
-                sed -i "s/^max_batch_size:.*/max_batch_size: ${MAX_BATCH}/" config.pbtxt && \
+                sed -i "s/^max_batch_size:.*/max_batch_size: ${MAX_BATCH}/" config.pbtxt)
+
+    # python model already has instance count and kind
+    if [ $BACKEND == "python" ]; then
+        (cd models/$MODEL_NAME && \
+                sed -i "s/count:.*/count: ${INSTANCE_CNT}/" config.pbtxt)
+    else
+        (cd models/$MODEL_NAME && \
                 echo "instance_group [ { kind: ${KIND}, count: ${INSTANCE_CNT} }]" >> config.pbtxt)
+    fi
+
     if [ $BACKEND == "custom" ]; then
         (cd models/$MODEL_NAME && \
-            sed -i "s/dims:.*\[.*\]/dims: \[ ${SHAPE} \]/g" config.pbtxt)
+                sed -i "s/dims:.*\[.*\]/dims: \[ ${SHAPE} \]/g" config.pbtxt)
     fi
     if [ $DYNAMIC_BATCH > 1 ] && [ $BACKEND != "openvino" ]; then
         (cd models/$MODEL_NAME && \

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/python_models/identity_fp32/config.pbtxt
+++ b/qa/python_models/identity_fp32/config.pbtxt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/python_models/identity_fp32/config.pbtxt
+++ b/qa/python_models/identity_fp32/config.pbtxt
@@ -44,3 +44,9 @@ output [
   }
 ]
 
+instance_group [
+  {
+    count: 1
+    kind : KIND_CPU
+  }
+]


### PR DESCRIPTION
…omodel correctly.

- Fixes L0_backend_python failure on jetson