### PR TITLE
Remove `DALI_VERSION` from `build.py`

### DIFF
--- a/build.py
+++ b/build.py
@@ -319,8 +319,7 @@ class BuildScript:
     def cmake(self, args):
         # Pass some additional envvars into cmake...
         env_args = []
-        for k in ('TRT_VERSION', 'DALI_VERSION', 'CMAKE_TOOLCHAIN_FILE',
-                  'VCPKG_TARGET_TRIPLET'):
+        for k in ('TRT_VERSION', 'CMAKE_TOOLCHAIN_FILE', 'VCPKG_TARGET_TRIPLET'):
             env_args += [f'"-D{k}={self.envvar_ref(k)}"']
         self.cmd(f'cmake {" ".join(env_args)} {" ".join(args)}',
                  check_exitcode=True)


### PR DESCRIPTION
Currently, `build.py` script specifies `DALI_VERSION` variable to be set using environment variable. However, in https://github.com/triton-inference-server/dali_backend/pull/133, DALI Backend changed the way of setting the version of DALI which it builds against. Right now, DALI Backend includes a [DALI_VERSION file](https://github.com/triton-inference-server/dali_backend/blob/main/DALI_VERSION) and this file is going to specify the DALI version required for the build. We changed this, because of practical reasons: since DALI C/C++ APIs are yet experimental, there might happen a situation, when DALI last minute changes the API, which is result will break DALI Backend. We want to be able to manually control DALI version. In general, in DALI Backend we are going to keep the latest DALI, but there might be a missing release in between.

From the `tritonserver` side there's not much to change w.r.t. way of building DALI Backend. Default CMake routines in DALI Backend target the `tritonserver` build and they are able to pick up the `DALI_VERSION file` properly. To maintain the flexibility, we've kept the `DALI_VERSION CMake variable`, which overrides the `DALI_VERSION file` when set. Anyway, in regular release build, `build.py` should not pass `-D DALI_VERSION` to the CMake command.

Signed-off-by: szalpal <mszolucha@nvidia.com>