### PR TITLE
fix error when deploying a model from mlflow

### DIFF
--- a/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
+++ b/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
@@ -303,6 +303,11 @@ class TritonPlugin(BaseDeploymentClient):
                 elif file.name == 'config.pbtxt':
                     config_file = file.name
                     copy_paths['config_path'] = {}
+                elif file.suffix == '.txt' and file.stem != 'requirements':
+                    copy_paths[file.stem] = {
+                        'from': file,
+                        'to': triton_deployment_dir
+                    }
             if model_file is None:
                 for file in artifact_path.iterdir():
                     if file.suffix == '.onnx':

--- a/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
+++ b/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
@@ -344,6 +344,9 @@ default_model_filename: "{}"
                 shutil.copy(copy_paths[key]['from'], copy_paths[key]['to'])
             print("Copied", copy_paths[key]['from'], "to",
                   copy_paths[key]['to'])
+        triton_deployment_dir = os.path.join(self.triton_model_repo, name)
+        version_folder = os.path.join(triton_deployment_dir, "1")
+        os.makedirs(version_folder, exist_ok=True)
         return copy_paths
 
     def _delete_deployment_files(self, name):

--- a/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
+++ b/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
@@ -302,6 +302,7 @@ class TritonPlugin(BaseDeploymentClient):
                         model_file = onnx_meta_data.get('data', None)
                 elif file.name == 'config.pbtxt':
                     config_file = file.name
+                    copy_paths['config_path'] = {}
             if model_file is None:
                 for file in artifact_path.iterdir():
                     if file.suffix == '.onnx':


### PR DESCRIPTION
Add `config_path` key to `copy_paths` to avoid `KeyError` when deploying from mlflow models in **onnx** flavor with `config.pbtxt`