### PR TITLE
Add --metrics-address to specify a listening address specifically for the metrics server

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1478,6 +1478,10 @@ Parse(TRITONSERVER_ServerOptions** server_options, int argc, char** argv)
         break;
       case OPTION_HTTP_ADDRESS:
         http_address = optarg;
+        // Use the same address for the metrics server if it was not changed already
+        if (metrics_address == metrics_address_) {
+          metrics_address = optarg;
+        }
         break;
       case OPTION_HTTP_THREAD_COUNT:
         http_thread_cnt = ParseIntOption(optarg);


### PR DESCRIPTION
Currently both the HTTP API and Prometheus metrics server listen on the same address specified using `--http-address`, but there are scenarios where you may want to expose the HTTP API only on localhost, and make the metrics more publicly accessible for Prometheus to scrape.

The existing implementation also prevents you from changing the address of the metrics server if the HTTP API is disabled (`TRITON_ENABLE_HTTP` unset), since the `--http-address` flag is not available in that case.

This PR introduces a new command line parameter `--metrics-address` that allows you to specify an address specifically for the Prometheus metrics server, which may be different from the `--http-address`.

I've implemented it to not be a breaking change; if you only specify `--http-address` without `--metrics-address` then the metrics server will listen on the same address as the HTTP server, just like the existing behavior.