### PR TITLE
Fix expected byte size calculation

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2419,7 +2419,7 @@ HTTPAPIServer::EVBufferToInput(
               "Unable to parse 'data'");
 
           if (dtype == TRITONSERVER_TYPE_BYTES) {
-            byte_size = 0;
+            byte_size = 0;  // initialize for its recursive computation
             RETURN_IF_ERR(JsonBytesArrayByteSize(tensor_data, &byte_size));
           } else {
             byte_size = element_cnt * TRITONSERVER_DataTypeByteSize(dtype);

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -243,8 +243,6 @@ TRITONSERVER_Error*
 JsonBytesArrayByteSize(
     triton::common::TritonJson::Value& tensor_data, size_t* byte_size)
 {
-  *byte_size = 0;
-
   for (size_t i = 0; i < tensor_data.ArraySize(); i++) {
     triton::common::TritonJson::Value el;
     RETURN_IF_ERR(tensor_data.At(i, &el));
@@ -2421,6 +2419,7 @@ HTTPAPIServer::EVBufferToInput(
               "Unable to parse 'data'");
 
           if (dtype == TRITONSERVER_TYPE_BYTES) {
+            byte_size = 0;
             RETURN_IF_ERR(JsonBytesArrayByteSize(tensor_data, &byte_size));
           } else {
             byte_size = element_cnt * TRITONSERVER_DataTypeByteSize(dtype);


### PR DESCRIPTION
When the data type is BYTE, `JsonBytesArrayByteSize` function is called to calculate the expected byte size. The calculation uses depth-first search (DFS) to finds each characters from the input, no matter how "deep" they are nested within the dimensions, and greedily sums the byte size along the search. The function calls itself iteratively to complete the DFS.

The original search function will initialize the byte size to 0 whenever it is called. This is incorrect as when the DFS switches branch, the byte size from the previous branch is discarded. The updated search function fixes the re-initialization bug.

For example, the original function calculates `['a', 'b']` correctly as there is no nested array, and also `[['a', 'b']]` correctly as there is no branch switch, but `[['a'], ['b']]` incorrectly when switching branch from `['a']` to `['b']`, which is fixed in this PR.