### PR TITLE
Adding test for Model Instance Kind Example added to Python Backend

### DIFF
--- a/qa/L0_backend_python/examples/test.sh
+++ b/qa/L0_backend_python/examples/test.sh
@@ -38,11 +38,14 @@ RET=0
 rm -fr *.log python_backend/
 
 # Install torch 
-# Skip torch install on Jetson since it is already installed.
+# Skip torch, torchvision and pillow install on Jetson since it is already installed.
 if [ "$TEST_JETSON" == "0" ]; then
     pip3 uninstall -y torch
-    pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html torchvision==0.14.0+cu117 validators
+    pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html torchvision==0.14.0+cu117 pillow
 fi
+
+# Install `validators` for Model Instance Kind example
+pip3 install validators
 
 # Install JAX
 if [ "$TEST_JETSON" == "0" ]; then
@@ -393,7 +396,7 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 
 set +e
-python3 examples/instance_kind/client.py > $CLIENT_LOG
+python3 examples/instance_kind/client.py --label_file examples/instance_kind/resnet50_labels.txt > $CLIENT_LOG
 if [ $? -ne 0 ]; then
     echo -e "\n***\n*** Failed to verify Model instance Kind example. \n***"
     RET=1

--- a/qa/L0_backend_python/examples/test.sh
+++ b/qa/L0_backend_python/examples/test.sh
@@ -38,10 +38,10 @@ RET=0
 rm -fr *.log python_backend/
 
 # Install torch 
-# Skip torch, torchvision and pillow install on Jetson since it is already installed.
+# Skip torch and torchvision install on Jetson since it is already installed.
 if [ "$TEST_JETSON" == "0" ]; then
     pip3 uninstall -y torch
-    pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html torchvision==0.14.0+cu117 pillow
+    pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html torchvision==0.14.0+cu117
 fi
 
 # Install `validators` for Model Instance Kind example


### PR DESCRIPTION
https://github.com/triton-inference-server/python_backend/pull/209 adds adds example, showing how to integrate KIND_GPU/KIND_CPU with the Python model.

This PR adjusts L0_backend_python/examples/test.sh to make sure added example is verified.