### PR TITLE
Escape double quote for trace JSON byte tensor data output

### DIFF
--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -575,7 +575,7 @@ TraceManager::TraceTensorActivity(
           return;
         }
         std::string str(cbase + offset, len);
-        *ss << "\"" << str << "\"";
+        *ss << "\\\"" << str << "\\\"";
         offset += len;
 
         if (e < (element_count - 1))


### PR DESCRIPTION
Fix issue [4636](https://github.com/triton-inference-server/server/issues/4636).

The JSON byte tensor data output **before fix**: 
```
[
  {
    "id":1,
    "activity":"TENSOR_QUEUE_INPUT",
    "tensor":{"name":"inputs","data":""a","b"","shape":"2,1","dtype":"BYTES"}
  },
  {
    "id":1,
    "activity":"TENSOR_BACKEND_OUTPUT",
    "tensor":{"name":"input_ids","data":"97,98","shape":"2","dtype":"INT32"}
  }
]
```
Notice the `TENSOR_QUEUE_INPUT` `tensor` `data`, `""a","b""`, is invalid.

**After fix**:
```
[
  {
    "id":1,
    "activity":"TENSOR_QUEUE_INPUT",
    "tensor":{"name":"inputs","data":"\"a\",\"b\"","shape":"2,1","dtype":"BYTES"}
  },
  {
    "id":1,
    "activity":"TENSOR_BACKEND_OUTPUT",
    "tensor":{"name":"input_ids","data":"97,98","shape":"2","dtype":"INT32"}
  }
]
```
```
$ cat trace.json | jq
[
  {
    "id": 1,
    "activity": "TENSOR_QUEUE_INPUT",
    "tensor": {
      "name": "inputs",
      "data": "\"a\",\"b\"",
      "shape": "2,1",
      "dtype": "BYTES"
    }
  },
  {
    "id": 1,
    "activity": "TENSOR_BACKEND_OUTPUT",
    "tensor": {
      "name": "input_ids",
      "data": "97,98",
      "shape": "2",
      "dtype": "INT32"
    }
  }
]
$ 
```