### PR TITLE
Resolve disable-auto-complete-config and strict-model-config conflict

### DIFF
--- a/qa/L0_model_config/cli_messages/cli_deprecation/expected
+++ b/qa/L0_model_config/cli_messages/cli_deprecation/expected
@@ -1,0 +1,1 @@
+Warning: '--strict-model-config' has been deprecated! Please use '--disable-auto-complete-config' instead.

--- a/qa/L0_model_config/cli_messages/cli_override/expected
+++ b/qa/L0_model_config/cli_messages/cli_override/expected
@@ -1,0 +1,1 @@
+Warning: Overriding deprecated '--strict-model-config' from False to True in favor of '--disable-auto-complete-config'!

--- a/src/main.cc
+++ b/src/main.cc
@@ -1450,7 +1450,9 @@ Parse(TRITONSERVER_ServerOptions** server_options, int argc, char** argv)
         disable_auto_complete_config = true;
         break;
       case OPTION_STRICT_MODEL_CONFIG:
-        std::cerr << "Warning: '--strict-model-config' has been deprecated! Please use '--disable-auto-complete-config' instead." << std::endl;
+        std::cerr << "Warning: '--strict-model-config' has been deprecated! "
+                     "Please use '--disable-auto-complete-config' instead."
+                  << std::endl;
         strict_model_config_present = true;
         strict_model_config = ParseBoolOption(optarg);
         break;
@@ -1789,10 +1791,13 @@ Parse(TRITONSERVER_ServerOptions** server_options, int argc, char** argv)
   // and --strict-model-config
   if (disable_auto_complete_config && strict_model_config_present) {
     if (!strict_model_config) {
-      std::cerr << "Warning: Overriding deprecated '--strict-model-config' from False to True in favor of '--disable-auto-complete-config'!" << std::endl;
+      std::cerr
+          << "Warning: Overriding deprecated '--strict-model-config' from "
+             "False to True in favor of '--disable-auto-complete-config'!"
+          << std::endl;
     }
     strict_model_config = true;
-  } 
+  }
 
   FAIL_IF_ERR(
       TRITONSERVER_ServerOptionsNew(server_options), "creating server options");


### PR DESCRIPTION
This PR adds a warning on startup for the user if they are using the now deprecated `--strict-model-config` flag. Additionally, we add a warning that the `--disable-auto-complete-config` flag will be used instead of the `--strict-model-config` if both are provided and they contradict. In the event the two options are in agreement, then the user only gets the deprecation warning.