### PR TITLE
Adding default base container for ORT backend build

### DIFF
--- a/build.py
+++ b/build.py
@@ -631,16 +631,25 @@ def onnxruntime_cmake_args(images, library_paths):
                                  'TRITON_ENABLE_ONNXRUNTIME_OPENVINO', False)
         ]
     else:
+        ort_image = None
+        if ('base' in images) and ('ort-base' in images):
+            ort_image = images['ort-base']
+        elif ('base' in images):
+            # If ort-base is not specified, we default to
+            # tensorrt:22.12-py3 base container for ort backend
+            # build with cuda 11.8 library as ORT does
+            # not support cuda 12 in 23.01 containers.
+            ort_image = 'nvcr.io/nvidia/tensorrt:22.12-py3'
         if target_platform() == 'windows':
-            if 'ort-base' in images:
+            if ort_image is not None:
                 cargs.append(
                     cmake_backend_arg('onnxruntime', 'TRITON_BUILD_CONTAINER',
-                                      None, images['ort-base']))
+                                      None, ort_image))
         else:
-            if 'ort-base' in images:
+            if ort_image is not None:
                 cargs.append(
                     cmake_backend_arg('onnxruntime', 'TRITON_BUILD_CONTAINER',
-                                      None, images['ort-base']))
+                                      None, ort_image))
             else:
                 cargs.append(
                     cmake_backend_arg('onnxruntime',

--- a/build.py
+++ b/build.py
@@ -632,10 +632,11 @@ def onnxruntime_cmake_args(images, library_paths):
         ]
     else:
         # If ort-base is not specified, we default to
-        # tensorrt:22.12-py3 base container for ort backend
-        # build with cuda 11.8 library as ORT does
-        # not support cuda 12 in 23.01 containers.
-        ort_image = 'nvcr.io/nvidia/tensorrt:22.12-py3'
+        # tritonserver:22.12-py3-min base container
+        # for ort backend build with cuda 11.8 library
+        # as ORT does not support cuda 12 in 23.01
+        # containers.
+        ort_image = 'nvcr.io/nvidia/tritonserver:22.12-py3-min'
         if ('ort-base' in images):
             ort_image = images['ort-base']
         if target_platform() == 'windows':

--- a/build.py
+++ b/build.py
@@ -631,15 +631,13 @@ def onnxruntime_cmake_args(images, library_paths):
                                  'TRITON_ENABLE_ONNXRUNTIME_OPENVINO', False)
         ]
     else:
-        ort_image = None
-        if ('base' in images) and ('ort-base' in images):
+        # If ort-base is not specified, we default to
+        # tensorrt:22.12-py3 base container for ort backend
+        # build with cuda 11.8 library as ORT does
+        # not support cuda 12 in 23.01 containers.
+        ort_image = 'nvcr.io/nvidia/tensorrt:22.12-py3'
+        if ('ort-base' in images):
             ort_image = images['ort-base']
-        elif ('base' in images):
-            # If ort-base is not specified, we default to
-            # tensorrt:22.12-py3 base container for ort backend
-            # build with cuda 11.8 library as ORT does
-            # not support cuda 12 in 23.01 containers.
-            ort_image = 'nvcr.io/nvidia/tensorrt:22.12-py3'
         if target_platform() == 'windows':
             if ort_image is not None:
                 cargs.append(


### PR DESCRIPTION
This will use 22.12 container for ORT backend build by default so the user doesn't have to explicitly provide it as an option in build.py.

See the discussion in this issue here: https://github.com/triton-inference-server/server/issues/5309