### PR TITLE
Adding the fixes for arm32

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -698,7 +698,7 @@ CheckBinaryInputData(
     triton::common::TritonJson::Value binary_data_size_json;
     if (params_json.Find("binary_data_size", &binary_data_size_json)) {
       RETURN_MSG_IF_ERR(
-          binary_data_size_json.AsUInt(byte_size),
+          binary_data_size_json.AsUInt(reinterpret_cast<uint64_t*>(byte_size)),
           "Unable to parse 'binary_data_size'");
       *is_binary = true;
     }
@@ -2521,7 +2521,7 @@ HTTPAPIServer::EVBufferToInput(
       uint64_t shm_offset;
       const char* shm_region;
       RETURN_IF_ERR(CheckSharedMemoryData(
-          request_input, &use_shm, &shm_region, &shm_offset, &byte_size));
+          request_input, &use_shm, &shm_region, &shm_offset, reinterpret_cast<uint64_t*>(&byte_size)));
       if (use_shm) {
         void* base;
         TRITONSERVER_MemoryType memory_type;

--- a/src/test/distributed_addsub/src/distributed_addsub.cc
+++ b/src/test/distributed_addsub/src/distributed_addsub.cc
@@ -661,10 +661,10 @@ TRITONBACKEND_ModelInstanceExecute(
     uint64_t input_1_byte_size = input_byte_size;
     GUARDED_RESPOND_IF_ERROR(
         responses, r,
-        ReadInputTensor(request, "INPUT0", input_0.data(), &input_0_byte_size));
+        ReadInputTensor(request, "INPUT0", input_0.data(), reinterpret_cast<size_t*>(&input_0_byte_size)));
     GUARDED_RESPOND_IF_ERROR(
         responses, r,
-        ReadInputTensor(request, "INPUT1", input_1.data(), &input_1_byte_size));
+        ReadInputTensor(request, "INPUT1", input_1.data(), reinterpret_cast<size_t*>(&input_1_byte_size)));
     if (responses[r] == nullptr) {
       LOG_MESSAGE(
           TRITONSERVER_LOG_ERROR,


### PR DESCRIPTION
I intend on using the Triton Inference server on 3 devices (amd64, arm64 and arm/v7). After trying to build the server for my arm/v7 device, I noticed that there where casting errors. I realized that I needed to make similar fixes in the backend and core repositories as well. Once all the casting issues have been solved in the 3 repos, I was able to correctly run inferences on all three of my devices.