### PR TITLE
Remove extra quotes for shared memory in test

### DIFF
--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -79,7 +79,7 @@ fi
 PERF_CLIENT_PERCENTILE_ARGS="" &&
     (( ${PERF_CLIENT_PERCENTILE} != 0 )) &&
     PERF_CLIENT_PERCENTILE_ARGS="--percentile=${PERF_CLIENT_PERCENTILE}"
-PERF_CLIENT_EXTRA_ARGS="$PERF_CLIENT_PERCENTILE_ARGS --shared-memory \"${SHARED_MEMORY}\""
+PERF_CLIENT_EXTRA_ARGS="$PERF_CLIENT_PERCENTILE_ARGS --shared-memory ${SHARED_MEMORY}"
 
 # Overload use of PERF_CLIENT_PROTOCOL for convenience with existing test and 
 # reporting structure, though "triton_c_api" is not strictly a "protocol".


### PR DESCRIPTION
After shared memory validation was added to perf client [here](https://github.com/triton-inference-server/client/commit/1dab8821644c05c2f971be3108585b83e0d0c083), it made it clear that shared memory is not being correctly parsed in this test. An error is not returned, so it does not affect test results (we should look into checking for this later). However, this fix will allow perf_client to run.