### PR TITLE
Add timed wait during UNLOAD while the model becomes UNAVAILABLE in SageMaker

### DIFF
--- a/docker/sagemaker/serve
+++ b/docker/sagemaker/serve
@@ -26,13 +26,21 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 SAGEMAKER_SINGLE_MODEL_REPO=/opt/ml/model/
-SAGEMAKER_MULTI_MODEL_REPO=/opt/ml/models/
+
+# Note: in Triton on SageMaker, each model url is registered as a separate repository
+# e.g., /opt/ml/models/<hash>/model. Specifying MME model repo path as /opt/ml/models causes Triton
+# to treat it as an additional empty repository and changes 
+# the state of all models to be UNAVAILABLE in the model repository
+# https://github.com/triton-inference-server/core/blob/main/src/model_repository_manager.cc#L914,L922
+# On Triton, this path will be a dummy path as it's mandatory to specify a model repo when starting triton
+SAGEMAKER_MULTI_MODEL_REPO=/tmp/sagemaker
 
 SAGEMAKER_MODEL_REPO=${SAGEMAKER_SINGLE_MODEL_REPO}
 is_mme_mode=false
 
 if [ -n "$SAGEMAKER_MULTI_MODEL" ]; then
     if [ "$SAGEMAKER_MULTI_MODEL" == "true" ]; then
+        mkdir -p ${SAGEMAKER_MULTI_MODEL_REPO}
         SAGEMAKER_MODEL_REPO=${SAGEMAKER_MULTI_MODEL_REPO}
         is_mme_mode=true
         echo "Triton is running in SageMaker MME mode." 

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -727,7 +727,7 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
     evhtp_send_reply(req, EVHTP_RES_BADREQ);
 
     LOG_ERROR
-        << "Error when unloading SagMaker Model with dependents for model: "
+        << "Error when unloading SageMaker Model with dependents for model: "
         << model_name << std::endl;
 
     TRITONSERVER_ErrorDelete(unload_err);

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -642,7 +642,7 @@ SagemakerAPIServer::SageMakerMMECheckUnloadedModelIsUnavailable(
   TRITONSERVER_ServerModelIndex(
       server_.get(), ready_flag, &server_model_index_message);
 
-  std::shared_ptr<TRITONSERVER_Message> managed_msg(
+  std::shared_ptr<TRITONSERVER_Message> shared_ptr_msg(
       server_model_index_message,
       [](TRITONSERVER_Message* msg) { TRITONSERVER_MessageDelete(msg); });
 

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -635,22 +635,22 @@ SagemakerAPIServer::SageMakerMMECheckUnloadedModelIsUnavailable(
   /* Use the RepositoryIndex API to check if the model state has become
   UNAVAILABLE i.e. model is no longer in the 'in-the-process-of' being
   UNLOADED. Consequently, the reason field should be 'unloaded'.*/
-  TRITONSERVER_Message* server_model_index_message_ = nullptr;
+  TRITONSERVER_Message* server_model_index_message = nullptr;
   uint32_t ready_flag = 0;  // value of 1 should be set if only the 'ready'
                             // models are required from the index. In this case,
                             // we need all models.
   TRITONSERVER_ServerModelIndex(
-      server_.get(), ready_flag, &server_model_index_message_);
+      server_.get(), ready_flag, &server_model_index_message);
 
   std::shared_ptr<TRITONSERVER_Message> managed_msg(
-      server_model_index_message_,
+      server_model_index_message,
       [](TRITONSERVER_Message* msg) { TRITONSERVER_MessageDelete(msg); });
 
   const char* index_buffer;
   size_t index_byte_size;
 
   RETURN_IF_ERR(TRITONSERVER_MessageSerializeToJson(
-      server_model_index_message_, &index_buffer, &index_byte_size));
+      server_model_index_message, &index_buffer, &index_byte_size));
 
   /* Read into json buffer*/
   triton::common::TritonJson::Value server_model_index_json;
@@ -731,6 +731,7 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
         << model_name << std::endl;
 
     TRITONSERVER_ErrorDelete(unload_err);
+    return;
   }
 
   /*Note: Model status check is repo-specific and therefore must be run before
@@ -771,8 +772,8 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
     TRITONSERVER_ErrorDelete(unload_err);
   }
 
-  if (is_model_unavailable == false &&
-      unload_time_in_secs >= UNLOAD_TIMEOUT_SECS_) {
+  if ((is_model_unavailable == false) &&
+      (unload_time_in_secs >= UNLOAD_TIMEOUT_SECS_)) {
     LOG_ERROR << "Error: UNLOAD did not complete within expected "
               << UNLOAD_TIMEOUT_SECS_
               << " seconds. This may "

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -655,6 +655,8 @@ SagemakerAPIServer::SageMakerMMECheckUnloadedModelIsUnavailable(
   TRITONSERVER_MessageSerializeToJson(
       server_model_index_message_, &index_buffer, &index_byte_size);
 
+  LOG_VERBOSE(1) << "Printing entire model index repository" << index_buffer;
+
   /* Read into json buffer*/
   triton::common::TritonJson::Value server_model_index_json;
   server_model_index_json.Parse(index_buffer, index_byte_size);

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -628,9 +628,12 @@ SagemakerAPIServer::SageMakerMMEHandleInfer(
   }
 }
 
-bool
-SagemakerAPIServer::SageMakerMMEUnloadModelCheckStatus(const char* model_name)
+TRITONSERVER_Error*
+SagemakerAPIServer::SageMakerMMECheckUnloadedModelIsUnavailable(
+    const char* model_name, bool* is_model_unavailable)
 {
+  LOG_VERBOSE(1) << "Inside function to check if model is unavailable";
+
   /* Use the RepositoryIndex API to check if the model state has become
   UNAVAILABLE i.e. model is no longer in the 'in-the-process-of' being
   UNLOADED. Consequently, the reason field should be 'unloaded'.*/
@@ -657,37 +660,39 @@ SagemakerAPIServer::SageMakerMMEUnloadModelCheckStatus(const char* model_name)
   server_model_index_json.Parse(index_buffer, index_byte_size);
 
   const char* name;
-  size_t name_len;
-
-  const char* version;
-  size_t version_len;
-
   const char* state;
-  size_t state_len;
-
   const char* reason;
+  size_t name_len;
+  size_t state_len;
   size_t reason_len;
-
-  bool is_model_unavailable = false;
-
 
   for (size_t id = 0; id < server_model_index_json.ArraySize(); ++id) {
     triton::common::TritonJson::Value index_json;
     server_model_index_json.IndexAsObject(id, &index_json);
 
-    index_json.MemberAsString("name", &name, &name_len);
-    index_json.MemberAsString("version", &version, &version_len);
-    index_json.MemberAsString("state", &state, &state_len);
-    index_json.MemberAsString("reason", &reason, &reason_len);
+    RETURN_IF_ERR(index_json.MemberAsString("name", &name, &name_len));
 
-    if (strcmp(name, model_name) == 0) {
-      if (strcmp(state, UNLOAD_EXPECTED_STATE_.c_str()) == 0 &&
-          strcmp(reason, UNLOAD_EXPECTED_REASON_.c_str()) == 0) {
-        is_model_unavailable = true;
+    if (std::string(name) == std::string(model_name)) {
+      LOG_VERBOSE(1) << "Model name matched: " << name;
+      RETURN_IF_ERR(index_json.MemberAsString("state", &state, &state_len));
+
+      if (std::string(state) == UNLOAD_EXPECTED_STATE_) {
+        RETURN_IF_ERR(
+            index_json.MemberAsString("reason", &reason, &reason_len));
+        LOG_VERBOSE(1) << "reason: " << reason;
+        if (std::string(reason) == UNLOAD_EXPECTED_REASON_) {
+          LOG_VERBOSE(1) << "state: " << state;
+
+          LOG_VERBOSE(1) << "BEFORE setting to true" << *is_model_unavailable;
+          *is_model_unavailable = true;
+          LOG_VERBOSE(1) << "AFTER setting to true" << *is_model_unavailable;
+          break;
+        }
       }
     }
   }
-  return is_model_unavailable;
+
+  return nullptr;
 }
 
 void
@@ -705,6 +710,8 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
       evhtp_kv_find(req->headers_in, "X-Amzn-SageMaker-Target-Model");
 
   LOG_INFO << "Unloading SageMaker TargetModel: " << targetModel << std::endl;
+
+  auto start_time = std::chrono::high_resolution_clock::now();
 
   /* Always unload dependents as well - this is required to unload dependents in
    * ensemble */
@@ -725,8 +732,8 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
 
   /*Note: Model status check is repo-specific and therefore must be run before
    * unregistering the repo, else the model information is lost*/
-  bool is_model_unavailable = false;
-  uint32_t unload_time_in_secs = 0;
+  bool* is_model_unavailable = new bool(false);
+  float unload_time_in_secs = 0;
 
   /* Wait for the model to be completely unloaded. SageMaker waits a maximum
   of 360 seconds for the UNLOAD request to timeout. Setting a limit of 350
@@ -736,23 +743,43 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
     LOG_VERBOSE(1) << "Using Model Repository Index during UNLOAD to check for "
                       "status of model: "
                    << model_name;
-    while (!is_model_unavailable &&
+    while (*is_model_unavailable == false &&
            unload_time_in_secs < UNLOAD_TIMEOUT_SECS_) {
-      is_model_unavailable = SageMakerMMEUnloadModelCheckStatus(model_name);
-      sleep(1);
-      unload_time_in_secs += 1;
+      LOG_VERBOSE(1) << "In the loop to wait for model to be unavailable";
+      unload_err = SageMakerMMECheckUnloadedModelIsUnavailable(
+          model_name, is_model_unavailable);
+      if (unload_err != nullptr) {
+        LOG_VERBOSE(1) << "** Received non-zero exit code on checking for "
+                          "model unavailability";
+        LOG_VERBOSE(1) << "Printing error message"
+                       << TRITONSERVER_ErrorMessage(unload_err);
+        break;
+      }
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(UNLOAD_SLEEP_MILLISECONDS_));
+
+      auto end_time = std::chrono::high_resolution_clock::now();
+
+      unload_time_in_secs =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              end_time - start_time)
+              .count() /
+          1000.0;
     }
     LOG_INFO << "UNLOAD for model " << model_name << " took "
              << unload_time_in_secs << " seconds.";
   }
 
-  if (is_model_unavailable == false &&
+  if (*is_model_unavailable == false &&
       unload_time_in_secs >= UNLOAD_TIMEOUT_SECS_) {
     LOG_ERROR << "Error: UNLOAD did not complete within expected "
               << UNLOAD_TIMEOUT_SECS_
               << " seconds. This may "
                  "result in SageMaker UNLOAD timeout.";
   }
+
+  /* Delete allocate mem for bool */
+  delete is_model_unavailable;
 
   std::string repo_parent_path = sagemaker_models_list_.at(model_name);
 
@@ -764,11 +791,11 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
     evhtp_send_reply(req, EVHTP_RES_BADREQ);
     LOG_ERROR << "Unable to unregister model repository for path: "
               << repo_parent_path << std::endl;
-    TRITONSERVER_ErrorDelete(unload_err);
   } else {
     evhtp_send_reply(req, EVHTP_RES_OK);
   }
 
+  TRITONSERVER_ErrorDelete(unload_err);
   std::lock_guard<std::mutex> lock(mutex_);
   sagemaker_models_list_.erase(model_name);
 }

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -106,7 +106,8 @@ class SagemakerAPIServer : public HTTPAPIServer {
 
   void SageMakerMMEUnloadModel(evhtp_request_t* req, const char* model_name);
 
-  bool SageMakerMMEUnloadModelCheckStatus(const char* model_name);
+  TRITONSERVER_Error* SageMakerMMECheckUnloadedModelIsUnavailable(
+      const char* model_name, bool* is_model_unavailable);
 
   void SageMakerMMEListModel(evhtp_request_t* req);
 
@@ -162,6 +163,7 @@ class SagemakerAPIServer : public HTTPAPIServer {
 
   /* Constants */
   const uint32_t UNLOAD_TIMEOUT_SECS_ = 350;
+  const uint32_t UNLOAD_SLEEP_MILLISECONDS_ = 500;
   const std::string UNLOAD_EXPECTED_STATE_ = "UNAVAILABLE";
   const std::string UNLOAD_EXPECTED_REASON_ = "unloaded";
 };

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -159,7 +159,7 @@ class SagemakerAPIServer : public HTTPAPIServer {
   std::unordered_map<std::string, std::string> sagemaker_models_list_;
 
   /* Mutex to handle concurrent updates */
-  std::mutex mutex_;
+  std::mutex models_list_mutex_;
 
   /* Constants */
   const uint32_t UNLOAD_TIMEOUT_SECS_ = 350;

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -162,7 +162,7 @@ class SagemakerAPIServer : public HTTPAPIServer {
 
   /* Constants */
   const uint32_t UNLOAD_TIMEOUT_SECS_ = 350;
-  const std::string UNLOAD_EXPECTED_STATUS_ = "UNAVAILABLE";
+  const std::string UNLOAD_EXPECTED_STATE_ = "UNAVAILABLE";
   const std::string UNLOAD_EXPECTED_REASON_ = "unloaded";
 };
 

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <sys/stat.h>
+
 #include <fstream>
 #include <mutex>
 
@@ -105,6 +106,8 @@ class SagemakerAPIServer : public HTTPAPIServer {
 
   void SageMakerMMEUnloadModel(evhtp_request_t* req, const char* model_name);
 
+  bool SageMakerMMEUnloadModelCheckStatus(const char* model_name);
+
   void SageMakerMMEListModel(evhtp_request_t* req);
 
   void SageMakerMMEGetModel(evhtp_request_t* req, const char* model_name);
@@ -156,6 +159,11 @@ class SagemakerAPIServer : public HTTPAPIServer {
 
   /* Mutex to handle concurrent updates */
   std::mutex mutex_;
+
+  /* Constants */
+  const uint32_t UNLOAD_TIMEOUT_SECS_ = 350;
+  const std::string UNLOAD_EXPECTED_STATUS_ = "UNAVAILABLE";
+  const std::string UNLOAD_EXPECTED_REASON_ = "unloaded";
 };
 
 }}  // namespace triton::server


### PR DESCRIPTION
This PR updates the behavior of SageMaker UNLOAD function to use the repository index and verify that the model has been completely UNLOADED to the best of Triton's ability i.e. the model _state_ is `UNAVAILABLE` and the _reason_ is `unloaded`.

This (at least in case of python backend) ensures that the function returns only after the associated python workers for the models have been killed.