### PR TITLE
Allow gdb commands to fail if process doesn't exist

### DIFF
--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -177,10 +177,10 @@ function run_server () {
         if command -v gdb; then
           GDB_LOG="gdb_bt.${SERVER_PID}.log"
           echo -e "=== WARNING: SERVER FAILED TO START, DUMPING GDB BACKTRACE TO [${PWD}/${GDB_LOG}] ==="
-          # Dump backtrace log for quick analysis
-          gdb -batch -ex "thread apply all bt" -p "${SERVER_PID}" 2>&1 | tee "${GDB_LOG}"
+          # Dump backtrace log for quick analysis. Allow these commands to fail.
+          gdb -batch -ex "thread apply all bt" -p "${SERVER_PID}" 2>&1 | tee "${GDB_LOG}" || true
           # Generate core dump for deeper analysis. Default filename is "core.${PID}"
-          gdb -batch -ex "gcore" -p "${SERVER_PID}"
+          gdb -batch -ex "gcore" -p "${SERVER_PID}" || true
         else
           echo -e "=== ERROR: SERVER FAILED TO START, BUT GDB NOT FOUND ==="
         fi


### PR DESCRIPTION
If the process doesn't exist (example: a test that expects server startup to fail, but not hang), then the gdb commands will fail that the PID doesn't exist and that error will propogate to fail the test. 

Add `|| true` to the commands since its OK if these commands fail for whatever reason and shouldn't alter the test result.