### PR TITLE
Enable isolation for windows container build process. Moving away from commit hash reference and start using tag.

### DIFF
--- a/Dockerfile.win10.min
+++ b/Dockerfile.win10.min
@@ -58,12 +58,8 @@ ARG VS_INSTALL_PATH_WP="C:\BuildTools"
 RUN powershell.exe Start-Process -FilePath vs_buildtools.exe -ArgumentList "--wait","--quiet","--norestart","--nocache","--installPath","%VS_INSTALL_PATH_WP%","--channelUri","C:\tmp\doesnotexist.chman","--add","Microsoft.VisualStudio.Workload.VCTools`;includeRecommended","--add","Microsoft.Component.MSBuild" -Wait -PassThru
 
 WORKDIR /
-# vcpkg 2021.05.12 does not contain b64 port, so checking out master branch here (commit a82c62d)
-# should be switched to next vcpkg tag when one is created
-# option --depth=1 should also be restored
-RUN git clone --single-branch -b master https://github.com/microsoft/vcpkg.git
+RUN git clone --single-branch -b 2022.04.12 --depth=1 https://github.com/microsoft/vcpkg.git
 WORKDIR /vcpkg
-RUN git checkout a82c62d
 RUN bootstrap-vcpkg.bat
 RUN vcpkg.exe update
 RUN vcpkg.exe install openssl:x64-windows openssl-windows:x64-windows rapidjson:x64-windows re2:x64-windows boost-interprocess:x64-windows boost-stacktrace:x64-windows zlib:x64-windows pthread:x64-windows b64:x64-windows

--- a/build.py
+++ b/build.py
@@ -1333,6 +1333,7 @@ def create_docker_build_script(script_name, container_install_dir,
 
         if target_platform() == 'windows':
             runargs += ['--memory', FLAGS.container_memory]
+            runargs += ['--isolation=process']
             runargs += [
                 '-v', '\\\\.\pipe\docker_engine:\\\\.\pipe\docker_engine'
             ]


### PR DESCRIPTION
**Dockerfile.win10.min**
---
Moving away from checking out the specific commit and start using [vcpkg:tag:2022.04.12](https://github.com/microsoft/vcpkg/tree/2022.04.12) repository tag reference. 


**build.py** 
---
During the new CI runner node to setup, I got an issue with the docker engine. Our [buyild.py](https://github.com/triton-inference-server/server/blob/main/build.py) Python script starts the docker build process inside docker container and on particular node we are getting issue with obtaining proper process from the kernel like.
```
hcsshim::CreateComputeSystem <CONTAINER HASH>: The requested resource is in use.
```
I was able to use flag `--isolation=process` in order to handle the issue.
This approach has a reference to official documentation:
[Microsoft : Virtualization / Containers on Windows / Windows Container Essentials / Isolation Modes](https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container)
[Docker : Security](https://docs.docker.com/engine/security/)[](https://jirasw.nvidia.com/secure/RapidBoard.jspa?rapidView=28774&view=detail&selectedIssue=DLIS-3582#)