### PR TITLE
Remove beta tag from cache doc

### DIFF
--- a/docs/user_guide/response_cache.md
+++ b/docs/user_guide/response_cache.md
@@ -28,8 +28,6 @@
 
 # Triton Response Cache
 
-**This feature is currently in beta and may be subject to change.**
-
 ## Overview
 
 In this document an *inference request* is the model name, model version, and


### PR DESCRIPTION
Looks like beta tag was re-added in the doc rework PR accidentally, so removing it again.