### PR TITLE
Update Go Test

### DIFF
--- a/qa/L0_simple_go_client/test.sh
+++ b/qa/L0_simple_go_client/test.sh
@@ -60,8 +60,9 @@ git clone --single-branch --depth=1 -b $TRITON_COMMON_REPO_TAG \
 bash gen_go_stubs.sh
 popd
 
+# Copy to the GOPATH, where Go expects to find packages.
 PACKAGE_PATH="${GOPATH}/src/github.com/triton-inference-server"
-rm -r ${PACKAGE_PATH}/client
+rm -rf ${PACKAGE_PATH}/client
 mkdir -p ${PACKAGE_PATH}
 cp -r client $PACKAGE_PATH
 

--- a/qa/L0_simple_go_client/test.sh
+++ b/qa/L0_simple_go_client/test.sh
@@ -50,6 +50,7 @@ RET=0
 
 # Generate Go stubs.
 rm -fr client common
+## TODO: Remove branch below after CI passes
 git clone -b dyas-go-fix https://github.com/triton-inference-server/client.git
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 

--- a/qa/L0_simple_go_client/test.sh
+++ b/qa/L0_simple_go_client/test.sh
@@ -50,8 +50,7 @@ RET=0
 
 # Generate Go stubs.
 rm -fr client common
-## TODO: Remove branch below after CI passes
-git clone -b dyas-go-fix https://github.com/triton-inference-server/client.git
+git clone https://github.com/triton-inference-server/client.git
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 pushd ${GO_CLIENT_DIR}
@@ -60,7 +59,7 @@ git clone --single-branch --depth=1 -b $TRITON_COMMON_REPO_TAG \
 bash gen_go_stubs.sh
 popd
 
-# Copy to the GOPATH, where Go expects to find packages.
+# Copy packages to GOPATH, where Go expects to find packages.
 PACKAGE_PATH="${GOPATH}/src/github.com/triton-inference-server"
 rm -rf ${PACKAGE_PATH}/client
 mkdir -p ${PACKAGE_PATH}

--- a/qa/L0_simple_go_client/test.sh
+++ b/qa/L0_simple_go_client/test.sh
@@ -47,8 +47,14 @@ fi
 
 RET=0
 
+# Get Go package name from gen_go_stubs.sh in client repo
+rm -fr client
+# TODO: Remove branch after QA run
+git clone -b dyas-go-fix https://github.com/triton-inference-server/client.git
+source <(grep '^export PACKAGE.*=' client/src/grpc_generated/go/gen_go_stubs.sh)
+
 # Fix to allow global stubs import
-sed -i 's/.\/nvidia_inferenceserver/nvidia_inferenceserver/g' $SIMPLE_GO_CLIENT
+#sed -i "s/.\/$PACKAGE/$PACKAGE/g" $SIMPLE_GO_CLIENT
 
 PACKAGE_PATH="${GOPATH}/src"
 mkdir -p ${PACKAGE_PATH}
@@ -61,10 +67,9 @@ mkdir core && cp common/protobuf/*.proto core/.
 
 # Requires protoc and protoc-gen-go plugin: https://github.com/golang/protobuf#installation
 # Use "M" arguments since go_package is not specified in .proto files.
-# As mentioned here: https://developers.google.com/protocol-buffers/docs/reference/go-generated#package
-GO_PACKAGE="nvidia_inferenceserver"
-protoc -I core --go_out=plugins=grpc:${PACKAGE_PATH} --go_opt=Mgrpc_service.proto=./${GO_PACKAGE} \
-    --go_opt=Mmodel_config.proto=./${GO_PACKAGE} core/*.proto
+# As mentioned here: https://developers.google.com/protocol-buffers/docs/reference/go-generated#package)
+protoc -I core --go_out=plugins=grpc:${PACKAGE_PATH} --go_opt=Mgrpc_service.proto=./${PACKAGE} \
+    --go_opt=Mmodel_config.proto=./${PACKAGE} core/*.proto
 
 set +e
 

--- a/qa/L0_simple_go_client/test.sh
+++ b/qa/L0_simple_go_client/test.sh
@@ -54,7 +54,7 @@ git clone -b dyas-go-fix https://github.com/triton-inference-server/client.git
 source <(grep '^export PACKAGE.*=' client/src/grpc_generated/go/gen_go_stubs.sh)
 
 # Fix to allow global stubs import
-#sed -i "s/.\/$PACKAGE/$PACKAGE/g" $SIMPLE_GO_CLIENT
+sed -i "s/.\/$PACKAGE/$PACKAGE/g" $SIMPLE_GO_CLIENT
 
 PACKAGE_PATH="${GOPATH}/src"
 mkdir -p ${PACKAGE_PATH}


### PR DESCRIPTION
Update Go test to generate Go stubs and packages from the client repository. This makes it so that we have one source of truth (the client script).

This PR updates the testing so that the changes in [this client PR](github.com/triton-inference-server/client/pull/138) do not break the L0_simple_go_client test.