### PR TITLE
Fix checking of return code from memgrowth tests

### DIFF
--- a/qa/L0_client_memory_growth/test.sh
+++ b/qa/L0_client_memory_growth/test.sh
@@ -126,9 +126,10 @@ for PROTOCOL in http grpc; do
         set +e
         SECONDS=0
         $LEAKCHECK $LEAKCHECK_ARGS $MEMORY_GROWTH_TEST $EXTRA_ARGS >> ${CLIENT_LOG} 2>&1
+        TEST_RETCODE=$?
         TEST_DURATION=$SECONDS
         set -e
-        if [ $? -ne 0 ]; then
+        if [ ${TEST_RETCODE} -ne 0 ]; then
             cat ${CLIENT_LOG}
             RET=1
             echo -e "\n***\n*** Test FAILED\n***"

--- a/qa/L0_client_memory_growth/test.sh
+++ b/qa/L0_client_memory_growth/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_memory_growth/test.sh
+++ b/qa/L0_memory_growth/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -242,8 +242,9 @@ set +e
 if [ $SKIP_BUSYOP -ne 1 ]; then
     SECONDS=0
     python $BUSY_OP_TEST -v -m graphdef_busyop -d $DELAY_CYCLES -n $NUM_REQUESTS > $CLIENT_LOG 2>&1
+    TEST_RETCODE=$?
     TEST_DURATION=$SECONDS
-    if [ $? -ne 0 ]; then
+    if [ ${TEST_RETCODE} -ne 0 ]; then
         cat $CLIENT_LOG
         echo -e "\n***\n*** Test graphdef_busyop Failed\n***"
         RET=1


### PR DESCRIPTION
Currently we're checking the return code of `TEST_DURATION=${SECONDS}` in the example below:
```
valgrind --tool=massif memory_growth_test ...
TEST_DURATION=${SECONDS}
if [ $? -ne 0]; then
   ...
fi
```
which is just a variable assignment and will always succeed.

This change makes sure we check the return code of the actual valgrind test on the line above:
```
valgrind --tool=massif memory_growth_test ...
TEST_RETCODE=$?
TEST_DURATION=${SECONDS}
if [ ${TEST_RETCODE} -ne 0]; then
   ...
fi
```

Occasionally seeing the following error in the `client_memory_growth.http.c++` section of `L0_client_memory_growth` test
> Failed to update context stat: Timer not set correctly. Send time from 1672873758293288720 to 0.
> error: unable to run model: failed to parse the request JSON buffer: The document is empty. at 0

It looks like this might have been silently failing because of the above error code checking logic.

Related: https://github.com/triton-inference-server/server/issues/4196