### PR TITLE
Shift copying of NCCL for TF2 backend into build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -1103,15 +1103,16 @@ RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \
  && rm -f ${_CUDA_COMPAT_PATH}/lib
 '''
 
-    elif ('pytorch' in backends) or ('tensorflow1' in backends):
-        cuda_arch = 'sbsa' if target_machine == 'aarch64' else 'x86_64'
+    else:
         libs_arch = 'aarch64' if target_machine == 'aarch64' else 'x86_64'
-        # Add extra dependencies for tensorflow1/pytorch backend.
-        # Note: Even though the build is cpu-only, the version of tensorflow1/
-        # pytorch we are using depend upon libraries like cuda and cudnn. Since
-        # these dependencies are not present in the ubuntu base image,
-        # we must copy these from the Triton min container ourselves.
-        df += '''
+        if ('pytorch' in backends) or ('tensorflow1' in backends):
+            # Add extra dependencies for tensorflow1/pytorch backend.
+            # Note: Even though the build is cpu-only, the version of tensorflow1/
+            # pytorch we are using depend upon libraries like cuda and cudnn. Since
+            # these dependencies are not present in the ubuntu base image,
+            # we must copy these from the Triton min container ourselves.
+            cuda_arch = 'sbsa' if target_machine == 'aarch64' else 'x86_64'
+            df += '''
 RUN mkdir -p /usr/local/cuda/lib64/stubs
 COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusparse.so /usr/local/cuda/lib64/stubs/libcusparse.so.11
 COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusolver.so /usr/local/cuda/lib64/stubs/libcusolver.so.11
@@ -1125,7 +1126,6 @@ COPY --from=min_container /usr/local/cuda-11.6/targets/{cuda_arch}-linux/lib/lib
 COPY --from=min_container /usr/local/cuda-11.6/targets/{cuda_arch}-linux/lib/libcupti.so.11.6 /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
 COPY --from=min_container /usr/local/cuda-11.6/targets/{cuda_arch}-linux/lib/libnvToolsExt.so.1 /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
 
-COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libnccl.so.2 /usr/lib/{libs_arch}-linux-gnu/libnccl.so.2
 COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.8 /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.8
 
 # patchelf is needed to add deps of libcublasLt.so.11 to libtorch_cuda.so
@@ -1134,6 +1134,17 @@ RUN apt-get update && \
 
 ENV LD_LIBRARY_PATH /usr/local/cuda/targets/{cuda_arch}-linux/lib:/usr/local/cuda/lib64/stubs:${{LD_LIBRARY_PATH}}
 '''.format(cuda_arch=cuda_arch, libs_arch=libs_arch)
+
+        if ('pytorch' in backends) or ('tensorflow1' in backends) \
+                or ('tensorflow2' in backends):
+            # Add NCCL dependency for tensorflow1/tensorflow2/pytorch backend.
+            # Note: Even though the build is cpu-only, the version of tensorflow1/tensorflow2/
+            # pytorch we are using depends upon the NCCL library. Since
+            # this dependencies is not present in the ubuntu base image,
+            # we must copy this from the Triton min container ourselves.
+            df += '''
+COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libnccl.so.2 /usr/lib/{libs_arch}-linux-gnu/libnccl.so.2
+'''.format(libs_arch=libs_arch)
 
     # Add dependencies needed for python backend
     if 'python' in backends:

--- a/compose.py
+++ b/compose.py
@@ -70,10 +70,12 @@ FROM {} AS full
 '''.format(argmap['TRITON_VERSION'], argmap['TRITON_CONTAINER_VERSION'],
            images["full"])
 
-    # PyTorch backend needs extra CUDA and other dependencies during runtime
-    # that are missing in the CPU only base container. These dependencies
-    # must be copied from the Triton Min image
-    if not FLAGS.enable_gpu and ('pytorch' in backends):
+    # PyTorch, TensorFlow 1 and TensorFlow 2 backends need extra CUDA and other
+    # dependencies during runtime that are missing in the CPU-only base container.
+    # These dependencies must be copied from the Triton Min image.
+    if not FLAGS.enable_gpu and (('pytorch' in backends) or
+                                 ('tensorflow1' in backends) or
+                                 ('tensorflow2' in backends)):
         df += '''
 FROM {} AS min_container
 
@@ -328,7 +330,7 @@ if __name__ == '__main__':
         action='append',
         required=False,
         help=
-        'Use specified Docker image to generate Docker image. Specified as <image-name>,<full-image-name>. <image-name> can be "min", "gpu-min" or "full". Both "min" and "full" need to be specified at the same time. This will override "--container-version". "gpu-min" is needed for CPU only container to copy TensorFlow and PyTorch deps.'
+        'Use specified Docker image to generate Docker image. Specified as <image-name>,<full-image-name>. <image-name> can be "min", "gpu-min" or "full". Both "min" and "full" need to be specified at the same time. This will override "--container-version". "gpu-min" is needed for CPU-only container to copy TensorFlow and PyTorch deps.'
     )
     parser.add_argument('--enable-gpu',
                         nargs='?',
@@ -380,8 +382,9 @@ if __name__ == '__main__':
             fail_if(
                 len(parts) != 2,
                 '--image must specific <image-name>,<full-image-registry>')
-            fail_if(parts[0] not in ['min', 'full', 'gpu-min'],
-                    'unsupported image-name \'{}\' for --image'.format(parts[0]))
+            fail_if(
+                parts[0] not in ['min', 'full', 'gpu-min'],
+                'unsupported image-name \'{}\' for --image'.format(parts[0]))
             log('image "{}": "{}"'.format(parts[0], parts[1]))
             images[parts[0]] = parts[1]
     else:
@@ -407,9 +410,11 @@ if __name__ == '__main__':
         len(images) < 2,
         "Need to specify both 'full' and 'min' images if at all")
 
-    # For cpu-only image we need to copy some cuda libraries and dependencies
-    # since we are using a PyTorch container that is not CPU-only
-    if ('pytorch' in FLAGS.backend) and ('gpu-min' not in images):
+    # For CPU-only image we need to copy some cuda libraries and dependencies
+    # since we are using PyTorch, TensorFlow 1, TensorFlow 2 containers that
+    # are not CPU-only.
+    if (('pytorch' in FLAGS.backend) or ('tensorflow1' in FLAGS.backend) or
+        ('tensorflow2' in FLAGS.backend)) and ('gpu-min' not in images):
         images["gpu-min"] = "nvcr.io/nvidia/tritonserver:{}-py3-min".format(
             FLAGS.container_version)
 


### PR DESCRIPTION
- Avoid extra copy of nccl library