### PR TITLE
Autocomplete is Used by Triton Supported Backends

### DIFF
--- a/docs/model_configuration.md
+++ b/docs/model_configuration.md
@@ -300,19 +300,24 @@ configuration](#minimal-model-configuration). You must still provide
 the optional portions of the model configuration by editing the
 config.pbtxt file.
 
-When a model is using the auto-complete feature, a default maximum batch size may 
-be set by using the `--backend-config=default-max-batch-size=<int>` command line argument. 
-This allows all models which are capable of batching and which make use of 
-[Auto Generated Model Configuration](#auto-generated-model-configuration) to have
-a default maximum batch size. This value is set to 2 by default. If the value is
-greater than 1, the [dynamic_batching](#dynamic-batcher) will be set for the model if
-no scheduler is provided in the configuration file. Backend developers may make use of this
-default-max-batch-size by obtaining it from the TRITONBACKEND_BackendConfig api. Currently, the following 
-backends which utilize these default batch values and enable dynamic batching in their
-generated model configurations are:
+### Default Max Batch Size and Dynamic Batcher
+
+When a model is using the auto-complete feature, a default maximum 
+batch size may be set by using the `--backend-config=default-max-batch-size=<int>` 
+command line argument. This allows all models which are capable of
+batching and which make use of [Auto Generated Model Configuration](#auto-generated-model-configuration)
+to have a default maximum batch size. This value is set to 2 by 
+default. Backend developers may make use of this default-max-batch-size
+by obtaining it from the TRITONBACKEND_BackendConfig api. Currently, the
+following backends which utilize these default batch values and turn on 
+dynamic batching in their generated model configurations are:
 
 1. [TensorFlow backend](https://github.com/triton-inference-server/tensorflow_backend)
 2. [Onnxruntime backend](https://github.com/triton-inference-server/onnxruntime_backend)
+
+If a value greater than 1 for the maximum batch size is set for the 
+model, the [dynamic_batching](#dynamic-batcher) config will be set
+if no scheduler is provided in the configuration file.
 
 
 ## Datatypes

--- a/docs/model_configuration.md
+++ b/docs/model_configuration.md
@@ -306,7 +306,7 @@ When a model is using the auto-complete feature, a default maximum
 batch size may be set by using the `--backend-config=default-max-batch-size=<int>` 
 command line argument. This allows all models which are capable of
 batching and which make use of [Auto Generated Model Configuration](#auto-generated-model-configuration)
-to have a default maximum batch size. This value is set to 2 by 
+to have a default maximum batch size. This value is set to 4 by 
 default. Backend developers may make use of this default-max-batch-size
 by obtaining it from the TRITONBACKEND_BackendConfig api. Currently, the
 following backends which utilize these default batch values and turn on 

--- a/docs/model_configuration.md
+++ b/docs/model_configuration.md
@@ -121,14 +121,6 @@ For models that do not support batching, or do not support batching in
 the specific ways described above, *max_batch_size* must be set to
 zero.
 
-When a model is using the auto-complete feature, a default maximum batch size may 
-be set by using the `--backend-config=default-max-batch-size=<int>` command line argument. 
-This allows all models which are capable of batching and which make use of 
-[Auto Generated Model configuration](#auto-generated-model-configuration) to have
-a default maximum batch size. This value is set to 4 by default. While none of the
-officially supported Triton backends implement this feature, backend developers 
-may make use of this value by obtaining it from the TRITONBACKEND_BackendConfig api.
-
 
 ### Inputs and Outputs
 
@@ -307,6 +299,21 @@ Triton only generates the [minimal portion of the model
 configuration](#minimal-model-configuration). You must still provide
 the optional portions of the model configuration by editing the
 config.pbtxt file.
+
+When a model is using the auto-complete feature, a default maximum batch size may 
+be set by using the `--backend-config=default-max-batch-size=<int>` command line argument. 
+This allows all models which are capable of batching and which make use of 
+[Auto Generated Model Configuration](#auto-generated-model-configuration) to have
+a default maximum batch size. This value is set to 2 by default. If the value is
+greater than 1, the [dynamic_batching](#dynamic-batcher) will be set for the model if
+no scheduler is provided in the configuration file. Backend developers may make use of this
+default-max-batch-size by obtaining it from the TRITONBACKEND_BackendConfig api. Currently, the following 
+backends which utilize these default batch values and enable dynamic batching in their
+generated model configurations are:
+
+1. [TensorFlow backend](https://github.com/triton-inference-server/tensorflow_backend)
+2. [Onnxruntime backend](https://github.com/triton-inference-server/onnxruntime_backend)
+
 
 ## Datatypes
 

--- a/qa/L0_backend_config/test.sh
+++ b/qa/L0_backend_config/test.sh
@@ -220,7 +220,7 @@ else
 
     # Assert the max-batch-size is 1 in the case batching is supported
     # in the model but not in the config.
-    MAX_BATCH_LOG_LINE=$(grep -a "\"max_batch_size\":1" $TRIAL.out)
+    MAX_BATCH_LOG_LINE=$(grep -a "\"max_batch_size\":0" $TRIAL.out)
     if [ "$MAX_BATCH_LOG_LINE" == "" ]; then
         echo "*** FAILED: Expected max batch size to be 1 but found: $MAX_BATCH_LOG_LINE\n"
         RET=1
@@ -291,7 +291,7 @@ else
 
     # Assert the max-batch-size is 1 in the case batching is supported
     # in the model but not in the config.
-    MAX_BATCH_LOG_LINE=$(grep -a "\"max_batch_size\":1" $TRIAL.out)
+    MAX_BATCH_LOG_LINE=$(grep -a "\"max_batch_size\":0" $TRIAL.out)
     if [ "$MAX_BATCH_LOG_LINE" == "" ]; then
         echo "*** FAILED: Expected max batch size to be 1 but found: $MAX_BATCH_LOG_LINE\n"
         RET=1

--- a/qa/L0_backend_config/test.sh
+++ b/qa/L0_backend_config/test.sh
@@ -90,7 +90,7 @@ else
         # Pick out the logged value of the default-max-batch-size which gets passed into model creation
         RESOLVED_DEFAULT_MAX_BATCH_SIZE=$(awk -v line="$RESULT_LOG_LINE" 'BEGIN {split(line, a, "]"); split(a[2], b, ": "); split(b[2], c, ","); print c[2]}')
 
-        if [ "$RESOLVED_DEFAULT_MAX_BATCH_SIZE" != "2" ]; then
+        if [ "$RESOLVED_DEFAULT_MAX_BATCH_SIZE" != "4" ]; then
             echo "*** FAILED: Found default-max-batch-size not equal to the expected default-max-batch-size. Expected: default-max-batch-size,4, Found: $RESOLVED_DEFAULT_MAX_BATCH_SIZE \n" 
             RET=1
         fi

--- a/qa/L0_backend_config/test.sh
+++ b/qa/L0_backend_config/test.sh
@@ -52,6 +52,9 @@ rm -f $SERVER_LOG_BASE*
 
 COMMON_ARGS="--model-repository=`pwd`/models --strict-model-config=false --log-verbose=1 "
 
+#TODO: NEED TO CHECK OTHER BACKENDS WHICH MAKE USE OF THIS.
+#  CAN DO THIS ALL AT ONCE BY LOADING ALL MODELS AND POLLING THE CONFIG 
+#  FOR EACH.
 NEGATIVE_PARSE_ARGS=("--backend-config=,default-max-batch-size=3 $COMMON_ARGS" \
                     "--backend-config=default-max-batch-size= $COMMON_ARGS" \
                     "--backend-config=default-max-batch-size $COMMON_ARGS" \
@@ -91,10 +94,16 @@ else
             RET=1
         fi
     else
-        echo "*** FAILED: No log statement stating default amx batch size\n"
+        echo "*** FAILED: No log statement stating default max batch size\n"
         RET=1
     fi
-    
+
+    # Assert we are also turning on the dynamic_batcher    
+    DYNAMIC_BATCHING_LOG_LINE=$(grep "\"dynamic_batching\": {}" $SERVER_LOG)
+    if [ "$DYNAMIC_BATCHING_LOG_LINE" == "" ]; then
+        echo "*** FAILED: Expected dynamic batching to be set in model config but was not found\n"
+        RET=1
+    fi
     kill $SERVER_PID
     wait $SERVER_PID
 fi
@@ -120,10 +129,17 @@ for ((i=0; i < ${#POSITIVE_TEST_ARGS[@]}; i++)); do
                 RET=1
             fi
         else
-            echo "*** FAILED: No log statement stating default amx batch size\n"
+            echo "*** FAILED: No log statement stating default max batch size\n"
             RET=1
         fi
         
+        # Assert we are also turning on the dynamic_batcher    
+        DYNAMIC_BATCHING_LOG_LINE=$(grep "\"dynamic_batching\": {}" $SERVER_LOG)
+        if [ "$DYNAMIC_BATCHING_LOG_LINE" == "" ]; then
+            echo "*** FAILED: Expected dynamic batching to be set in model config but was not found\n"
+            RET=1
+        fi
+
         kill $SERVER_PID
         wait $SERVER_PID
     fi

--- a/qa/L0_backend_config/test.sh
+++ b/qa/L0_backend_config/test.sh
@@ -181,7 +181,6 @@ TRIAL=tensorflow_batching_on
 if [ "$SERVER_PID" == "0" ]; then
     echo -e "*** FAILED: Server failed to start $SERVER\n"
     RET=1
-
 else
     save_model_config
 

--- a/qa/L0_backend_config/test.sh
+++ b/qa/L0_backend_config/test.sh
@@ -83,6 +83,9 @@ if [ "$SERVER_PID" == "0" ]; then
     RET=1
 
 else
+    kill $SERVER_PID
+    wait $SERVER_PID
+
     RESULT_LOG_LINE=$(grep "Adding default backend config setting:" $SERVER_LOG)
     if [ "$RESULT_LOG_LINE" != "" ]; then
         
@@ -97,15 +100,6 @@ else
         echo "*** FAILED: No log statement stating default max batch size\n"
         RET=1
     fi
-
-    # Assert we are also turning on the dynamic_batcher    
-    DYNAMIC_BATCHING_LOG_LINE=$(grep "\"dynamic_batching\": {}" $SERVER_LOG)
-    if [ "$DYNAMIC_BATCHING_LOG_LINE" == "" ]; then
-        echo "*** FAILED: Expected dynamic batching to be set in model config but was not found\n"
-        RET=1
-    fi
-    kill $SERVER_PID
-    wait $SERVER_PID
 fi
 
 for ((i=0; i < ${#POSITIVE_TEST_ARGS[@]}; i++)); do
@@ -118,6 +112,9 @@ for ((i=0; i < ${#POSITIVE_TEST_ARGS[@]}; i++)); do
         RET=1
 
     else
+        kill $SERVER_PID
+        wait $SERVER_PID
+
         RESULT_LOG_LINE=$(grep "Found overwritten default setting:" $SERVER_LOG)
         if [ "$RESULT_LOG_LINE" != "" ]; then
             
@@ -132,18 +129,7 @@ for ((i=0; i < ${#POSITIVE_TEST_ARGS[@]}; i++)); do
             echo "*** FAILED: No log statement stating default max batch size\n"
             RET=1
         fi
-        
-        # Assert we are also turning on the dynamic_batcher    
-        DYNAMIC_BATCHING_LOG_LINE=$(grep "\"dynamic_batching\": {}" $SERVER_LOG)
-        if [ "$DYNAMIC_BATCHING_LOG_LINE" == "" ]; then
-            echo "*** FAILED: Expected dynamic batching to be set in model config but was not found\n"
-            RET=1
-        fi
-
-        kill $SERVER_PID
-        wait $SERVER_PID
     fi
-
 done
 
 # Negative tests
@@ -165,6 +151,73 @@ for ((i=0; i < ${#NEGATIVE_PARSE_ARGS[@]}; i++)); do
         wait $SERVER_PID
     fi
 done
+
+
+#
+# Sepcific backend tests
+# 
+
+# Tensorflow 1: Batching ON
+rm -rf ./models/
+mkdir -p ./models/no_config
+cp -r /data/inferenceserver/${REPO_VERSION}/qa_model_repository/savedmodel_float32_float32_float32/1 ./models/no_config/
+
+SERVER_ARGS="--backend-config=tensorflow,default-max-batch-size=5 $COMMON_ARGS"
+SERVER_LOG=$SERVER_LOG_BASE.backend_config_tensorflow_batch_5.log
+run_server
+
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "*** FAILED: Server failed to start $SERVER\n"
+    RET=1
+
+else
+    kill $SERVER_PID
+    wait $SERVER_PID
+
+    # Assert the max-batch-size is the command line value
+    DYNAMIC_BATCHING_LOG_LINE=$(grep "\"max_batch_size\": 5" $SERVER_LOG)
+    if [ "$DYNAMIC_BATCHING_LOG_LINE" == "" ]; then
+        echo "*** FAILED: Expected max batch size to be 5 but found: $DYNAMIC_BATCHING_LOG_LINE\n"
+        RET=1
+    fi
+
+    # Assert we are also turning on the dynamic_batcher    
+    DYNAMIC_BATCHING_LOG_LINE=$(grep "\"dynamic_batching\": {}" $SERVER_LOG)
+    if [ "$DYNAMIC_BATCHING_LOG_LINE" == "" ]; then
+        echo "*** FAILED: Expected dynamic batching to be set in model config but was not found\n"
+        RET=1
+    fi
+fi
+
+# Tensorflow 1: Batching OFF
+SERVER_ARGS="--backend-config=tensorflow,default-max-batch-size=0 $COMMON_ARGS"
+SERVER_LOG=$SERVER_LOG_BASE.backend_config_tensorflow_batch_0.log
+run_server
+
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "*** FAILED: Server failed to start $SERVER\n"
+    RET=1
+
+else
+    kill $SERVER_PID
+    wait $SERVER_PID
+
+    # Assert the max-batch-size is 1 in the case batching is supported
+    # in the model but not in the config.
+    DYNAMIC_BATCHING_LOG_LINE=$(grep "\"max_batch_size\": 1" $SERVER_LOG)
+    if [ "$DYNAMIC_BATCHING_LOG_LINE" == "" ]; then
+        echo "*** FAILED: Expected max batch size to be 1 but found: $DYNAMIC_BATCHING_LOG_LINE\n"
+        RET=1
+    fi
+
+    # Assert batching disabled    
+    if [ $(grep -E '\"dynamic_batching\": \{}' $SERVER_LOG) == 0 ]; then
+        echo "*** FAILED: Expected dynamic batching found in configuration when none expected.\n"
+        RET=1
+    fi
+fi
+
+
 
 # Print test outcome
 if [ $RET -eq 0 ]; then

--- a/qa/L0_backend_config/test.sh
+++ b/qa/L0_backend_config/test.sh
@@ -221,7 +221,7 @@ else
     # in the model but not in the config.
     MAX_BATCH_LOG_LINE=$(grep -a "\"max_batch_size\":0" $TRIAL.out)
     if [ "$MAX_BATCH_LOG_LINE" == "" ]; then
-        echo "*** FAILED: Expected max batch size to be 1 but found: $MAX_BATCH_LOG_LINE\n"
+        echo "*** FAILED: Expected max batch size to be 0 but found: $MAX_BATCH_LOG_LINE\n"
         RET=1
     fi
 

--- a/qa/L0_backend_config/test.sh
+++ b/qa/L0_backend_config/test.sh
@@ -217,7 +217,7 @@ if [ "$SERVER_PID" == "0" ]; then
 else
     save_model_config
 
-    # Assert the max-batch-size is 1 in the case batching is supported
+    # Assert the max-batch-size is 0 in the case batching is supported
     # in the model but not in the config.
     MAX_BATCH_LOG_LINE=$(grep -a "\"max_batch_size\":0" $TRIAL.out)
     if [ "$MAX_BATCH_LOG_LINE" == "" ]; then
@@ -288,7 +288,7 @@ if [ "$SERVER_PID" == "0" ]; then
 else
     save_model_config
 
-    # Assert the max-batch-size is 1 in the case batching is supported
+    # Assert the max-batch-size is 0 in the case batching is supported
     # in the model but not in the config.
     MAX_BATCH_LOG_LINE=$(grep -a "\"max_batch_size\":0" $TRIAL.out)
     if [ "$MAX_BATCH_LOG_LINE" == "" ]; then

--- a/qa/L0_backend_config/test.sh
+++ b/qa/L0_backend_config/test.sh
@@ -292,7 +292,7 @@ else
     # in the model but not in the config.
     MAX_BATCH_LOG_LINE=$(grep -a "\"max_batch_size\":0" $TRIAL.out)
     if [ "$MAX_BATCH_LOG_LINE" == "" ]; then
-        echo "*** FAILED: Expected max batch size to be 1 but found: $MAX_BATCH_LOG_LINE\n"
+        echo "*** FAILED: Expected max batch size to be 0 but found: $MAX_BATCH_LOG_LINE\n"
         RET=1
     fi
 


### PR DESCRIPTION
- Updated L0_backend_config test to include backends which make use of the default-max-batch-size parameter.
- Updated the documentation to declare which backends make use of this feature.