### PR TITLE
Increase SERVER_TIMEOUT for L0_infer_valgrind

### DIFF
--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -64,6 +64,7 @@ class InferTest(tu.TestResultCollector):
                     output0_raw,
                     output1_raw,
                     swap,
+                    # 60 sec is the default value
                     network_timeout=60.0):
 
         def _infer_exact_helper(tester,

--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -41,6 +41,7 @@ TEST_SYSTEM_SHARED_MEMORY = bool(
 TEST_CUDA_SHARED_MEMORY = bool(int(os.environ.get('TEST_CUDA_SHARED_MEMORY',
                                                   0)))
 CPU_ONLY = (os.environ.get('TRITON_SERVER_CPU_ONLY') is not None)
+TEST_VALGRIND = bool(int(os.environ.get('TEST_VALGRIND', 0)))
 
 USE_GRPC = (os.environ.get('USE_GRPC', 1) != "0")
 USE_HTTP = (os.environ.get('USE_HTTP', 1) != "0")
@@ -56,8 +57,14 @@ np_dtype_string = np.dtype(object)
 
 class InferTest(tu.TestResultCollector):
 
-    def _full_exact(self, input_dtype, output0_dtype, output1_dtype,
-                    output0_raw, output1_raw, swap):
+    def _full_exact(self,
+                    input_dtype,
+                    output0_dtype,
+                    output1_dtype,
+                    output0_raw,
+                    output1_raw,
+                    swap,
+                    network_timeout=60.0):
 
         def _infer_exact_helper(tester,
                                 pf,
@@ -76,7 +83,8 @@ class InferTest(tu.TestResultCollector):
                                 use_http_json_tensors=True,
                                 skip_request_id_check=True,
                                 use_streaming=True,
-                                correlation_id=0):
+                                correlation_id=0,
+                                network_timeout=60.0):
             for bs in (1, batch_size):
                 # model that does not support batching
                 if bs == 1:
@@ -100,7 +108,8 @@ class InferTest(tu.TestResultCollector):
                         use_streaming=use_streaming,
                         correlation_id=correlation_id,
                         use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-                        use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY)
+                        use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
+                        network_timeout=network_timeout)
 
                 # model that supports batching.
                 iu.infer_exact(
@@ -122,7 +131,8 @@ class InferTest(tu.TestResultCollector):
                     use_streaming=use_streaming,
                     correlation_id=correlation_id,
                     use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
-                    use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY)
+                    use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
+                    network_timeout=network_timeout)
 
         input_size = 16
 
@@ -150,7 +160,8 @@ class InferTest(tu.TestResultCollector):
                                             output1_dtype,
                                             output0_raw=output0_raw,
                                             output1_raw=output1_raw,
-                                            swap=swap)
+                                            swap=swap,
+                                            network_timeout=network_timeout)
 
         if not CPU_ONLY and tu.validate_for_trt_model(
                 input_dtype, output0_dtype, output1_dtype, (input_size, 1, 1),
@@ -426,12 +437,16 @@ class InferTest(tu.TestResultCollector):
     if not (TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY):
 
         def test_class_bbb(self):
-            self._full_exact(np.int8,
-                             np.int8,
-                             np.int8,
-                             output0_raw=False,
-                             output1_raw=False,
-                             swap=True)
+            self._full_exact(
+                np.int8,
+                np.int8,
+                np.int8,
+                output0_raw=False,
+                output1_raw=False,
+                swap=True,
+                # Increase network_timeout for TensorFlow models for
+                # valgrind test.
+                network_timeout=100.0 if TEST_VALGRIND else 60.0)
 
         def test_class_sss(self):
             self._full_exact(np.int16,

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,7 +61,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=4000
+    SERVER_TIMEOUT=10000
     rm -f $LEAKCHECK_LOG_BASE*
 fi
 

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,7 +61,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=10000
+    SERVER_TIMEOUT=28800
     rm -f $LEAKCHECK_LOG_BASE*
 fi
 

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,7 +61,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=28800
+    SERVER_TIMEOUT=86400
     rm -f $LEAKCHECK_LOG_BASE*
 fi
 

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,7 +61,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=6000
+    SERVER_TIMEOUT=4000
     rm -f $LEAKCHECK_LOG_BASE*
     # Remove onnx and python backends for now as the server hangs up when 
     # loading onnx and python models during valgrind test.

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -64,7 +64,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     SERVER_TIMEOUT=4000
     rm -f $LEAKCHECK_LOG_BASE*
     # Remove onnx and python backends for now as the server hangs up when 
-    # loading onnx and python models during valgrind test.
+    # loading onnx and python models during valgrind test. DLIS-4056
     BACKENDS="graphdef savedmodel libtorch plan openvino"
 fi
 

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,8 +61,11 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=172800
+    SERVER_TIMEOUT=6000
     rm -f $LEAKCHECK_LOG_BASE*
+    # Remove onnx and python backends for now as the server hangs up when 
+    # loading onnx and python models during valgrind test.
+    BACKENDS="graphdef savedmodel libtorch plan openvino"
 fi
 
 if [ "$TEST_SYSTEM_SHARED_MEMORY" -eq 1 ] || [ "$TEST_CUDA_SHARED_MEMORY" -eq 1 ]; then

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,7 +61,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=86400
+    SERVER_TIMEOUT=172800
     rm -f $LEAKCHECK_LOG_BASE*
 fi
 

--- a/qa/common/check_valgrind_log.py
+++ b/qa/common/check_valgrind_log.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,10 +35,13 @@ import argparse
 #     -> tensorflow::LibHDFS::LoadAndBind()::{lambda(char const*, void**)#1}::operator()(char const*, void**)
 #     -> tensorflow::internal::LoadLibrary
 #     -> dlerror
+#   * InferenceEngine::getAvailableCoresTypes() leak in OpenVINO could be due to
+#     https://github.com/openvinotoolkit/openvino/issues/6593. Should be fixed
+#     after version 2021.4(https://github.com/openvinotoolkit/openvino/issues/6593#issuecomment-878093502).
 
 LEAK_WHITE_LIST = [
     'cnmem', 'tensorflow::NewSession', 'dl-init', 'dl-open', 'dlerror',
-    'libtorch'
+    'libtorch', 'InferenceEngine::getAvailableCoresTypes()'
 ]
 
 

--- a/qa/common/check_valgrind_log.py
+++ b/qa/common/check_valgrind_log.py
@@ -38,6 +38,7 @@ import argparse
 #   * InferenceEngine::getAvailableCoresTypes() leak in OpenVINO could be due to
 #     https://github.com/openvinotoolkit/openvino/issues/6593. Should be fixed
 #     after version 2021.4(https://github.com/openvinotoolkit/openvino/issues/6593#issuecomment-878093502).
+#     Remove this after migrating to OpenVINO to 2022.1: DLIS-4055
 
 LEAK_WHITE_LIST = [
     'cnmem', 'tensorflow::NewSession', 'dl-init', 'dl-open', 'dlerror',

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -113,7 +113,7 @@ def infer_exact(tester,
                 use_system_shared_memory=False,
                 use_cuda_shared_memory=False,
                 priority=0,
-                timeout_us=0):
+                network_timeout=60.0):
     # Lazy shm imports...
     if use_system_shared_memory or use_cuda_shared_memory:
         import tritonclient.utils.shared_memory as shm
@@ -295,8 +295,8 @@ def infer_exact(tester,
                                        output1_dtype)
 
         if config[1] == "http":
-            triton_client = httpclient.InferenceServerClient(config[0],
-                                                             verbose=True)
+            triton_client = httpclient.InferenceServerClient(
+                config[0], verbose=True, network_timeout=network_timeout)
         else:
             triton_client = grpcclient.InferenceServerClient(config[0],
                                                              verbose=True)

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -113,6 +113,7 @@ def infer_exact(tester,
                 use_system_shared_memory=False,
                 use_cuda_shared_memory=False,
                 priority=0,
+                # 60 sec is the default value
                 network_timeout=60.0):
     # Lazy shm imports...
     if use_system_shared_memory or use_cuda_shared_memory:


### PR DESCRIPTION
Related PRs:
common: https://github.com/triton-inference-server/common/pull/67
backend: https://github.com/triton-inference-server/backend/pull/67
tensorrt_backend: https://github.com/triton-inference-server/tensorrt_backend/pull/44