### PR TITLE
Add onnx and python models back to L0_infer_valgrind test

### DIFF
--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -63,6 +63,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
     SERVER_TIMEOUT=4000
     rm -f $LEAKCHECK_LOG_BASE*
+    BACKENDS="python"
 fi
 
 if [ "$TEST_SYSTEM_SHARED_MEMORY" -eq 1 ] || [ "$TEST_CUDA_SHARED_MEMORY" -eq 1 ]; then

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -349,6 +349,7 @@ done
 # separately to reduce the loading time.
 if [ "$TEST_VALGRIND" -eq 1 ]; then
   TESTING_BACKENDS="python python_dlpack onnx"
+  EXPECTED_NUM_TESTS=42
   if [ "$TEST_JETSON" == "0" ]; then
     if [[ "aarch64" != $(uname -m) ]] ; then
         pip3 install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
@@ -359,12 +360,6 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
 
   for BACKENDS in $TESTING_BACKENDS; do
     export BACKENDS
-    if [ "$BACKENDS" == "python" ] || [ "$BACKENDS" == "python_dlpack" ]; then
-      EXPECTED_NUM_TESTS=42
-    else
-      EXPECTED_NUM_TESTS=46
-    fi
-
     for TARGET in cpu gpu; do
       rm -fr *models
       generate_model_repository
@@ -418,6 +413,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
             check_test_results $TEST_RESULT_FILE $EXPECTED_NUM_TESTS
             if [ $? -ne 0 ]; then
                 cat $CLIENT_LOG
+                cat $TEST_RESULT_FILE
                 echo -e "\n***\n*** Test Result Verification Failed\n***"
                 RET=1
             fi

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,9 +61,9 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=4000
+    SERVER_TIMEOUT=18000
     rm -f $LEAKCHECK_LOG_BASE*
-    BACKENDS="onnx"
+    BACKENDS="graphdef savedmodel onnx libtorch plan openvino"
 fi
 
 if [ "$TEST_SYSTEM_SHARED_MEMORY" -eq 1 ] || [ "$TEST_CUDA_SHARED_MEMORY" -eq 1 ]; then

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -372,7 +372,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
       mv ./models/*nobatch_* ./nobatch_models/.
       cp -fr ./models/nop_* ./nobatch_models/.
 
-      for BATCHING in batch nobatch; do
+      for BATCHING_MODE in batch nobatch; do
         if [ "$TRITON_SERVER_CPU_ONLY" == "1" ]; then
           if [ "$TARGET" == "gpu" ]; then
               echo -e "Skip GPU testing on CPU-only device"
@@ -380,10 +380,10 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
           fi
         fi
 
-        SERVER_LOG=$SERVER_LOG_BASE.${TARGET}.${BACKENDS}.${BATCHING}.log
-        CLIENT_LOG=$CLIENT_LOG_BASE.${TARGET}.${BACKENDS}.${BATCHING}.log
+        SERVER_LOG=$SERVER_LOG_BASE.${TARGET}.${BACKENDS}.${BATCHING_MODE}.log
+        CLIENT_LOG=$CLIENT_LOG_BASE.${TARGET}.${BACKENDS}.${BATCHING_MODE}.log
 
-        if [ "$BATCHING" == "batch" ]; then
+        if [ "$BATCHING_MODE" == "batch" ]; then
           NOBATCH="0"
           export NOBATCH
           BATCH="1"
@@ -398,7 +398,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
         fi
 
         SERVER_ARGS="--model-repository=${MODELDIR} ${SERVER_ARGS_EXTRA}"
-        LEAKCHECK_LOG=$LEAKCHECK_LOG_BASE.${TARGET}.${BACKENDS}.${BATCHING}.log
+        LEAKCHECK_LOG=$LEAKCHECK_LOG_BASE.${TARGET}.${BACKENDS}.${BATCHING_MODE}.log
         LEAKCHECK_ARGS="$LEAKCHECK_ARGS_BASE --log-file=$LEAKCHECK_LOG"
         run_server_leakcheck
 

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -63,7 +63,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
     SERVER_TIMEOUT=4000
     rm -f $LEAKCHECK_LOG_BASE*
-    BACKENDS="python"
+    BACKENDS="onnx"
 fi
 
 if [ "$TEST_SYSTEM_SHARED_MEMORY" -eq 1 ] || [ "$TEST_CUDA_SHARED_MEMORY" -eq 1 ]; then

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,11 +61,11 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=21600
+    SERVER_TIMEOUT=4000
     rm -f $LEAKCHECK_LOG_BASE*
     # Remove 'python' and 'python_dlpack' from BACKENDS. Need to run python
     # models separately due to OOM issue.
-    BACKENDS="graphdef savedmodel onnx libtorch plan openvino"
+    BACKENDS="graphdef savedmodel libtorch plan openvino"
 fi
 
 if [ "$TEST_SYSTEM_SHARED_MEMORY" -eq 1 ] || [ "$TEST_CUDA_SHARED_MEMORY" -eq 1 ]; then

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -61,7 +61,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_LOG_BASE="./valgrind_test"
     LEAKCHECK=/usr/bin/valgrind
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
-    SERVER_TIMEOUT=18000
+    SERVER_TIMEOUT=21600
     rm -f $LEAKCHECK_LOG_BASE*
     BACKENDS="graphdef savedmodel onnx libtorch plan openvino"
 fi

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -63,9 +63,6 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
     LEAKCHECK_ARGS_BASE="--leak-check=full --show-leak-kinds=definite --max-threads=3000 --num-callers=20"
     SERVER_TIMEOUT=4000
     rm -f $LEAKCHECK_LOG_BASE*
-    # Remove onnx and python backends for now as the server hangs up when 
-    # loading onnx and python models during valgrind test. DLIS-4056
-    BACKENDS="graphdef savedmodel libtorch plan openvino"
 fi
 
 if [ "$TEST_SYSTEM_SHARED_MEMORY" -eq 1 ] || [ "$TEST_CUDA_SHARED_MEMORY" -eq 1 ]; then


### PR DESCRIPTION
Python models: Doesn't cause server hanging, only has OOM issue when loading all models at once.
Onnx models: It takes about 12 hours to load all the models. At some point the server stuck for a while when this [line](https://github.com/microsoft/onnxruntime/blob/rel-1.13.1/include/onnxruntime/core/common/spin_pause.h#L22) is called, but it will resume eventually. Reduce the instance count and the number of models being loaded help with the case.
Hence, modify to test with python and onnx models in separate runs.