### PR TITLE
Improve the stability of preserve ordering test in L0_batcher

### DIFF
--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3707,6 +3707,11 @@ ModelInferHandler::InferResponseComplete(
     return;
   }
 
+#ifdef TRITON_ENABLE_TRACING
+  state->trace_timestamps_.emplace_back(std::make_pair(
+      "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
+#endif  // TRITON_ENABLE_TRACING
+
   TRITONSERVER_Error* err = nullptr;
   // This callback is expected to be called exactly once for each request.
   // Will use the single response object in the response list to hold the
@@ -4292,6 +4297,11 @@ ModelStreamInferHandler::StreamInferResponseComplete(
                  << state->context_->unique_id_ << ", " << state->unique_id_
                  << " step " << state->step_ << ", callback index "
                  << state->cb_count_ << ", flags " << flags;
+
+#ifdef TRITON_ENABLE_TRACING
+  state->trace_timestamps_.emplace_back(std::make_pair(
+      "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
+#endif  // TRITON_ENABLE_TRACING
 
   // Log appropriate errors
   if (!state->is_decoupled_) {

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2813,6 +2813,13 @@ HTTPAPIServer::InferRequestClass::InferResponseComplete(
     err = infer_request->FinalizeResponse(response);
   }
 
+#ifdef TRITON_ENABLE_TRACING
+  if (infer_request->trace_ != nullptr) {
+    infer_request->trace_->CaptureTimestamp(
+        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
+  }
+#endif  // TRITON_ENABLE_TRACING
+
   if (err == nullptr) {
     evthr_defer(infer_request->thread_, OKReplyCallback, infer_request);
   } else {


### PR DESCRIPTION
This PR fixes the intermittent failure on L0_batcher preserve ordering subtest. 

Notice how just capturing the timestamp just before:

> evthr_defer(infer_request->thread_, OKReplyCallback, infer_request);

Fixes the issue. Using HTTP_SEND_START itself did not fix the issue. Need to study libevhttp library to figure out why the order gets broken. 

With INFER_RESPONSE_COMPLETE trace point the order is as expected.