### PR TITLE
Add gdb backtrace to qa tests when server fails to start within timeout

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -51,6 +51,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
             build-essential \
+            gdb \
             libarchive-dev \
             libboost-dev \
             python3-dev \

--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -173,6 +173,16 @@ function run_server () {
 
     wait_for_server_ready $SERVER_PID $SERVER_TIMEOUT
     if [ "$WAIT_RET" != "0" ]; then
+        # If gdb is installed, collect a backtrace from the hanging process
+        if command -v gdb; then
+          GDB_LOG="gdb_bt.${SERVER_PID}.log"
+          echo -e "=== WARNING: SERVER HANG DETECTED, DUMPING GDB BACKTRACE TO [${PWD}/${GDB_LOG}] ==="
+          gdb -batch -ex "thread apply all bt" -p "${SERVER_PID}" 2>&1 | tee "${GDB_LOG}"
+        else
+          echo -e "=== ERROR: SERVER HANG DETECTED, BUT GDB NOT FOUND ==="
+        fi
+
+        # Cleanup
         kill $SERVER_PID || true
         SERVER_PID=0
     fi

--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -176,10 +176,10 @@ function run_server () {
         # If gdb is installed, collect a backtrace from the hanging process
         if command -v gdb; then
           GDB_LOG="gdb_bt.${SERVER_PID}.log"
-          echo -e "=== WARNING: SERVER HANG DETECTED, DUMPING GDB BACKTRACE TO [${PWD}/${GDB_LOG}] ==="
+          echo -e "=== WARNING: SERVER FAILED TO START, DUMPING GDB BACKTRACE TO [${PWD}/${GDB_LOG}] ==="
           gdb -batch -ex "thread apply all bt" -p "${SERVER_PID}" 2>&1 | tee "${GDB_LOG}"
         else
-          echo -e "=== ERROR: SERVER HANG DETECTED, BUT GDB NOT FOUND ==="
+          echo -e "=== ERROR: SERVER FAILED TO START, BUT GDB NOT FOUND ==="
         fi
 
         # Cleanup

--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -177,7 +177,10 @@ function run_server () {
         if command -v gdb; then
           GDB_LOG="gdb_bt.${SERVER_PID}.log"
           echo -e "=== WARNING: SERVER FAILED TO START, DUMPING GDB BACKTRACE TO [${PWD}/${GDB_LOG}] ==="
+          # Dump backtrace log for quick analysis
           gdb -batch -ex "thread apply all bt" -p "${SERVER_PID}" 2>&1 | tee "${GDB_LOG}"
+          # Generate core dump for deeper analysis. Default filename is "core.${PID}"
+          gdb -batch -ex "gcore" -p "${SERVER_PID}"
         else
           echo -e "=== ERROR: SERVER FAILED TO START, BUT GDB NOT FOUND ==="
         fi


### PR DESCRIPTION
Help to better debug server hangs moving forward by capturing relevant backtrace rather than having to try to reproduce locally each time.

To demonstrate if it works or not, I added an intentional deadlock in `model_lifecycle.cc` on model load. Here's the output from the test. Note that even for a RELEASE build this helps point to an issue in core:
```
Thread 1 (Thread 0x7f80077f3000 (LWP 638148)):
#0  __lll_lock_wait (futex=futex@entry=0x5581ab4f1980, private=0) at lowlevellock.c:52
#1  0x00007f8008ec60a3 in __GI___pthread_mutex_lock (mutex=0x5581ab4f1980) at ../nptl/pthread_mutex_lock.c:80
#2  0x00007f80088892c6 in triton::core::ModelLifeCycle::AsyncLoad(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, inference::ModelConfig const&, bool, std::shared_ptr<triton::core::TritonRepoAgentModelList> const&, std::function<void (triton::core::Status)>&&) () from /opt/tritonserver/bin/../lib/libtritonserver.so
...
```

For issues on shared libraries (backends etc.) or issues requiring more detailed information, I am looking to add a DEBUG build as well. 

However, I think it's valuable to have it running in the RELEASE build tests as well just in case it appears in one build type and not the other in CI:

<details>
<summary>Test + GDB Backtrace Log</summary>

```
root@rmccormick-dt:/mnt/triton/jira/4548-debug-build/server/qa/L0_hang_bt# bash -x test.sh 
+ test -f /etc/shinit_v2
+ source /etc/shinit_v2
+++ sed -n 's/^NVRM.*Kernel Module *\([^() ]*\).*$/\1/p' /proc/driver/nvidia/version
+++ sed 's/^$/unknown/'
++ NV_DRIVER_VERS=525.78.01
++ export _CUDA_COMPAT_PATH=/usr/local/cuda/compat
++ _CUDA_COMPAT_PATH=/usr/local/cuda/compat
+++ hostname
++ _CUDA_COMPAT_CHECKFILE=/usr/local/cuda/compat/.525.78.01.rmccormick-dt.checked
++ _CUDA_COMPAT_REALLIB=/usr/local/cuda/compat/lib.real
++ _CUDA_COMPAT_SYMLINK=/usr/local/cuda/compat/lib
++ '[' '(' '(' -n 525.78.01 -a -e /dev/nvidiactl ')' -o -e /dev/nvgpu ')' -a '!' -e /usr/local/cuda/compat/.525.78.01.rmccormick-dt.checked ']'
+++ cat /sys/module/mlx5_core/version
+++ true
++ _DETECTED_MOFED=
++ '[' -n '' ']'
++ unset _DETECTED_MOFED
++ unset _CUDA_COMPAT_CHECKFILE
++ unset _CUDA_COMPAT_REALLIB
++ unset _CUDA_COMPAT_SYMLINK
+ '[' -z '' ']'
+ return
+ SERVER=/opt/tritonserver/bin/tritonserver
+ SERVER_ARGS=--model-repository=/mnt/triton/jira/4548-debug-build/server/qa/L0_hang_bt/models
+ SERVER_LOG=./inference_server.log
+ source ../common/util.sh
++ SERVER_IPADDR=localhost
++ SERVER_LOG=./inference_server.log
++ SERVER_TIMEOUT=120
++ SERVER_LD_PRELOAD=
++ MONITOR_FILE_TIMEOUT=10
+ export SERVER_TIMEOUT=10
+ SERVER_TIMEOUT=10
+ export CUDA_VISIBLE_DEVICES=
+ CUDA_VISIBLE_DEVICES=
+ echo 'Starting server with SERVER_TIMEOUT=10...'
Starting server with SERVER_TIMEOUT=10...
+ run_server
+ SERVER_PID=0
+ '[' -z /opt/tritonserver/bin/tritonserver ']'
+ '[' '!' -f /opt/tritonserver/bin/tritonserver ']'
+ '[' -z '' ']'
+ echo '=== Running /opt/tritonserver/bin/tritonserver --model-repository=/mnt/triton/jira/4548-debug-build/server/qa/L0_hang_bt/models'
=== Running /opt/tritonserver/bin/tritonserver --model-repository=/mnt/triton/jira/4548-debug-build/server/qa/L0_hang_bt/models
+ SERVER_PID=638148
+ wait_for_server_ready 638148 10
+ local spid=638148
+ shift
+ local wait_time_secs=10
+ shift
+ WAIT_RET=0
+ local wait_secs=10
+ LD_PRELOAD=:
+ echo 'In wait_for_server_ready: Waiting for 10 seconds...'
In wait_for_server_ready: Waiting for 10 seconds...
+ /opt/tritonserver/bin/tritonserver --model-repository=/mnt/triton/jira/4548-debug-build/server/qa/L0_hang_bt/models
+ test 10 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 9 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 8 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 7 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 6 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 5 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 4 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 3 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 2 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 1 -eq 0
+ kill -0 638148
+ sleep 1
+ set +e
++ curl -s -w '%{http_code}' localhost:8000/v2/health/ready
+ code=000
+ set -e
+ '[' 000 == 200 ']'
+ (( wait_secs-- ))
+ test 0 -eq 0
+ echo '=== Timeout 10 secs. Server not ready.'
=== Timeout 10 secs. Server not ready.
+ WAIT_RET=1
+ '[' 1 '!=' 0 ']'
+ command -v gdb
/usr/bin/gdb
+ GDB_LOG=gdb_bt.638148.log
+ echo -e '=== WARNING: SERVER HANG DETECTED, DUMPING GDB BACKTRACE TO [/mnt/triton/jira/4548-debug-build/server/qa/L0_hang_bt/gdb_bt.638148.log] ==='
=== WARNING: SERVER HANG DETECTED, DUMPING GDB BACKTRACE TO [/mnt/triton/jira/4548-debug-build/server/qa/L0_hang_bt/gdb_bt.638148.log] ===
+ gdb -batch -ex 'thread apply all bt' -p 638148
+ tee gdb_bt.638148.log
[New LWP 638150]
[New LWP 638151]
[New LWP 638152]
[New LWP 638153]
[New LWP 638154]
[New LWP 638155]
[New LWP 638156]
[New LWP 638157]
[New LWP 638158]
[New LWP 638159]
[New LWP 638160]
[New LWP 638161]
[New LWP 638162]
[New LWP 638163]
[New LWP 638164]
[New LWP 638165]
[New LWP 638166]
[New LWP 638167]
[New LWP 638168]
[New LWP 638169]
[New LWP 638170]
[New LWP 638171]
[New LWP 638172]
[New LWP 638173]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
__lll_lock_wait (futex=futex@entry=0x5581ab4f1980, private=0) at lowlevellock.c:52
52	lowlevellock.c: No such file or directory.

Thread 25 (Thread 0x7f7ffbaf1000 (LWP 638173)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 24 (Thread 0x7f7ffc2f2000 (LWP 638172)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 23 (Thread 0x7f7ffcaf3000 (LWP 638171)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 22 (Thread 0x7f7ffd2f4000 (LWP 638170)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 21 (Thread 0x7f7ffdaf5000 (LWP 638169)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 20 (Thread 0x7f7ffe2f6000 (LWP 638168)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 19 (Thread 0x7f7ffeaf7000 (LWP 638167)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 18 (Thread 0x7f7fff2f8000 (LWP 638166)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 17 (Thread 0x7f7fffaf9000 (LWP 638165)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 16 (Thread 0x7f80002fa000 (LWP 638164)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 15 (Thread 0x7f8000afb000 (LWP 638163)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 14 (Thread 0x7f80012fc000 (LWP 638162)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 13 (Thread 0x7f8001afd000 (LWP 638161)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 12 (Thread 0x7f80022fe000 (LWP 638160)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 11 (Thread 0x7f8002aff000 (LWP 638159)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 10 (Thread 0x7f8003300000 (LWP 638158)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 9 (Thread 0x7f8003b01000 (LWP 638157)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 8 (Thread 0x7f8004302000 (LWP 638156)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 7 (Thread 0x7f8004b03000 (LWP 638155)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 6 (Thread 0x7f8005304000 (LWP 638154)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 5 (Thread 0x7f8005b05000 (LWP 638153)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 4 (Thread 0x7f80067ea000 (LWP 638152)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 3 (Thread 0x7f8006feb000 (LWP 638151)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 2 (Thread 0x7f80077ec000 (LWP 638150)):
#0  futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x5581ab4c2930) at ../sysdeps/nptl/futex-internal.h:183
#1  __pthread_cond_wait_common (abstime=0x0, clockid=0, mutex=0x5581ab4c28e0, cond=0x5581ab4c2908) at pthread_cond_wait.c:508
#2  __pthread_cond_wait (cond=0x5581ab4c2908, mutex=0x5581ab4c28e0) at pthread_cond_wait.c:647
#3  0x00007f80083d4e30 in std::condition_variable::wait(std::unique_lock<std::mutex>&) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007f80089ca70a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<triton::common::ThreadPool::ThreadPool(unsigned long)::{lambda()#1}> > >::_M_run() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f80083dade4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007f8008ec3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#7  0x00007f80080c5133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

Thread 1 (Thread 0x7f80077f3000 (LWP 638148)):
#0  __lll_lock_wait (futex=futex@entry=0x5581ab4f1980, private=0) at lowlevellock.c:52
#1  0x00007f8008ec60a3 in __GI___pthread_mutex_lock (mutex=0x5581ab4f1980) at ../nptl/pthread_mutex_lock.c:80
#2  0x00007f80088892c6 in triton::core::ModelLifeCycle::AsyncLoad(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, inference::ModelConfig const&, bool, std::shared_ptr<triton::core::TritonRepoAgentModelList> const&, std::function<void (triton::core::Status)>&&) () from /opt/tritonserver/bin/../lib/libtritonserver.so
#3  0x00007f800889460a in triton::core::ModelRepositoryManager::LoadModelByDependency[abi:cxx11]() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#4  0x00007f800889e0de in triton::core::ModelRepositoryManager::PollAndUpdateInternal(bool*) () from /opt/tritonserver/bin/../lib/libtritonserver.so
#5  0x00007f800889f9cc in triton::core::ModelRepositoryManager::Create(triton::core::InferenceServer*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, bool, bool, triton::core::ModelLifeCycleOptions const&, std::unique_ptr<triton::core::ModelRepositoryManager, std::default_delete<triton::core::ModelRepositoryManager> >*) () from /opt/tritonserver/bin/../lib/libtritonserver.so
#6  0x00007f8008904592 in triton::core::InferenceServer::Init() () from /opt/tritonserver/bin/../lib/libtritonserver.so
#7  0x00007f800891874d in TRITONSERVER_ServerNew () from /opt/tritonserver/bin/../lib/libtritonserver.so
#8  0x00005581aa7d89e9 in main ()
[Inferior 1 (process 638148) detached]
+ kill 638148
+ SERVER_PID=0
+ '[' 0 == 0 ']'
+ echo -e '\n***\n*** Failed to start /opt/tritonserver/bin/tritonserver\n***'

***
*** Failed to start /opt/tritonserver/bin/tritonserver
***
+ cat ./inference_server.log
W0203 20:42:29.697729 638148 pinned_memory_manager.cc:236] Unable to allocate pinned system memory, pinned memory pool will not be available: no CUDA-capable device is detected
I0203 20:42:29.697951 638148 cuda_memory_manager.cc:115] CUDA memory pool disabled
+ exit 1
```

</details>