### PR TITLE
[Temporary Fix] TensorRT Plugin Generation

### DIFF
--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -465,7 +465,7 @@ chmod -R 777 $FORMATDESTDIR
 # FIXME: [DLIS-4138] Once TensorRT uploads a new custom sample plugin they maintain, we should switch to
 # that one. This uses the provided plugin code from Release 8.4. This could break when TensorRT makes 
 # changes to their plugin code.
-(git clone https://github.com/NVIDIA/TensorRT.git && \
+(git clone -b release/8.4 https://github.com/NVIDIA/TensorRT.git && \
 cd /workspace/TensorRT/samples/python/uff_custom_plugin && cmake . && make && \
 cp libclipplugin.so $PLGDESTDIR/.)
 LD_PRELOAD=$PLGDESTDIR/libclipplugin.so python3 $SRCDIR/gen_qa_trt_plugin_models.py --models_dir=$PLGDESTDIR

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -461,8 +461,12 @@ python3 $SRCDIR/gen_qa_ragged_models.py --tensorrt --models_dir=$RAGGEDDESTDIR
 chmod -R 777 $RAGGEDDESTDIR
 python3 $SRCDIR/gen_qa_trt_format_models.py --models_dir=$FORMATDESTDIR
 chmod -R 777 $FORMATDESTDIR
-# make shared library for custom clip plugin
-(cd /workspace/tensorrt/samples/python/uff_custom_plugin && cmake . && make && \
+# Make shared library for custom clip plugin.
+# FIXME: [DLIS-4138] Once TensorRT uploads a new custom sample plugin they maintain, we should switch to
+# that one. This uses the provided plugin code from Release 8.4. This could break when TensorRT makes 
+# changes to their plugin code.
+(git clone https://github.com/NVIDIA/TensorRT.git && \
+cd /workspace/TensorRT/samples/python/uff_custom_plugin && cmake . && make && \
 cp libclipplugin.so $PLGDESTDIR/.)
 LD_PRELOAD=$PLGDESTDIR/libclipplugin.so python3 $SRCDIR/gen_qa_trt_plugin_models.py --models_dir=$PLGDESTDIR
 chmod -R 777 $PLGDESTDIR


### PR DESCRIPTION
TensorRT removed their custom clip plugin sample, so this ticket switches model generation to use their 8.4 Release code. I checked with an engineer on their team and they don't foresee issues. They should be providing a new custom plugin sample in an upcoming TensorRT release.