### PR TITLE
Implement GRPC health check protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -314,6 +314,7 @@ if(${TRITON_ENABLE_GRPC})
       proto-library           # from repo-common
       triton-common-logging   # from repo-common
       triton-common-json      # from repo-common
+      health-library          # from repo-common
       grpc-service-library    # from repo-common
       triton-core-serverapi   # from repo-core
       triton-core-serverstub  # from repo-core

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -543,7 +543,7 @@ CommonHandler::SetUpAllRequests()
   };
   
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<grpc::health::v1::HealthCheckRequest>,
+      grpc::ServerAsyncResponseWriter<grpc::health::v1::HealthCheckResponse>,
       grpc::health::v1::HealthCheckRequest, grpc::health::v1::HealthCheckResponse>(
       "Check", 0, OnRegisterCheck, OnExecuteCheck, false /* async */,
       cq_);

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -512,8 +512,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterCheck =
       [this](
-          grpc::ServerContext* ctx, grpc.health.v1::HealthCheckRequest* request,
-          grpc::ServerAsyncResponseWriter<grpc.health.v1::HealthCheckResponse>*
+          grpc::ServerContext* ctx, grpc::health::v1::HealthCheckRequest* request,
+          grpc::ServerAsyncResponseWriter<grpc::health::v1::HealthCheckResponse>*
               responder,
           void* tag) {
         this->health_service_->RequestHealth(
@@ -521,8 +521,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   auto OnExecuteCheck = [this](
-                            grpc.health.v1::HealthCheckRequest& request,
-                            grpc.health.v1::HealthCheckResponse* response,
+                            grpc::health::v1::HealthCheckRequest& request,
+                            grpc::health::v1::HealthCheckResponse* response,
                             grpc::Status* status) {
     bool live = false;
     TRITONSERVER_Error* err =
@@ -540,8 +540,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::HealthAsyncResponseWriter<grpc.health.v1::Check>,
-      grpc.health.v1::HealthCheckRequest, grpc.health.v1::Check>(
+      grpc::HealthAsyncResponseWriter<grpc::health::v1::Check>,
+      grpc::health::v1::HealthCheckRequest, grpc::health::v1::Check>(
       "Check", 0, OnRegisterCheckLive, OnExecuteCheckLive, false /* async */,
       cq_);
 
@@ -550,8 +550,8 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterWatch =
       [this](
-          grpc::ServerContext* ctx, grpc.health.v1::HealthCheckRequest* request,
-          grpc::ServerAsyncResponseWriter<grpc.health.v1::HealthCheckResponse>*
+          grpc::ServerContext* ctx, grpc::health::v1::HealthCheckRequest* request,
+          grpc::ServerAsyncResponseWriter<grpc::health::v1::HealthCheckResponse>*
               responder,
           void* tag) {
         this->health_service_->RequestWatch(
@@ -559,8 +559,8 @@ CommonHandler::SetUpAllRequests()
       };
 
   auto OnExecuteWatch = [this](
-                            grpc.health.v1::HealthCheckRequest& request,
-                            grpc.health.v1::HealthCheckResponse* response,
+                            grpc::health::v1::HealthCheckRequest& request,
+                            grpc::health::v1::HealthCheckResponse* response,
                             grpc::Status* status) {
     // TODO: Once compiles, modify below to use streaming-type code to return
     // stream
@@ -580,8 +580,8 @@ CommonHandler::SetUpAllRequests()
   };
 
   new CommonCallData<
-      grpc::ServerAsyncResponseWriter<grpc.health.v1::ServerReadyResponse>,
-      grpc.health.v1::ServerReadyRequest, grpc.health.v1::ServerReadyResponse>(
+      grpc::ServerAsyncResponseWriter<grpc::health::v1::ServerReadyResponse>,
+      grpc::health::v1::ServerReadyRequest, grpc::health::v1::ServerReadyResponse>(
       "Watch", 0, OnRegisterServerReady, OnExecuteServerReady,
       false /* async */, cq_);
 

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -389,7 +389,8 @@ CommonHandler::CommonHandler(
     grpc::health::v1::Health::AsyncService* health_service,
     grpc::ServerCompletionQueue* cq)
     : name_(name), tritonserver_(tritonserver), shm_manager_(shm_manager),
-      trace_manager_(trace_manager), service_(service), health_service_(health_service), cq_(cq)
+      trace_manager_(trace_manager), service_(service),
+      health_service_(health_service), cq_(cq)
 {
 }
 
@@ -515,9 +516,10 @@ CommonHandler::SetUpAllRequests()
   //
   auto OnRegisterCheck =
       [this](
-          grpc::ServerContext* ctx, grpc::health::v1::HealthCheckRequest* request,
-          grpc::ServerAsyncResponseWriter<grpc::health::v1::HealthCheckResponse>*
-              responder,
+          grpc::ServerContext* ctx,
+          grpc::health::v1::HealthCheckRequest* request,
+          grpc::ServerAsyncResponseWriter<
+              grpc::health::v1::HealthCheckResponse>* responder,
           void* tag) {
         this->health_service_->RequestCheck(
             ctx, request, responder, this->cq_, this->cq_, tag);
@@ -531,64 +533,25 @@ CommonHandler::SetUpAllRequests()
     TRITONSERVER_Error* err =
         TRITONSERVER_ServerIsReady(tritonserver_.get(), &live);
 
-    auto serving_status = grpc::health::v1::HealthCheckResponse_ServingStatus_UNKNOWN;
+    auto serving_status =
+        grpc::health::v1::HealthCheckResponse_ServingStatus_UNKNOWN;
     if (err == nullptr) {
       serving_status =
-          live ? grpc::health::v1::HealthCheckResponse_ServingStatus_SERVING : grpc::health::v1::HealthCheckResponse_ServingStatus_NOT_SERVING;
+          live
+              ? grpc::health::v1::HealthCheckResponse_ServingStatus_SERVING
+              : grpc::health::v1::HealthCheckResponse_ServingStatus_NOT_SERVING;
     }
     response->set_status(serving_status);
 
     GrpcStatusUtil::Create(status, err);
     TRITONSERVER_ErrorDelete(err);
   };
-  
+
   new CommonCallData<
       grpc::ServerAsyncResponseWriter<grpc::health::v1::HealthCheckResponse>,
-      grpc::health::v1::HealthCheckRequest, grpc::health::v1::HealthCheckResponse>(
-      "Check", 0, OnRegisterCheck, OnExecuteCheck, false /* async */,
-      cq_);
-      
-  // TODO: Add health watch call
-  // //
-  // //  Health Watch
-  // //
-  // auto OnRegisterWatch =
-  //     [this](
-  //         grpc::ServerContext* ctx, grpc::health::v1::HealthCheckRequest* request,
-  //         grpc::ServerAsyncResponseWriter<grpc::health::v1::HealthCheckResponse>*
-  //             responder,
-  //         void* tag) {
-  //       this->health_service_->RequestWatch(
-  //           ctx, request, responder, this->cq_, this->cq_, tag);
-  //     };
-
-  // auto OnExecuteWatch = [this](
-  //                           grpc::health::v1::HealthCheckRequest& request,
-  //                           grpc::health::v1::HealthCheckResponse* response,
-  //                           grpc::Status* status) {
-  //   // TODO: Once compiles, modify below to use streaming-type code to return
-  //   // stream
-  //   bool live = false;
-  //   TRITONSERVER_Error* err =
-  //       TRITONSERVER_ServerIsReady(tritonserver_.get(), &live);
-
-  //   auto serving_status = grpc::health::v1::HealthCheckResponse_ServingStatus_UNKNOWN;
-  //   if (err == nullptr) {
-  //     serving_status =
-  //         live ? grpc::health::v1::HealthCheckResponse_ServingStatus_SERVING : grpc::health::v1::HealthCheckResponse_ServingStatus_NOT_SERVING;
-  //   }
-  //   response->set_status(serving_status);
-
-  //   GrpcStatusUtil::Create(status, err);
-  //   TRITONSERVER_ErrorDelete(err);
-  // };
-
-  // new CommonCallData<
-  //     grpc::ServerAsyncResponseWriter<grpc::health::v1::HealthCheckResponse>,
-  //     grpc::health::v1::HealthCheckRequest, grpc::health::v1::HealthCheckResponse>(
-  //     "Watch", 0, OnRegisterWatch, OnExecuteWatch,
-  //     false /* async */, cq_);
-
+      grpc::health::v1::HealthCheckRequest,
+      grpc::health::v1::HealthCheckResponse>(
+      "Check", 0, OnRegisterCheck, OnExecuteCheck, false /* async */, cq_);
 
   //
   //  ModelReady
@@ -4821,6 +4784,7 @@ GRPCServer::Start()
   grpc_builder_.AddListeningPort(server_addr_, credentials, &bound_port);
   grpc_builder_.SetMaxMessageSize(MAX_GRPC_MESSAGE_SIZE);
   grpc_builder_.RegisterService(&service_);
+  grpc_builder_.RegisterService(&health_service_);
   // GRPC KeepAlive Docs: https://grpc.github.io/grpc/cpp/md_doc_keepalive.html
   // NOTE: In order to work properly, the client-side settings should
   // be in agreement with server-side settings.
@@ -4871,8 +4835,8 @@ GRPCServer::Start()
 
   // A common Handler for other non-inference requests
   CommonHandler* hcommon = new CommonHandler(
-      "CommonHandler", server_, shm_manager_, trace_manager_, &service_, &health_service_,
-      common_cq_.get());
+      "CommonHandler", server_, shm_manager_, trace_manager_, &service_,
+      &health_service_, common_cq_.get());
   hcommon->Start();
   common_handler_.reset(hcommon);
 

--- a/src/grpc_server.cc
+++ b/src/grpc_server.cc
@@ -511,6 +511,7 @@ CommonHandler::SetUpAllRequests()
       inference::ServerReadyRequest, inference::ServerReadyResponse>(
       "ServerReady", 0, OnRegisterServerReady, OnExecuteServerReady,
       false /* async */, cq_);
+
   //
   //  Health Check
   //

--- a/src/grpc_server.h
+++ b/src/grpc_server.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -61,6 +61,10 @@ struct KeepAliveOptions {
   int http2_min_recv_ping_interval_without_data_ms;
   int http2_max_ping_strikes;
 };
+
+/// HealthCheckResponse type used by GRPC health API
+///
+typedef enum { UNKNOWN, SERVING, NOT_SERVING, SERVICE_UNKNOWN } ServingStatus;
 
 class GRPCServer {
  public:
@@ -128,6 +132,7 @@ class GRPCServer {
   std::vector<std::unique_ptr<HandlerBase>> model_stream_infer_handlers_;
 
   inference::GRPCInferenceService::AsyncService service_;
+  grpc.health.v1::Health::AsyncService health_service_;
   bool running_;
 };
 

--- a/src/grpc_server.h
+++ b/src/grpc_server.h
@@ -133,7 +133,7 @@ class GRPCServer {
   std::vector<std::unique_ptr<HandlerBase>> model_stream_infer_handlers_;
 
   inference::GRPCInferenceService::AsyncService service_;
-  grpc.health.v1::Health::AsyncService health_service_;
+  grpc::health::v1::Health::AsyncService health_service_;
   bool running_;
 };
 

--- a/src/grpc_server.h
+++ b/src/grpc_server.h
@@ -26,8 +26,8 @@
 #pragma once
 
 #include <grpc++/grpc++.h>
-#include "health.grpc.pb.h"
 #include "grpc_service.grpc.pb.h"
+#include "health.grpc.pb.h"
 #include "shared_memory_manager.h"
 #include "tracer.h"
 #include "triton/core/tritonserver.h"
@@ -62,10 +62,6 @@ struct KeepAliveOptions {
   int http2_min_recv_ping_interval_without_data_ms;
   int http2_max_ping_strikes;
 };
-
-/// HealthCheckResponse type used by GRPC health API
-///
-typedef enum { UNKNOWN, SERVING, NOT_SERVING, SERVICE_UNKNOWN } ServingStatus;
 
 class GRPCServer {
  public:

--- a/src/grpc_server.h
+++ b/src/grpc_server.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <grpc++/grpc++.h>
+#include "health.grpc.pb.h"
 #include "grpc_service.grpc.pb.h"
 #include "shared_memory_manager.h"
 #include "tracer.h"


### PR DESCRIPTION
Implement GRPC's standard health check protocol. This can be used with tools like grpc-health-probe and Kubernetes liveness probes (as of [Kubernetes 1.24](https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/)).

As stated in the protobuf, only Check is implemented. This is what's used by grpc-health-probe and looks to be used in Kubernetes ([code example](https://github.com/kubernetes/kubernetes/blob/425ff1c8e2d29874926abb7da37641cf785c4ff3/test/images/agnhost/grpc-health-checking/grpc-health-checking.go#L66-L93), [prior documentation](https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/)). If we need to implement Watch later, we can, but this PR is focused on enabling health checks. That'd require engineering effort for implementing a way to provide a stream of SERVING and NOT_SERVING when the server changes status, and exceeds the scope for this PR.