### PR TITLE
Remove nvidia-ml deps for multi_server

### DIFF
--- a/src/servers/CMakeLists.txt
+++ b/src/servers/CMakeLists.txt
@@ -396,8 +396,6 @@ if(${TRITON_ENABLE_GPU})
 target_include_directories(multi_server PRIVATE ${CUDA_INCLUDE_DIRS})
 target_link_libraries(
   multi_server
-  PUBLIC -L/usr/local/cuda/lib64/stubs
-  PUBLIC -lnvidia-ml
   PRIVATE ${CUDA_LIBRARIES}
 )
 endif() # TRITON_ENABLE_GPU


### PR DESCRIPTION
- We do not need to link against the nvidia-ml library for multi_server