### PR TITLE
Remove OpenVINO from mem leak whitelist

### DIFF
--- a/qa/L0_client_memory_growth/test.sh
+++ b/qa/L0_client_memory_growth/test.sh
@@ -135,8 +135,8 @@ for PROTOCOL in http grpc; do
         else
             python3 ../common/check_valgrind_log.py -f $LEAKCHECK_LOG
             if [ $? -ne 0 ]; then
-            echo -e "\n***\n*** Memory leak detected\n***"
-            RET=1
+                echo -e "\n***\n*** Memory leak detected\n***"
+                RET=1
             fi
 
             set +e

--- a/qa/L0_client_valgrind/test.sh
+++ b/qa/L0_client_valgrind/test.sh
@@ -87,8 +87,8 @@ for PROTOCOL in http grpc; do
         else
             python3 ../common/check_valgrind_log.py -f $LEAKCHECK_LOG
             if [ $? -ne 0 ]; then
-            echo -e "\n***\n*** Memory leak detected\n***"
-            RET=1
+                echo -e "\n***\n*** Memory leak detected\n***"
+                RET=1
             fi
         fi
     done

--- a/qa/common/check_valgrind_log.py
+++ b/qa/common/check_valgrind_log.py
@@ -35,14 +35,10 @@ import argparse
 #     -> tensorflow::LibHDFS::LoadAndBind()::{lambda(char const*, void**)#1}::operator()(char const*, void**)
 #     -> tensorflow::internal::LoadLibrary
 #     -> dlerror
-#   * InferenceEngine::getAvailableCoresTypes() leak in OpenVINO could be due to
-#     https://github.com/openvinotoolkit/openvino/issues/6593. Should be fixed
-#     after version 2021.4(https://github.com/openvinotoolkit/openvino/issues/6593#issuecomment-878093502).
-#     Remove this after migrating to OpenVINO to 2022.1: DLIS-4055
 
 LEAK_WHITE_LIST = [
     'cnmem', 'tensorflow::NewSession', 'dl-init', 'dl-open', 'dlerror',
-    'libtorch', 'InferenceEngine::getAvailableCoresTypes()'
+    'libtorch'
 ]
 
 


### PR DESCRIPTION
After upgrading OpenVINO from 2021.x to 2022.1, `InferenceEngine` is no longer used by the openvino_backend, so the memory leak from 2021.x is no longer an issue.