### PR TITLE
Initialize Local Request ID to Empty String

### DIFF
--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3896,7 +3896,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           "unable to retrieve request ID string");
     }
 
-    if ((request_id == "") || (request_id[0] == '\0')) {
+    if ((!strcmp(request_id, "")) || (request_id[0] == '\0')) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {
@@ -4324,7 +4324,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
-    if ((request_id == "") || (request_id[0] == '\0')) {
+    if (!strcmp(request_id, "") || (request_id[0] == '\0')) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3889,14 +3889,14 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           InferResponseComplete, reinterpret_cast<void*>(state));
     }
     // Get request ID for logging in case of error.
-    const char* request_id = nullptr;
+    const char* request_id = "";
     if (irequest != nullptr) {
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
     }
 
-    if ((request_id == nullptr) || (request_id[0] == '\0')) {
+    if ((request_id == "") || (request_id[0] == '\0')) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {
@@ -4320,11 +4320,11 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           StreamInferResponseComplete, reinterpret_cast<void*>(state));
     }
     // Get request ID for logging in case of error.
-    const char* request_id = nullptr;
+    const char* request_id = "";
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
-    if ((request_id == nullptr) || (request_id[0] == '\0')) {
+    if ((request_id == "") || (request_id[0] == '\0')) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3896,7 +3896,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           "unable to retrieve request ID string");
     }
 
-    if ((!strcmp(request_id, "")) || (request_id[0] == '\0')) {
+    if ((!strncmp(request_id, "", 1))) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {
@@ -4324,7 +4324,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     LOG_TRITONSERVER_ERROR(
         TRITONSERVER_InferenceRequestId(irequest, &request_id),
         "unable to retrieve request ID string");
-    if (!strcmp(request_id, "") || (request_id[0] == '\0')) {
+    if (!strncmp(request_id, "", 1)) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -3896,7 +3896,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
           "unable to retrieve request ID string");
     }
 
-    if ((!strncmp(request_id, "", 1))) {
+    if (!strncmp(request_id, "", 1)) {
       request_id = "<id_unknown>";
     }
     if (err == nullptr) {

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2883,7 +2883,7 @@ HTTPAPIServer::HandleInfer(
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      if ((!strncmp(request_id, "", 1))) {
+      if (!strncmp(request_id, "", 1)) {
         request_id = "<id_unknown>";
       }
       if (err == nullptr) {

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2883,7 +2883,7 @@ HTTPAPIServer::HandleInfer(
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      if ((request_id == "") || (request_id[0] == '\0')) {
+      if ((!strcmp(request_id, "")) || (request_id[0] == '\0')) {
         request_id = "<id_unknown>";
       }
       if (err == nullptr) {
@@ -3067,7 +3067,7 @@ HTTPAPIServer::InferRequestClass::FinalizeResponse(
 
   const char* request_id = "";
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseId(response, &request_id));
-  if ((request_id != "") && (request_id[0] != '\0')) {
+  if ((strcmp(request_id, "")) && (request_id[0] != '\0')) {
     RETURN_IF_ERR(response_json.AddStringRef("id", request_id));
   }
 

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2883,7 +2883,7 @@ HTTPAPIServer::HandleInfer(
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      if ((!strcmp(request_id, "")) || (request_id[0] == '\0')) {
+      if ((!strncmp(request_id, "", 1))) {
         request_id = "<id_unknown>";
       }
       if (err == nullptr) {
@@ -3067,7 +3067,7 @@ HTTPAPIServer::InferRequestClass::FinalizeResponse(
 
   const char* request_id = "";
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseId(response, &request_id));
-  if ((strcmp(request_id, "")) && (request_id[0] != '\0')) {
+  if ((strncmp(request_id, "", 1))) {
     RETURN_IF_ERR(response_json.AddStringRef("id", request_id));
   }
 

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3067,7 +3067,7 @@ HTTPAPIServer::InferRequestClass::FinalizeResponse(
 
   const char* request_id = "";
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseId(response, &request_id));
-  if ((strncmp(request_id, "", 1))) {
+  if (strncmp(request_id, "", 1)) {
     RETURN_IF_ERR(response_json.AddStringRef("id", request_id));
   }
 

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2843,7 +2843,7 @@ HTTPAPIServer::HandleInfer(
       err = GetInferenceHeaderLength(req, content_length, &header_length);
     }
   }
-  const char* request_id = nullptr;
+  const char* request_id = "";
 
   if (err == nullptr) {
     connection_paused = true;
@@ -2883,7 +2883,7 @@ HTTPAPIServer::HandleInfer(
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");
-      if ((request_id == nullptr) || (request_id[0] == '\0')) {
+      if ((request_id == "") || (request_id[0] == '\0')) {
         request_id = "<id_unknown>";
       }
       if (err == nullptr) {
@@ -3065,9 +3065,9 @@ HTTPAPIServer::InferRequestClass::FinalizeResponse(
   triton::common::TritonJson::Value response_json(
       triton::common::TritonJson::ValueType::OBJECT);
 
-  const char* request_id = nullptr;
+  const char* request_id = "";
   RETURN_IF_ERR(TRITONSERVER_InferenceResponseId(response, &request_id));
-  if ((request_id != nullptr) && (request_id[0] != '\0')) {
+  if ((request_id != "") && (request_id[0] != '\0')) {
     RETURN_IF_ERR(response_json.AddStringRef("id", request_id));
   }
 


### PR DESCRIPTION
Initialize local request ID to empty string. This is to prevent null pointers from being accessed.