### PR TITLE
Add metric API unit test to L0_metrics

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -115,7 +115,8 @@ RUN mkdir -p qa/common && \
     cp ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/backends/implicit_state/libtriton_implicit_state.so qa/L0_implicit_state/. && \
     mkdir qa/L0_data_compression/models && \
     cp -r /workspace/docs/examples/model_repository/simple qa/L0_data_compression/models && \
-    cp ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/bin/data_compressor_test qa/L0_data_compression/.
+    cp ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/bin/data_compressor_test qa/L0_data_compression/. && \
+    cp ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/bin/metrics_api_test qa/L0_metrics/. && \
 
 # caffe2plan will not exist if the build was done without TensorRT enabled
 RUN if [ -f ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/bin/caffe2plan ]; then \

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -116,7 +116,7 @@ RUN mkdir -p qa/common && \
     mkdir qa/L0_data_compression/models && \
     cp -r /workspace/docs/examples/model_repository/simple qa/L0_data_compression/models && \
     cp ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/bin/data_compressor_test qa/L0_data_compression/. && \
-    cp ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/bin/metrics_api_test qa/L0_metrics/. && \
+    cp ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/bin/metrics_api_test qa/L0_metrics/.
 
 # caffe2plan will not exist if the build was done without TensorRT enabled
 RUN if [ -f ${TRITONTMP_DIR}/tritonbuild/tritonserver/install/bin/caffe2plan ]; then \

--- a/qa/L0_metrics/test.sh
+++ b/qa/L0_metrics/test.sh
@@ -57,7 +57,7 @@ rm -fr *.log
 
 set +e
 export CUDA_VISIBLE_DEVICES=0
-$UNIT_TEST >>$TEST_LOG 2>&1
+LD_LIBRARY_PATH=/opt/tritonserver/lib:$LD_LIBRARY_PATH $UNIT_TEST >>$TEST_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $TEST_LOG
     echo -e "\n***\n*** Metrics API Unit Test Failed\n***"

--- a/qa/L0_metrics/test.sh
+++ b/qa/L0_metrics/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -49,6 +49,21 @@ source ../common/util.sh
 rm -f $SERVER_LOG
 
 RET=0
+
+TEST_LOG="./metrics_api_test.log"
+UNIT_TEST=./metrics_api_test
+
+rm -fr *.log
+
+set +e
+export CUDA_VISIBLE_DEVICES=0
+$UNIT_TEST >>$TEST_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $TEST_LOG
+    echo -e "\n***\n*** Metrics API Unit Test Failed\n***"
+    RET=1
+fi
+set -e
 
 # Prepare a libtorch float32 model with basic config
 rm -rf $MODELDIR


### PR DESCRIPTION
Appears that the unit test in https://github.com/triton-inference-server/core/pull/46 wasn't added to existing test