### PR TITLE
Record INFER_RESPONSE_COMPLETE only at the first callback

### DIFF
--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -4299,8 +4299,10 @@ ModelStreamInferHandler::StreamInferResponseComplete(
                  << state->cb_count_ << ", flags " << flags;
 
 #ifdef TRITON_ENABLE_TRACING
-  state->trace_timestamps_.emplace_back(std::make_pair(
-      "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
+  if (state->cb_count_ == 1) {
+    state->trace_timestamps_.emplace_back(std::make_pair(
+        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
+  }
 #endif  // TRITON_ENABLE_TRACING
 
   // Log appropriate errors


### PR DESCRIPTION
For decoupled model the map with the timestamps was getting corrupted as the callbacks can be recorded along with timestamps for GRPC_SEND_START and GRPC_SEND_END. Recording the only the first callback into the timestamp when tracing.

```
first = "INFER_RESPONSE_COMPLETE", second = 2271529015212328}, {first = "INFER_RESPONSE_COMPLETE", second = 2271529015285980}, {first = "GRPC_SEND_START", second = 2271529015386244}, {first = "", 
    second = 48}, {first = "", second = 435710686577}, {first = <error reading variable: Cannot create a lazy string with address 0x0, and a non-zero length.>, second = 140587214766080}, {
    first = "\260Z\000`\335\177\000\000P\213\000`\335\177\000\000\200\016\000\354\334\177\000\000\001\000\000\000\000\000\000\000\060", '\000' <repeats 23 times>, "\250\016\000\354\334\177", '\000' <repeats 26 times>, "\060\365\002\354\334\177\000\000\b\000\000\000\000\000\000\000\020\020\000\354\334\177\000\000\020\020\000\354\334\177\000\000\310\021\000\354\334\177\000\000H\365\002\354\334\177\000\000\030\021\000\354\334\177\000", second = 11}, {first = <error: Cannot access memory at address 0x65636e6575716573>, second = 64}, {first = "", second = 140586828959328}, {
    first = <error reading variable: Cannot create a lazy string with address 0x0, and a non-zero length.>, second = 140587170026752}, {
    first = "\311\303\220\363\017\036\372UH\211\345H\203\354\020H\211}\370H\213E\370\276\000\000\000\000H\211\307\350\337H\000\000\311\30
```