### PR TITLE
Remove tagged openvino backend

### DIFF
--- a/compose.py
+++ b/compose.py
@@ -106,10 +106,6 @@ COPY --chown=1000:1000 --from=full /opt/tritonserver/include include/
 def add_requested_backends(ddir, dockerfile_name, backends):
     df = "# Copying over backends \n"
     for backend in backends:
-        if backend == 'openvino':
-            import build
-            ver = next(iter(build.TRITON_VERSION_MAP.values()))
-            backend = build.tagged_backend(backend, ver[4][0])
         df += '''COPY --chown=1000:1000 --from=full /opt/tritonserver/backends/{} /opt/tritonserver/backends/{}
 '''.format(backend, backend)
     if len(backends) > 0:


### PR DESCRIPTION
After upgrading openvino to 2022.1, the `build.py` no longer requires tagged openvino backend. This PR removes the tagged openvino backend from `compose.py` as well.