### PR TITLE
Add triton_c_api to perf tests

### DIFF
--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -83,13 +83,10 @@ PERF_CLIENT_EXTRA_ARGS="$PERF_CLIENT_PERCENTILE_ARGS --shared-memory \"${SHARED_
 # Overload use of PERF_CLIENT_PROTOCOL for convenience with existing test and 
 # reporting structure, though "triton_c_api" is not strictly a "protocol".
 if [[ "${PERF_CLIENT_PROTOCOL}" == "triton_c_api" ]]; then
-    # Using C API requires extra info to start in-process server
-    # NOTE: PA C API doesn't expose --backend-directory, but defaults to
-    #       ${TRITON_DIR}/backends
+    # Server will be run in-process with C API
     SERVICE_ARGS="--service-kind triton_c_api \
                   --triton-server-directory ${TRITON_DIR} \
                   --model-repository ${MODEL_REPO}"
-# Otherwise run as normal via HTTP/GRPC
 else
     SERVICE_ARGS="-i ${PERF_CLIENT_PROTOCOL}"
 fi

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -139,13 +139,6 @@ for BACKEND in $BACKENDS; do
         REPO_DIR=./custom_models
     elif [ $BACKEND == "python" ]; then
         REPO_DIR=./python_models
-
-        # FIXME: If PA C API adds SHMEM support, remove this.
-        if [[ "${PERF_CLIENT_PROTOCOL}" == "triton_c_api" ]]; then
-            echo "WARNING: Python backend requires Shared Memory and PA C API \
-                  does not support shared memory. Skipping this test."
-            continue
-        fi
     else
         REPO_DIR=$DATADIR/qa_identity_model_repository
     fi

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -139,6 +139,13 @@ for BACKEND in $BACKENDS; do
         REPO_DIR=./custom_models
     elif [ $BACKEND == "python" ]; then
         REPO_DIR=./python_models
+
+        # FIXME: If PA C API adds SHMEM support, remove this.
+        if [[ "${PERF_CLIENT_PROTOCOL}" == "triton_c_api" ]]; then
+            echo "WARNING: Python backend requires Shared Memory and PA C API \
+                  does not support shared memory. Skipping this test."
+            continue
+        fi
     else
         REPO_DIR=$DATADIR/qa_identity_model_repository
     fi

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -218,8 +218,11 @@ for BACKEND in $BACKENDS; do
     echo -e "\"l_instance_count\":${INSTANCE_CNT}," >> ${RESULTDIR}/${NAME}.tjson
     echo -e "\"s_architecture\":\"${ARCH}\"}]" >> ${RESULTDIR}/${NAME}.tjson
 
-    kill $SERVER_PID
-    wait $SERVER_PID
+    # SERVER_PID may not be set if using "triton_c_api" for example
+    if [[ -n "${SERVER_PID}" ]]; then
+        kill $SERVER_PID
+        wait $SERVER_PID
+    fi
 
     if [ -f $REPORTER ]; then
         set +e

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -169,7 +169,7 @@ for BACKEND in $BACKENDS; do
                 echo "dynamic_batching { preferred_batch_size: [ ${DYNAMIC_BATCH} ] }" >> config.pbtxt)
     fi
 
-    # Don't start separate server if testing perf with C API
+    # Only start separate server if not using C API, since C API runs server in-process
     if [[ "${PERF_CLIENT_PROTOCOL}" != "triton_c_api" ]]; then
         SERVER_LOG="${RESULTDIR}/${NAME}.serverlog"
         run_server

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -193,15 +193,6 @@ for BACKEND in $BACKENDS; do
     if [ $? -ne 0 ]; then
         RET=1
     fi
-
-    # No metrics endpoint available when running with C API
-    if [[ "${PERF_CLIENT_PROTOCOL}" != "triton_c_api" ]]; then
-        curl localhost:8002/metrics -o ${RESULTDIR}/${NAME}.metrics >> ${RESULTDIR}/${NAME}.log 2>&1
-        if [ $? -ne 0 ]; then
-            RET=1
-            exit $RET
-        fi
-    fi
     set -e
 
     echo -e "[{\"s_benchmark_kind\":\"benchmark_perf\"," >> ${RESULTDIR}/${NAME}.tjson

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -84,6 +84,8 @@ PERF_CLIENT_EXTRA_ARGS="$PERF_CLIENT_PERCENTILE_ARGS --shared-memory \"${SHARED_
 # reporting structure, though "triton_c_api" is not strictly a "protocol".
 if [[ "${PERF_CLIENT_PROTOCOL}" == "triton_c_api" ]]; then
     # Using C API requires extra info to start in-process server
+    # NOTE: PA C API doesn't expose --backend-directory, but defaults to
+    #       ${TRITON_DIR}/backends
     SERVICE_ARGS="--service-kind triton_c_api \
                   --triton-server-directory ${TRITON_DIR} \
                   --model-repository ${MODEL_REPO}"

--- a/qa/L0_perf_nomodel/test.sh
+++ b/qa/L0_perf_nomodel/test.sh
@@ -38,7 +38,7 @@ if [ ! -z "$TEST_REPO_ARCH" ]; then
     REPO_VERSION=${REPO_VERSION}_${TEST_REPO_ARCH}
 fi
 
-rm -f *.log *.serverlog *.csv *.metrics *.tjson *.json
+rm -f *.log *.serverlog *.csv *.tjson *.json
 
 # Descriptive name for the current results
 UNDERTEST_NAME=${NVIDIA_TRITON_SERVER_VERSION}

--- a/qa/L0_perf_nomodel/test.sh
+++ b/qa/L0_perf_nomodel/test.sh
@@ -109,6 +109,7 @@ else
         2
         2
         2)
+    # Small payloads
     TEST_TENSOR_SIZES=(
         1
         1
@@ -145,6 +146,7 @@ TEST_PROTOCOLS+=(
     grpc
     http
     triton_c_api)
+# Large payloads
 TEST_TENSOR_SIZES+=(
     ${TENSOR_SIZE_16MB}
     ${TENSOR_SIZE_16MB}
@@ -185,7 +187,7 @@ for idx in "${!TEST_NAMES[@]}"; do
     TEST_INSTANCE_COUNT=${TEST_INSTANCE_COUNTS[$idx]}
     TEST_CONCURRENCY=${TEST_CONCURRENCY[$idx]}
 
-    # PA C API doesn't support shared memory, so skip this combination
+    # FIXME: If PA C API adds SHMEM support, remove this.
     if [[ "${BENCHMARK_TEST_SHARED_MEMORY}" != "none" ]] && \
        [[ "${TEST_PROTOCOL}" == "triton_c_api" ]]; then
       echo "WARNING: Perf Analyzer C API doesn't currently support shared \

--- a/qa/L0_perf_nomodel/test.sh
+++ b/qa/L0_perf_nomodel/test.sh
@@ -190,8 +190,7 @@ for idx in "${!TEST_NAMES[@]}"; do
     # FIXME: If PA C API adds SHMEM support, remove this.
     if [[ "${BENCHMARK_TEST_SHARED_MEMORY}" != "none" ]] && \
        [[ "${TEST_PROTOCOL}" == "triton_c_api" ]]; then
-      echo "WARNING: Perf Analyzer C API doesn't currently support shared \
-            memory. Skipping this configuration."
+      echo "WARNING: Perf Analyzer C API doesn't currently support shared memory, skipping."
       continue
     fi
 

--- a/qa/L0_perf_nomodel/test.sh
+++ b/qa/L0_perf_nomodel/test.sh
@@ -190,7 +190,7 @@ for idx in "${!TEST_NAMES[@]}"; do
     # FIXME: If PA C API adds SHMEM support, remove this.
     if [[ "${BENCHMARK_TEST_SHARED_MEMORY}" != "none" ]] && \
        [[ "${TEST_PROTOCOL}" == "triton_c_api" ]]; then
-      echo "WARNING: Perf Analyzer C API doesn't currently support shared memory, skipping."
+      echo "WARNING: Perf Analyzer does not support shared memory I/O when benchmarking directly with Triton C API, skipping."
       continue
     fi
 

--- a/qa/L0_perf_nomodel/test.sh
+++ b/qa/L0_perf_nomodel/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -53,19 +53,7 @@ rm -fr models && mkdir -p models && \
     cp -r $MODEL_PATH models/. && \
     (cd models/$MODEL_NAME && \
             sed -i "s/^max_batch_size:.*/max_batch_size: ${MAX_BATCH}/" config.pbtxt && \
-            echo "instance_group [ { count: ${INSTANCE_CNT} }]" >> config.pbtxt && \
-            echo "model_warmup [{" >> config.pbtxt && \
-            echo "    name : \"sample\"" >> config.pbtxt && \
-            echo "    batch_size: 1" >> config.pbtxt && \
-            echo "    inputs {" >> config.pbtxt && \
-            echo "        key: \"input\"" >> config.pbtxt && \
-            echo "        value: {" >> config.pbtxt && \
-            echo "            data_type: TYPE_FP32" >> config.pbtxt && \
-            echo "            dims: [ 224, 224, 3 ]" >> config.pbtxt && \
-            echo "            random_data: true" >> config.pbtxt && \
-            echo "        }" >> config.pbtxt && \
-            echo "    }" >> config.pbtxt && \
-            echo "}]" >> config.pbtxt)
+            echo "instance_group [ { count: ${INSTANCE_CNT} }]")
 
 # Onnx and onnx-trt models are very slow on Jetson.
 MEASUREMENT_WINDOW=5000

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -131,7 +131,7 @@ echo -e "\"l_instance_count\":${INSTANCE_CNT}," >> ${NAME}.tjson
 echo -e "\"s_architecture\":\"${ARCH}\"}]" >> ${NAME}.tjson
 
 # SERVER_PID may not be set if using "triton_c_api" for example
-if [[ "${SERVER_PID}" -ne 0 ]]; then
+if [[ -n "${SERVER_PID}" ]]; then
   kill $SERVER_PID
   wait $SERVER_PID
 fi

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -81,6 +81,10 @@ set +e
 # reporting structure, though "triton_c_api" is not strictly a "protocol".
 if [[ "${PERF_CLIENT_PROTOCOL}" == "triton_c_api" ]]; then
     # Using C API requires extra info to start in-process server
+    # NOTE: PA C API doesn't expose --backend-directory, but defaults to
+    #       ${TRITON_DIR}/backends
+    # NOTE: PA C API doesn't expose --backend-config, but this is only used
+    #       for tfserving grpc test currently.
     SERVICE_ARGS="--service-kind triton_c_api \
                   --triton-server-directory ${TRITON_DIR} \
                   --model-repository ${MODEL_REPO}"

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -106,7 +106,7 @@ $PERF_CLIENT -v -m $MODEL_NAME -p${MEASUREMENT_WINDOW} \
                 -b${STATIC_BATCH} --concurrency-range ${CONCURRENCY} \
                 ${SERVICE_ARGS} \
                 -f ${NAME}.csv 2>&1 | tee ${NAME}.log
-
+# Check perf client succeeded
 if (( $? != 0 )); then
     RET=1
 fi

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -47,8 +47,6 @@ RET=0
 MAX_BATCH=${STATIC_BATCH}
 NAME=${MODEL_NAME}_sbatch${STATIC_BATCH}_instance${INSTANCE_CNT}_${PERF_CLIENT_PROTOCOL}
 
-# Append model warmup to every model config. Helps stabilize all results, and
-# helps for C API tests since a separate PA run won't warmup model for C API.
 rm -fr models && mkdir -p models && \
     cp -r $MODEL_PATH models/. && \
     (cd models/$MODEL_NAME && \

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -79,7 +79,6 @@ set +e
 
 # Overload use of PERF_CLIENT_PROTOCOL for convenience with existing test and 
 # reporting structure, though "triton_c_api" is not strictly a "protocol".
-# This should be easily extensible for other service kinds.
 if [[ "${PERF_CLIENT_PROTOCOL}" == "triton_c_api" ]]; then
     # Using C API requires extra info to start in-process server
     SERVICE_ARGS="--service-kind triton_c_api \

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -47,11 +47,25 @@ RET=0
 MAX_BATCH=${STATIC_BATCH}
 NAME=${MODEL_NAME}_sbatch${STATIC_BATCH}_instance${INSTANCE_CNT}_${PERF_CLIENT_PROTOCOL}
 
+# Append model warmup to every model config. Helps stabilize all results, and
+# helps for C API tests since a separate PA run won't warmup model for C API.
 rm -fr models && mkdir -p models && \
     cp -r $MODEL_PATH models/. && \
     (cd models/$MODEL_NAME && \
             sed -i "s/^max_batch_size:.*/max_batch_size: ${MAX_BATCH}/" config.pbtxt && \
-            echo "instance_group [ { count: ${INSTANCE_CNT} }]" >> config.pbtxt)
+            echo "instance_group [ { count: ${INSTANCE_CNT} }]" >> config.pbtxt && \
+            echo "model_warmup [{" >> config.pbtxt && \
+            echo "    name : \"sample\"" >> config.pbtxt && \
+            echo "    batch_size: 1" >> config.pbtxt && \
+            echo "    inputs {" >> config.pbtxt && \
+            echo "        key: \"input\"" >> config.pbtxt && \
+            echo "        value: {" >> config.pbtxt && \
+            echo "            data_type: TYPE_FP32" >> config.pbtxt && \
+            echo "            dims: [ 224, 224, 3 ]" >> config.pbtxt && \
+            echo "            random_data: true" >> config.pbtxt && \
+            echo "        }" >> config.pbtxt && \
+            echo "    }" >> config.pbtxt && \
+            echo "}]" >> config.pbtxt)
 
 # Onnx and onnx-trt models are very slow on Jetson.
 MEASUREMENT_WINDOW=5000

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_perf_resnet/test.sh
+++ b/qa/L0_perf_resnet/test.sh
@@ -137,7 +137,7 @@ done
 # Tests with optimization enabled models
 for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
     for PROTOCOL in $PROTOCOLS; do
-        # NOTE: Skip TF-TRT for C API test, it is too inconsistent with
+        # DLIS-3805: Skip TF-TRT for C API test, it is too inconsistent with
         # generating TRT engine in time for perf measurement window
         if [[ "${MODEL_NAME}" == "${TFTRT_MODEL_NAME}" ]] && \
            [[ "${PROTOCOL}" == "triton_c_api" ]]; then

--- a/qa/L0_perf_resnet/test.sh
+++ b/qa/L0_perf_resnet/test.sh
@@ -137,6 +137,13 @@ done
 # Tests with optimization enabled models
 for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
     for PROTOCOL in $PROTOCOLS; do
+        # NOTE: Skip TF-TRT for C API test, it is too inconsistent with
+        # generating TRT engine in time for perf measurement window
+        if [[ "${MODEL_NAME}" == "${TFTRT_MODEL_NAME}" ]] && \
+           [[ "${PROTOCOL}" == "triton_c_api" ]]; then
+           continue
+        fi
+
         REPO=`pwd`/optimized_model_store
         FRAMEWORK=$(echo ${MODEL_NAME} | cut -d '_' -f 3,4)
         MODEL_NAME=${MODEL_NAME} \

--- a/qa/L0_perf_resnet/test.sh
+++ b/qa/L0_perf_resnet/test.sh
@@ -137,13 +137,6 @@ done
 # Tests with optimization enabled models
 for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
     for PROTOCOL in $PROTOCOLS; do
-        # DLIS-3805: Skip TF-TRT for C API test, it is too inconsistent with
-        # generating TRT engine in time for perf measurement window
-        if [[ "${MODEL_NAME}" == "${TFTRT_MODEL_NAME}" ]] && \
-           [[ "${PROTOCOL}" == "triton_c_api" ]]; then
-           continue
-        fi
-
         REPO=`pwd`/optimized_model_store
         FRAMEWORK=$(echo ${MODEL_NAME} | cut -d '_' -f 3,4)
         MODEL_NAME=${MODEL_NAME} \

--- a/qa/L0_perf_resnet/test.sh
+++ b/qa/L0_perf_resnet/test.sh
@@ -104,22 +104,6 @@ for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
     fi
     echo "} ]" >> ${CONFIG_PATH}
     echo "}}" >> ${CONFIG_PATH}
-
-    # Give TFTRT more time to generate an engine with a server-side warmup request
-    if [ "${MODEL_NAME}" = "${TFTRT_MODEL_NAME}" ] ; then
-        echo "model_warmup [{" >> ${CONFIG_PATH} && \
-        echo "    name : \"sample\"" >> ${CONFIG_PATH} && \
-        echo "    batch_size: 1" >> ${CONFIG_PATH} && \
-        echo "    inputs {" >> ${CONFIG_PATH} && \
-        echo "        key: \"input\"" >> ${CONFIG_PATH} && \
-        echo "        value: {" >> ${CONFIG_PATH} && \
-        echo "            data_type: TYPE_FP32" >> ${CONFIG_PATH} && \
-        echo "            dims: [ 224, 224, 3 ]" >> ${CONFIG_PATH} && \
-        echo "            random_data: true" >> ${CONFIG_PATH} && \
-        echo "        }" >> ${CONFIG_PATH} && \
-        echo "    }" >> ${CONFIG_PATH} && \
-        echo "}]" >> ${CONFIG_PATH}
-    fi
 done
 
 # Create the TensorRT plan from Caffe model

--- a/qa/L0_perf_resnet/test.sh
+++ b/qa/L0_perf_resnet/test.sh
@@ -38,7 +38,7 @@ if [ ! -z "$TEST_REPO_ARCH" ]; then
     REPO_VERSION=${REPO_VERSION}_${TEST_REPO_ARCH}
 fi
 
-rm -f *.log *.serverlog *.csv *.metrics *.tjson *.json
+rm -f *.log *.serverlog *.csv *.tjson *.json
 
 PROTOCOLS="grpc http triton_c_api"
 

--- a/qa/L0_perf_resnet/test.sh
+++ b/qa/L0_perf_resnet/test.sh
@@ -40,7 +40,7 @@ fi
 
 rm -f *.log *.serverlog *.csv *.metrics *.tjson *.json
 
-PROTOCOLS="grpc http"
+PROTOCOLS="grpc http triton_c_api"
 
 TRT_MODEL_NAME="resnet50_fp16_plan"
 TF_MODEL_NAME="resnet50v1.5_fp16_savedmodel"

--- a/qa/L0_perf_resnet/test.sh
+++ b/qa/L0_perf_resnet/test.sh
@@ -104,6 +104,22 @@ for MODEL_NAME in $OPTIMIZED_MODEL_NAMES; do
     fi
     echo "} ]" >> ${CONFIG_PATH}
     echo "}}" >> ${CONFIG_PATH}
+
+    # Give TFTRT more time to generate an engine with a server-side warmup request
+    if [ "${MODEL_NAME}" = "${TFTRT_MODEL_NAME}" ] ; then
+        echo "model_warmup [{" >> ${CONFIG_PATH} && \
+        echo "    name : \"sample\"" >> ${CONFIG_PATH} && \
+        echo "    batch_size: 1" >> ${CONFIG_PATH} && \
+        echo "    inputs {" >> ${CONFIG_PATH} && \
+        echo "        key: \"input\"" >> ${CONFIG_PATH} && \
+        echo "        value: {" >> ${CONFIG_PATH} && \
+        echo "            data_type: TYPE_FP32" >> ${CONFIG_PATH} && \
+        echo "            dims: [ 224, 224, 3 ]" >> ${CONFIG_PATH} && \
+        echo "            random_data: true" >> ${CONFIG_PATH} && \
+        echo "        }" >> ${CONFIG_PATH} && \
+        echo "    }" >> ${CONFIG_PATH} && \
+        echo "}]" >> ${CONFIG_PATH}
+    fi
 done
 
 # Create the TensorRT plan from Caffe model


### PR DESCRIPTION
- [x] resnet
- [x] nomodel
- [x] skip/check [unsupported combinations](https://github.com/triton-inference-server/server/blob/main/docs/perf_analyzer.md#non-supported-functionalities) with C API
  - [x] SHM / CUDA SHM
  - [x] Python backend requires SHM, so skip
- [ ] email
  - [x] add CAPI protocol to existing test, gitlab kibana summary
- [x] dashboards
  - [x] add visualizations, filter by protocol