### PR TITLE
Add libgtest-dev as system package

### DIFF
--- a/build.py
+++ b/build.py
@@ -922,6 +922,7 @@ RUN apt-get update && \
             libarchive-dev \
             pkg-config \
             uuid-dev \
+            libgtest-dev \
             libnuma-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I could not get a debug build to work with build.py. This fixed it for me. Perhaps a sub-project or third-party module used to install this and now it does not.