### PR TITLE
Provide an ability to use temporary AWS credentials in the AWS Deployment

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -107,6 +107,7 @@ $ aws s3 cp --recursive docs/examples/model_repository s3://triton-inference-ser
 ```
 
 ### AWS Model Repository
+#### Explicit credentials
 To load the model from the AWS S3, you need to convert the following AWS credentials in the base64 format and add it to the values.yaml
 
 ```
@@ -118,6 +119,9 @@ echo -n 'SECRECT_KEY_ID' | base64
 ```
 echo -n 'SECRET_ACCESS_KEY' | base64
 ```
+
+#### Assume role credentials
+Assuming a role to authenticate using temporary credentials can be achieved by ensuring that the creation of secrets above is disabled and setting the `serviceAccountName` value to name of the Kubernetes Service Account containing the the aws `role-arn` with permissions to the S3 bucket configured in `modelRepositoryPath`.
 
 ## Deploy Prometheus and Grafana
 

--- a/deploy/aws/templates/deployment.yaml
+++ b/deploy/aws/templates/deployment.yaml
@@ -47,6 +47,10 @@ spec:
         release: {{ .Release.Name }}
 
     spec:
+      {{- with .Values.serviceAccountName }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.imageName }}"
@@ -61,6 +65,7 @@ spec:
                  "--repository-poll-secs=5"]
 
           env:
+          {{- if .Values.secret.create }}
           - name: AWS_DEFAULT_REGION
             valueFrom:
               secretKeyRef:
@@ -76,6 +81,7 @@ spec:
               secretKeyRef:
                 name: aws-credentials
                 key: AWS_SECRET_ACCESS_KEY
+          {{- end }}
 
           ports:
             - containerPort: 8000

--- a/deploy/aws/templates/secrets.yaml
+++ b/deploy/aws/templates/secrets.yaml
@@ -24,12 +24,15 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+{{- with .Values.secret }}
+{{ if .create }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: aws-credentials
 type: Opaque
 data:
-  AWS_DEFAULT_REGION: {{ .Values.secret.region }}
-  AWS_ACCESS_KEY_ID: {{ .Values.secret.id }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.secret.key }}
+  AWS_DEFAULT_REGION: {{ .region }}
+  AWS_ACCESS_KEY_ID: {{ .id }}
+  AWS_SECRET_ACCESS_KEY: {{ .key }}
+{{- end }}

--- a/deploy/aws/values.yaml
+++ b/deploy/aws/values.yaml
@@ -36,6 +36,9 @@ service:
   type: LoadBalancer
 
 secret:
+  create: true
   region: AWS_REGION
   id: AWS_SECRET_KEY_ID
   key: AWS_SECRET_ACCESS_KEY
+
+serviceAccountName:


### PR DESCRIPTION
This should solve #2657.

The solution for this is to remove the secrets within the aws helm chart:
https://github.com/triton-inference-server/server/blob/main/deploy/aws/templates/secrets.yaml
https://github.com/triton-inference-server/server/blob/main/deploy/aws/templates/deployment.yaml#L64-L78

Doing so means that Triton will not use specific credentials to authenticate (https://github.com/triton-inference-server/core/blob/01f1d365d740a49268227ca5dd86cf493ba9cc89/src/filesystem.cc#L1566)

The AWS SDK will then check for numerous environment variables (https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/credentials.html#credother) and if you specify a serviceAccountName for the deployment you will automatically get these into the pod for you by EKS.

I've tested this on an EKS cluster and Triton has successfully pulled the models from the secure s3 bucket.