### PR TITLE
Add section on cc_model_filenames to model config docs

### DIFF
--- a/docs/model_configuration.md
+++ b/docs/model_configuration.md
@@ -648,7 +648,7 @@ execution as described above when the ensemble receives multiple requests.
 ## CUDA Compute Capability
 
 Similar to the `default_model_filename` field, you can optionally specify the 
-`cc_model_filenames` field to map the server's 
+`cc_model_filenames` field to map the GPU's
 [CUDA Compute Capability](https://developer.nvidia.com/cuda-gpus) 
 to a correspoding model filename at model load time. This is particularly 
 useful for TensorRT models, since they are generally tied to a specific 

--- a/docs/model_configuration.md
+++ b/docs/model_configuration.md
@@ -645,6 +645,28 @@ However, each composing model that makes up an ensemble can specify
 `instance_group` in its config file and individually support parallel
 execution as described above when the ensemble receives multiple requests.
 
+## CUDA Compute Capability
+
+Similar to the `default_model_filename` field, you can optionally specify the 
+`cc_model_filenames` field to map the server's 
+[CUDA Compute Capability](https://developer.nvidia.com/cuda-gpus) 
+to a correspoding model filename at model load time. This is particularly 
+useful for TensorRT models, since they are generally tied to a specific 
+compute capability. 
+
+```
+cc_model_filenames [
+  {
+    key: "7.5"
+    value: "resnet50_T4.plan"
+  },
+  {
+    key: "8.0"
+    value: "resnet50_A100.plan"
+  }
+]
+```
+
 ## Scheduling And Batching
 
 Triton supports batch inferencing by allowing individual inference


### PR DESCRIPTION
We reference the model configuration doc for `cc_model_filenames` [here](https://github.com/triton-inference-server/server/blob/185253ce225a0b012e73cade5c9a948ef9e75abd/docs/model_repository.md#tensorrt-models), but there is no corresponding documentation on it, so I added a short section.