### PR TITLE
Add bfloat to client

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -334,7 +334,7 @@ RUN rm -f /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip3 install --upgrade wheel setuptools && \
-    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil awscli six grpcio-channelz
+    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil awscli six grpcio-channelz bfloat16
 
 # L0_http_fuzz is hitting similar issue with boofuzz with latest version (0.4.0):
 # https://github.com/jtpereyda/boofuzz/issues/529

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -334,7 +334,8 @@ RUN rm -f /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip3 install --upgrade wheel setuptools && \
-    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil awscli six grpcio-channelz bfloat16
+    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil awscli six grpcio-channelz && \
+    pip3 install --upgrade bfloat16
 
 # L0_http_fuzz is hitting similar issue with boofuzz with latest version (0.4.0):
 # https://github.com/jtpereyda/boofuzz/issues/529

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -82,7 +82,6 @@ RUN apt-get update && \
             maven && \
     pip3 install --upgrade wheel setuptools && \
     pip3 install --upgrade grpcio-tools && \
-    pip3 install bfloat16 && \
     pip3 install --upgrade pip
 
 ARG CMAKE_UBUNTU_VERSION
@@ -206,6 +205,7 @@ COPY qa/images/mug.jpg images/mug.jpg
 # are not needed for building but including them allows this image to
 # be used to run the client examples.
 RUN pip3 install --upgrade numpy pillow attrdict && \
+    pip3 install --upgrade bfloat16 && \
     find install/python/ -maxdepth 1 -type f -name \
          "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
     xargs pip3 install --upgrade

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -82,6 +82,7 @@ RUN apt-get update && \
             maven && \
     pip3 install --upgrade wheel setuptools && \
     pip3 install --upgrade grpcio-tools && \
+    pip3 install bfloat16 && \
     pip3 install --upgrade pip
 
 ARG CMAKE_UBUNTU_VERSION


### PR DESCRIPTION
Adding bfloat16 to client and QA containers. Not sure if I'm missing something but I think bfloat16 should be supported in python client with the current change. Reusing Ryan's test for bfloat16 testing. 
Related PR: https://github.com/triton-inference-server/client/pull/118