### PR TITLE
Fix instance type to CPU for optional python model (#4230)

### DIFF
--- a/qa/python_models/optional/config.pbtxt
+++ b/qa/python_models/optional/config.pbtxt
@@ -53,3 +53,10 @@ output [
     dims: [ 1 ]
   }
 ]
+
+instance_group [
+  {
+    count: 1
+    kind : KIND_CPU
+  }
+]


### PR DESCRIPTION
- Fixed jetson failure since GPU instances are not supported