### PR TITLE
Port Collision Detection

### DIFF
--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -39,9 +39,9 @@ import infer_util as iu
 import test_util as tu
 import threading
 
-import tritongrpcclient as grpcclient
-import tritonhttpclient as httpclient
-from tritonclientutils import InferenceServerException
+import tritonclient.grpc as grpcclient
+import tritonclient.http as httpclient
+from tritonclient.utils import InferenceServerException
 
 
 class LifeCycleTest(tu.TestResultCollector):

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -222,8 +222,6 @@ if [ `grep -c "failed to start GRPC service: Unavailable - Port '0.0.0.0:8001' a
 fi
 
 SERVER_PID=$SAVED_SERVER_PID
-set -e
-
 kill $SERVER_PID
 wait $SERVER_PID
 
@@ -254,7 +252,6 @@ if [ `grep -c "failed to start HTTP service: Unavailable - Port '0.0.0.0:8000' a
 fi
 
 SERVER_PID=$SAVED_SERVER_PID
-set -e
 
 kill $SERVER_PID
 wait $SERVER_PID
@@ -286,7 +283,6 @@ if [ `grep -c "failed to start Metrics service: Unavailable - Port '0.0.0.0:8002
 fi
 
 SERVER_PID=$SAVED_SERVER_PID
-set -e
 
 kill $SERVER_PID
 wait $SERVER_PID
@@ -306,13 +302,13 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 SAVED_SERVER_PID=$SERVER_PID
 SERVER_ARGS="--model-repository=`pwd`/models --grpc-port 8003 --http-port 8004 --metrics-port 8005"
-run_server
+# Use nowait to avoid curl to port 8000
+run_server_nowait
 if [ "$SERVER_PID" == "0" ]; then
     echo -e "\n***\n*** Failed to start $SERVER\n***"
     cat $SERVER_LOG
     exit 1
 fi
-set -e
 
 kill $SERVER_PID
 wait $SERVER_PID

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -40,13 +40,12 @@ fi
 
 export CUDA_VISIBLE_DEVICES=0
 
-TEST_RESULT_FILE='test_results.txt'
 CLIENT_LOG="./client.log"
-LC_TEST=lifecycle_test.py
-
 DATADIR=/data/inferenceserver/${REPO_VERSION}
-
+LC_TEST=lifecycle_test.py
+SLEEP_TIME=10
 SERVER=/opt/tritonserver/bin/tritonserver
+TEST_RESULT_FILE='test_results.txt'
 source ../common/util.sh
 
 RET=0
@@ -70,7 +69,7 @@ if [ "$SERVER_PID" == "0" ]; then
     cat $SERVER_LOG
     exit 1
 fi
-sleep 10
+sleep $SLEEP_TIME
 
 rm -f $CLIENT_LOG
 set +e
@@ -104,7 +103,7 @@ if [ "$SERVER_PID" == "0" ]; then
     cat $SERVER_LOG
     exit 1
 fi
-sleep 10
+sleep $SLEEP_TIME
 
 
 rm -f $CLIENT_LOG
@@ -141,7 +140,7 @@ if [ "$SERVER_PID" == "0" ]; then
     cat $SERVER_LOG
     exit 1
 fi
-sleep 10
+sleep $SLEEP_TIME
 
 
 rm -f $CLIENT_LOG
@@ -178,7 +177,7 @@ if [ "$SERVER_PID" == "0" ]; then
     cat $SERVER_LOG
     exit 1
 fi
-sleep 10
+sleep $SLEEP_TIME
 
 
 rm -f $CLIENT_LOG
@@ -217,7 +216,7 @@ fi
 SAVED_SERVER_PID=$SERVER_PID
 SERVER_ARGS="--model-repository=`pwd`/models --http-port 8003 --metrics-port 8004"
 run_server
-sleep 10
+sleep $SLEEP_TIME
 # check server log for the warning messages
 if [ `grep -c "failed to start GRPC service: Unavailable - Port '0.0.0.0:8001' already in use" $SERVER_LOG` != "1" ]; then
     echo -e "\n***\n*** Server log ${SERVER_LOG} did not report GRPC port collision\n***"
@@ -247,7 +246,7 @@ fi
 SAVED_SERVER_PID=$SERVER_PID
 SERVER_ARGS="--model-repository=`pwd`/models --grpc-port 8003 --metrics-port 8004"
 run_server
-sleep 10
+sleep $SLEEP_TIME
 # check server log for the warning messages
 if [ `grep -c "failed to start HTTP service: Unavailable - Port '0.0.0.0:8000' already in use" $SERVER_LOG` != "1" ]; then
     echo -e "\n***\n*** Server log ${SERVER_LOG} did not report HTTP port collision\n***"
@@ -278,7 +277,7 @@ fi
 SAVED_SERVER_PID=$SERVER_PID
 SERVER_ARGS="--model-repository=`pwd`/models --grpc-port 8003 --http-port 8004"
 run_server
-sleep 10
+sleep $SLEEP_TIME
 # check server log for the warning messages
 if [ `grep -c "failed to start Metrics service: Unavailable - Port '0.0.0.0:8002' already in use" $SERVER_LOG` != "1" ]; then
     echo -e "\n***\n*** Server log ${SERVER_LOG} did not report metrics port collision\n***"
@@ -308,7 +307,7 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 SAVED_SERVER_PID=$SERVER_PID
 run_server
-sleep 10
+sleep $SLEEP_TIME
 # check server log for the warning messages
 if [ `grep -c "failed to start.*service: Unavailable - Port '.*' already in use" $SERVER_LOG` == "0" ]; then
     echo -e "\n***\n*** Server log ${SERVER_LOG} did not report port collision\n***"
@@ -343,7 +342,7 @@ SERVER_LOG="./inference_server_$LOG_IDX.log"
 SAVED_SERVER_PID=$SERVER_PID
 SERVER_ARGS="--model-repository=`pwd`/models --grpc-port 8003 --http-port 8004 --metrics-port 8005"
 run_server
-sleep 10
+sleep $SLEEP_TIME
 if [ "$SERVER_PID" == "0" ]; then
     echo -e "\n***\n*** Failed to start $SERVER\n***"
     cat $SERVER_LOG

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -25,7 +25,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-REPO_VERSION=22.03dev
+REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
 if [ "$#" -ge 1 ]; then
     REPO_VERSION=$1
 fi
@@ -211,7 +211,7 @@ fi
 SAVED_SERVER_PID=$SERVER_PID
 SERVER_ARGS="--model-repository=`pwd`/models --http-port 8003 --metrics-port 8004"
 run_server
-sleep 5
+sleep 10
 # check server log for the warning messages
 if [ `grep -c "failed to start GRPC service: Unavailable - Port '0.0.0.0:8001' already in use" $SERVER_LOG` != "1" ]; then
     echo -e "\n***\n*** Server log ${SERVER_LOG} did not report GRPC port collision\n***"

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -4449,14 +4449,6 @@ GRPCServer::Start()
 
   int bound_port = 0;
   grpc_builder_.AddListeningPort(server_addr_, credentials, &bound_port);
-  if(bound_port == 0){
-    // Binding port failed
-    // TODO: FAIL here, clean up as needed
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_UNAVAILABLE, (std::string("Port '")
-                    + server_addr_ + " already in use ")
-                    .c_str());
-  }
   grpc_builder_.SetMaxMessageSize(MAX_GRPC_MESSAGE_SIZE);
   grpc_builder_.RegisterService(&service_);
   // GRPC KeepAlive Docs: https://grpc.github.io/grpc/cpp/md_doc_keepalive.html
@@ -4499,7 +4491,14 @@ GRPCServer::Start()
   model_infer_cq_ = grpc_builder_.AddCompletionQueue();
   model_stream_infer_cq_ = grpc_builder_.AddCompletionQueue();
   grpc_server_ = grpc_builder_.BuildAndStart();
-
+  //Check if binding port failed
+  if(bound_port == 0){
+    return TRITONSERVER_ErrorNew(
+      TRITONSERVER_ERROR_UNAVAILABLE, (std::string("Port '")
+                  + server_addr_ + "' already in use ")
+                  .c_str());
+  }
+  
   // A common Handler for other non-inference requests
   CommonHandler* hcommon = new CommonHandler(
       "CommonHandler", server_, shm_manager_, trace_manager_, &service_,

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -38,6 +38,8 @@
 #include <queue>
 #include <sstream>
 #include <thread>
+#include "classification.h"
+#include "common.h"
 #include "grpc++/grpc++.h"
 #include "grpc++/security/server_credentials.h"
 #include "grpc++/server.h"
@@ -45,8 +47,6 @@
 #include "grpc++/server_context.h"
 #include "grpc++/support/status.h"
 #include "triton/common/logging.h"
-#include "classification.h"
-#include "common.h"
 #include "triton/core/tritonserver.h"
 
 #define TRITONJSON_STATUSTYPE TRITONSERVER_Error*
@@ -1042,8 +1042,9 @@ CommonHandler::SetUpAllRequests()
 
           err = cache_miss_json.MemberAsUInt("count", &ucnt);
           GOTO_IF_ERR(err, earlyexit);
-          statistics->mutable_inference_stats()->mutable_cache_miss()->set_count(
-              ucnt);
+          statistics->mutable_inference_stats()
+              ->mutable_cache_miss()
+              ->set_count(ucnt);
           err = cache_miss_json.MemberAsUInt("ns", &ucnt);
           GOTO_IF_ERR(err, earlyexit);
           statistics->mutable_inference_stats()->mutable_cache_miss()->set_ns(
@@ -4491,14 +4492,13 @@ GRPCServer::Start()
   model_infer_cq_ = grpc_builder_.AddCompletionQueue();
   model_stream_infer_cq_ = grpc_builder_.AddCompletionQueue();
   grpc_server_ = grpc_builder_.BuildAndStart();
-  //Check if binding port failed
-  if(grpc_server_ == nullptr){
+  // Check if binding port failed
+  if (grpc_server_ == nullptr) {
     return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_UNAVAILABLE, (std::string("Port '")
-                  + server_addr_ + "' already in use ")
-                  .c_str());
+        TRITONSERVER_ERROR_UNAVAILABLE,
+        (std::string("Port '") + server_addr_ + "' already in use ").c_str());
   }
-  
+
   // A common Handler for other non-inference requests
   CommonHandler* hcommon = new CommonHandler(
       "CommonHandler", server_, shm_manager_, trace_manager_, &service_,

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -4448,7 +4448,8 @@ GRPCServer::Start()
     credentials = grpc::InsecureServerCredentials();
   }
 
-  grpc_builder_.AddListeningPort(server_addr_, credentials);
+  int bound_port = 0;
+  grpc_builder_.AddListeningPort(server_addr_, credentials, &bound_port);
   grpc_builder_.SetMaxMessageSize(MAX_GRPC_MESSAGE_SIZE);
   grpc_builder_.RegisterService(&service_);
   // GRPC KeepAlive Docs: https://grpc.github.io/grpc/cpp/md_doc_keepalive.html
@@ -4493,7 +4494,7 @@ GRPCServer::Start()
   model_stream_infer_cq_ = grpc_builder_.AddCompletionQueue();
   grpc_server_ = grpc_builder_.BuildAndStart();
   // Check if binding port failed
-  if (grpc_server_ == nullptr) {
+  if (bound_port == 0) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_UNAVAILABLE,
         (std::string("Port '") + server_addr_ + "' already in use ").c_str());

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -4447,7 +4447,16 @@ GRPCServer::Start()
     credentials = grpc::InsecureServerCredentials();
   }
 
-  grpc_builder_.AddListeningPort(server_addr_, credentials);
+  int bound_port = 0;
+  grpc_builder_.AddListeningPort(server_addr_, credentials, &bound_port);
+  if(bound_port == 0){
+    // Binding port failed
+    // TODO: FAIL here, clean up as needed
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNAVAILABLE, (std::string("Port '")
+                    + server_addr_ + " already in use ")
+                    .c_str());
+  }
   grpc_builder_.SetMaxMessageSize(MAX_GRPC_MESSAGE_SIZE);
   grpc_builder_.RegisterService(&service_);
   // GRPC KeepAlive Docs: https://grpc.github.io/grpc/cpp/md_doc_keepalive.html

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -77,9 +77,11 @@ HTTPServer::Start()
     evhtp_enable_flag(htp_, EVHTP_FLAG_ENABLE_NODELAY);
     evhtp_set_gencb(htp_, HTTPServer::Dispatch, this);
     evhtp_use_threads_wexit(htp_, NULL, NULL, thread_cnt_, NULL);
-    int success = evhtp_bind_socket(htp_, "0.0.0.0", port_, 1024);
-    if (success != 0){
-      //TODO: Throw Triton error
+    if (evhtp_bind_socket(htp_, "0.0.0.0", port_, 1024) != 0){
+      return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNAVAILABLE, (std::string("Port '")
+                    + std::to_string(port_) + "' already in use ")
+                    .c_str());
     }
 
     // Set listening event for breaking event loop

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -36,8 +36,6 @@
 #include <list>
 #include <thread>
 #include "classification.h"
-#include "data_compressor.h"
-#include "triton/common/logging.h"
 
 #define TRITONJSON_STATUSTYPE TRITONSERVER_Error*
 #define TRITONJSON_STATUSRETURN(M) \

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -77,7 +77,10 @@ HTTPServer::Start()
     evhtp_enable_flag(htp_, EVHTP_FLAG_ENABLE_NODELAY);
     evhtp_set_gencb(htp_, HTTPServer::Dispatch, this);
     evhtp_use_threads_wexit(htp_, NULL, NULL, thread_cnt_, NULL);
-    evhtp_bind_socket(htp_, "0.0.0.0", port_, 1024);
+    int success = evhtp_bind_socket(htp_, "0.0.0.0", port_, 1024);
+    if (success != 0){
+      //TODO: Throw Triton error
+    }
 
     // Set listening event for breaking event loop
     evutil_socketpair(AF_UNIX, SOCK_STREAM, 0, fds_);

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -77,11 +77,12 @@ HTTPServer::Start()
     evhtp_enable_flag(htp_, EVHTP_FLAG_ENABLE_NODELAY);
     evhtp_set_gencb(htp_, HTTPServer::Dispatch, this);
     evhtp_use_threads_wexit(htp_, NULL, NULL, thread_cnt_, NULL);
-    if (evhtp_bind_socket(htp_, "0.0.0.0", port_, 1024) != 0){
+    if (evhtp_bind_socket(htp_, "0.0.0.0", port_, 1024) != 0) {
       return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_UNAVAILABLE, (std::string("Port '")
-                    + std::to_string(port_) + "' already in use ")
-                    .c_str());
+          TRITONSERVER_ERROR_UNAVAILABLE,
+          (std::string("Port '0.0.0.0:") + std::to_string(port_) +
+           "' already in use ")
+              .c_str());
     }
 
     // Set listening event for breaking event loop

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -32,11 +32,9 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
-#include "common.h"
 #include "data_compressor.h"
 #include "shared_memory_manager.h"
 #include "tracer.h"
-#include "triton/common/constants.h"
 #include "triton/common/logging.h"
 #include "triton/core/tritonserver.h"
 

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include "common.h"
 #include "data_compressor.h"
 #include "shared_memory_manager.h"
 #include "tracer.h"

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -32,11 +32,12 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
-#include "triton/common/logging.h"
 #include "common.h"
 #include "data_compressor.h"
 #include "shared_memory_manager.h"
 #include "tracer.h"
+#include "triton/common/constants.h"
+#include "triton/common/logging.h"
 #include "triton/core/tritonserver.h"
 
 #include <evhtp/evhtp.h>


### PR DESCRIPTION
Detect whether the port assigned to GRPC, HTTP, or metrics is already in use when server is starting up. If so, return a error.