### PR TITLE
Add work around to enable building PyTorch backend in CPU-only container

### DIFF
--- a/build.py
+++ b/build.py
@@ -1092,9 +1092,10 @@ RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \
 '''
 
     elif 'pytorch' in backends:
-        # The cpu-only build uses ubuntu as the base image, and so the cuda,
-        # openmpi, nccl and cudnn libs are not available. We must copy these
-        # pytorch dependencies from the Triton min container ourselves.
+        # Add dependencies for pytorch backend. Note: Even though the build is
+        # cpu-only, the version of pytorch we are using depends upon libraries
+        # like cuda and cudnn. Since these dependencies are not present in ubuntu 
+        # base image, we must copy these from the Triton min container ourselves.
         df += '''
 RUN mkdir -p /usr/local/cuda/lib64/stubs
 COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusparse.so /usr/local/cuda/lib64/stubs/libcusparse.so.11

--- a/build.py
+++ b/build.py
@@ -1114,7 +1114,8 @@ ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 FROM gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:22.03-py3-min as min_container
 
 COPY --from=build /usr/local/cuda /usr/local/cuda
-COPY --from=build /usr/lib/x86_64-linux-gnu/libmpi.so.40 /usr/lib/x86_64-linux-gnu/libmpi.so.40
+RUN apt-get update && \
+        apt-get install -y --no-install-recommends openmpi-bin
 COPY --from=build /usr/lib/x86_64-linux-gnu/libnccl.so.2 /usr/lib/x86_64-linux-gnu/libnccl.so.2
 COPY --from=build /usr/lib/x86_64-linux-gnu/libcudnn.so.8 /usr/lib/x86_64-linux-gnu/libcudnn.so.8
 

--- a/build.py
+++ b/build.py
@@ -1113,11 +1113,11 @@ ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
         df += '''
 FROM gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:22.03-py3-min as min_container
 
-COPY --from=build /usr/local/cuda /usr/local/cuda
+COPY --from=min_container /usr/local/cuda /usr/local/cuda
 RUN apt-get update && \
         apt-get install -y --no-install-recommends openmpi-bin
-COPY --from=build /usr/lib/x86_64-linux-gnu/libnccl.so.2 /usr/lib/x86_64-linux-gnu/libnccl.so.2
-COPY --from=build /usr/lib/x86_64-linux-gnu/libcudnn.so.8 /usr/lib/x86_64-linux-gnu/libcudnn.so.8
+COPY --from=min_container /usr/lib/x86_64-linux-gnu/libnccl.so.2 /usr/lib/x86_64-linux-gnu/libnccl.so.2
+COPY --from=min_container /usr/lib/x86_64-linux-gnu/libcudnn.so.8 /usr/lib/x86_64-linux-gnu/libcudnn.so.8
 
 ENV LD_LIBRARY_PATH /usr/local/cuda/targets/x86_64-linux/lib:${LD_LIBRARY_PATH}
 '''

--- a/build.py
+++ b/build.py
@@ -1109,7 +1109,7 @@ ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
     # The cpu-only build uses ubuntu as the base image, and so the
     # cuda, openmpi, nccl and cudnn files are not available in /opt/nvidia in the base
     # image, so we must copy them from the min container outselves.
-    if not enable_gpu and ('pytorch' in backends):
+    if not enable_gpu:
         df += '''
 FROM gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:22.03-py3-min as min_container
 


### PR DESCRIPTION
- Use Triton min container to copy out cuda libraries, cudnn, nccl for CPU only build when PyTorch backend is enabled.

> This is needed because the pytorch NGC container has a build that is not designed for a CPU only environment. 