### PR TITLE
Fix L0_logging with new number of logs

### DIFF
--- a/qa/L0_logging/test.sh
+++ b/qa/L0_logging/test.sh
@@ -216,7 +216,7 @@ fi
 
 # Check redirection worked properly (server log has tolerance of 40 due to 
 # unavoidable onnx framework logging)
-expected_log_count=79
+expected_log_count=75
 actual_log_count=$(grep -c ^[IWEV][0-9][0-9][0-9][0-9].* ./log_file.log)
 if [ $actual_log_count -lt $expected_log_count ]; then
     echo $actual_log_count


### PR DESCRIPTION
Update the expected numbers to address the table printing of gRPC keepalive paramteres:

### Before

```
> I0410 23:12:55.866256 288 grpc_server.cc:4888] === GRPC KeepAlive Options ===
> I0410 23:12:55.866268 288 grpc_server.cc:4889] keepalive_time_ms: 7200000
> I0410 23:12:55.866272 288 grpc_server.cc:4891] keepalive_timeout_ms: 20000
> I0410 23:12:55.866275 288 grpc_server.cc:4893] keepalive_permit_without_calls: 0
> I0410 23:12:55.866279 288 grpc_server.cc:4895] http2_max_pings_without_data: 2
> I0410 23:12:55.866283 288 grpc_server.cc:4897] http2_min_recv_ping_interval_without_data_ms: 300000
> I0410 23:12:55.866286 288 grpc_server.cc:4900] http2_max_ping_strikes: 2

```

### After

```
< I0410 22:56:34.139461 1317 grpc_server.cc:2344] 
< +----------------------------------------------+---------+
< | GRPC KeepAlive Option                        | Value   |
< +----------------------------------------------+---------+
< | keepalive_time_ms                            | 7200000 |
< | keepalive_timeout_ms                         | 20000   |
< | keepalive_permit_without_calls               | 0       |
< | http2_max_pings_without_data                 | 2       |
< | http2_min_recv_ping_interval_without_data_ms | 300000  |
< | http2_max_ping_strikes                       | 2       |
< +----------------------------------------------+---------+

```