### PR TITLE
Re-throw certain specific OOM errors as 507 for SageMaker MME + repo path enhancement

### DIFF
--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -462,12 +462,11 @@ SagemakerAPIServer::SageMakerMMEHandleLoadError(
       LOG_VERBOSE(1)
           << "Received an OOM error during LOAD MODEL. Returning a 507.";
       return;
-    } else {
-      /* Return a 400*/
-      evhtp_send_reply(req, EVHTP_RES_BADREQ);
-      return;
     }
   }
+  /* Return a 400*/
+  evhtp_send_reply(req, EVHTP_RES_BADREQ);
+  return;
 }
 
 

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -520,8 +520,13 @@ SagemakerAPIServer::SageMakerMMELoadModel(
       repo_path, model_path_regex_, &repo_parent_path, &subdir,
       &customer_subdir);
 
+  std::string subdir_path = subdir;
+  if (!customer_subdir.empty()) {
+    subdir_path = subdir + "/" + customer_subdir;
+  }
+
   auto param = TRITONSERVER_ParameterNew(
-      subdir.c_str(), TRITONSERVER_PARAMETER_STRING, model_name.c_str());
+      subdir_path.c_str(), TRITONSERVER_PARAMETER_STRING, model_name.c_str());
 
   if (param != nullptr) {
     subdir_modelname_map.emplace_back(param);

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -451,7 +451,7 @@ SagemakerAPIServer::SageMakerMMEHandleLoadError(
       "CUDA out of memory", /* pytorch */
       "CUDA_OUT_OF_MEMORY", /* tensorflow */
       "Out of memory",      /* generic */
-  };
+      "out of memory", "MemoryError"};
 
   EVBufferAddErrorJson(req->buffer_out, load_err);
 

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -501,6 +501,7 @@ SagemakerAPIServer::SageMakerMMELoadModel(
             TRITONSERVER_ErrorNew(
                 TRITONSERVER_ERROR_INTERNAL,
                 "More than one version or model directories found. Note that "
+                "hidden folders are not allowed and "
                 "Ensemble models are not supported in SageMaker MME mode."));
         closedir(dir);
         return;

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -441,7 +441,7 @@ SagemakerAPIServer::SageMakerMMEListModel(evhtp_request_t* req)
 }
 
 void
-SagemakerAPIServer::SageMakerMMEHandlLoadError(
+SagemakerAPIServer::SageMakerMMEHandleLoadError(
     evhtp_request_t* req, TRITONSERVER_Error* load_err)
 {
   const char* message = TRITONSERVER_ErrorMessage(load_err);
@@ -570,7 +570,7 @@ SagemakerAPIServer::SageMakerMMELoadModel(
     TRITONSERVER_ErrorDelete(err);
     return;
   } else if (err != nullptr) {
-    SageMakerMMEHandlLoadError(req, err);
+    SageMakerMMEHandleLoadError(req, err);
   } else {
     std::lock_guard<std::mutex> lock(mutex_);
 

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -86,6 +86,9 @@ class SagemakerAPIServer : public HTTPAPIServer {
       evhtp_request_t* req,
       const std::unordered_map<std::string, std::string> parse_map);
 
+  void SageMakerMMEHandlLoadError(
+      evhtp_request_t* req, TRITONSERVER_Error* load_err);
+
   void SageMakerMMEUnloadModel(evhtp_request_t* req, const char* model_name);
 
   void SageMakerMMEListModel(evhtp_request_t* req);

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <mutex>
+#include <sys/stat.h>
 
 #include "common.h"
 #include "dirent.h"

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -86,7 +86,7 @@ class SagemakerAPIServer : public HTTPAPIServer {
       evhtp_request_t* req,
       const std::unordered_map<std::string, std::string> parse_map);
 
-  void SageMakerMMEHandlLoadError(
+  void SageMakerMMEHandleLoadError(
       evhtp_request_t* req, TRITONSERVER_Error* load_err);
 
   void SageMakerMMEUnloadModel(evhtp_request_t* req, const char* model_name);


### PR DESCRIPTION
1. This change is an addition to the MME changes in this PR: https://github.com/triton-inference-server/server/pull/4181. 
2. This change adds the ability for the SM endpoint to throw a 507 to the SM platform as per  - https://docs.aws.amazon.com/sagemaker/latest/dg/mms-container-apis.html#multi-model-api-load-model. 
3. Can be updated to throw capture more specific errors for different backends.
4. It also adds the ability for Triton on SM to handle the model artifact within two locations i.e. both `/opt/ml/models/<hash>/model` as well as `/opt/ml/models/<hash>/model/<model_subdir>`. The second one is useful if the customer is re-using a model after trying it in SME mode.