### PR TITLE
Enable nvtx markers in pytorch backend

### DIFF
--- a/build.py
+++ b/build.py
@@ -627,6 +627,9 @@ def pytorch_cmake_args(images):
             cargs.append(
                 cmake_backend_enable('pytorch',
                                      'TRITON_PYTORCH_ENABLE_TORCHTRT', True))
+        cargs.append(
+            cmake_backend_enable('pytorch',
+                                 'TRITON_ENABLE_NVTX', FLAGS.enable_nvtx))
     return cargs
 
 


### PR DESCRIPTION
Added this as a part of work on a bug. Might do so for some other backends if required in future.
See linked PR here: https://github.com/triton-inference-server/pytorch_backend/pull/64