### PR TITLE
Update ORT to 1.12 release

### DIFF
--- a/build.py
+++ b/build.py
@@ -95,7 +95,7 @@ TRITON_VERSION_MAP = {
     '2.24.0dev': (
         '22.07dev',  # triton container
         '22.06',  # upstream container
-        '1.11.1',  # ORT
+        '1.12',  # ORT
         '2021.4.582',  # ORT OpenVINO
         (('2021.4', None), ('2021.4', '2021.4.582'),
          ('SPECIFIC', 'f2f281e6')),  # Standalone OpenVINO

--- a/build.py
+++ b/build.py
@@ -95,7 +95,7 @@ TRITON_VERSION_MAP = {
     '2.24.0dev': (
         '22.07dev',  # triton container
         '22.06',  # upstream container
-        '1.12',  # ORT
+        '1.12.0',  # ORT
         '2021.4.582',  # ORT OpenVINO
         (('2021.4', None), ('2021.4', '2021.4.582'),
          ('SPECIFIC', 'f2f281e6')),  # Standalone OpenVINO

--- a/build.py
+++ b/build.py
@@ -96,7 +96,7 @@ TRITON_VERSION_MAP = {
         '22.07dev',  # triton container
         '22.06',  # upstream container
         '1.12.0',  # ORT
-        '2022.1.0',  # ORT OpenVINO
+        '2021.4.582',  # ORT OpenVINO
         (('2021.4', None), ('2021.4', '2021.4.582'),
          ('SPECIFIC', 'f2f281e6')),  # Standalone OpenVINO
         '2.2.9',  # DCGM version

--- a/build.py
+++ b/build.py
@@ -96,7 +96,7 @@ TRITON_VERSION_MAP = {
         '22.07dev',  # triton container
         '22.06',  # upstream container
         '1.12.0',  # ORT
-        '2021.4.582',  # ORT OpenVINO
+        '2022.1.0',  # ORT OpenVINO
         (('2021.4', None), ('2021.4', '2021.4.582'),
          ('SPECIFIC', 'f2f281e6')),  # Standalone OpenVINO
         '2.2.9',  # DCGM version


### PR DESCRIPTION
ORT 1.12 release branch is ready for validation. We have not released yet. Release is scheduled for 7/21.