### PR TITLE
Small refactoring (if/else paths)

### DIFF
--- a/qa/L0_trt_reformat_free/trt_reformat_free_test.py
+++ b/qa/L0_trt_reformat_free/trt_reformat_free_test.py
@@ -49,8 +49,12 @@ def div_up(a, b):
 def reformat(format, tensor_np):
     if format == "CHW2":
         factor = 2
-    if format == "CHW32":
+    elif format == "CHW32":
         factor = 32
+    else:
+        raise ValueError(
+            "Unexpected format {} for testing reformat-free input".format(
+                format))
     shape = list(tensor_np.shape) + [factor]
     shape[-4] = div_up(shape[-4], factor)
     reformatted_tensor_np = np.empty(shape, tensor_np.dtype)

--- a/qa/L0_trt_reformat_free/trt_reformat_free_test.py
+++ b/qa/L0_trt_reformat_free/trt_reformat_free_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_implicit_models.py
+++ b/qa/common/gen_qa_implicit_models.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_implicit_models.py
+++ b/qa/common/gen_qa_implicit_models.py
@@ -328,6 +328,10 @@ def create_onnx_modelfile_with_initial_state(models_dir, model_version,
         identity = onnx.helper.make_node("Identity", ["_INPUT"], ["OUTPUT"])
         identity_output_state = onnx.helper.make_node("Identity", ["_INPUT"],
                                                       ["OUTPUT_STATE"])
+        onnx_nodes = [
+            internal_input, internal_input_state, identity,
+            identity_output_state
+        ]
     else:
         add = onnx.helper.make_node("Add", ["_INPUT", "_INPUT_STATE"], ["CAST"])
         cast = onnx.helper.make_node("Cast", ["CAST"], ["OUTPUT"],
@@ -335,22 +339,14 @@ def create_onnx_modelfile_with_initial_state(models_dir, model_version,
         cast_output_state = onnx.helper.make_node("Cast", ["CAST"],
                                                   ["OUTPUT_STATE"],
                                                   to=onnx_dtype)
-
-    # Avoid cast from float16 to float16
-    # (bug in Onnx Runtime, cast from float16 to float16 will become cast from float16 to float32)
-    if onnx_dtype == onnx.TensorProto.FLOAT16:
-        cast = onnx.helper.make_node("Identity", ["CAST"], ["OUTPUT"])
-        cast_output_state = onnx.helper.make_node("Identity", ["CAST"],
+        # Avoid cast from float16 to float16
+        # (bug in Onnx Runtime, cast from float16 to float16 will become cast from float16 to float32)
+        if onnx_dtype == onnx.TensorProto.FLOAT16:
+            cast = onnx.helper.make_node("Identity", ["CAST"], ["OUTPUT"])
+            cast_output_state = onnx.helper.make_node("Identity", ["CAST"],
                                                   ["OUTPUT_STATE"])
-
-    if onnx_dtype != onnx.TensorProto.STRING:
         onnx_nodes = [
             internal_input, internal_input_state, add, cast, cast_output_state
-        ]
-    else:
-        onnx_nodes = [
-            internal_input, internal_input_state, identity,
-            identity_output_state
         ]
 
     onnx_inputs = [onnx_input_state, onnx_input, onnx_start, onnx_ready]

--- a/qa/common/gen_qa_implicit_models.py
+++ b/qa/common/gen_qa_implicit_models.py
@@ -344,7 +344,7 @@ def create_onnx_modelfile_with_initial_state(models_dir, model_version,
         if onnx_dtype == onnx.TensorProto.FLOAT16:
             cast = onnx.helper.make_node("Identity", ["CAST"], ["OUTPUT"])
             cast_output_state = onnx.helper.make_node("Identity", ["CAST"],
-                                                  ["OUTPUT_STATE"])
+                                                      ["OUTPUT_STATE"])
         onnx_nodes = [
             internal_input, internal_input_state, add, cast, cast_output_state
         ]


### PR DESCRIPTION
- Catch uninitialized variable in trt_reformat_free and use if/elif/else instead of separate if statements
- In gen_qa_implicit_models, combine if/else statements to minimize number of checks and improve flow for readability