### PR TITLE
Adding repo tag to torch.hub.load to fix compatibility issues

### DIFF
--- a/qa/python_models/torchvision/resnet50/model.py
+++ b/qa/python_models/torchvision/resnet50/model.py
@@ -37,7 +37,13 @@ class TritonPythonModel:
         This function initializes pre-trained ResNet50 model.
         """
         self.device = 'cuda' if args["model_instance_kind"] == "GPU" else 'cpu'
-        self.model = torch.hub.load("pytorch/vision:v0.14.1", "resnet50", weights="IMAGENET1K_V2")\
+        # Our tests currently depend on torchvision=0.14,
+        # to make sure `torch.hub` loads Resnet50 implementation
+        # compatible with torchvision=0.14, we need to provide tag
+        self.model = torch.hub.load(
+                            "pytorch/vision:v0.14.1",
+                            "resnet50",
+                            weights="IMAGENET1K_V2")\
                         .to(self.device)\
                         .eval()
 

--- a/qa/python_models/torchvision/resnet50/model.py
+++ b/qa/python_models/torchvision/resnet50/model.py
@@ -37,7 +37,7 @@ class TritonPythonModel:
         This function initializes pre-trained ResNet50 model.
         """
         self.device = 'cuda' if args["model_instance_kind"] == "GPU" else 'cpu'
-        self.model = torch.hub.load("pytorch/vision", "resnet50", weights="IMAGENET1K_V2")\
+        self.model = torch.hub.load("pytorch/vision:v0.14.1", "resnet50", weights="IMAGENET1K_V2")\
                         .to(self.device)\
                         .eval()
 


### PR DESCRIPTION
To make sure `ResNet50` model is loaded and compatible with `torchvision=0.14`, that we are using in tests, torch hub needs a proper tag.