### PR TITLE
Add metrics config CLI

### DIFF
--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -887,7 +887,7 @@ TritonServerParameters::BuildTritonServerOptions()
         TRITONSERVER_ServerOptionsSetMetricsConfig(
             loptions, std::get<0>(mcs).c_str(), std::get<1>(mcs).c_str(),
             std::get<2>(mcs).c_str()),
-        "setting metrics configurtion");
+        "setting metrics configuration");
   }
 
 #endif  // TRITON_ENABLE_METRICS
@@ -915,7 +915,7 @@ TritonServerParameters::BuildTritonServerOptions()
           ParseException,
           TRITONSERVER_ServerOptionsSetCacheConfig(
               loptions, cache_name.c_str(), json_config_str.c_str()),
-          "setting cache configurtion");
+          "setting cache configuration");
     }
   }
 
@@ -930,7 +930,7 @@ TritonServerParameters::BuildTritonServerOptions()
         TRITONSERVER_ServerOptionsSetBackendConfig(
             loptions, std::get<0>(bcs).c_str(), std::get<1>(bcs).c_str(),
             std::get<2>(bcs).c_str()),
-        "setting backend configurtion");
+        "setting backend configuration");
   }
   for (const auto& limit : load_gpu_limit_) {
     THROW_IF_ERR(
@@ -1469,14 +1469,14 @@ TritonParser::ParseMetricsConfigOption(const std::string& arg)
   int delim_setting = arg.find("=", delim_name + 1);
 
   // No name-specific configs currently supported, though it may be in
-  // the future. Map to empty string name like other global configs for now.
+  // the future. Map global configs to empty string like other configs for now.
   std::string name_string = std::string();
   if (delim_name >= 0) {
     std::stringstream ss;
     ss << "--metrics-config option format is "
        << "<setting>=<value>. Got " << arg << std::endl;
     throw ParseException(ss.str());
-  }  // else global backend config
+  }  // else global metrics config
 
   if (delim_setting < 0) {
     std::stringstream ss;

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -275,6 +275,7 @@ enum TritonOptionId {
   OPTION_ALLOW_CPU_METRICS,
   OPTION_METRICS_PORT,
   OPTION_METRICS_INTERVAL_MS,
+  OPTION_METRICS_CONFIG,
 #endif  // TRITON_ENABLE_METRICS
 #ifdef TRITON_ENABLE_TRACING
   OPTION_TRACE_FILEPATH,
@@ -480,6 +481,10 @@ std::vector<Option> TritonParser::recognized_options_
       {OPTION_METRICS_INTERVAL_MS, "metrics-interval-ms", Option::ArgFloat,
        "Metrics will be collected once every <metrics-interval-ms> "
        "milliseconds. Default is 2000 milliseconds."},
+      {OPTION_METRICS_CONFIG, "metrics-config", "<string>=<string>",
+       "Specify a metrics-specific configuration setting. The format of this "
+       "flag is --metrics-config=<setting>=<value>. It can be specified "
+       "multiple times."},
 #endif  // TRITON_ENABLE_METRICS
 #ifdef TRITON_ENABLE_TRACING
       {OPTION_TRACE_FILEPATH, "trace-file", Option::ArgStr,
@@ -849,6 +854,15 @@ TritonServerParameters::BuildTritonServerOptions()
       TRITONSERVER_ServerOptionsSetMetricsInterval(
           loptions, metrics_interval_ms_),
       "setting metrics interval");
+  for (const auto& mcs : metrics_config_settings_) {
+    THROW_IF_ERR(
+        ParseException,
+        TRITONSERVER_ServerOptionsSetMetricsConfig(
+            loptions, std::get<0>(mcs).c_str(), std::get<1>(mcs).c_str(),
+            std::get<2>(mcs).c_str()),
+        "setting metrics configurtion");
+  }
+
 #endif  // TRITON_ENABLE_METRICS
 
   THROW_IF_ERR(
@@ -1165,6 +1179,10 @@ TritonParser::Parse(int argc, char** argv)
       case OPTION_METRICS_INTERVAL_MS:
         lparams.metrics_interval_ms_ = ParseOption<int>(optarg);
         break;
+      case OPTION_METRICS_CONFIG:
+        lparams.metrics_config_settings_.push_back(
+            ParseMetricsConfigOption(optarg));
+        break;
 #endif  // TRITON_ENABLE_METRICS
 
 #ifdef TRITON_ENABLE_TRACING
@@ -1402,6 +1420,43 @@ TritonParser::Usage()
     }
   }
   return ss.str();
+}
+
+std::tuple<std::string, std::string, std::string>
+TritonParser::ParseMetricsConfigOption(const std::string& arg)
+{
+  // Format is "<setting>=<value>" for generic configs/settings
+  int delim_name = arg.find(",");
+  int delim_setting = arg.find("=", delim_name + 1);
+
+  // No name-specific configs currently supported, though it may be in
+  // the future. Map to empty string name like other global configs for now.
+  std::string name_string = std::string();
+  if (delim_name >= 0) {
+    std::stringstream ss;
+    ss << "--metrics-config option format is "
+       << "<setting>=<value>. Got " << arg << std::endl;
+    throw ParseException(ss.str());
+  }  // else global backend config
+
+  if (delim_setting < 0) {
+    std::stringstream ss;
+    ss << "--metrics-config option format is "
+       << "<setting>=<value>. Got " << arg << std::endl;
+    throw ParseException(ss.str());
+  }
+  std::string setting_string =
+      arg.substr(delim_name + 1, delim_setting - delim_name - 1);
+  std::string value_string = arg.substr(delim_setting + 1);
+
+  if (setting_string.empty() || value_string.empty()) {
+    std::stringstream ss;
+    ss << "--metrics-config option format is "
+       << "<setting>=<value>. Got " << arg << std::endl;
+    throw ParseException(ss.str());
+  }
+
+  return {name_string, setting_string, value_string};
 }
 
 std::tuple<std::string, std::string, std::string>

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -202,8 +202,6 @@ struct TritonServerParameters {
   float metrics_interval_ms_{2000};
   bool allow_gpu_metrics_{true};
   bool allow_cpu_metrics_{true};
-
-  // Metrics configuration
   std::vector<std::tuple<std::string, std::string, std::string>>
       metrics_config_settings_;
 #endif  // TRITON_ENABLE_METRICS

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -202,6 +202,10 @@ struct TritonServerParameters {
   float metrics_interval_ms_{2000};
   bool allow_gpu_metrics_{true};
   bool allow_cpu_metrics_{true};
+
+  // Metrics configuration
+  std::vector<std::tuple<std::string, std::string, std::string>>
+      metrics_config_settings_;
 #endif  // TRITON_ENABLE_METRICS
 
 #ifdef TRITON_ENABLE_SAGEMAKER
@@ -271,6 +275,8 @@ class TritonParser {
   std::tuple<std::string, std::string, std::string> ParseBackendConfigOption(
       const std::string& arg);
   std::tuple<std::string, std::string, std::string> ParseHostPolicyOption(
+      const std::string& arg);
+  std::tuple<std::string, std::string, std::string> ParseMetricsConfigOption(
       const std::string& arg);
 #ifdef TRITON_ENABLE_TRACING
   TRITONSERVER_InferenceTraceLevel ParseTraceLevelOption(std::string arg);


### PR DESCRIPTION
Preliminary changes to expose config settings. These will be used to opt-in and toggle future metrics features.

Below are just rough ideas of things that would be configured based on user feedback, not the exact set of args we will necessarily support. We can roll out functionality in stages based on feedback and priorities.

Example (settings/values TBD): 
```
# Use summaries instead of counters for all built-in latency related metrics
tritonserver --metrics-config summaries=all 
# other alternatives for the same thing
tritonserver --metrics-config summaries=true
tritonserver --metrics-config summaries=*   (similar to --load-model support)

# specify custom quantiles for summary metrics
tritonserver \
  --metrics-config summaries=all
  --metrics-config summary_quantiles=0.5, 0.75, 0.9, 0.95, 0.99, 0.999

# only use summaries for compute metrics, counters otherwise, etc.
tritonserver --metrics-config summaries=compute

# specify histogram buckets across all histograms. possible ability to override per-model in model configs
tritonserver \
  --metrics-config histograms=all 
  --metrics-config histogram_buckets=0.01, 0.1, 1, 10, 100, 1000

# specify metric name prefixes, ex: omniverse
tritonserver \
  --metrics-config metrics-prefix="my_product_prefix_"

# specify additional labels, ex: omniverse
tritonserver \
  --metrics-config metrics-labels="key:value"
```


Core PR: https://github.com/triton-inference-server/core/pull/181