### PR TITLE
Add L0_libtorch_io_names test and update docs for new Naming Convention for PyTorch backend

### DIFF
--- a/docs/model_configuration.md
+++ b/docs/model_configuration.md
@@ -138,37 +138,47 @@ expected by the model.
 
 #### Special Conventions for PyTorch Backend
 
-***Naming Convention:*** Due to the absence of names for outputs in TorchScript
-models, the "name" attribute of outputs in the configuration must follow a
-specific naming convention i.e. "\<name\>__\<index\>". Where \<name\> can be
-any string and \<index\> refers to the position of the corresponding output.
-For inputs, the user has the choice to follow the above naming convention or use
-the names of input arguments to the forward function instead.
+**Naming Convention:** 
 
-This means that if there are two inputs and two outputs, the outputs must be named
-as: "OUTPUT__0" and "OUTPUT__1" such that "OUTPUT__0" refers to first output
-and "OUTPUT__1" refers to the second output.
+Due to the absence of sufficient metadata for inputs/outputs in TorchScript
+model files, the "name" attribute of inputs/outputs in the configuration must
+follow specific naming conventions. These are detailed below.
 
-Similarly, for the inputs, the first and second inputs would be named "INPUT__0"
-and "INPUT__1" respectively. Alternatively, if the forward function for the
-Torchscript model was defined as `forward(self, input0, input1)`, the first and
-second inputs could also be named "input0" and "input1" respectively. 
+1. [Only for Inputs] When the input is not a Dictionary of Tensors, the input
+names in the configuration file can mirror the names of the input arguements to
+the forward function in the model's definition.
 
-***Dictionary of Tensors as Input:*** The PyTorch Backend supports passing
-the inputs to the model in the form of a Dictionary of Tensors. This is only
-supported when there is a *single* input to the model of type Dictionary that
-contains a mapping from a string to a tensor. As an example, if there is a 
-model that expects the input of the form:
+For example, if the forward function for the Torchscript model was defined as
+`forward(self, input0, input1)`, the first and second inputs should be named
+"input0" and "input1" respectively. 
+
+2. `<name>__<index>`: Where \<name\> can be any string and \<index\> is an
+integer index that refers to the position of the corresponding input/output.
+
+This means that if there are two inputs and two outputs, the first and second
+inputs would could named "INPUT__0" and "INPUT__1" and the first and second
+outputs can be named "OUTPUT__0" and "OUTPUT__1" respectively.
+
+3. If all inputs (or outputs) do not follow the same naming convention, then we
+enforce strict ordering from the model configuration i.e. we assume the order of
+inputs (or outputs) in the configuartion is the true ordering of these inputs.
+
+***Dictionary of Tensors as Input:*** 
+
+The PyTorch backend supports passing of inputs to the model in the form of a
+Dictionary of Tensors. This is only supported when there is a *single* input to
+the model of type Dictionary that contains a mapping of string to tensor. As an
+example, if there is a model that expects the input of the form:
 
 ```
 {'A': tensor1, 'B': tensor2}
 ```
 
-Then the input fields in the configuration do not need to follow the "\<name\>__\<index\>" 
-convention. Instead, the names of the inputs in this case must map to the string
-value 'key' for that specific tensor. In this case the inputs would be "A" and "B",
-where input "A" refers to value corresponding to tensor1 and "B" refers to the
-value corresponding to tensor2.
+The input names in the configuration in this case must not to follow the above
+naming conventions `<name>__<index>`. Instead, the names of the inputs in this
+case must map to the string value 'key' for that specific tensor. For this case,
+the inputs would be "A" and "B", where input "A" refers to value corresponding to
+tensor1 and "B" refers to the value corresponding to tensor2.
 
 <br>
 

--- a/docs/model_configuration.md
+++ b/docs/model_configuration.md
@@ -145,7 +145,7 @@ model files, the "name" attribute of inputs/outputs in the configuration must
 follow specific naming conventions. These are detailed below.
 
 1. [Only for Inputs] When the input is not a Dictionary of Tensors, the input
-names in the configuration file can mirror the names of the input arguements to
+names in the configuration file should mirror the names of the input arguments to
 the forward function in the model's definition.
 
 For example, if the forward function for the Torchscript model was defined as
@@ -156,8 +156,8 @@ For example, if the forward function for the Torchscript model was defined as
 integer index that refers to the position of the corresponding input/output.
 
 This means that if there are two inputs and two outputs, the first and second
-inputs would could named "INPUT__0" and "INPUT__1" and the first and second
-outputs can be named "OUTPUT__0" and "OUTPUT__1" respectively.
+inputs can be named "INPUT__0" and "INPUT__1" and the first and second outputs
+can be named "OUTPUT__0" and "OUTPUT__1" respectively.
 
 3. If all inputs (or outputs) do not follow the same naming convention, then we
 enforce strict ordering from the model configuration i.e. we assume the order of
@@ -174,7 +174,7 @@ example, if there is a model that expects the input of the form:
 {'A': tensor1, 'B': tensor2}
 ```
 
-The input names in the configuration in this case must not to follow the above
+The input names in the configuration in this case must not follow the above
 naming conventions `<name>__<index>`. Instead, the names of the inputs in this
 case must map to the string value 'key' for that specific tensor. For this case,
 the inputs would be "A" and "B", where input "A" refers to value corresponding to

--- a/qa/L0_libtorch_io_names/io_names_client.py
+++ b/qa/L0_libtorch_io_names/io_names_client.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+sys.path.append("../common")
+
+from builtins import range
+from future.utils import iteritems
+import unittest
+import test_util as tu
+import numpy as np
+
+import tritonclient.http as httpclient
+from tritonclient.utils import np_to_triton_dtype
+from tritonclient.utils import InferenceServerException
+
+
+class IONamingConvention(tu.TestResultCollector):
+
+    def _infer_helper(self, model_name, io_names):
+        triton_client = httpclient.InferenceServerClient("localhost:8000", verbose=False)
+
+        # Create the data for the two inputs. Initialize the first to unique
+        # integers and the second to all ones.
+        input0_data = np.arange(start=0, stop=16, dtype=np.float32)
+        input0_data = np.expand_dims(input0_data, axis=0)
+        input1_data = np.full(shape=(1, 16), fill_value=-1, dtype=np.float32)
+
+        inputs = []
+        output_req = []
+        inputs.append(
+            httpclient.InferInput(io_names[0], [1, 16], "FP32"))
+        inputs[-1].set_data_from_numpy(input0_data)
+        inputs.append(
+            httpclient.InferInput(io_names[1], [1, 16], "FP32"))
+        inputs[-1].set_data_from_numpy(input1_data)
+        output_req.append(
+            httpclient.InferRequestedOutput(io_names[2],
+                                            binary_data=True))
+        output_req.append(
+            httpclient.InferRequestedOutput(io_names[3],
+                                            binary_data=True))
+
+        results = triton_client.infer(model_name,
+                                    inputs,
+                                    outputs=output_req)
+
+        output0_data = results.as_numpy(io_names[2])
+        output1_data = results.as_numpy(io_names[3])
+        for i in range(16):
+            self.assertEqual(input0_data[0][i] - input1_data[0][i], output0_data[0][i])
+            self.assertEqual(input0_data[0][i] + input1_data[0][i], output1_data[0][i])
+
+    def test_io_index(self):
+        io_names = ["INPUT__0", "INPUT__1", "OUTPUT__0", "OUTPUT__1"]
+        self._infer_helper("libtorch_io_index", io_names)
+
+    def test_output_index(self):
+        io_names = ["INPUT0", "INPUT1", "OUTPUT__0", "OUTPUT__1"]
+        self._infer_helper("libtorch_output_index", io_names)
+
+    def test_no_output_index(self):
+        io_names = ["INPUT0", "INPUT1", "OUTPUT0", "OUTPUT1"]
+        self._infer_helper("libtorch_no_output_index", io_names)
+
+    def test_no_arguements_no_output_index(self):
+        io_names = ["INPUTA", "INPUTB", "OUTPUTA", "OUTPUTB"]
+        self._infer_helper("libtorch_no_arguements_output_index", io_names)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qa/L0_libtorch_io_names/io_names_client.py
+++ b/qa/L0_libtorch_io_names/io_names_client.py
@@ -92,21 +92,21 @@ class IONamingConvention(tu.TestResultCollector):
         io_names = ["INPUT0", "INPUT1", "OUTPUT0", "OUTPUT1"]
         self._infer_helper("libtorch_no_output_index", io_names)
 
-    def test_no_arguements_no_output_index(self):
+    def test_no_arguments_no_output_index(self):
         io_names = ["INPUTA", "INPUTB", "OUTPUTA", "OUTPUTB"]
-        self._infer_helper("libtorch_no_arguements_output_index", io_names)
+        self._infer_helper("libtorch_no_arguments_output_index", io_names)
 
     def test_mix_index(self):
         io_names = ["INPUTA", "INPUT__1", "OUTPUTA", "OUTPUT__1"]
         self._infer_helper("libtorch_mix_index", io_names)
 
-    def test_mix_arguements(self):
+    def test_mix_arguments(self):
         io_names = ["INPUT0", "INPUTB", "OUTPUTA", "OUTPUT__1"]
-        self._infer_helper("libtorch_mix_arguements", io_names)
+        self._infer_helper("libtorch_mix_arguments", io_names)
 
-    def test_mix_arguements_index(self):
+    def test_mix_arguments_index(self):
         io_names = ["INPUT0", "INPUT__1", "OUTPUT0", "OUTPUT__1"]
-        self._infer_helper("libtorch_mix_arguements_index", io_names)
+        self._infer_helper("libtorch_mix_arguments_index", io_names)
 
     def test_unordered_index(self):
         io_names = ["INPUT1", "INPUT0", "OUT__1", "OUT__0"]

--- a/qa/L0_libtorch_io_names/io_names_client.py
+++ b/qa/L0_libtorch_io_names/io_names_client.py
@@ -41,8 +41,9 @@ from tritonclient.utils import InferenceServerException
 
 class IONamingConvention(tu.TestResultCollector):
 
-    def _infer_helper(self, model_name, io_names):
-        triton_client = httpclient.InferenceServerClient("localhost:8000", verbose=False)
+    def _infer_helper(self, model_name, io_names, reversed_order=False):
+        triton_client = httpclient.InferenceServerClient("localhost:8000",
+                                                         verbose=False)
 
         # Create the data for the two inputs. Initialize the first to unique
         # integers and the second to all ones.
@@ -53,27 +54,31 @@ class IONamingConvention(tu.TestResultCollector):
         inputs = []
         output_req = []
         inputs.append(
-            httpclient.InferInput(io_names[0], [1, 16], "FP32"))
+            httpclient.InferInput(
+                io_names[0] if not reversed_order else io_names[1], [1, 16],
+                "FP32"))
         inputs[-1].set_data_from_numpy(input0_data)
         inputs.append(
-            httpclient.InferInput(io_names[1], [1, 16], "FP32"))
+            httpclient.InferInput(
+                io_names[1] if not reversed_order else io_names[0], [1, 16],
+                "FP32"))
         inputs[-1].set_data_from_numpy(input1_data)
         output_req.append(
-            httpclient.InferRequestedOutput(io_names[2],
-                                            binary_data=True))
+            httpclient.InferRequestedOutput(io_names[2], binary_data=True))
         output_req.append(
-            httpclient.InferRequestedOutput(io_names[3],
-                                            binary_data=True))
+            httpclient.InferRequestedOutput(io_names[3], binary_data=True))
 
-        results = triton_client.infer(model_name,
-                                    inputs,
-                                    outputs=output_req)
+        results = triton_client.infer(model_name, inputs, outputs=output_req)
 
-        output0_data = results.as_numpy(io_names[2])
-        output1_data = results.as_numpy(io_names[3])
+        output0_data = results.as_numpy(
+            io_names[2] if not reversed_order else io_names[3])
+        output1_data = results.as_numpy(
+            io_names[3] if not reversed_order else io_names[2])
         for i in range(16):
-            self.assertEqual(input0_data[0][i] - input1_data[0][i], output0_data[0][i])
-            self.assertEqual(input0_data[0][i] + input1_data[0][i], output1_data[0][i])
+            self.assertEqual(input0_data[0][i] - input1_data[0][i],
+                             output0_data[0][i])
+            self.assertEqual(input0_data[0][i] + input1_data[0][i],
+                             output1_data[0][i])
 
     def test_io_index(self):
         io_names = ["INPUT__0", "INPUT__1", "OUTPUT__0", "OUTPUT__1"]
@@ -90,6 +95,25 @@ class IONamingConvention(tu.TestResultCollector):
     def test_no_arguements_no_output_index(self):
         io_names = ["INPUTA", "INPUTB", "OUTPUTA", "OUTPUTB"]
         self._infer_helper("libtorch_no_arguements_output_index", io_names)
+
+    def test_mix_index(self):
+        io_names = ["INPUTA", "INPUT__1", "OUTPUTA", "OUTPUT__1"]
+        self._infer_helper("libtorch_mix_index", io_names)
+
+    def test_mix_arguements(self):
+        io_names = ["INPUT0", "INPUTB", "OUTPUTA", "OUTPUT__1"]
+        self._infer_helper("libtorch_mix_arguements", io_names)
+
+    def test_mix_arguements_index(self):
+        io_names = ["INPUT0", "INPUT__1", "OUTPUT0", "OUTPUT__1"]
+        self._infer_helper("libtorch_mix_arguements_index", io_names)
+
+    def test_unordered_index(self):
+        io_names = ["INPUT1", "INPUT0", "OUT__1", "OUT__0"]
+        self._infer_helper("libtorch_unordered_index",
+                           io_names,
+                           reversed_order=True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qa/L0_libtorch_io_names/test.sh
+++ b/qa/L0_libtorch_io_names/test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
+if [ "$#" -ge 1 ]; then
+    REPO_VERSION=$1
+fi
+if [ -z "$REPO_VERSION" ]; then
+    echo -e "Repository version must be specified"
+    echo -e "\n***\n*** Test Failed\n***"
+    exit 1
+fi
+if [ ! -z "$TEST_REPO_ARCH" ]; then
+    REPO_VERSION=${REPO_VERSION}_${TEST_REPO_ARCH}
+fi
+
+export CUDA_VISIBLE_DEVICES=0
+
+IO_NAMES_CLIENT=./io_names_client.py
+DATADIR=/data/inferenceserver/${REPO_VERSION}/qa_model_repository
+
+rm -rf models && mkdir -p models
+
+# Prepare models
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_output_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_output_index/' models/libtorch_output_index/config.pbtxt
+
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_io_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_io_index/' models/libtorch_io_index/config.pbtxt && \
+    sed -i 's/INPUT0/INPUT__0/' models/libtorch_io_index/config.pbtxt && \
+    sed -i 's/INPUT1/INPUT__1/' models/libtorch_io_index/config.pbtxt
+
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_no_output_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_no_output_index/' models/libtorch_no_output_index/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUTPUT0/' models/libtorch_no_output_index/config.pbtxt && \
+    sed -i 's/OUTPUT__1/OUTPUT1/' models/libtorch_no_output_index/config.pbtxt
+
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_no_arguements_output_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_no_arguements_output_index/' models/libtorch_no_arguements_output_index/config.pbtxt && \
+    sed -i 's/INPUT0/INPUTA/' models/libtorch_no_arguements_output_index/config.pbtxt && \
+    sed -i 's/INPUT1/INPUTB/' models/libtorch_no_arguements_output_index/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_no_arguements_output_index/config.pbtxt && \
+    sed -i 's/OUTPUT__1/OUTPUTB/' models/libtorch_no_arguements_output_index/config.pbtxt
+
+SERVER=/opt/tritonserver/bin/tritonserver
+SERVER_ARGS="--model-repository=models"
+SERVER_LOG="./inference_server.log"
+source ../common/util.sh
+
+rm -f *.log
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+RET=0
+
+set +e
+
+CLIENT_LOG=client.log
+python $IO_NAMES_CLIENT >> $CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    RET=1
+fi
+
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+if [ $RET -eq 0 ]; then
+    echo -e "\n***\n*** Test Passed\n***"
+else
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test FAILED\n***"
+fi
+
+exit $RET

--- a/qa/L0_libtorch_io_names/test.sh
+++ b/qa/L0_libtorch_io_names/test.sh
@@ -66,6 +66,31 @@ cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_no_arguements_ou
     sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_no_arguements_output_index/config.pbtxt && \
     sed -i 's/OUTPUT__1/OUTPUTB/' models/libtorch_no_arguements_output_index/config.pbtxt
 
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_mix_index/' models/libtorch_mix_index/config.pbtxt && \
+    sed -i 's/INPUT0/INPUTA/' models/libtorch_mix_index/config.pbtxt && \
+    sed -i 's/INPUT1/INPUT__1/' models/libtorch_mix_index/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_mix_index/config.pbtxt
+
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_arguements && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_mix_arguements/' models/libtorch_mix_arguements/config.pbtxt && \
+    sed -i 's/INPUT1/INPUTB/' models/libtorch_mix_arguements/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_mix_arguements/config.pbtxt
+
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_arguements_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_mix_arguements_index/' models/libtorch_mix_arguements_index/config.pbtxt && \
+    sed -i 's/INPUT1/INPUT__1/' models/libtorch_mix_arguements_index/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUTPUT0/' models/libtorch_mix_arguements_index/config.pbtxt
+
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_unordered_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_unordered_index/' models/libtorch_unordered_index/config.pbtxt && \
+    sed -i 's/INPUT0/INPUT_TMP1/' models/libtorch_unordered_index/config.pbtxt && \
+    sed -i 's/INPUT1/INPUT0/' models/libtorch_unordered_index/config.pbtxt && \
+    sed -i 's/INPUT_TMP1/INPUT1/' models/libtorch_unordered_index/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUT__1/' models/libtorch_unordered_index/config.pbtxt && \
+    sed -i 's/OUTPUT__1/OUT__0/' models/libtorch_unordered_index/config.pbtxt
+
+
 SERVER=/opt/tritonserver/bin/tritonserver
 SERVER_ARGS="--model-repository=models"
 SERVER_LOG="./inference_server.log"

--- a/qa/L0_libtorch_io_names/test.sh
+++ b/qa/L0_libtorch_io_names/test.sh
@@ -59,12 +59,12 @@ cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_no_output_index 
     sed -i 's/OUTPUT__0/OUTPUT0/' models/libtorch_no_output_index/config.pbtxt && \
     sed -i 's/OUTPUT__1/OUTPUT1/' models/libtorch_no_output_index/config.pbtxt
 
-cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_no_arguements_output_index && \
-    sed -i 's/libtorch_float32_float32_float32/libtorch_no_arguements_output_index/' models/libtorch_no_arguements_output_index/config.pbtxt && \
-    sed -i 's/INPUT0/INPUTA/' models/libtorch_no_arguements_output_index/config.pbtxt && \
-    sed -i 's/INPUT1/INPUTB/' models/libtorch_no_arguements_output_index/config.pbtxt && \
-    sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_no_arguements_output_index/config.pbtxt && \
-    sed -i 's/OUTPUT__1/OUTPUTB/' models/libtorch_no_arguements_output_index/config.pbtxt
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_no_arguments_output_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_no_arguments_output_index/' models/libtorch_no_arguments_output_index/config.pbtxt && \
+    sed -i 's/INPUT0/INPUTA/' models/libtorch_no_arguments_output_index/config.pbtxt && \
+    sed -i 's/INPUT1/INPUTB/' models/libtorch_no_arguments_output_index/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_no_arguments_output_index/config.pbtxt && \
+    sed -i 's/OUTPUT__1/OUTPUTB/' models/libtorch_no_arguments_output_index/config.pbtxt
 
 cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_index && \
     sed -i 's/libtorch_float32_float32_float32/libtorch_mix_index/' models/libtorch_mix_index/config.pbtxt && \
@@ -72,15 +72,15 @@ cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_index && \
     sed -i 's/INPUT1/INPUT__1/' models/libtorch_mix_index/config.pbtxt && \
     sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_mix_index/config.pbtxt
 
-cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_arguements && \
-    sed -i 's/libtorch_float32_float32_float32/libtorch_mix_arguements/' models/libtorch_mix_arguements/config.pbtxt && \
-    sed -i 's/INPUT1/INPUTB/' models/libtorch_mix_arguements/config.pbtxt && \
-    sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_mix_arguements/config.pbtxt
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_arguments && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_mix_arguments/' models/libtorch_mix_arguments/config.pbtxt && \
+    sed -i 's/INPUT1/INPUTB/' models/libtorch_mix_arguments/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUTPUTA/' models/libtorch_mix_arguments/config.pbtxt
 
-cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_arguements_index && \
-    sed -i 's/libtorch_float32_float32_float32/libtorch_mix_arguements_index/' models/libtorch_mix_arguements_index/config.pbtxt && \
-    sed -i 's/INPUT1/INPUT__1/' models/libtorch_mix_arguements_index/config.pbtxt && \
-    sed -i 's/OUTPUT__0/OUTPUT0/' models/libtorch_mix_arguements_index/config.pbtxt
+cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_mix_arguments_index && \
+    sed -i 's/libtorch_float32_float32_float32/libtorch_mix_arguments_index/' models/libtorch_mix_arguments_index/config.pbtxt && \
+    sed -i 's/INPUT1/INPUT__1/' models/libtorch_mix_arguments_index/config.pbtxt && \
+    sed -i 's/OUTPUT__0/OUTPUT0/' models/libtorch_mix_arguments_index/config.pbtxt
 
 cp -r $DATADIR/libtorch_float32_float32_float32 models/libtorch_unordered_index && \
     sed -i 's/libtorch_float32_float32_float32/libtorch_unordered_index/' models/libtorch_unordered_index/config.pbtxt && \

--- a/qa/L0_simple_go_client/test.sh
+++ b/qa/L0_simple_go_client/test.sh
@@ -60,7 +60,7 @@ git clone --single-branch --depth=1 -b $TRITON_COMMON_REPO_TAG \
 mkdir core && cp common/protobuf/*.proto core/.
 
 # Requires protoc and protoc-gen-go plugin: https://github.com/golang/protobuf#installation
-# Use "M" arguements since go_package is not specified in .proto files.
+# Use "M" arguments since go_package is not specified in .proto files.
 # As mentioned here: https://developers.google.com/protocol-buffers/docs/reference/go-generated#package
 GO_PACKAGE="nvidia_inferenceserver"
 protoc -I core --go_out=plugins=grpc:${PACKAGE_PATH} --go_opt=Mgrpc_service.proto=./${GO_PACKAGE} \


### PR DESCRIPTION
- Tests fall back to enforcing ordering for cases when index and model arguement naming convention for I/O is not met
- These models that would earlier fail to load, now load succesfully and the input/outputs assume the order they are specified in inside the model configuration file