### PR TITLE
Add 'TF-TRT' and `ORT-TRT' keywords to docs for searchability

### DIFF
--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -217,7 +217,7 @@ of the supported model frameworks. These optimization settings are
 controlled by the model configuration [optimization
 policy](model_configuration.md#optimization-policy).
 
-### ONNX with TensorRT Optimization
+### ONNX with TensorRT Optimization (ORT-TRT)
 
 One especially powerful optimization is to use TensorRT in
 conjunction with an ONNX model. As an example of TensorRT optimization

--- a/docs/optimization.md
+++ b/docs/optimization.md
@@ -288,7 +288,7 @@ optimization { execution_accelerators {
 }}
 ```
 
-### TensorFlow with TensorRT Optimization
+### TensorFlow with TensorRT Optimization (TF-TRT)
 
 TensorRT optimization applied to a TensorFlow model works similarly to
 TensorRT and ONNX described above. To enable TensorRT optimization you


### PR DESCRIPTION
Having this keyword included should benefit users searching for Triton support of TF-TRT models. Currently it's only mentioned explicitly in a few CI test comments.