### PR TITLE
Use ip for minio server address

### DIFF
--- a/qa/L0_storage_S3_local/test.sh
+++ b/qa/L0_storage_S3_local/test.sh
@@ -121,7 +121,7 @@ export MINIO_ACCESS_KEY="minio"
 # https://github.com/minio/minio/issues/15030
 export MINIO_CI_CD=true
 MINIO_VOLUMES="/usr/local/share/minio/"
-MINIO_OPTS="-C /etc/minio --address localhost:4572"
+MINIO_OPTS="-C /etc/minio --address 127.0.0.1:4572"
 export MINIO_SECRET_KEY="miniostorage"
 
 (curl -O https://raw.githubusercontent.com/minio/minio-service/master/linux-systemd/minio.service && \


### PR DESCRIPTION
There was a recent version update on the MinIO server (RELEASE.2023-01-02T09-40-09Z), which seems to have caused the server failed to start. Changing the server address from localhost:4572 to 127.0.0.1:4572 solved the issue.