### PR TITLE
Solve the problem of Chinese garbled characters when using custom metrics.

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -141,6 +141,9 @@ HTTPMetricsServer::Handle(evhtp_request_t* req)
   }
 
   evhtp_res res = EVHTP_RES_BADREQ;
+  evhtp_headers_add_header(
+      req->headers_out,
+      evhtp_header_new(kContentTypeHeader, "text/plain; charset=utf-8", 1, 1));
 
   // Call to metric endpoint should not have any trailing string
   if (RE2::FullMatch(std::string(req->uri->path->full), api_regex_)) {


### PR DESCRIPTION
When an attribute with Chinese character is added to the custom metrics, garbled characters will appear on the web page, as the following example.
```
# HELP triton_custom_metrics Some business information triton_custom_metrics
# TYPE triton_custom_metrics counter
triton_custom_metrics{project_name="猫鈧伱┾€溌�"} 1.000000
```
Just setting content type to `text/plain; charset=utf-8` in the http header can solve this problem.