### PR TITLE
Revert "Use special ORT branch 'tensorrt-8.5ea' brought in by the ORT 1.12.1 release to make use of the built-in tensorrt parser."

### DIFF
--- a/build.py
+++ b/build.py
@@ -70,7 +70,7 @@ TRITON_VERSION_MAP = {
     '2.27.0dev': (
         '22.10dev',  # triton container
         '22.08',  # upstream container
-        '1.12.1',  # ORT
+        '1.12.0',  # ORT
         '2022.1.0',  # ORT OpenVINO
         '2022.1.0',  # Standalone OpenVINO
         '2.2.9',  # DCGM version


### PR DESCRIPTION
Reverts triton-inference-server/server#4816