### PR TITLE
Improvements to SM server and entrypoint

### DIFF
--- a/docker/sagemaker/serve
+++ b/docker/sagemaker/serve
@@ -52,8 +52,11 @@ fi
 if [ -n "$SAGEMAKER_TRITON_THREAD_COUNT" ]; then
     SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --sagemaker-thread-count=${SAGEMAKER_TRITON_THREAD_COUNT}"
 fi
+# Enable verbose logging by default. If env variable is specified, use value from env variable
 if [ -n "$SAGEMAKER_TRITON_LOG_VERBOSE" ]; then
     SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --log-verbose=${SAGEMAKER_TRITON_LOG_VERBOSE}"
+else
+    SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --log-verbose=true"
 fi
 if [ -n "$SAGEMAKER_TRITON_LOG_INFO" ]; then
     SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --log-info=${SAGEMAKER_TRITON_LOG_INFO}"

--- a/qa/L0_sagemaker/test.sh
+++ b/qa/L0_sagemaker/test.sh
@@ -353,11 +353,12 @@ if [ "$SERVER_PID" == "0" ]; then
     exit 1
 fi
 
-# Ping and expect error code
+# Ping and expect server to still be running (using 'live' instead of 'ready')
+# https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/rest_predict_v2.yaml#L10-L26
 set +e
 code=`curl -s -w %{http_code} -o ./ping.out localhost:8080/ping`
 set -e
-if [ "$code" == "200" ]; then
+if [ "$code" != "200" ]; then
     cat ./ping.out
     echo -e "\n***\n*** Test Failed\n***"
     RET=1

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -785,7 +785,10 @@ SagemakerAPIServer::SageMakerMMECheckOOMError(TRITONSERVER_Error* err)
       "Src tensor is not initialized",
       "CNMEM_STATUS_OUT_OF_MEMORY",
       "CUDNN_STATUS_NOT_INITIALIZED",
-      "CUBLAS_STATUS_ALLOC_FAILED"};
+      "CUBLAS_STATUS_ALLOC_FAILED",
+      "CUBLAS_STATUS_NOT_INITIALIZED",
+      "Failed to allocate memory",
+      "failed to allocate memory"};
 
   /*
     TODO: Improve the search to do pattern match on whole words only

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -77,7 +77,7 @@ class SagemakerAPIServer : public HTTPAPIServer {
         model_path_regex_(
             R"((\/opt\/ml\/models\/[0-9A-Za-z._]+)\/(model)\/?([0-9A-Za-z._]+)?)"),
         platform_ensemble_regex_(R"(platform:(\s)*\"ensemble\")"),
-        ping_mode_("ready"),
+        ping_mode_("live"),
         model_name_(GetEnvironmentVariableOrDefault(
             "SAGEMAKER_TRITON_DEFAULT_MODEL_NAME",
             "unspecified_SAGEMAKER_TRITON_DEFAULT_MODEL_NAME")),


### PR DESCRIPTION
1. Enable verbose logging by default, customers can still disable it by specifying `SAGEMAKER_TRITON_LOG_VERBOSE`:`false`.
2. Added more strings for OOM checker to detect, in order to return 507
3. Changed /ping health check to rely on 'live', instead of 'ready' to handle SageMaker corner cases where it expects model server to react with '200' for /ping even if model load has failed separately for some other models, whereas has succeeded for others and are ready to be served. (difference of 'live'/'ready' is found in kserve description - https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/rest_predict_v2.yaml#L10-L26)