### PR TITLE
Enable model namespacing in SageMaker entrypoint

### DIFF
--- a/docker/sagemaker/serve
+++ b/docker/sagemaker/serve
@@ -48,6 +48,12 @@ if [ -n "$SAGEMAKER_MULTI_MODEL" ]; then
 fi
 
 SAGEMAKER_ARGS="--model-repository=${SAGEMAKER_MODEL_REPO}"
+#Set model namespacing to true, but allow disabling if required
+if [ -n "$SAGEMAKER_TRITON_DISABLE_MODEL_NAMESPACING" ]; then
+    SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --model-namespacing=${SAGEMAKER_TRITON_DISABLE_MODEL_NAMESPACING}"
+else
+    SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --model-namespacing=true"
+fi
 if [ -n "$SAGEMAKER_BIND_TO_PORT" ]; then
     SAGEMAKER_ARGS="${SAGEMAKER_ARGS} --sagemaker-port=${SAGEMAKER_BIND_TO_PORT}"
 fi


### PR DESCRIPTION
This issue was recently addressed: https://github.com/triton-inference-server/server/issues/5150, one of the associated PRs is - https://github.com/triton-inference-server/server/pull/5362/files.

This change requires that `--model-namespacing=true` option be added to the tritonserver start command. Adding it to the SageMaker entrypoint script that specifies the start command.