### PR TITLE
Updating model control stress test to add python backend

### DIFF
--- a/qa/python_models/torchvision/resnet50/config.pbtxt
+++ b/qa/python_models/torchvision/resnet50/config.pbtxt
@@ -28,14 +28,13 @@ name: "resnet50_python"
 backend: "python"
 max_batch_size: 128
 input {
-    name: "INPUT__0"
+    name: "INPUT0"
     data_type: TYPE_FP32
     format: FORMAT_NCHW
     dims: [ 3, 224, 224 ]
   }
 output {
-    name: "OUTPUT__0"
+    name: "OUTPUT0"
     data_type: TYPE_FP32
     dims: [ 1000 ]
-    label_filename: "resnet50_labels.txt"
   }

--- a/qa/python_models/torchvision/resnet50/config.pbtxt
+++ b/qa/python_models/torchvision/resnet50/config.pbtxt
@@ -1,0 +1,41 @@
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "resnet50_python"
+backend: "python"
+max_batch_size: 128
+input {
+    name: "INPUT__0"
+    data_type: TYPE_FP32
+    format: FORMAT_NCHW
+    dims: [ 3, 224, 224 ]
+  }
+output {
+    name: "OUTPUT__0"
+    data_type: TYPE_FP32
+    dims: [ 1000 ]
+    label_filename: "resnet50_labels.txt"
+  }

--- a/qa/python_models/torchvision/resnet50/model.py
+++ b/qa/python_models/torchvision/resnet50/model.py
@@ -1,0 +1,58 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
+import torch
+import triton_python_backend_utils as pb_utils
+from torchvision.models import ResNet50_Weights, resnet50
+
+
+class TritonPythonModel:
+
+    def initialize(self, args):
+        """
+        This function initializes ResNet50 model with the best 
+        weights available in `torchvision.models` subpackage. 
+        """
+        self.model = resnet50(weights=ResNet50_Weights.DEFAULT)
+        self.model.eval()
+
+    def execute(self, requests):
+        """
+        This function receives a list of requests (`pb_utils.InferenceRequest`),
+        performs inference on every request and appends it to responses.
+        """
+        responses = []
+        for request in requests:
+            input_tensor = pb_utils.get_input_tensor_by_name(
+                request, "INPUT__0")
+            # This tensor is read-only, we need to make a copy
+            input_data_ro = input_tensor.as_numpy()
+            input_data = np.array(input_data_ro)
+            result = self.model(torch.tensor(input_data))
+            out_tensor = pb_utils.Tensor("OUTPUT__0", result.detach().numpy())
+            responses.append(pb_utils.InferenceResponse([out_tensor]))
+        return responses


### PR DESCRIPTION
This PR adds 2 files, required by a python backend for the test.
To enhance model control stress test to check memory growth for Python models, `model.py` initializes a ResNet50 model with the best weights available in `torchvision.models` subpackage.
`config.pbtxt` describes the model's configuration.