### PR TITLE
Fix L0_backend_python

### DIFF
--- a/qa/L0_backend_python/python_unittest.py
+++ b/qa/L0_backend_python/python_unittest.py
@@ -56,8 +56,9 @@ class PythonUnittest(tu.TestResultCollector):
 
         if model_name == 'bls' or model_name == 'bls_memory' or model_name == 'bls_memory_async':
             # For these tests, the memory region size will be grown. Because of
-            # this we need to use the shared memory probe only on the second
+            # this we need to use the shared memory probe only on the later
             # call so that the probe can detect the leak correctly.
+            self._run_unittest(model_name)
             self._run_unittest(model_name)
             with self._shm_leak_detector.Probe() as shm_probe:
                 self._run_unittest(model_name)

--- a/qa/L0_backend_python/python_unittest.py
+++ b/qa/L0_backend_python/python_unittest.py
@@ -59,6 +59,8 @@ class PythonUnittest(tu.TestResultCollector):
             # this we need to use the shared memory probe only on the later
             # call so that the probe can detect the leak correctly.
             self._run_unittest(model_name)
+
+            # [FIXME] See DLIS-3684
             self._run_unittest(model_name)
             with self._shm_leak_detector.Probe() as shm_probe:
                 self._run_unittest(model_name)


### PR DESCRIPTION
Looks like in some cases there could be shared memory growth on the second call too.