### PR TITLE
Fix broken links after refactor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ The User Guide describes how to configure Triton, organize and configure your mo
 * Buillding a Model Pipeline [[Overview](README.md#model-pipeline)]
 * Managing Model Availablity [[Overview](README.md#model-management) || [Details](user_guide/model_management.md)]
 * Collecting Server Metrics [[Overview](README.md#metrics) || [Details](user_guide/metrics.md)]
-* Supporting Custom Ops/layers [[Overview](README.md#framework-custom-operations) || [Details]((user_guide/custom_operations.md))]
+* Supporting Custom Ops/layers [[Overview](README.md#framework-custom-operations) || [Details](user_guide/custom_operations.md)]
 * Using the Client API [[Overview](README.md#client-libraries-and-examples) || [Details](https://github.com/triton-inference-server/client)]
 * Analyzing Performance [[Overview](README.md#performance-analysis)]
 * Deploying on edge (Jetson) [[Overview](README.md#jetson-and-jetpack)]
@@ -133,7 +133,7 @@ Rate limiter manages the rate at which requests are scheduled on model instances
 For a few of the Backends (check [Additional Resources](README.md#resources)) some or all of intialization is deffered till the first inference request is received, the benefit is resource conservation but comes with the downside of the initial requests getting processed slower than expected. Users can pre-"warm up" the model by instructing Triton to intialize the model. [Learn more](user_guide/model_configuration.md#model-warmup). 
 
 #### Inference Request/Response Cache
-Triton has a feature which allows inference responses to get cached. [Learn More](https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md).
+Triton has a feature which allows inference responses to get cached. [Learn More](user_guide/response_cache.md).
 
 ### Model Pipeline
 Building ensembles is as easy as adding an addition configuration file which outlines the specific flow of tensors from one model to another. Any additional changes required by the model ensemble can be made in existing (individual) model configurations. 
@@ -178,7 +178,7 @@ The following resources are recommended to explore the full suite of Triton Infe
 
 - **Configuring Deployment**: Triton comes with three tools which can be used to configure deployment setting, measure performance and recommend optimizations.
   - [Model Analyzer](https://github.com/triton-inference-server/model_analyzer) Model Analyzer is CLI tool built to recommend deployment configurations for Triton Inference Server based on user's Quality of Service Requirements. It also generates detailed reports about model performance to summarize the benefits and trade offs of different configurations.
-  - [Perf Analyzer](https://github.com/triton-inference-server/server/blob/main/docs/perf_analyzer.md): Perf Analyzer is a CLI application built to generate inference requests and measures the latency of those requests and throughput of the model being served .
+  - [Perf Analyzer](user_guide/perf_analyzer.md): Perf Analyzer is a CLI application built to generate inference requests and measures the latency of those requests and throughput of the model being served .
   - [Model Navigator](https://github.com/triton-inference-server/model_navigator):
   The Triton Model Navigator is a tool that provides the ability to automate the process of moving model from source to optimal format and configuration for deployment on Triton Inference Server. The tool supports export model from source to all possible formats and applies the Triton Inference Server backend optimizations.
 

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -47,7 +47,7 @@ The Triton source is distributed across multiple GitHub repositories
 that together can be built and installed to create a complete Triton
 installation. Triton server is built using CMake and (optionally)
 Docker. To simplify the build process, Triton provides a
-[build.py](../build.py) script. The build.py script will generate the
+[build.py](../../build.py) script. The build.py script will generate the
 CMake and Docker build steps required to build Triton, and will
 optionally invoke those steps or leave the invocation to you, as
 described below.
@@ -277,7 +277,7 @@ For Windows 10, build.py supports both a Docker build and a non-Docker
 build in a similar way as described for [Ubuntu](#ubuntu). The primary
 difference is that the minimal/base image used as the base of
 Dockerfile.buildbase image can be built from the provided
-[Dockerfile.win10.min](../Dockerfile.win10.min) file as described in
+[Dockerfile.win10.min](../../Dockerfile.win10.min) file as described in
 [Windows 10 "Min" Image](#windows-10-min-image). When running build.py
 use the --image flag to specify the tag that you assigned to this
 image. For example, --image=base,win10-py3-min.
@@ -296,7 +296,7 @@ step.
 
 The "min" container describes the base dependencies needed to perform
 the Windows build. The Windows min container is
-[Dockerfile.win10.min](../Dockerfile.win10.min).
+[Dockerfile.win10.min](../../Dockerfile.win10.min).
 
 Before building the min container you must download the appropriate
 cuDNN and TensorRT versions and place them in the same directory as

--- a/docs/customization_guide/inference_protocols.md
+++ b/docs/customization_guide/inference_protocols.md
@@ -135,13 +135,13 @@ All capabilities of Triton server are encapsulated in the shared
 library and are exposed via the Server API. The `tritonserver`
 executable implements HTTP/REST and GRPC endpoints and uses the Server
 API to communicate with core Triton logic. The primary source files
-for the endpoints are [grpc_server.cc](../src/grpc_server.cc) and
-[http_server.cc](../src/http_server.cc). In these source files you can
+for the endpoints are [grpc_server.cc](../../src/grpc_server.cc) and
+[http_server.cc](../../src/http_server.cc). In these source files you can
 see the Server API being used.
 
 You can use the Server API in your own application as well. A simple
 example using the Server API can be found in
-[simple.cc](../src/simple.cc).
+[simple.cc](../../src/simple.cc).
 
 ### API Description
 
@@ -166,7 +166,7 @@ all of the features and capabilities of Triton. A
 `TRITONSERVER_Server` object is created by calling
 `TRITONSERVER_ServerNew` with a set of options that indicate how the
 object should be initialized.  Use of `TRITONSERVER_ServerNew` is
-demonstrated in [simple.cc](../src/simple.cc). Once you have created a
+demonstrated in [simple.cc](../../src/simple.cc). Once you have created a
 `TRITONSERVER_Server` object, you can begin using the rest of the
 Server API as described below.
 
@@ -185,12 +185,12 @@ the Server API function. As a result, your application is responsible
 for managing the lifecycle of the returned `TRITONSERVER_Error`
 object. You must delete the error object using
 `TRITONSERVER_ErrorDelete` when you are done using it. Macros such as
-`FAIL_IF_ERR` shown in [common.h](../src/common.h) are useful for
+`FAIL_IF_ERR` shown in [common.h](../../src/common.h) are useful for
 managing error object lifetimes.
 
 #### Versioning and Backwards Compatibility
 
-A typical pattern, demonstrated in [simple.cc](../src/simple.cc) and
+A typical pattern, demonstrated in [simple.cc](../../src/simple.cc) and
 shown below, shows how you can compare the Server API version provided
 by the shared library against the Server API version that you compiled
 your application against. The Server API is backwards compatible, so
@@ -218,14 +218,14 @@ The Server API contains functions for checking health and readiness,
 getting model information, getting model statistics and metrics,
 loading and unloading models, etc. The use of these functions is
 straightforward and some of these functions are demonstrated in
-[simple.cc](../src/simple.cc) and all are documented in
+[simple.cc](../../src/simple.cc) and all are documented in
 [tritonserver.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonserver.h).
 
 #### Inference APIs
 
 Performing an inference request requires the use of many Server API
 functions and objects, as demonstrated in
-[simple.cc](../src/simple.cc). The general usage requires the
+[simple.cc](../../src/simple.cc). The general usage requires the
 following steps.
 
 * Create a `TRITONSERVER_ResponseAllocator` using
@@ -242,7 +242,7 @@ following steps.
   `TRITONSERVER_ResponseAllocatorAllocFn_t` and
   `TRITONSERVER_ResponseAllocatorReleaseFn_t` as defined in
   [tritonserver.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonserver.h). In
-  [simple.cc](../src/simple.cc), these callback functions are
+  [simple.cc](../../src/simple.cc), these callback functions are
   implemented as `ResponseAlloc` and `ResponseRelease`.
 
 * Create an inference request as a `TRITONSERVER_InferenceRequest`
@@ -277,7 +277,7 @@ following steps.
 
   You can reuse an existing `TRITONSERVER_InferenceRequest` object for
   a new inference request. A couple of examples of how this is done
-  and why it is useful are shown in [simple.cc](../src/simple.cc).
+  and why it is useful are shown in [simple.cc](../../src/simple.cc).
 
 * Ask Triton to execute the inference request using
   `TRITONSERVER_ServerInferAsync`. `TRITONSERVER_ServerInferAsync` is
@@ -285,7 +285,7 @@ following steps.
   is returned via a callback into your application. You register this
   callback using `TRITONSERVER_InferenceRequestSetResponseCallback`
   before you invoke `TRITONSERVER_ServerInferAsync`. In
-  [simple.cc](../src/simple.cc) this callback is
+  [simple.cc](../../src/simple.cc) this callback is
   `InferResponseComplete`.
 
   When you invoke `TRITONSERVER_ServerInferAsync` and it returns
@@ -311,7 +311,7 @@ following steps.
   output tensors, and `TRITONSERVER_InferenceResponseOutput` to get
   information about each output tensor.
 
-  Note that the [simple.cc](../src/simple.cc) example uses a
+  Note that the [simple.cc](../../src/simple.cc) example uses a
   std::promise to simply wait for the response, but synchronizing
   response handling in this way is not required. You can have multiple
   inference requests in flight at the same time and can issue
@@ -322,12 +322,12 @@ is documented in
 [tritonserver.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonserver.h).
 
 A simple example using the C API can be found in
-[simple.cc](../src/simple.cc).  A more complicated example can be
+[simple.cc](../../src/simple.cc).  A more complicated example can be
 found in the source that implements the HTTP/REST and GRPC endpoints
 for Triton. These endpoints use the C API to communicate with the core
 of Triton. The primary source files for the endpoints are
-[grpc_server.cc](../src/grpc_server.cc) and
-[http_server.cc](../src/http_server.cc).
+[grpc_server.cc](../../src/grpc_server.cc) and
+[http_server.cc](../../src/http_server.cc).
 
 ## Java bindings for In-Process Triton Server API
 
@@ -341,14 +341,14 @@ generated from `tritonserver.java`.
 A simple example using the Java API can be found in
 [Samples folder](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver/samples)
 which includes `Simple.java` which is similar to 
-[`simple.cc`](https://github.com/triton-inference-server/server/blob/main/src/servers/simple.cc). 
+[`simple.cc`](../../src/simple.cc). 
 Please refer to
 [sample usage documentation](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver#sample-usage)
 to learn about how to build and run `Simple.java`.
 
-In the [QA folder](../qa), folders starting with L0_java include Java API tests.
+In the [QA folder](../../qa), folders starting with L0_java include Java API tests.
 These can be useful references for getting started, such as the
-[ResNet50 test](../qa/L0_java_resnet).
+[ResNet50 test](../../qa/L0_java_resnet).
 
 ### Java API setup instructions
 

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -44,7 +44,7 @@ Launching and maintaining Triton Inference Server revolves around the use of bui
 The [model repository](../user_guide/model_repository.md) is the directory where you
 place the models that you want Triton to serve. An example model
 repository is included in the
-[docs/examples/model_repository](examples/model_repository). Before
+[docs/examples/model_repository](../examples/model_repository). Before
 using the repository, you must fetch any missing model definition
 files from their public model zoos via the provided script.
 

--- a/docs/user_guide/architecture.md
+++ b/docs/user_guide/architecture.md
@@ -312,7 +312,7 @@ for every variable-sized dimension for the starting request. For other
 non-starting requests in the sequence, the input state is the output state of
 the previous request in the sequence. For an example ONNX model that uses
 implicit state you can refer to
-[this ONNX model](../qa/common/gen_qa_implicit_models.py#L101).
+[this ONNX model](../../qa/common/gen_qa_implicit_models.py#L101).
 This is a simple accumulator model that stores the partial sum of the requests
 in a sequence in Triton using implicit state. For state initialization, if the
 request is starting, the model sets the "OUTPUT\_STATE" to be equal to the

--- a/docs/user_guide/decoupled_models.md
+++ b/docs/user_guide/decoupled_models.md
@@ -87,10 +87,10 @@ exactly one response per request. Even standard ModelInfer RPC in the GRPC endpo
 does not support decoupled responses. In order to run inference on a decoupled
 model, the client must use the bi-directional streaming RPC. See
 [here](https://github.com/triton-inference-server/common/blob/main/protobuf/grpc_service.proto)
-for more details. The [decoupled_test.py](../qa/L0_decoupled/decoupled_test.py) demonstrates
+for more details. The [decoupled_test.py](../../qa/L0_decoupled/decoupled_test.py) demonstrates
 how the gRPC streaming can be used to infer decoupled models.
 
 If using [Triton's in-process C API](../customization_guide/inference_protocols.md#in-process-triton-server-api),
 your application should be cognizant that the callback function you registered with 
 `TRITONSERVER_InferenceRequestSetResponseCallback` can be invoked any number of times,
-each time with a new response. You can take a look at [grpc_server.cc](../src/grpc_server.cc)
+each time with a new response. You can take a look at [grpc_server.cc](../../src/grpc_server.cc)

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -48,12 +48,12 @@ leading to a streamlined deployment.
 ## Can Triton Inference Server run on systems that don't have GPUs?
 
 Yes, the QuickStart guide describes how to [run Triton on a CPU-Only
-System](quickstart.md#run-on-cpu-only-system).
+System](../getting_started/quickstart.md#run-on-cpu-only-system).
 
 ## Can Triton Inference Server be used in non-Docker environments?
 
 Yes. Triton Inference Server can also be [built from
-source](build.md#building-without-docker) on your "bare metal"
+source](../customization_guide/build.md#building-without-docker) on your "bare metal"
 system.
 
 ## Do you provide client libraries for languages other than C++ and Python?
@@ -84,7 +84,7 @@ library to suit your specific needs.
 
 In an AWS environment, the Triton Inference Server docker container
 can run on [CPU-only instances or GPU compute
-instances](quickstart.md#run-triton). Triton can run directly on the
+instances](../getting_started/quickstart.md#run-triton). Triton can run directly on the
 compute instance or inside Elastic Kubernetes Service (EKS). In
 addition, other AWS services such as Elastic Load Balancer (ELB) can
 be used for load balancing traffic among multiple Triton
@@ -155,7 +155,7 @@ available Triton instances.
 
 The NGC build is a Release build and does not contain Debug symbols. 
 The build.py as well defaults to a Release build. Refer to the instructions
-in [build.md](build.md#building-with-debug-symbols) to create a Debug build
+in [build.md](../customization_guide/build.md#building-with-debug-symbols) to create a Debug build
 of Triton. This will help find the cause of the segmentation fault when
 looking at the gdb trace for the segfault.
 

--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -92,7 +92,7 @@ Count*. The count metrics are illustrated by the following examples:
 |Count         |Success Count   |`nv_inference_request_success` |Number of successful inference requests received by Triton (each request is counted as 1, even if the request contains a batch) |Per model  |Per request  |
 |              |Failure Count   |`nv_inference_request_failure` |Number of failed inference requests received by Triton (each request is counted as 1, even if the request contains a batch) |Per model  |Per request  |
 |              |Inference Count |`nv_inference_count` |Number of inferences performed (a batch of "n" is counted as "n" inferences, does not include cached requests)|Per model|Per request|
-|              |Execution Count |`nv_inference_exec_count` |Number of inference batch executions (see [Count Metrics](#count-metrics), does not include cached requests)|Per model|Per request|
+|              |Execution Count |`nv_inference_exec_count` |Number of inference batch executions (see [Inference Request Metrics](#inference-request-metrics), does not include cached requests)|Per model|Per request|
 |Latency       |Request Time    |`nv_inference_request_duration_us` |Cumulative end-to-end inference request handling time (includes cached requests) |Per model  |Per request  |
 |              |Queue Time      |`nv_inference_queue_duration_us` |Cumulative time requests spend waiting in the scheduling queue (includes cached requests) |Per model  |Per request  |
 |              |Compute Input Time|`nv_inference_compute_input_duration_us` |Cumulative time requests spend processing inference inputs (in the framework backend, does not include cached requests)     |Per model  |Per request  |
@@ -135,7 +135,7 @@ If building Triton locally, the `TRITON_ENABLE_METRICS_CPU` CMake build flag can
 
 Compute latency metrics in the [Inference Request Metrics table](#inference-request-metrics) above are calculated for the
 time spent in model inference backends. If the response cache is enabled for a
-given model (see [Response Cache](https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md)
+given model (see [Response Cache](response_cache.md)
 docs for more info), total inference times may be affected by response cache
 lookup times.
 

--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -301,7 +301,7 @@ include a `backend` field or your model name must be in the
 form `<model_name>.<backend_name>`.
 
 You can also see the model configuration generated for a model by
-Triton using the [model configuration endpoint](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_model_configuration.md). The
+Triton using the [model configuration endpoint](../protocol/extension_model_configuration.md). The
 easiest way to do this is to use a utility like *curl*:
 
 ```bash
@@ -333,7 +333,7 @@ dynamic batching in their generated model configurations are:
 3. [TensorRT backend](https://github.com/triton-inference-server/tensorrt_backend)
    1. TensorRT models store the maximum batch size explicitly and do not make use
    of the default-max-batch-size parameter. However, if max_batch_size > 1 
-   and no [scheduler](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#scheduling-and-batching)
+   and no [scheduler](model_configuration.md#scheduling-and-batching)
    is provided, the dynamic batch scheduler will be enabled.
    
 If a value greater than 1 for the maximum batch size is set for the 
@@ -1015,7 +1015,7 @@ response_cache {
 ```
 
 See the [Response
-Cache](https://github.com/triton-inference-server/server/blob/main/docs/response_cache.md)
+Cache](response_cache.md)
 and [ModelConfig
 protobuf](https://github.com/triton-inference-server/common/blob/main/protobuf/model_config.proto).
 docs for more information.

--- a/docs/user_guide/model_management.md
+++ b/docs/user_guide/model_management.md
@@ -43,7 +43,7 @@ UNAVAILABLE and will not be available for inferencing.
 
 Changes to the model repository while the server is running will be
 ignored. Model load and unload requests using the [model control
-protocol](protocol/extension_model_repository.md) will have no affect
+protocol](../protocol/extension_model_repository.md) will have no affect
 and will return an error response.
 
 This model control mode is selected by specifying
@@ -64,7 +64,7 @@ UNAVAILABLE and will not be available for inferencing.
 
 After startup, all model load and unload actions must be initiated
 explicitly by using the [model control
-protocol](protocol/extension_model_repository.md). The response
+protocol](../protocol/extension_model_repository.md). The response
 status of the model control request indicates success or failure of
 the load or unload action. When attempting to reload an already loaded
 model, if the reload fails for any reason the already loaded model
@@ -97,7 +97,7 @@ polling interval with the `--repository-poll-secs` option. The console
 log or the [model ready
 protocol](https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/required_api.md)
 or the index operation of the [model control
-protocol](protocol/extension_model_repository.md) can be used to
+protocol](../protocol/extension_model_repository.md) can be used to
 determine when model repository changes have taken effect.
 
 **WARNING: There is no synchronization between when Triton polls the
@@ -107,7 +107,7 @@ to unexpected behavior. For this reason POLL mode is not recommended
 for use in production environments.**
 
 Model load and unload requests using the [model control
-protocol](protocol/extension_model_repository.md) will have no affect
+protocol](../protocol/extension_model_repository.md) will have no affect
 and will return an error response.
 
 This model control mode is enabled by specifying
@@ -156,7 +156,7 @@ allowed on the contents of a model's sub-directory varies depending on
 how Triton is using that model. The state of a model can be determined
 by using the [model
 metadata](../customization_guide/inference_protocols.md#inference-protocols-and-apis) or
-[repository index](protocol/extension_model_repository.md#index) APIs.
+[repository index](../protocol/extension_model_repository.md#index) APIs.
 
 * If the model is actively loading or unloading, no files or
 directories within that sub-directory must be added, removed or

--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -76,7 +76,7 @@ corresponding model. The config.pbtxt file describes the [model
 configuration](model_configuration.md) for the model. For some models,
 config.pbtxt is required while for others it is optional. See
 [Auto-Generated Model
-Configuration](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#auto-generated-model-configuration) 
+Configuration](model_configuration.md#auto-generated-model-configuration) 
 for more information.
 
 Each <model-name> directory must have at least one numeric

--- a/docs/user_guide/optimization.md
+++ b/docs/user_guide/optimization.md
@@ -32,7 +32,7 @@ The Triton Inference Server has many features that you can use to
 decrease latency and increase throughput for your model. This section
 discusses these features and demonstrates how you can use them to
 improve the performance of your model. As a prerequisite you should
-follow the [QuickStart](quickstart.md) to get Triton and client
+follow the [QuickStart](../getting_started/quickstart.md) to get Triton and client
 examples running with the example model repository.
 
 This section focuses on understanding latency and throughput tradeoffs
@@ -49,10 +49,10 @@ performance.
 
 As a running example demonstrating the optimization features and
 options, we will use a TensorFlow Inception model that you can obtain
-by following the [QuickStart](quickstart.md). As a baseline we use
+by following the [QuickStart](../getting_started/quickstart.md). As a baseline we use
 perf_analyzer to determine the performance of the model using a [basic
 model configuration that does not enable any performance
-features](examples/model_repository/inception_graphdef/config.pbtxt).
+features](../examples/model_repository/inception_graphdef/config.pbtxt).
 
 ```
 $ perf_analyzer -m inception_graphdef --percentile=95 --concurrency-range 1:4
@@ -91,7 +91,7 @@ larger batch that will often execute much more efficiently than
 executing the individual requests independently. To enable the dynamic
 batcher stop Triton, add the following line to the end of the [model
 configuration file for
-inception_graphdef](examples/model_repository/inception_graphdef/config.pbtxt),
+inception_graphdef](../examples/model_repository/inception_graphdef/config.pbtxt),
 and then restart Triton.
 
 ```
@@ -159,7 +159,7 @@ remove any dynamic batching settings you may have previously added to
 the model configuration (we discuss combining dynamic batcher and
 multiple model instances below), add the following lines to the end of
 the [model configuration
-file](examples/model_repository/inception_graphdef/config.pbtxt), and
+file](../examples/model_repository/inception_graphdef/config.pbtxt), and
 then restart Triton.
 
 ```
@@ -222,10 +222,10 @@ policy](model_configuration.md#optimization-policy).
 One especially powerful optimization is to use TensorRT in
 conjunction with an ONNX model. As an example of TensorRT optimization
 applied to an ONNX model, we will use an ONNX DenseNet model that you
-can obtain by following [QuickStart](quickstart.md). As a baseline we
+can obtain by following [QuickStart](../getting_started/quickstart.md). As a baseline we
 use perf_analyzer to determine the performance of the model using a
 [basic model configuration that does not enable any performance
-features](examples/model_repository/densenet_onnx/config.pbtxt).
+features](../examples/model_repository/densenet_onnx/config.pbtxt).
 
 ```
 $ perf_analyzer -m densenet_onnx --percentile=95 --concurrency-range 1:4
@@ -310,10 +310,10 @@ section of the model configuration protobuf.
 
 As an example of TensorRT optimization applied to a TensorFlow model,
 we will use a TensorFlow Inception model that you can obtain by
-following the [QuickStart](quickstart.md). As a baseline we use
+following the [QuickStart](../getting_started/quickstart.md). As a baseline we use
 perf_analyzer to determine the performance of the model using a [basic
 model configuration that does not enable any performance
-features](examples/model_repository/inception_graphdef/config.pbtxt).
+features](../examples/model_repository/inception_graphdef/config.pbtxt).
 
 ```
 $ perf_analyzer -m inception_graphdef --percentile=95 --concurrency-range 1:4
@@ -379,8 +379,9 @@ to evaluate the model's performance with and without the optimization.
 
 Many modern CPUs are composed of multiple cores, memories and interconnects that
 expose different performance characteristics depending on how threads and
-data are allocated [cite https://www.kernel.org/doc/html/latest/vm/numa.html].
-Triton allows you to set host policies that describe this NUMA configuration for
+data are allocated.
+Triton allows you to set host policies that describe this
+[NUMA](https://www.kernel.org/doc/html/latest/mm/numa.html) configuration for
 your system and then assign model instances to different host policies
 to exploit these NUMA properties.
 

--- a/docs/user_guide/perf_analyzer.md
+++ b/docs/user_guide/perf_analyzer.md
@@ -568,7 +568,7 @@ TensorFlow Session. There is a resource limit on the number of
 concurrent threads serving requests. When benchmarking at a higher
 request concurrency, you can see higher throughput because of this.  
 Unlike TFS, by default Triton is configured with only a single
-[instance count](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#instance-groups). Hence, at a higher request concurrency, most
+[instance count](model_configuration.md#instance-groups). Hence, at a higher request concurrency, most
 of the requests are blocked on the instance availability. To
 configure Triton to behave like TFS, set the instance count to a
 reasonably high value and then set
@@ -657,7 +657,7 @@ that are optimized for Triton.
 Using third-party benchmark suites like jmeter fails to take advantage of the
 optimized libraries. Some of these optimizations includes but are not limited
 to:
-1. Using [binary tensor data extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_binary_data.md) with HTTP requests.
+1. Using [binary tensor data extension](../protocol/extension_binary_data.md) with HTTP requests.
 2. Effective re-use of gRPC message allocation in subsequent requests.
 3. Avoiding extra memory copy via libcurl interface.
 

--- a/docs/user_guide/performance_tuning.md
+++ b/docs/user_guide/performance_tuning.md
@@ -38,18 +38,18 @@ For those who wish to jump right in, skip to the [end-to-end example](#end-to-en
 ## Overview
 
 1. Is my model compatible with Triton?
-    - If your model falls under one of Triton's [supported backends](https://github.com/triton-inference-server/backend), then we can simply try to deploy the model as described in the [Quickstart](https://github.com/triton-inference-server/server/blob/main/docs/quickstart.md) guide. 
-    For the ONNXRuntime, TensorFlow SavedModel, and TensorRT backends, the minimal model configuration can be inferred from the model using Triton's [AutoComplete](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#auto-generated-model-configuration) feature. 
+    - If your model falls under one of Triton's [supported backends](https://github.com/triton-inference-server/backend), then we can simply try to deploy the model as described in the [Quickstart](../getting_started/quickstart.md) guide. 
+    For the ONNXRuntime, TensorFlow SavedModel, and TensorRT backends, the minimal model configuration can be inferred from the model using Triton's [AutoComplete](model_configuration.md#auto-generated-model-configuration) feature. 
     This means that a `config.pbtxt` may still be provided, but is not required unless you want to explicitly set certain parameters. 
     Additionally, by enabling verbose logging via `--log-verbose=1`, you can see the complete config that Triton sees internally in the server log output. 
-    For other backends, refer to the [Minimal Model Configuration](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#minimal-model-configuration) required to get started.
+    For other backends, refer to the [Minimal Model Configuration](model_configuration.md#minimal-model-configuration) required to get started.
     - If your model does not come from a supported backend, you can look into the [Python Backend](https://github.com/triton-inference-server/python_backend) or writing a [Custom C++ Backend](https://github.com/triton-inference-server/backend/blob/main/examples/README.md) to support your model. 
     The Python Backend provides a simple interface to execute requests through a generic python script, but may not be as performant as a Custom C++ Backend. 
     Depending on your use case, the Python Backend performance may be a sufficient tradeoff for the simplicity of implementation.
 
 2. Can I run inference on my served model?
     - Assuming you were able to load your model on Triton, the next step is to verify that we can run inference requests and get a baseline performance benchmark of your model. 
-    Triton's [Perf Analyzer](https://github.com/triton-inference-server/server/blob/main/docs/perf_analyzer.md) tool specifically fits this purpose. 
+    Triton's [Perf Analyzer](perf_analyzer.md) tool specifically fits this purpose. 
     Here is a simplified output for demonstration purposes:
 
     ```
@@ -69,12 +69,12 @@ For those who wish to jump right in, skip to the [end-to-end example](#end-to-en
     - The definition of "performing well" is subject to change for each use case. 
     Some common metrics are throughput, latency, and GPU utilization. 
     There are many variables that can be tweaked just within your model configuration (`config.pbtxt`) to obtain different results.
-    - As your model, config, or use case evolves, [Perf Analyzer](https://github.com/triton-inference-server/server/blob/main/docs/perf_analyzer.md) is a great tool to quickly verify model functionality and performance.
+    - As your model, config, or use case evolves, [Perf Analyzer](perf_analyzer.md) is a great tool to quickly verify model functionality and performance.
 
 3. How can I improve my model performance?
     - To further understand the best model configuration you can provide to Triton for your use case, Triton's [Model Analyzer](https://github.com/triton-inference-server/model_analyzer) tool can help. 
     Model Analyzer can automatically or [manually](https://github.com/triton-inference-server/model_analyzer/blob/main/docs/config_search.md) search through config combinations to find the optimal triton configuration to meet your constraints.
-    After running Model Analyzer to find the optimal configurations for your model/use case, you can transfer the generated config files to your [Model Repository](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md). 
+    After running Model Analyzer to find the optimal configurations for your model/use case, you can transfer the generated config files to your [Model Repository](model_repository.md). 
     Model Analyzer provides a [Quickstart](https://github.com/triton-inference-server/model_analyzer/blob/main/docs/quick_start.md) guide with some examples to walk through.
     - Upon serving the model with the newly optimized configuration file found by Model Analyzer and running Perf Analyzer again, you should expect to find better performance numbers in most cases compared to a default config.
     - Some parameters that can be tuned for a model may not be exposed to Model Analyzer's automatic search since they don't apply to all models.
@@ -82,16 +82,16 @@ For those who wish to jump right in, skip to the [end-to-end example](#end-to-en
     The [ONNXRuntime Backend](https://github.com/triton-inference-server/onnxruntime_backend), for example, has several [parameters](https://github.com/triton-inference-server/onnxruntime_backend#model-config-options) that affect the level of parallelization when executing inference on a model. 
     These backend-specific options may be worth investigating if the defaults are not providing sufficient performance. 
     To tune custom sets of parameters, Model Analyzer supports [Manual Configuration Search](https://github.com/triton-inference-server/model_analyzer/blob/main/docs/config_search.md).
-    - To learn more about further optimizations for your model configuration, see the [Optimization](https://github.com/triton-inference-server/server/blob/main/docs/optimization.md) docs.
+    - To learn more about further optimizations for your model configuration, see the [Optimization](optimization.md) docs.
 
 ### Other Areas of Interest
 
 1. My model performs slowly when it is first loaded by Triton (cold-start penalty), what do I do?
-    - Triton exposes the ability to run [ModelWarmup](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#model-warmup) requests when first loading the model to ensure that the model is sufficiently warmed up before being marked "READY" for inference.
+    - Triton exposes the ability to run [ModelWarmup](model_configuration.md#model-warmup) requests when first loading the model to ensure that the model is sufficiently warmed up before being marked "READY" for inference.
 
 2. Why doesn't my model perform significantly faster on GPU?
     - Most official backends supported by Triton are optimized for GPU inference and should perform well on GPU out of the box.
-    - Triton exposes options for you to optimize your model further on the GPU. Triton's [Framework Specific Optimizations](https://github.com/triton-inference-server/server/blob/main/docs/optimization.md#framework-specific-optimization) goes into further detail on this topic.
+    - Triton exposes options for you to optimize your model further on the GPU. Triton's [Framework Specific Optimizations](optimization.md#framework-specific-optimization) goes into further detail on this topic.
     - Complete conversion of your model to a backend fully optimized for GPU inference such as [TensorRT](https://developer.nvidia.com/tensorrt) may provide even better results. 
     You may find more Triton-specific details about TensorRT in the [TensorRT Backend](https://github.com/triton-inference-server/tensorrt_backend).
     - If none of the above can help get sufficient GPU-accelerated performance for your model, the model may simply be better designed for CPU execution and the [OpenVINO Backend](https://github.com/triton-inference-server/openvino_backend) may help further optimize your CPU execution.
@@ -99,12 +99,12 @@ For those who wish to jump right in, skip to the [end-to-end example](#end-to-en
 ## End-to-end Example
 
 > **Note**
-> If you have never worked with Triton before, you may be interested in first checking out the [Quickstart](https://github.com/triton-inference-server/server/blob/main/docs/quickstart.md) example. 
+> If you have never worked with Triton before, you may be interested in first checking out the [Quickstart](../getting_started/quickstart.md) example. 
 > Some basic understanding of Triton may be useful for the following section, but this example is meant to be straightforward enough without prior experience.
 
 Let's take an ONNX model as our example since ONNX is designed to be a format that can be [easily exported](https://github.com/onnx/tutorials#converting-to-onnx-format) from most other frameworks.
 
-1. Create a [Model Repository](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md) and download our example `densenet_onnx` model into it.
+1. Create a [Model Repository](model_repository.md) and download our example `densenet_onnx` model into it.
 
 ```bash
 # Create model repository with placeholder for model and version 1
@@ -115,10 +115,10 @@ wget -O models/densenet_onnx/1/model.onnx
 https://contentmamluswest001.blob.core.windows.net/content/14b2744cf8d6418c87ffddc3f3127242/9502630827244d60a1214f250e3bbca7/08aed7327d694b8dbaee2c97b8d0fcba/densenet121-1.2.onnx
 ```
 
-2. Create a minimal [Model Configuration](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md) for the `densenet_onnx` model in our [Model Repository](https://github.com/triton-inference-server/server/blob/main/docs/model_repository.md) at `./models/densenet_onnx/config.pbtxt`. 
+2. Create a minimal [Model Configuration](model_configuration.md) for the `densenet_onnx` model in our [Model Repository](model_repository.md) at `./models/densenet_onnx/config.pbtxt`. 
 
 > **Note**
-> This is a slightly simplified version of another [example config](https://github.com/triton-inference-server/server/blob/main/docs/examples/model_repository/densenet_onnx/config.pbtxt) that utilizes other [Model Configuration](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md) features not necessary for this example.
+> This is a slightly simplified version of another [example config](../examples/model_repository/densenet_onnx/config.pbtxt) that utilizes other [Model Configuration](model_configuration.md) features not necessary for this example.
 
 ```protobuf
 name: "densenet_onnx"
@@ -141,7 +141,7 @@ output: [
 ```
 
 > **Note**
-> As of the 22.07 release, both Triton and Model Analyzer support fully auto-completing the config file for [backends that support it](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#auto-generated-model-configuration). 
+> As of the 22.07 release, both Triton and Model Analyzer support fully auto-completing the config file for [backends that support it](model_configuration.md#auto-generated-model-configuration). 
 > So for an ONNX model, for example, this step can be skipped unless you want to explicitly set certain parameters.
 
 3. Start server and client containers in the background
@@ -254,9 +254,9 @@ Example Model Analyzer output summary:
 | densenet_onnx_config_4 | 0 | Enabled | 5/GPU | 69.939 | 291.468 | 3966 | 58.2 |
 | densenet_onnx_config_default | 0 | Disabled | 1/GPU | 12.658 | 167.549 | 3116 | 51.3 |
 
-In the table above, we see that setting our GPU [Instance Count](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#instance-groups) to 4 allows us to achieve the highest throughput and almost lowest latency on this system. 
+In the table above, we see that setting our GPU [Instance Count](model_configuration.md#instance-groups) to 4 allows us to achieve the highest throughput and almost lowest latency on this system. 
 
-Also, note that this `densenet_onnx` model has a fixed batch-size that is explicitly specified in the first dimension of the Input/Output `dims`, therefore the `max_batch_size` parameter is set to 0 as described [here](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#maximum-batch-size). 
+Also, note that this `densenet_onnx` model has a fixed batch-size that is explicitly specified in the first dimension of the Input/Output `dims`, therefore the `max_batch_size` parameter is set to 0 as described [here](model_configuration.md#maximum-batch-size). 
 For models that support dynamic batch size, Model Analyzer would also tune the `max_batch_size` parameter.
 
 > **Warning**
@@ -277,7 +277,7 @@ cp ./results/densenet_onnx_config_3/config.pbtxt /mnt/models/densenet_onnx/
 ```
 
 Now that we have an optimized Model Configuration, we are ready to take our model to deployment. 
-For further manual tuning, read the [Model Configuration](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md) and [Optimization](https://github.com/triton-inference-server/server/blob/main/docs/optimization.md#) docs to learn more about Triton's complete set of capabilities.
+For further manual tuning, read the [Model Configuration](model_configuration.md) and [Optimization](optimization.md#) docs to learn more about Triton's complete set of capabilities.
 
 In this example, we happened to get both the highest throughput and almost lowest latency from the same configuration, but in some cases this is a tradeoff that must be made. 
 Certain models or configurations may achieve a higher throughput but also incur a higher latency in return. 

--- a/docs/user_guide/response_cache.md
+++ b/docs/user_guide/response_cache.md
@@ -75,7 +75,7 @@ configuration. **By default, no model uses response caching even if the response
 cache is enabled with the `--response-cache-byte-size` flag.** For more
 information on enabling the response cache for each model, see the [model
 configuration
-docs](https://github.com/triton-inference-server/server/blob/main/docs/model_configuration.md#response-cache).
+docs](model_configuration.md#response-cache).
 
 ## Replacement Policy
 
@@ -121,4 +121,4 @@ of managing the cache.
   are eligible for caching. The Sequence Batcher does not currently support
   response caching.
 - The response cache does not currently support
-  [decoupled models](https://github.com/triton-inference-server/server/blob/main/docs/decoupled_models.md).
+  [decoupled models](decoupled_models.md).

--- a/docs/user_guide/trace.md
+++ b/docs/user_guide/trace.md
@@ -46,7 +46,7 @@ trace multiple informations. Use the --help option to get more information.
 In addition to configure trace settings in command line arguments, The user may
 modify the trace setting when Triton server
 is running via the trace APIs, more information can be found in [trace
-protocol](protocol/extension_trace.md).
+protocol](../protocol/extension_trace.md).
 
 ## Supported Trace Level Option
 
@@ -137,7 +137,7 @@ including its "name", "data" and "dtype". For example:
 
 ## Trace Summary Tool
 
-An example [trace summary tool](../qa/common/trace_summary.py) can be
+An example [trace summary tool](../../qa/common/trace_summary.py) can be
 used to summarize a set of traces collected from Triton. Basic usage
 is:
 

--- a/docs/user_guide/v1_to_v2.md
+++ b/docs/user_guide/v1_to_v2.md
@@ -61,7 +61,7 @@ version 2.
   more information.
 
 * Building Triton has changed significantly in version 2. See
-  [build](build.md) for more information.
+  [build](../customization_guide/build.md) for more information.
 
 * In the Docker containers the environment variables indicating the
   Triton version have changed to have a TRITON prefix, for example,


### PR DESCRIPTION
Used [markdown-link-checker](https://github.com/tcort/markdown-link-check) to scrape through the docs for broken links.

example:
```bash
for f in $(ls); do 
  docker run -v ${HOME}:/mnt:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /mnt/triton/main/server/docs/user_guide/$f 
  echo -e "\n===============\n===============\n"; 
done
```

I'm sure links in other repos will be broken as well and should be fixed.