### PR TITLE
Correct number of resource copies for R4

### DIFF
--- a/docs/rate_limiter.md
+++ b/docs/rate_limiter.md
@@ -88,7 +88,7 @@ will create the following resources with the indicated copies:
 R1: 4
 R2: 5
 R3: 10
-R4: 7
+R4: 5
 ```
 
 These values ensure that all model instances can be successfully


### PR DESCRIPTION
According to "The available number of resource copies are, by default, the max across all model instances that list that resource."

"R4: 7" should change to "R4: 5"