### PR TITLE
Add concurrent loading speedup test

### DIFF
--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -1631,6 +1631,8 @@ fi
 kill $SERVER_PID
 wait $SERVER_PID
 
+LOG_IDX=$((LOG_IDX+1))
+
 # LifeCycleTest.test_load_gpu_limit
 # dependency of the Python model to be used
 pip install cuda-python
@@ -1654,6 +1656,8 @@ elif [ `grep -c "expects device ID >= 0, got -1" $SERVER_LOG` == "0" ]; then
     RET=1
 fi
 
+LOG_IDX=$((LOG_IDX+1))
+
 SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit --model-load-gpu-limit 0:-0.4"
 SERVER_LOG="./inference_server_$LOG_IDX.log"
 run_server
@@ -1668,6 +1672,8 @@ elif [ `grep -c "expects limit fraction to be in range \[0.0, 1.0\], got -0.4" $
     RET=1
 fi
 
+LOG_IDX=$((LOG_IDX+1))
+
 # Run server to stop model loading if > 60% of GPU 0 memory is used
 SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit --model-load-gpu-limit 0:0.6"
 SERVER_LOG="./inference_server_$LOG_IDX.log"
@@ -1681,6 +1687,37 @@ fi
 set +e
 python $LC_TEST LifeCycleTest.test_load_gpu_limit >>$CLIENT_LOG 2>&1
 check_unit_test
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+LOG_IDX=$((LOG_IDX+1))
+
+# LifeCycleTest.test_concurrent_load_speedup
+rm -rf models config.pbtxt.*
+mkdir models
+cp -r identity_zero_1_int32 models/identity_zero_1_int32_1 && mkdir -p models/identity_zero_1_int32_1/1
+cp -r models/identity_zero_1_int32_1 models/identity_zero_1_int32_2
+sed -i "s/identity_zero_1_int32/identity_zero_1_int32_1/" models/identity_zero_1_int32_1/config.pbtxt
+sed -i "s/identity_zero_1_int32/identity_zero_1_int32_2/" models/identity_zero_1_int32_2/config.pbtxt
+
+SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit"
+SERVER_LOG="./inference_server_$LOG_IDX.log"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+python $LC_TEST LifeCycleTest.test_concurrent_load_speedup >>$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
 set -e
 
 kill $SERVER_PID

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -1695,7 +1695,7 @@ wait $SERVER_PID
 LOG_IDX=$((LOG_IDX+1))
 
 # LifeCycleTest.test_concurrent_load_speedup
-rm -rf models config.pbtxt.*
+rm -rf models
 mkdir models
 cp -r identity_zero_1_int32 models/identity_zero_1_int32_1 && mkdir -p models/identity_zero_1_int32_1/1
 cp -r models/identity_zero_1_int32_1 models/identity_zero_1_int32_2
@@ -1713,6 +1713,41 @@ fi
 
 set +e
 python $LC_TEST LifeCycleTest.test_concurrent_load_speedup >>$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+LOG_IDX=$((LOG_IDX+1))
+
+# LifeCycleTest.test_concurrent_load_unload
+rm -rf models
+mkdir models
+cp -r identity_zero_1_int32 models && mkdir -p models/identity_zero_1_int32/1
+cp -r ensemble_zero_1_float32 models && mkdir -p models/ensemble_zero_1_float32/1
+cp -r ../custom_models/custom_zero_1_float32 models/. && \
+    mkdir -p models/custom_zero_1_float32/1 && \
+    (cd models/custom_zero_1_float32 && \
+        echo "parameters [" >> config.pbtxt && \
+        echo "{ key: \"creation_delay_sec\"; value: { string_value: \"10\" }}" >> config.pbtxt && \
+        echo "]" >> config.pbtxt)
+
+SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit"
+SERVER_LOG="./inference_server_$LOG_IDX.log"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+python $LC_TEST LifeCycleTest.test_concurrent_load_unload >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -1725,6 +1725,34 @@ wait $SERVER_PID
 
 LOG_IDX=$((LOG_IDX+1))
 
+# LifeCycleTest.test_concurrent_load
+rm -rf models
+mkdir models
+cp -r identity_zero_1_int32 models && mkdir -p models/identity_zero_1_int32/1
+
+SERVER_ARGS="--model-repository=`pwd`/models --model-control-mode=explicit"
+SERVER_LOG="./inference_server_$LOG_IDX.log"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+python $LC_TEST LifeCycleTest.test_concurrent_load >>$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
+LOG_IDX=$((LOG_IDX+1))
+
 # LifeCycleTest.test_concurrent_load_unload
 rm -rf models
 mkdir models


### PR DESCRIPTION
Add a case to L0_lifecycle to ensure a speedup is observed when two models are loading in parallel.
Core PR: https://github.com/triton-inference-server/core/pull/137