### PR TITLE
Update Javacpp-presets build to use version tag instead of head of master

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -40,6 +40,7 @@ ARG TRITON_MODEL_ANALYZER_REPO_TAG=main
 ARG CMAKE_UBUNTU_VERSION=20.04
 ARG TRITON_ENABLE_GPU=ON
 ARG JAVA_BINDINGS_MAVEN_VERSION=3.8.4
+ARG JAVA_BINDINGS_JAVACPP_PRESETS_TAG=1.5.8
 
 # DCGM version to install for Model Analyzer
 ARG DCGM_VERSION=2.2.9
@@ -118,6 +119,7 @@ ARG TRITON_BACKEND_REPO_TAG
 ARG TRITON_THIRD_PARTY_REPO_TAG
 ARG TRITON_ENABLE_GPU
 ARG JAVA_BINDINGS_MAVEN_VERSION
+ARG JAVA_BINDINGS_JAVACPP_PRESETS_TAG
 ARG TARGETPLATFORM
 
 WORKDIR /workspace
@@ -148,6 +150,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         source /workspace/client/src/java-api-bindings/scripts/install_dependencies_and_build.sh \
         --maven-version ${JAVA_BINDINGS_MAVEN_VERSION} \
         --core-tag ${TRITON_CORE_REPO_TAG} \
+        --javacpp-tag ${JAVA_BINDINGS_JAVACPP_PRESETS_TAG} \
         --jar-install-path /workspace/install/java-api-bindings; \
     fi
 


### PR DESCRIPTION
Previously we were using  head of master on javacpp-presets to build tritonserver. This caused an error when Javaccp-presets repo transitioned to a full version (thus removing their *-snapshot from the maven repo). Now we can use the actual build