### PR TITLE
Prefix Logs with Request ID

### DIFF
--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -2569,7 +2569,7 @@ class LifeCycleTest(tu.TestResultCollector):
         except InferenceServerException as ex:
             self.assertIn("in ensemble 'ensemble_zero_1_float32'", ex.message())
             self.assertIn(
-                "Server is stopping, scheduler for model has stopped accepting new inference requests'",
+                "Server is stopping, scheduler for model has stopped accepting new inference requests",
                 ex.message())
 
         # Wait until the results are available in user_data

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -2567,9 +2567,9 @@ class LifeCycleTest(tu.TestResultCollector):
             self.assertTrue(False,
                             "expected error for new inference during shutdown")
         except InferenceServerException as ex:
+            self.assertIn("in ensemble 'ensemble_zero_1_float32'", ex.message())
             self.assertIn(
-                "in ensemble 'ensemble_zero_1_float32', [request id: <id_unknown>]" \
-                "Server is stopping, scheduler for model has stopped accepting new inference requests",
+                "Server is stopping, scheduler for model has stopped accepting new inference requests'",
                 ex.message())
 
         # Wait until the results are available in user_data

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -2568,7 +2568,8 @@ class LifeCycleTest(tu.TestResultCollector):
                             "expected error for new inference during shutdown")
         except InferenceServerException as ex:
             self.assertIn(
-                "in ensemble 'ensemble_zero_1_float32', Server is stopping, scheduler for model has stopped accepting new inference requests",
+                "in ensemble 'ensemble_zero_1_float32', [request id: <id_unknown>]" \
+                "Server is stopping, scheduler for model has stopped accepting new inference requests",
                 ex.message())
 
         # Wait until the results are available in user_data

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3684,7 +3684,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
-    if ((request_id != nullptr) && (request_id[0] != '\0')) {
+    if ((request_id == nullptr) || (request_id[0] == '\0')) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {
@@ -4112,7 +4112,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
-    if ((request_id != nullptr) && (request_id[0] != '\0')) {
+    if ((request_id == nullptr) || (request_id[0] == '\0')) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3698,11 +3698,11 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      LOG_VERBOSE(1) << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
+      LOG_VERBOSE(1) << irequest->IdString() << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestDelete(irequest),
-          "deleting GRPC inference request");
+          (irequest->IdString() + "deleting GRPC inference request").c_str());
 
       grpc::Status status;
       GrpcStatusUtil::Create(&status, err);
@@ -4126,11 +4126,11 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
       }
-      LOG_VERBOSE(1) << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
+      LOG_VERBOSE(1) << irequest->IdString() << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestDelete(irequest),
-          "deleting GRPC inference request");
+          (irequest->IdString() + "deleting GRPC inference request").c_str());
 
       grpc::Status status;
       GrpcStatusUtil::Create(&status, err);
@@ -4196,7 +4196,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        LOG_VERBOSE(1) << "Write for " << Name() << ", rpc_ok=" << rpc_ok
+        LOG_VERBOSE(1) << irequest->IdString() << "Write for " << Name() << ", rpc_ok=" << rpc_ok
                        << ", context " << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
                        << ", failed";
@@ -4209,7 +4209,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // right away... need to wait for any pending reads, inferences
       // and writes to complete.
       if (!state->context_->PopCompletedResponse(state)) {
-        LOG_ERROR << "Unexpected response for " << Name()
+        LOG_ERROR << irequest->IdString() << "Unexpected response for " << Name()
                   << ", rpc_ok=" << rpc_ok << ", context "
                   << state->context_->unique_id_ << ", " << state->unique_id_
                   << " step " << state->step_;
@@ -4244,7 +4244,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        LOG_VERBOSE(1) << "Write for " << Name() << ", rpc_ok=" << rpc_ok
+        LOG_VERBOSE(1) << irequest->IdString() << "Write for " << Name() << ", rpc_ok=" << rpc_ok
                        << ", context " << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
                        << ", failed";
@@ -4276,7 +4276,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         // Will delay the write of the response by the specified time.
         // This can be used to test the flow where there are other
         // responses available to be written.
-        LOG_INFO << "Delaying the write of the response by "
+        LOG_INFO << irequest->IdString() << "Delaying the write of the response by "
                  << state->delay_response_ms_ << " ms...";
         std::this_thread::sleep_for(
             std::chrono::milliseconds(state->delay_response_ms_));

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3684,8 +3684,9 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
-    if (request_id != nullptr)
-      &&(request_id[0] != '\0') { request_id = "<id_unknown>"; }
+    if ((request_id != nullptr) && (request_id[0] != '\0')) {
+      request_id = "<id_unknown>";
+    }
     if (err == nullptr) {
       TRITONSERVER_InferenceTrace* triton_trace = nullptr;
 #ifdef TRITON_ENABLE_TRACING

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3679,6 +3679,13 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           &state->alloc_payload_ /* response_allocator_userp */,
           InferResponseComplete, reinterpret_cast<void*>(state));
     }
+    // Get request ID for logging in case of error.
+    const char* request_id = nullptr;
+    LOG_TRITONSERVER_ERROR(
+        TRITONSERVER_InferenceRequestId(irequest, &request_id),
+        "unable to retrieve request ID string");
+    if (request_id != nullptr)
+      &&(request_id[0] != '\0') { request_id = "<id_unknown>"; }
     if (err == nullptr) {
       TRITONSERVER_InferenceTrace* triton_trace = nullptr;
 #ifdef TRITON_ENABLE_TRACING
@@ -3698,13 +3705,6 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      const char* request_id = "";
-      LOG_TRITONSERVER_ERROR(
-          TRITONSERVER_InferenceRequestId(irequest, &request_id),
-          "unable to retrieve request ID string");
-      if (request_id == nullptr || *request_id == 0) {
-        request_id = "<id_unknown>";
-      }
       LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
@@ -4106,6 +4106,13 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           &state->alloc_payload_ /* response_allocator_userp */,
           StreamInferResponseComplete, reinterpret_cast<void*>(state));
     }
+    // Get request ID for logging in case of error.
+    const char* request_id = nullptr;
+    LOG_TRITONSERVER_ERROR(
+        TRITONSERVER_InferenceRequestId(irequest, &request_id),
+        "unable to retrieve request ID string");
+    if (request_id != nullptr)
+      &&(request_id[0] != '\0') { request_id = "<id_unknown>"; }
     if (err == nullptr) {
       TRITONSERVER_InferenceTrace* triton_trace = nullptr;
 #ifdef TRITON_ENABLE_TRACING
@@ -4133,13 +4140,6 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         response = state->response_queue_->GetLastAllocatedResponse();
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
-      }
-      const char* request_id = "";
-      LOG_TRITONSERVER_ERROR(
-          TRITONSERVER_InferenceRequestId(irequest, &request_id),
-          "unable to retrieve request ID string");
-      if (request_id == nullptr || *request_id == 0) {
-        request_id = "<id_unknown>";
       }
       LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3699,7 +3699,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
       const char *id;
-      RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+      RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
           irequest, &id));
       LOG_VERBOSE(1) << id
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
@@ -4131,7 +4131,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         response = state->response_queue_->GetNonDecoupledResponse();
       }
       const char *id;
-      RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+      RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
           irequest, &id));
       LOG_VERBOSE(1) << id
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
@@ -4205,7 +4205,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // inferences and writes to complete.
       if (!rpc_ok) {
         const char *id;
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
             irequest, &id));
         LOG_VERBOSE(1) << id << "Write for " << Name()
                        << ", rpc_ok=" << rpc_ok << ", context "
@@ -4222,7 +4222,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // and writes to complete.
       if (!state->context_->PopCompletedResponse(state)) {
         const char *id;
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
             irequest, &id));
         LOG_ERROR << id << "Unexpected response for "
                   << Name() << ", rpc_ok=" << rpc_ok << ", context "
@@ -4260,7 +4260,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // inferences and writes to complete.
       if (!rpc_ok) {
         const char *id;
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
             irequest, &id));
         LOG_VERBOSE(1) << id << "Write for " << Name()
                        << ", rpc_ok=" << rpc_ok << ", context "
@@ -4296,7 +4296,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         // This can be used to test the flow where there are other
         // responses available to be written.
         const char *id;
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
             irequest, &id));
         LOG_INFO << id
                  << "Delaying the write of the response by "

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3698,10 +3698,13 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      const char* request_id = "<id_unknown>";
+      const char* request_id = "";
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
+      if (request_id == nullptr || * request_id = 0) {
+        request_id = "<id_unknown>";
+      }
       LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
@@ -4131,10 +4134,13 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
       }
-      const char* request_id = "<id_unknown>";
+      const char* request_id = "";
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
+      if (request_id == nullptr || * request_id = 0) {
+        request_id = "<id_unknown>";
+      }
       LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -4206,13 +4206,8 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        const char* request_id;
-        LOG_TRITONSERVER_ERROR(
-            TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
-            "unable to retrieve request ID string");
-        LOG_VERBOSE(1) << request_id << "Write for " << Name()
-                       << ", rpc_ok=" << rpc_ok << ", context "
-                       << state->context_->unique_id_ << ", "
+        LOG_VERBOSE(1) << "Write for " << Name() << ", rpc_ok=" << rpc_ok
+                       << ", context " << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
                        << ", failed";
         state->context_->finish_ok_ = false;
@@ -4224,11 +4219,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // right away... need to wait for any pending reads, inferences
       // and writes to complete.
       if (!state->context_->PopCompletedResponse(state)) {
-        const char* request_id;
-        LOG_TRITONSERVER_ERROR(
-            TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
-            "unable to retrieve request ID string");
-        LOG_ERROR << request_id << "Unexpected response for " << Name()
+        LOG_ERROR << "Unexpected response for " << Name()
                   << ", rpc_ok=" << rpc_ok << ", context "
                   << state->context_->unique_id_ << ", " << state->unique_id_
                   << " step " << state->step_;
@@ -4263,13 +4254,8 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        const char* request_id;
-        LOG_TRITONSERVER_ERROR(
-            TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
-            "unable to retrieve request ID string");
-        LOG_VERBOSE(1) << request_id << "Write for " << Name()
-                       << ", rpc_ok=" << rpc_ok << ", context "
-                       << state->context_->unique_id_ << ", "
+        LOG_VERBOSE(1) << "Write for " << Name() << ", rpc_ok=" << rpc_ok
+                       << ", context " << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
                        << ", failed";
         state->context_->finish_ok_ = false;
@@ -4300,11 +4286,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         // Will delay the write of the response by the specified time.
         // This can be used to test the flow where there are other
         // responses available to be written.
-        const char* request_id;
-        LOG_TRITONSERVER_ERROR(
-            TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
-            "unable to retrieve request ID string");
-        LOG_INFO << request_id << "Delaying the write of the response by "
+        LOG_INFO << "Delaying the write of the response by "
                  << state->delay_response_ms_ << " ms...";
         std::this_thread::sleep_for(
             std::chrono::milliseconds(state->delay_response_ms_));

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -4112,8 +4112,9 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
-    if (request_id != nullptr)
-      &&(request_id[0] != '\0') { request_id = "<id_unknown>"; }
+    if ((request_id != nullptr) && (request_id[0] != '\0')) {
+      request_id = "<id_unknown>";
+    }
     if (err == nullptr) {
       TRITONSERVER_InferenceTrace* triton_trace = nullptr;
 #ifdef TRITON_ENABLE_TRACING

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3698,12 +3698,15 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      LOG_VERBOSE(1) << irequest->IdString()
+      const char *id;
+      RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+          irequest, &id));
+      LOG_VERBOSE(1) << id
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestDelete(irequest),
-          (irequest->IdString() + "deleting GRPC inference request").c_str());
+          "deleting GRPC inference request");
 
       grpc::Status status;
       GrpcStatusUtil::Create(&status, err);
@@ -4127,12 +4130,15 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
       }
-      LOG_VERBOSE(1) << irequest->IdString()
+      const char *id;
+      RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+          irequest, &id));
+      LOG_VERBOSE(1) << id
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestDelete(irequest),
-          (irequest->IdString() + "deleting GRPC inference request").c_str());
+          "deleting GRPC inference request");
 
       grpc::Status status;
       GrpcStatusUtil::Create(&status, err);
@@ -4198,7 +4204,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        LOG_VERBOSE(1) << irequest->IdString() << "Write for " << Name()
+        const char *id;
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+            irequest, &id));
+        LOG_VERBOSE(1) << id << "Write for " << Name()
                        << ", rpc_ok=" << rpc_ok << ", context "
                        << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
@@ -4212,7 +4221,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // right away... need to wait for any pending reads, inferences
       // and writes to complete.
       if (!state->context_->PopCompletedResponse(state)) {
-        LOG_ERROR << irequest->IdString() << "Unexpected response for "
+        const char *id;
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+            irequest, &id));
+        LOG_ERROR << id << "Unexpected response for "
                   << Name() << ", rpc_ok=" << rpc_ok << ", context "
                   << state->context_->unique_id_ << ", " << state->unique_id_
                   << " step " << state->step_;
@@ -4247,7 +4259,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        LOG_VERBOSE(1) << irequest->IdString() << "Write for " << Name()
+        const char *id;
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+            irequest, &id));
+        LOG_VERBOSE(1) << id << "Write for " << Name()
                        << ", rpc_ok=" << rpc_ok << ", context "
                        << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
@@ -4280,7 +4295,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         // Will delay the write of the response by the specified time.
         // This can be used to test the flow where there are other
         // responses available to be written.
-        LOG_INFO << irequest->IdString()
+        const char *id;
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestId(
+            irequest, &id));
+        LOG_INFO << id
                  << "Delaying the write of the response by "
                  << state->delay_response_ms_ << " ms...";
         std::this_thread::sleep_for(

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3698,7 +3698,8 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      LOG_VERBOSE(1) << irequest->IdString() << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
+      LOG_VERBOSE(1) << irequest->IdString()
+                     << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestDelete(irequest),
@@ -4126,7 +4127,8 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
       }
-      LOG_VERBOSE(1) << irequest->IdString() << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
+      LOG_VERBOSE(1) << irequest->IdString()
+                     << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestDelete(irequest),
@@ -4196,8 +4198,9 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        LOG_VERBOSE(1) << irequest->IdString() << "Write for " << Name() << ", rpc_ok=" << rpc_ok
-                       << ", context " << state->context_->unique_id_ << ", "
+        LOG_VERBOSE(1) << irequest->IdString() << "Write for " << Name()
+                       << ", rpc_ok=" << rpc_ok << ", context "
+                       << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
                        << ", failed";
         state->context_->finish_ok_ = false;
@@ -4209,8 +4212,8 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // right away... need to wait for any pending reads, inferences
       // and writes to complete.
       if (!state->context_->PopCompletedResponse(state)) {
-        LOG_ERROR << irequest->IdString() << "Unexpected response for " << Name()
-                  << ", rpc_ok=" << rpc_ok << ", context "
+        LOG_ERROR << irequest->IdString() << "Unexpected response for "
+                  << Name() << ", rpc_ok=" << rpc_ok << ", context "
                   << state->context_->unique_id_ << ", " << state->unique_id_
                   << " step " << state->step_;
         state->context_->finish_ok_ = false;
@@ -4244,8 +4247,9 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        LOG_VERBOSE(1) << irequest->IdString() << "Write for " << Name() << ", rpc_ok=" << rpc_ok
-                       << ", context " << state->context_->unique_id_ << ", "
+        LOG_VERBOSE(1) << irequest->IdString() << "Write for " << Name()
+                       << ", rpc_ok=" << rpc_ok << ", context "
+                       << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
                        << ", failed";
         state->context_->finish_ok_ = false;
@@ -4276,7 +4280,8 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         // Will delay the write of the response by the specified time.
         // This can be used to test the flow where there are other
         // responses available to be written.
-        LOG_INFO << irequest->IdString() << "Delaying the write of the response by "
+        LOG_INFO << irequest->IdString()
+                 << "Delaying the write of the response by "
                  << state->delay_response_ms_ << " ms...";
         std::this_thread::sleep_for(
             std::chrono::milliseconds(state->delay_response_ms_));

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -4204,10 +4204,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        const char *id;
+        const char *request_id;
         RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-            irequest, &id));
-        LOG_VERBOSE(1) << id << "Write for " << Name()
+            irequest, &request_id));
+        LOG_VERBOSE(1) << request_id << "Write for " << Name()
                        << ", rpc_ok=" << rpc_ok << ", context "
                        << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
@@ -4221,10 +4221,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // right away... need to wait for any pending reads, inferences
       // and writes to complete.
       if (!state->context_->PopCompletedResponse(state)) {
-        const char *id;
+        const char *request_id;
         RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-            irequest, &id));
-        LOG_ERROR << id << "Unexpected response for "
+            irequest, &request_id));
+        LOG_ERROR << request_id << "Unexpected response for "
                   << Name() << ", rpc_ok=" << rpc_ok << ", context "
                   << state->context_->unique_id_ << ", " << state->unique_id_
                   << " step " << state->step_;
@@ -4259,10 +4259,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        const char *id;
+        const char *request_id;
         RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-            irequest, &id));
-        LOG_VERBOSE(1) << id << "Write for " << Name()
+            irequest, &request_id));
+        LOG_VERBOSE(1) << request_id << "Write for " << Name()
                        << ", rpc_ok=" << rpc_ok << ", context "
                        << state->context_->unique_id_ << ", "
                        << state->unique_id_ << " step " << state->step_
@@ -4295,10 +4295,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         // Will delay the write of the response by the specified time.
         // This can be used to test the flow where there are other
         // responses available to be written.
-        const char *id;
+        const char *request_id;
         RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-            irequest, &id));
-        LOG_INFO << id
+            irequest, &request_id));
+        LOG_INFO << request_id
                  << "Delaying the write of the response by "
                  << state->delay_response_ms_ << " ms...";
         std::this_thread::sleep_for(

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3698,7 +3698,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      const char* request_id;
+      const char* request_id = "";
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
           "unable to retrieve request ID string");
@@ -4131,7 +4131,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
       }
-      const char* request_id;
+      const char* request_id = "";
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
           "unable to retrieve request ID string");

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3702,7 +3702,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      if (request_id == nullptr || * request_id = 0) {
+      if (request_id == nullptr || *request_id == 0) {
         request_id = "<id_unknown>";
       }
       LOG_VERBOSE(1) << "[request id: " << request_id << "]"
@@ -4138,7 +4138,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      if (request_id == nullptr || * request_id = 0) {
+      if (request_id == nullptr || *request_id == 0) {
         request_id = "<id_unknown>";
       }
       LOG_VERBOSE(1) << "[request id: " << request_id << "]"

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3698,7 +3698,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      const char* request_id = "";
+      const char* request_id = "<id_unknown>";
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
@@ -4131,7 +4131,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
       }
-      const char* request_id = "";
+      const char* request_id = "<id_unknown>";
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3700,9 +3700,9 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     if (err != nullptr) {
       const char* request_id = "";
       LOG_TRITONSERVER_ERROR(
-          TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+          TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      LOG_VERBOSE(1) << request_id
+      LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
@@ -4133,9 +4133,9 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       }
       const char* request_id = "";
       LOG_TRITONSERVER_ERROR(
-          TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+          TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      LOG_VERBOSE(1) << request_id
+      LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3698,10 +3698,11 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      const char *id;
-      RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-          irequest, &id));
-      LOG_VERBOSE(1) << id
+      const char* request_id;
+      LOG_TRITONSERVER_ERROR(
+          TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+          "unable to retrieve request ID string");
+      LOG_VERBOSE(1) << request_id
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
@@ -4130,10 +4131,11 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
       }
-      const char *id;
-      RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-          irequest, &id));
-      LOG_VERBOSE(1) << id
+      const char* request_id;
+      LOG_TRITONSERVER_ERROR(
+          TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+          "unable to retrieve request ID string");
+      LOG_VERBOSE(1) << request_id
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
@@ -4204,9 +4206,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        const char *request_id;
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-            irequest, &request_id));
+        const char* request_id;
+        LOG_TRITONSERVER_ERROR(
+            TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+            "unable to retrieve request ID string");
         LOG_VERBOSE(1) << request_id << "Write for " << Name()
                        << ", rpc_ok=" << rpc_ok << ", context "
                        << state->context_->unique_id_ << ", "
@@ -4221,11 +4224,12 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // right away... need to wait for any pending reads, inferences
       // and writes to complete.
       if (!state->context_->PopCompletedResponse(state)) {
-        const char *request_id;
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-            irequest, &request_id));
-        LOG_ERROR << request_id << "Unexpected response for "
-                  << Name() << ", rpc_ok=" << rpc_ok << ", context "
+        const char* request_id;
+        LOG_TRITONSERVER_ERROR(
+            TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+            "unable to retrieve request ID string");
+        LOG_ERROR << request_id << "Unexpected response for " << Name()
+                  << ", rpc_ok=" << rpc_ok << ", context "
                   << state->context_->unique_id_ << ", " << state->unique_id_
                   << " step " << state->step_;
         state->context_->finish_ok_ = false;
@@ -4259,9 +4263,10 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       // cancel right away... need to wait for any pending reads,
       // inferences and writes to complete.
       if (!rpc_ok) {
-        const char *request_id;
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-            irequest, &request_id));
+        const char* request_id;
+        LOG_TRITONSERVER_ERROR(
+            TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+            "unable to retrieve request ID string");
         LOG_VERBOSE(1) << request_id << "Write for " << Name()
                        << ", rpc_ok=" << rpc_ok << ", context "
                        << state->context_->unique_id_ << ", "
@@ -4295,11 +4300,11 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         // Will delay the write of the response by the specified time.
         // This can be used to test the flow where there are other
         // responses available to be written.
-        const char *request_id;
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestIdString(
-            irequest, &request_id));
-        LOG_INFO << request_id
-                 << "Delaying the write of the response by "
+        const char* request_id;
+        LOG_TRITONSERVER_ERROR(
+            TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+            "unable to retrieve request ID string");
+        LOG_INFO << request_id << "Delaying the write of the response by "
                  << state->delay_response_ms_ << " ms...";
         std::this_thread::sleep_for(
             std::chrono::milliseconds(state->delay_response_ms_));

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3706,7 +3706,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     // has initiated... completion callback will transition to
     // COMPLETE. If error go immediately to COMPLETE.
     if (err != nullptr) {
-      LOG_VERBOSE(1) << "[request id: " << request_id << "]"
+      LOG_VERBOSE(1) << "[request id: " << request_id << "] "
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(
@@ -4143,7 +4143,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
       } else {
         response = state->response_queue_->GetNonDecoupledResponse();
       }
-      LOG_VERBOSE(1) << "[request id: " << request_id << "]"
+      LOG_VERBOSE(1) << "[request id: " << request_id << "] "
                      << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
 
       LOG_TRITONSERVER_ERROR(

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2726,7 +2726,7 @@ HTTPAPIServer::HandleInfer(
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      if ((request_id != nullptr) && (request_id[0] != '\0')) {
+      if ((request_id == nullptr) || (request_id[0] == '\0')) {
         request_id = "<id_unknown>";
       }
       if (err == nullptr) {
@@ -2910,7 +2910,7 @@ HTTPAPIServer::InferRequestClass::FinalizeResponse(
 
   const char* request_id = nullptr;
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseId(response, &request_id));
-  if ((request_id != nullptr) && (request_id[0] != '\0')) {
+  if ((request_id == nullptr) || (request_id[0] == '\0')) {
     RETURN_IF_ERR(response_json.AddStringRef("id", request_id));
   }
 

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2737,7 +2737,12 @@ HTTPAPIServer::HandleInfer(
   }
 
   if (err != nullptr) {
-    LOG_VERBOSE(1) << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
+    const char* request_id;
+    LOG_TRITONSERVER_ERROR(
+        TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+        "unable to retrieve request ID string");
+    LOG_VERBOSE(1) << request_id
+                   << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
     evhtp_headers_add_header(
         req->headers_out,
         evhtp_header_new(kContentTypeHeader, "application/json", 1, 1));

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2737,9 +2737,9 @@ HTTPAPIServer::HandleInfer(
   }
 
   if (err != nullptr) {
-    const char* request_id = "";
+    const char* request_id = "<id_unknown>";
     LOG_TRITONSERVER_ERROR(
-        TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
+        TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
     LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                    << "Infer failed: " << TRITONSERVER_ErrorMessage(err);

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2726,8 +2726,9 @@ HTTPAPIServer::HandleInfer(
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      if (request_id != nullptr)
-        &&(request_id[0] != '\0') { request_id = "<id_unknown>"; }
+      if ((request_id != nullptr) && (request_id[0] != '\0')) {
+        request_id = "<id_unknown>";
+      }
       if (err == nullptr) {
         err = TRITONSERVER_ServerInferAsync(
             server_.get(), irequest, triton_trace);

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2737,7 +2737,7 @@ HTTPAPIServer::HandleInfer(
   }
 
   if (err != nullptr) {
-    const char* request_id;
+    const char* request_id = "";
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
         "unable to retrieve request ID string");
@@ -2904,7 +2904,7 @@ HTTPAPIServer::InferRequestClass::FinalizeResponse(
   triton::common::TritonJson::Value response_json(
       triton::common::TritonJson::ValueType::OBJECT);
 
-  const char* request_id;
+  const char* request_id = "";
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseId(response, &request_id));
   if ((request_id != nullptr) && (request_id[0] != '\0')) {
     RETURN_IF_ERR(response_json.AddStringRef("id", request_id));

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2741,7 +2741,7 @@ HTTPAPIServer::HandleInfer(
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
-    if (request_id == nullptr || * request_id = 0) {
+    if (request_id == nullptr || *request_id == 0) {
       request_id = "<id_unknown>";
     }
     LOG_VERBOSE(1) << "[request id: " << request_id << "]"

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2910,7 +2910,7 @@ HTTPAPIServer::InferRequestClass::FinalizeResponse(
 
   const char* request_id = nullptr;
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseId(response, &request_id));
-  if ((request_id == nullptr) || (request_id[0] == '\0')) {
+  if ((request_id != nullptr) && (request_id[0] != '\0')) {
     RETURN_IF_ERR(response_json.AddStringRef("id", request_id));
   }
 

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2737,10 +2737,13 @@ HTTPAPIServer::HandleInfer(
   }
 
   if (err != nullptr) {
-    const char* request_id = "<id_unknown>";
+    const char* request_id = "";
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
+    if (request_id == nullptr || * request_id = 0) {
+      request_id = "<id_unknown>";
+    }
     LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                    << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
     evhtp_headers_add_header(

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2741,7 +2741,7 @@ HTTPAPIServer::HandleInfer(
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestIdString(irequest, &request_id),
         "unable to retrieve request ID string");
-    LOG_VERBOSE(1) << request_id
+    LOG_VERBOSE(1) << "[request id: " << request_id << "]"
                    << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
     evhtp_headers_add_header(
         req->headers_out,

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2904,7 +2904,7 @@ HTTPAPIServer::InferRequestClass::FinalizeResponse(
   triton::common::TritonJson::Value response_json(
       triton::common::TritonJson::ValueType::OBJECT);
 
-  const char* request_id = "";
+  const char* request_id = nullptr;
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseId(response, &request_id));
   if ((request_id != nullptr) && (request_id[0] != '\0')) {
     RETURN_IF_ERR(response_json.AddStringRef("id", request_id));

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2745,7 +2745,7 @@ HTTPAPIServer::HandleInfer(
   }
 
   if (err != nullptr) {
-    LOG_VERBOSE(1) << "[request id: " << request_id << "]"
+    LOG_VERBOSE(1) << "[request id: " << request_id << "] "
                    << "Infer failed: " << TRITONSERVER_ErrorMessage(err);
     evhtp_headers_add_header(
         req->headers_out,


### PR DESCRIPTION
Prefix logs with the request ID, where possible.

Related changes:
Backend: https://github.com/triton-inference-server/backend/pull/60
Core: https://github.com/triton-inference-server/core/pull/85