### PR TITLE
Document custom batching cache functions

### DIFF
--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -934,15 +934,15 @@ timeout.
 
 You can set custom batching rules that work _in addition to_ the behavior of the dynamic batcher.
 To do so, you would implement five functions in [tritonbackend.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonbackend.h) 
-and create a shared library. These functions are:
+and create a shared library. These functions are described below.
 
 | Function | Description| 
 | :--          |   :--           |
 | TRITONBACKEND_ModelBatchIncludeRequest | Determines whether a request should be included in the current batch |
 | TRITONBACKEND_ModelBatchInitialize | Initializes record-keeping data structure for a new batch |
-| TRITONBACKEND_ModelBatchFinalize | Frees memory of record-keeping data structure |
+| TRITONBACKEND_ModelBatchFinalize | Frees memory of record-keeping data structure after batch is formed |
 | TRITONBACKEND_ModelBatcherInitialize | Initializes read-only data structure for use with all batches |
-| TRITONBACKEND_ModelBatcherFinalize | Frees read-only batcher data structure |
+| TRITONBACKEND_ModelBatcherFinalize | Frees read-only batcher data structure after model is unloaded |
 
 The path to the shared library can be passed into the model configuration via the parameter 
 `TRITON_BATCH_STRATEGY_PATH`. If not provided, the dynamic batcher will look for a custom 

--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -939,10 +939,10 @@ and create a shared library. These functions are described below.
 | Function | Description| 
 | :--          |   :--           |
 | TRITONBACKEND_ModelBatchIncludeRequest | Determines whether a request should be included in the current batch |
-| TRITONBACKEND_ModelBatchInitialize | Initializes record-keeping data structure for a new batch |
-| TRITONBACKEND_ModelBatchFinalize | Frees memory of record-keeping data structure after batch is formed |
-| TRITONBACKEND_ModelBatcherInitialize | Initializes read-only data structure for use with all batches |
-| TRITONBACKEND_ModelBatcherFinalize | Frees read-only batcher data structure after model is unloaded |
+| TRITONBACKEND_ModelBatchInitialize | Initializes a record-keeping data structure for a new batch |
+| TRITONBACKEND_ModelBatchFinalize | Frees memory of the record-keeping data structure after batch is formed |
+| TRITONBACKEND_ModelBatcherInitialize | Initializes a read-only data structure for use with all batches |
+| TRITONBACKEND_ModelBatcherFinalize | Frees the read-only data structure after model is unloaded |
 
 The path to the shared library can be passed into the model configuration via the parameter 
 `TRITON_BATCH_STRATEGY_PATH`. If not provided, the dynamic batcher will look for a custom 

--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -932,13 +932,17 @@ timeout.
 
 #### Custom Batching
 
-You can set custom batching rules that work _in addition to_ the default behavior of the dynamic 
-batcher. To do so, you would implement three functions in [tritonbackend.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonbackend.h) 
-and create a shared library. These functions are `TRITONBACKEND_ModelBatchIncludeRequest`, 
-`TRITONBACKEND_ModelBatchInitialize`, and `TRITONBACKEND_ModelBatchFinalize`. 
-You can also implement  two optional functions in your shared library: 
-`TRITONBACKEND_ModelBatchCacheInitialize` and `TRITONBACKEND_ModelBatchCacheFinalize` to store 
-read-only information that is initialized once and used across batches.
+You can set custom batching rules that work _in addition to_ the behavior of the dynamic batcher.
+To do so, you would implement five functions in [tritonbackend.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonbackend.h) 
+and create a shared library. These functions are:
+
+| Function | Description| 
+| :--          |   :--           |
+| TRITONBACKEND_ModelBatchIncludeRequest | Determines whether a request should be included in the current batch |
+| TRITONBACKEND_ModelBatchInitialize | Initializes record-keeping data structure for a new batch |
+| TRITONBACKEND_ModelBatchFinalize | Frees memory of record-keeping data structure |
+| TRITONBACKEND_ModelBatcherInitialize | Initializes read-only data structure for use with all batches |
+| TRITONBACKEND_ModelBatcherFinalize | Frees read-only batcher data structure |
 
 The path to the shared library can be passed into the model configuration via the parameter 
 `TRITON_BATCH_STRATEGY_PATH`. If not provided, the dynamic batcher will look for a custom 

--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -940,9 +940,9 @@ and create a shared library. These functions are described below.
 | :--          |   :--           |
 | TRITONBACKEND_ModelBatchIncludeRequest | Determines whether a request should be included in the current batch |
 | TRITONBACKEND_ModelBatchInitialize | Initializes a record-keeping data structure for a new batch |
-| TRITONBACKEND_ModelBatchFinalize | Frees memory of the record-keeping data structure after batch is formed |
+| TRITONBACKEND_ModelBatchFinalize | Deallocates the record-keeping data structure after a batch is formed |
 | TRITONBACKEND_ModelBatcherInitialize | Initializes a read-only data structure for use with all batches |
-| TRITONBACKEND_ModelBatcherFinalize | Frees the read-only data structure after model is unloaded |
+| TRITONBACKEND_ModelBatcherFinalize | Deallocates the read-only data structure after the model is unloaded |
 
 The path to the shared library can be passed into the model configuration via the parameter 
 `TRITON_BATCH_STRATEGY_PATH`. If not provided, the dynamic batcher will look for a custom 

--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -932,7 +932,7 @@ timeout.
 
 #### Custom Batching
 
-You can set custom batching rules that work _in addition to_ the behavior of the dynamic batcher.
+You can set custom batching rules that work _in addition to_ the specified behavior of the dynamic batcher.
 To do so, you would implement five functions in [tritonbackend.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonbackend.h) 
 and create a shared library. These functions are described below.
 

--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -932,10 +932,13 @@ timeout.
 
 #### Custom Batching
 
-You can set custom batching rules that work _in addition to_ the default behavior of the dynamic
-batcher. To do so, you would implement three functions in [tritonbackend.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonbackend.h)
-and create a shared library. These functions are `TRITONBACKEND_ModelBatchIncludeRequest`,
-`TRITONBACKEND_ModelBatchInitialize`, and `TRITONBACKEND_ModelBatchFinalize`.
+You can set custom batching rules that work _in addition to_ the default behavior of the dynamic 
+batcher. To do so, you would implement three functions in [tritonbackend.h](https://github.com/triton-inference-server/core/blob/main/include/triton/core/tritonbackend.h) 
+and create a shared library. These functions are `TRITONBACKEND_ModelBatchIncludeRequest`, 
+`TRITONBACKEND_ModelBatchInitialize`, and `TRITONBACKEND_ModelBatchFinalize`. 
+You can also implement  two optional functions in your shared library: 
+`TRITONBACKEND_ModelBatchCacheInitialize` and `TRITONBACKEND_ModelBatchCacheFinalize` to store 
+read-only information that is initialized once and used across batches.
 
 The path to the shared library can be passed into the model configuration via the parameter 
 `TRITON_BATCH_STRATEGY_PATH`. If not provided, the dynamic batcher will look for a custom 

--- a/qa/L0_batch_custom/test.sh
+++ b/qa/L0_batch_custom/test.sh
@@ -51,8 +51,7 @@ SERVER=/opt/tritonserver/bin/tritonserver
 SERVER_ARGS="--model-repository=models --log-verbose 1"
 SERVER_LOG_BASE="./inference_server.log"
 TEST_RESULT_FILE='test_results.txt'
-# TODO: Update backend repo tag below to main
-TRITON_BACKEND_REPO_TAG=${TRITON_BACKEND_REPO_TAG:="dyas-custom-batching"}
+TRITON_BACKEND_REPO_TAG=${TRITON_BACKEND_REPO_TAG:="main"}
 
 source ../common/util.sh
 RET=0


### PR DESCRIPTION
This PR builds on #5177. For custom batching where the user defines additional constraints for the dynamic batcher, this PR allows the user to call two new optional functions that initialize and finalize once. This allows them to create a cached object that can be read for every batch without needing to be re-initialized.

An example use case is where the user needs to read a value from the model config for batching, so they would only want to read it from the config once and save it to use with their custom batch-handling logic. See volume_batching.cc in this PR as an example.

The server PR documents these two new functions.

Backend: https://github.com/triton-inference-server/backend/pull/76
Core: https://github.com/triton-inference-server/core/pull/149