### PR TITLE
Using alternative managed symbolic links  for library paths

### DIFF
--- a/build.py
+++ b/build.py
@@ -1101,9 +1101,9 @@ COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublas.so /usr/local/cu
 COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/libcublasLt.so.11
 
 RUN mkdir -p /usr/local/cuda/targets/{cuda_arch}-linux/lib
-COPY --from=min_container /usr/local/cuda-11.8/targets/{cuda_arch}-linux/lib/libcudart.so.11.0 /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
-COPY --from=min_container /usr/local/cuda-11.8/targets/{cuda_arch}-linux/lib/libcupti.so.11.8 /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
-COPY --from=min_container /usr/local/cuda-11.8/targets/{cuda_arch}-linux/lib/libnvToolsExt.so.1 /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
+COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libcudart.so.* /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
+COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libcupti.so.* /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
+COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libnvToolsExt.so.* /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
 
 COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.8 /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.8
 

--- a/build.py
+++ b/build.py
@@ -997,7 +997,7 @@ COPY --chown=1000:1000 docker/sagemaker/serve /usr/bin/.
     # stage of the PyTorch backend
     if not FLAGS.enable_gpu and ('pytorch' in backends):
         df += '''
-RUN patchelf --add-needed /usr/local/cuda/lib64/stubs/libcublasLt.so.11 backends/pytorch/libtorch_cuda.so
+RUN patchelf --add-needed /usr/local/cuda/lib64/stubs/libcublasLt.so backends/pytorch/libtorch_cuda.so
 '''
 
     with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
@@ -1093,21 +1093,21 @@ RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \
             cuda_arch = 'sbsa' if target_machine == 'aarch64' else 'x86_64'
             df += '''
 RUN mkdir -p /usr/local/cuda/lib64/stubs
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusparse.so /usr/local/cuda/lib64/stubs/libcusparse.so.11
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusolver.so /usr/local/cuda/lib64/stubs/libcusolver.so.11
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcurand.so /usr/local/cuda/lib64/stubs/libcurand.so.10
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcufft.so /usr/local/cuda/lib64/stubs/libcufft.so.10
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublas.so /usr/local/cuda/lib64/stubs/libcublas.so.11
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/libcublasLt.so.11
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusparse.so /usr/local/cuda/lib64/stubs/.
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusolver.so /usr/local/cuda/lib64/stubs/.
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcurand.so /usr/local/cuda/lib64/stubs/.
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcufft.so /usr/local/cuda/lib64/stubs/.
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublas.so /usr/local/cuda/lib64/stubs/.
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/.
 
 RUN mkdir -p /usr/local/cuda/targets/{cuda_arch}-linux/lib
-COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libcudart.so.* /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
-COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libcupti.so.* /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
-COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libnvToolsExt.so.* /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
+COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libcudart.so /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
+COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libcupti.so /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
+COPY --from=min_container /usr/local/cuda/targets/{cuda_arch}-linux/lib/libnvToolsExt.so /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
 
-COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.8 /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.8
+COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libcudnn.so /usr/lib/{libs_arch}-linux-gnu/libcudnn.so
 
-# patchelf is needed to add deps of libcublasLt.so.11 to libtorch_cuda.so
+# patchelf is needed to add deps of libcublasLt.so to libtorch_cuda.so
 RUN apt-get update && \
         apt-get install -y --no-install-recommends openmpi-bin patchelf
 
@@ -1122,7 +1122,7 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/targets/{cuda_arch}-linux/lib:/usr/local/cud
             # this dependency is not present in the ubuntu base image, we must
             # copy it from the Triton min container ourselves.
             df += '''
-COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libnccl.so.2 /usr/lib/{libs_arch}-linux-gnu/libnccl.so.2
+COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libnccl.so /usr/lib/{libs_arch}-linux-gnu/libnccl.so
 '''.format(libs_arch=libs_arch)
 
     # Add dependencies needed for python backend


### PR DESCRIPTION
**OBSERVATIONS:**
Triton server uses `build.py` to generate `Dockerfile` for CPU only builds.
One of the steps for it is the `COPY` library dependencies.
As of now those library dependencies are using version specific path instead of using CUDA defined symlinks with [alternatives](https://linux.die.net/man/8/alternatives) .

**HYPOTHESIS**
Change hardcoded version values to the defined alternatives.

**BENEFITS:**
Triton server build became less version agnostic