### PR TITLE
Use abs path for ldscript to avoid ```no such file error``` when build tests

### DIFF
--- a/src/test/distributed_addsub/CMakeLists.txt
+++ b/src/test/distributed_addsub/CMakeLists.txt
@@ -64,7 +64,7 @@ set_target_properties(
   POSITION_INDEPENDENT_CODE ON
   OUTPUT_NAME triton_distributed_addsub
   LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtriton_distributed_addsub.ldscript
-  LINK_FLAGS "-Wl,--version-script libtriton_distributed_addsub.ldscript"
+  LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_BINARY_DIR}/libtriton_distributed_addsub.ldscript"
 )
 
 #

--- a/src/test/dyna_sequence/CMakeLists.txt
+++ b/src/test/dyna_sequence/CMakeLists.txt
@@ -64,7 +64,7 @@ set_target_properties(
   POSITION_INDEPENDENT_CODE ON
   OUTPUT_NAME triton_dyna_sequence
   LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtriton_dyna_sequence.ldscript
-  LINK_FLAGS "-Wl,--version-script libtriton_dyna_sequence.ldscript"
+  LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_BINARY_DIR}/libtriton_dyna_sequence.ldscript"
 )
 
 #

--- a/src/test/implicit_state/CMakeLists.txt
+++ b/src/test/implicit_state/CMakeLists.txt
@@ -64,7 +64,7 @@ set_target_properties(
   POSITION_INDEPENDENT_CODE ON
   OUTPUT_NAME triton_implicit_state
   LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtriton_implicit_state.ldscript
-  LINK_FLAGS "-Wl,--version-script libtriton_implicit_state.ldscript"
+  LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_BINARY_DIR}/libtriton_implicit_state.ldscript"
 )
 
 #

--- a/src/test/query_backend/CMakeLists.txt
+++ b/src/test/query_backend/CMakeLists.txt
@@ -64,7 +64,7 @@ set_target_properties(
   POSITION_INDEPENDENT_CODE ON
   OUTPUT_NAME triton_query
   LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtriton_query.ldscript
-  LINK_FLAGS "-Wl,--version-script libtriton_query.ldscript"
+  LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_BINARY_DIR}/libtriton_query.ldscript"
 )
 
 #

--- a/src/test/repoagent/relocation_repoagent/CMakeLists.txt
+++ b/src/test/repoagent/relocation_repoagent/CMakeLists.txt
@@ -61,7 +61,7 @@ set_target_properties(
   POSITION_INDEPENDENT_CODE ON
   OUTPUT_NAME tritonrepoagent_relocation
   LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtritonrepoagent_relocation.ldscript
-  LINK_FLAGS "-Wl,--version-script libtritonrepoagent_relocation.ldscript"
+  LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_BINARY_DIR}/libtritonrepoagent_relocation.ldscript"
 )
 
 #

--- a/src/test/sequence/CMakeLists.txt
+++ b/src/test/sequence/CMakeLists.txt
@@ -64,7 +64,7 @@ set_target_properties(
   POSITION_INDEPENDENT_CODE ON
   OUTPUT_NAME triton_sequence
   LINK_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libtriton_sequence.ldscript
-  LINK_FLAGS "-Wl,--version-script libtriton_sequence.ldscript"
+  LINK_FLAGS "-Wl,--version-script ${CMAKE_CURRENT_BINARY_DIR}/libtriton_sequence.ldscript"
 )
 
 #


### PR DESCRIPTION
Tools version:
* cmake version 3.25.3
* gcc (GCC) 12.2.1 20230201
* ninja: 1.11.1

Build Config: ```cmake -DCMAKE_BUILD_TYPE=Release -G "Ninja" -DCMAKE_INSTALL_PREFIX=/tmp/install  /path/to/triton-inference-server/server/```

I got some linking errors because the ```*.ldscript``` cannot be found. So I think We can change it to the absolute path to avoid it.
