### PR TITLE
Removing deprecated usage of  config.max_workspace_size in favor of config.set_memory_pool_limit

### DIFF
--- a/qa/common/gen_qa_dyna_sequence_implicit_models.py
+++ b/qa/common/gen_qa_dyna_sequence_implicit_models.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -405,7 +405,7 @@ def create_plan_fixed_modelfile(models_dir, model_version, max_batch, dtype,
     network.mark_output(out0_state.get_output(0))
 
     config = builder.create_builder_config()
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -497,7 +497,7 @@ def create_plan_fixed_rf_modelfile(models_dir, model_version, max_batch, dtype,
 
     config = builder.create_builder_config()
     config.flags = flags
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)

--- a/qa/common/gen_qa_dyna_sequence_models.py
+++ b/qa/common/gen_qa_dyna_sequence_models.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -484,7 +484,7 @@ def create_plan_shape_tensor_modelfile(models_dir, model_version, max_batch,
     config = builder.create_builder_config()
     config.flags = flags
     config.add_optimization_profile(profile)
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -530,7 +530,7 @@ def create_plan_fixed_modelfile(models_dir, model_version, max_batch, dtype,
     network.mark_output(out0.get_output(0))
 
     config = builder.create_builder_config()
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -603,7 +603,7 @@ def create_plan_fixed_rf_modelfile(models_dir, model_version, max_batch, dtype,
 
     config = builder.create_builder_config()
     config.flags = flags
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -696,7 +696,7 @@ def create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype,
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
 
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -812,7 +812,7 @@ def create_plan_dynamic_rf_modelfile(models_dir, model_version, max_batch,
     config = builder.create_builder_config()
     config.flags = flags
     config.add_optimization_profile(profile)
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:

--- a/qa/common/gen_qa_identity_models.py
+++ b/qa/common/gen_qa_identity_models.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -757,7 +757,7 @@ def create_plan_dynamic_rf_modelfile(models_dir, model_version, io_cnt,
             flags |= 1 << int(trt.BuilderFlag.FP16)
     config = builder.create_builder_config()
     config.flags = flags
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     config.add_optimization_profile(profile)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -861,7 +861,7 @@ def create_plan_shape_tensor_modelfile(models_dir, model_version, io_cnt,
             flags |= 1 << int(trt.BuilderFlag.FP16)
     config.flags = flags
 
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -922,7 +922,7 @@ def create_plan_dynamic_modelfile(models_dir, model_version, io_cnt, max_batch,
                           max_shape)
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:

--- a/qa/common/gen_qa_implicit_models.py
+++ b/qa/common/gen_qa_implicit_models.py
@@ -584,7 +584,7 @@ def create_plan_fixed_modelfile(models_dir, model_version, max_batch, dtype,
     network.mark_output(out0_state.get_output(0))
 
     config = builder.create_builder_config()
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -664,7 +664,7 @@ def create_plan_fixed_rf_modelfile(models_dir, model_version, max_batch, dtype,
 
     config = builder.create_builder_config()
     config.flags = flags
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -758,7 +758,7 @@ def create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype,
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
 
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -876,7 +876,7 @@ def create_plan_dynamic_rf_modelfile(models_dir, model_version, max_batch,
     config.flags = flags
     config.add_optimization_profile(profile)
 
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:

--- a/qa/common/gen_qa_models.py
+++ b/qa/common/gen_qa_models.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -574,7 +574,7 @@ def create_plan_dynamic_rf_modelfile(models_dir, max_batch, model_version,
     config = builder.create_builder_config()
     config.flags = flags
     config.add_optimization_profile(profile)
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -720,7 +720,7 @@ def create_plan_dynamic_modelfile(models_dir, max_batch, model_version,
                                       [1 + i] + opt_shape, [1 + i] + max_shape)
             config.add_optimization_profile(profile[10 + i])
 
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -796,7 +796,7 @@ def create_plan_fixed_rf_modelfile(models_dir, max_batch, model_version,
             flags |= 1 << int(trt.BuilderFlag.FP16)
     config = builder.create_builder_config()
     config.flags = flags
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -844,7 +844,7 @@ def create_plan_fixed_modelfile(models_dir, max_batch, model_version,
     network.mark_output(out1.get_output(0))
 
     config = builder.create_builder_config()
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -278,7 +278,7 @@ def create_plan_modelfile(models_dir, model_version, dtype):
                           max_shape)
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -561,7 +561,7 @@ def create_plan_itemshape_modelfile(models_dir, model_version, dtype):
                       max_shape + [2])
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:

--- a/qa/common/gen_qa_reshape_models.py
+++ b/qa/common/gen_qa_reshape_models.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -333,7 +333,7 @@ def create_plan_modelfile(models_dir, model_version, max_batch, dtype,
         network.mark_output(out0.get_output(0))
 
     config = builder.create_builder_config()
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)

--- a/qa/common/gen_qa_sequence_models.py
+++ b/qa/common/gen_qa_sequence_models.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -460,7 +460,7 @@ def create_plan_shape_tensor_modelfile(models_dir, model_version, max_batch,
     config.flags = flags
     config.add_optimization_profile(profile)
 
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -501,7 +501,7 @@ def create_plan_fixed_modelfile(models_dir, model_version, max_batch, dtype,
     network.mark_output(out0.get_output(0))
 
     config = builder.create_builder_config()
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -566,7 +566,7 @@ def create_plan_fixed_rf_modelfile(models_dir, model_version, max_batch, dtype,
 
     config = builder.create_builder_config()
     config.flags = flags
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
@@ -646,7 +646,7 @@ def create_plan_dynamic_modelfile(models_dir, model_version, max_batch, dtype,
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
 
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -749,7 +749,7 @@ def create_plan_dynamic_rf_modelfile(models_dir, model_version, max_batch,
     config.flags = flags
     config.add_optimization_profile(profile)
 
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:

--- a/qa/common/gen_qa_trt_data_dependent_shape.py
+++ b/qa/common/gen_qa_trt_data_dependent_shape.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -116,7 +116,7 @@ def create_data_dependent_modelfile(models_dir,
     profile.set_shape("INPUT", min_shape, opt_shape, max_shape)
     config = builder.create_builder_config()
     config.add_optimization_profile(profile)
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     
     # serialized model
     engine_bytes = builder.build_serialized_network(network, config)

--- a/qa/common/gen_qa_trt_format_models.py
+++ b/qa/common/gen_qa_trt_format_models.py
@@ -184,7 +184,7 @@ def create_plan_dynamic_modelfile(models_dir,
     config = builder.create_builder_config()
     config.flags = flags
     config.add_optimization_profile(profile)
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     try:
         engine_bytes = builder.build_serialized_network(network, config)
     except AttributeError:
@@ -262,7 +262,7 @@ def create_plan_fixed_modelfile(models_dir, max_batch, model_version,
             flags |= 1 << int(trt.BuilderFlag.FP16)
     config = builder.create_builder_config()
     config.flags = flags
-    config.max_workspace_size = 1 << 20
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
     builder.max_batch_size = max(1, max_batch)
     try:
         engine_bytes = builder.build_serialized_network(network, config)

--- a/qa/common/gen_qa_trt_plugin_models.py
+++ b/qa/common/gen_qa_trt_plugin_models.py
@@ -149,7 +149,7 @@ def create_plan_modelfile(models_dir, max_batch, model_version, plugin_name,
             network.mark_output(plugin_layer.get_output(0))
 
             config = builder.create_builder_config()
-            config.max_workspace_size = 1 << 20
+            config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
 
             try:
                 engine_bytes = builder.build_serialized_network(network, config)
@@ -180,7 +180,7 @@ def create_plan_modelfile(models_dir, max_batch, model_version, plugin_name,
             network.mark_output(plugin_layer.get_output(0))
 
             config = builder.create_builder_config()
-            config.max_workspace_size = 1 << 20
+            config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 20)
             builder.max_batch_size = max(1, max_batch)
 
             try:


### PR DESCRIPTION
New usage requires:
[set_memory_pool_limit](https://docs.nvidia.com/deeplearning/tensorrt/api/python_api/infer/Core/BuilderConfig.html#tensorrt.IBuilderConfig.set_memory_pool_limit) (pool: tensorrt.tensorrt.MemoryPoolType, pool_size: int)

pool: [tensorrt.tensorrt.MemoryPoolType](https://docs.nvidia.com/deeplearning/tensorrt/api/python_api/infer/Core/BuilderConfig.html?highlight=tensorrt%20tensorrt%20memorypooltype#tensorrt.MemoryPoolType) was set to `trt.MemoryPoolType.WORKSPACE`, since according to api docs : 

> WORKSPACE is used by TensorRT to store intermediate buffers within an operation. This is equivalent to the deprecated IBuilderConfig.max_workspace_size and overrides that value. 