### PR TITLE
fix: Update to support parsing string tensor data

### DIFF
--- a/qa/common/trace_summary.py
+++ b/qa/common/trace_summary.py
@@ -27,8 +27,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import csv
 import json
-import sys
 import numpy as np
 
 FLAGS = None
@@ -389,7 +389,10 @@ TRITON_TYPE_TO_NUMPY = {
 
 def get_numpy_array(tensor):
     dtype = TRITON_TYPE_TO_NUMPY[tensor["dtype"]]
-    value = map(float, tensor["data"].split(","))
+    if dtype == np.object_:
+        value = next(csv.reader([tensor["data"]], skipinitialspace=True))
+    else:
+        value = map(float, tensor["data"].split(","))
     shape = map(int, tensor["shape"].split(","))
     array = np.array(list(value), dtype=dtype)
     array = array.reshape(list(shape))


### PR DESCRIPTION
Fixes: #4720 

Added support for splitting strings in `get_numpy_array` using python csv import, example 

```
>>> import csv
>>> next(csv.reader(['"3", "a, b", "C"'], skipinitialspace=True))
['3', 'a, b', 'C']
```