### PR TITLE
Build testing custom op with backward compatibility

### DIFF
--- a/qa/common/gen_qa_custom_ops
+++ b/qa/common/gen_qa_custom_ops
@@ -79,12 +79,12 @@ g++ -std=c++11 -O2 -shared -fPIC zero_out_op_kernel_1.cc -o $DESTDIR/libzeroout.
 cp /opt/tensorflow/tensorflow-source/tensorflow/examples/adding_an_op/cuda_op_kernel.cc .
 cp /opt/tensorflow/tensorflow-source/tensorflow/examples/adding_an_op/cuda_op_kernel.cu.cc .
 patch -i $SRCDIR/cuda_op_kernel.cu.cc.patch cuda_op_kernel.cu.cc
-nvcc -std=c++11 -O2 -c -o cuda_op_kernel.cu.o cuda_op_kernel.cu.cc \${TF_CFLAGS[@]} -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+nvcc -std=c++11 -O2 -c -arch=all -o cuda_op_kernel.cu.o cuda_op_kernel.cu.cc \${TF_CFLAGS[@]} -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
 g++ -std=c++11 -shared -o $DESTDIR/libcudaop.so cuda_op_kernel.cc cuda_op_kernel.cu.o \${TF_CFLAGS[@]} -fPIC -L/usr/local/cuda/lib64 -lcudart \${TF_LFLAGS[@]}
 
 cp $SRCDIR/busy_op_kernel.cc .
 cp $SRCDIR/busy_op_kernel.cu.cc .
-nvcc -std=c++11 -O2 -c -o busy_op_kernel.cu.o busy_op_kernel.cu.cc \${TF_CFLAGS[@]} -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
+nvcc -std=c++11 -O2 -c -arch=all -o busy_op_kernel.cu.o busy_op_kernel.cu.cc \${TF_CFLAGS[@]} -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC
 g++ -std=c++11 -shared -o $DESTDIR/libbusyop.so busy_op_kernel.cc busy_op_kernel.cu.o \${TF_CFLAGS[@]} -fPIC -L/usr/local/cuda/lib64 -lcudart \${TF_LFLAGS[@]}
 
 python3 $SRCDIR/gen_qa_custom_ops_models.py --graphdef --savedmodel \


### PR DESCRIPTION
Fix the PTX error if the op is compiled with newer CUDA version and used with older CUDA version.

Before:
```
graphdef_busyop | 1       | UNAVAILABLE: Internal: unable to create stream: the provided PTX was compiled with an unsupported toolchain.
```

After:
```
graphdef_busyop | 1       | READY
```