### PR TITLE
Fix MacOS ARM docker building

### DIFF
--- a/build.py
+++ b/build.py
@@ -841,7 +841,9 @@ RUN curl -o /tmp/cuda-keyring.deb \
 
 def install_miniconda(conda_version, target_machine):
     if target_machine == "arm64":
-        # Arm architecture on MacOS named arm64
+        # This branch used for the case when linux container builds on MacOS with ARM chip
+        # macos arm arch names "arm64" when in linux it's names "aarch64".
+        # So we just replace the architecture to able find right conda version for Linux 
         target_machine = "aarch64"
     if conda_version == '':
         fail(

--- a/build.py
+++ b/build.py
@@ -840,6 +840,9 @@ RUN curl -o /tmp/cuda-keyring.deb \
 
 
 def install_miniconda(conda_version, target_machine):
+    if target_machine == "arm64":
+        # Arm architecture on MacOS named arm64
+        target_machine = "aarch64"
     if conda_version == '':
         fail(
             'unable to determine default repo-tag, CONDA version not known for {}'


### PR DESCRIPTION
This little fix allows to build `tritonserver` docker image on MacOS with M-series chip. 
Actually in MacOS with arm chip `arch` command will return `arm64`, while on linux its returns `aarch64`, it's broke *miniconda* installing, because they have no install script for `Linux-arm64`.