### PR TITLE
Lifecycle test fixes

### DIFF
--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -1315,7 +1315,9 @@ class LifeCycleTest(tu.TestResultCollector):
                 # should NOT unload the existing versions in model control mode.
                 self.assertTrue(
                     triton_client.is_model_ready(savedmodel_name, "1"))
-                self.assertTrue(
+                # Version 3 did not exist in the first model repository, so
+                # it should still not be loaded.
+                self.assertFalse(
                     triton_client.is_model_ready(savedmodel_name, "3"))
         except Exception as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
@@ -1330,6 +1332,9 @@ class LifeCycleTest(tu.TestResultCollector):
         try:
             triton_client = httpclient.InferenceServerClient("localhost:8000",
                                                              verbose=True)
+            # Unload existing in-memory model from first model repository
+            triton_client.unload_model(savedmodel_name)
+            # Load model from second model repository since original was deleted
             triton_client.load_model(savedmodel_name)
         except Exception as ex:
             self.assertIn("failed to load '{}'".format(savedmodel_name),

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -1038,6 +1038,28 @@ fi
 
 LOG_IDX=$((LOG_IDX+1))
 
+# Test loading a startup model that doesn't exist, it should fail
+rm -fr models && mkdir models
+INVALID_MODEL="does-not-exist"
+SERVER_ARGS="--model-repository=`pwd`/models \
+             --model-control-mode=explicit \
+             --strict-readiness=true \
+             --exit-on-error=true \
+             --load-model=${INVALID_MODEL}"
+SERVER_LOG="./inference_server_$LOG_IDX.log"
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    echo -e "\n***\n*** Failed: $SERVER started successfully when it was expected to fail\n***"
+    echo -e "ERROR: Startup model [${INVALID_MODEL}] should have failed to load."
+    cat $SERVER_LOG
+    RET=1
+
+    kill $SERVER_PID
+    wait $SERVER_PID
+fi
+
+LOG_IDX=$((LOG_IDX+1))
+
 # LifeCycleTest.test_model_repository_index
 rm -fr models models_0 config.pbtxt.*
 mkdir models models_0

--- a/qa/L0_nan_inf/models/nan_inf_output/1/model.py
+++ b/qa/L0_nan_inf/models/nan_inf_output/1/model.py
@@ -32,7 +32,7 @@ import triton_python_backend_utils as pb_utils
 class TritonPythonModel:
 
     def initialize(self, args):
-        self.model_config = model_config = json.loads(args['model_config'])
+        self.model_config = json.loads(args['model_config'])
 
     def execute(self, requests):
         """ This function is called on inference request.


### PR DESCRIPTION
- add new test to assert failure on loading non-existing startup (`--load-model`) model
- update lifecycle test to expect existing models to still be ready in model control mode after a failed load of the same model
- unused var cleanup