### PR TITLE
Opentelemetry trace support for Triton tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,14 @@ else()
   set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/lib/cmake/protobuf")
 endif()
 
+# Triton with Opentelemetry is not supported on Windows
+# FIXME: add location for Windows, when support is added
+if (WIN32)
+  set(_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR "")
+else()
+  set(_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/lib/cmake/opentelemetry-cpp")
+endif()
+
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(TRITON_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/install)
 else()
@@ -210,7 +218,7 @@ ExternalProject_Add(triton-server
     -Daws-c-common_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-c-common/cmake
     -Daws-checksums_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-checksums/cmake
     -DCURL_DIR:STRING=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/curl/lib/cmake/CURL
-    -Dopentelemetry-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/lib/cmake/opentelemetry-cpp
+    -Dopentelemetry-cpp_DIR:PATH=${_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR}
     -DTRITON_THIRD_PARTY_REPO_TAG:STRING=${TRITON_THIRD_PARTY_REPO_TAG}
     -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG}
     -DTRITON_CORE_REPO_TAG:STRING=${TRITON_CORE_REPO_TAG}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,8 @@ ExternalProject_Add(triton-server
     -Daws-c-event-stream_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-c-event-stream/cmake
     -Daws-c-common_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-c-common/cmake
     -Daws-checksums_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/aws-sdk-cpp/lib/aws-checksums/cmake
+    -DCURL_DIR:STRING=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/curl/lib/cmake/CURL
+    -Dopentelemetry-cpp_DIR:PATH=${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/lib/cmake/opentelemetry-cpp
     -DTRITON_THIRD_PARTY_REPO_TAG:STRING=${TRITON_THIRD_PARTY_REPO_TAG}
     -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG}
     -DTRITON_CORE_REPO_TAG:STRING=${TRITON_CORE_REPO_TAG}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,17 @@ if(${TRITON_ENABLE_HTTP} OR ${TRITON_ENABLE_METRICS} OR
   message(STATUS "Using libevent ${Libevent_VERSION}")
 endif()
 
+# OpenTelemetry
+#
+if(${TRITON_ENABLE_TRACING})
+  find_package(CURL CONFIG REQUIRED)
+  message(STATUS "Using curl ${CURL_VERSION}")
+  find_package(nlohmann_json CONFIG REQUIRED)
+  message(STATUS "Using nlohmann_json for otel")
+  find_package(opentelemetry-cpp CONFIG REQUIRED)
+  message(STATUS "Using opentelemetry-cpp ${opentelemetry-cpp_VERSION}")
+endif()
+
 # re2
 #
 find_library(RE2_LIBRARY NAMES re2)
@@ -226,9 +237,15 @@ if(${TRITON_ENABLE_STATS})
 endif() # TRITON_ENABLE_STATS
 
 if(${TRITON_ENABLE_TRACING})
+  
   target_compile_definitions(
     main
     PRIVATE TRITON_ENABLE_TRACING=1
+  )
+  target_include_directories(
+    main
+    PRIVATE
+      ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
   )
 endif() # TRITON_ENABLE_TRACING
 
@@ -281,6 +298,7 @@ if(${TRITON_ENABLE_GRPC})
     main
     PRIVATE
       $<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>
+      ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
   )
 
   target_compile_definitions(
@@ -370,8 +388,12 @@ if(${TRITON_ENABLE_HTTP}
 
   target_include_directories(
     http-endpoint-library
-    PRIVATE $<TARGET_PROPERTY:libevhtp::evhtp,INTERFACE_INCLUDE_DIRECTORIES>
+    PRIVATE 
+      $<TARGET_PROPERTY:libevhtp::evhtp,INTERFACE_INCLUDE_DIRECTORIES>
+      ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+      #tracing-library
   )
+  
 
   if(${TRITON_ENABLE_GPU})
     target_compile_definitions(
@@ -478,6 +500,16 @@ if(${TRITON_ENABLE_TRACING})
     tracing-library EXCLUDE_FROM_ALL
     tracer.cc tracer.h
   )
+  
+  target_include_directories(
+    tracing-library 
+    PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  )
+
+  target_link_libraries(
+    tracing-library
+    PRIVATE 
+    ${OPENTELEMETRY_CPP_LIBRARIES})
 
   target_link_libraries(
     tracing-library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -298,7 +298,6 @@ if(${TRITON_ENABLE_GRPC})
     main
     PRIVATE
       $<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>
-      ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
   )
 
   target_compile_definitions(
@@ -391,7 +390,6 @@ if(${TRITON_ENABLE_HTTP}
     PRIVATE 
       $<TARGET_PROPERTY:libevhtp::evhtp,INTERFACE_INCLUDE_DIRECTORIES>
       ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
-      #tracing-library
   )
   
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,13 +78,15 @@ endif()
 
 # OpenTelemetry
 #
-if(${TRITON_ENABLE_TRACING})
-  find_package(CURL CONFIG REQUIRED)
-  message(STATUS "Using curl ${CURL_VERSION}")
-  find_package(nlohmann_json CONFIG REQUIRED)
-  message(STATUS "Using nlohmann_json for otel")
-  find_package(opentelemetry-cpp CONFIG REQUIRED)
-  message(STATUS "Using opentelemetry-cpp ${opentelemetry-cpp_VERSION}")
+if (NOT WIN32)
+  if(${TRITON_ENABLE_TRACING})
+    find_package(CURL CONFIG REQUIRED)
+    message(STATUS "Using curl ${CURL_VERSION}")
+    find_package(nlohmann_json CONFIG REQUIRED)
+    message(STATUS "Using nlohmann_json for otel")
+    find_package(opentelemetry-cpp CONFIG REQUIRED)
+    message(STATUS "Using opentelemetry-cpp ${opentelemetry-cpp_VERSION}")
+  endif()
 endif()
 
 # re2
@@ -237,16 +239,18 @@ if(${TRITON_ENABLE_STATS})
 endif() # TRITON_ENABLE_STATS
 
 if(${TRITON_ENABLE_TRACING})
-  
   target_compile_definitions(
     main
     PRIVATE TRITON_ENABLE_TRACING=1
   )
-  target_include_directories(
-    main
-    PRIVATE
-      ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
-  )
+# FIXME: remove, when Windows support is added for Opentelemetry
+  if (NOT WIN32)
+    target_include_directories(
+      main
+      PRIVATE
+        ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+    )
+  endif()
 endif() # TRITON_ENABLE_TRACING
 
 if(${TRITON_ENABLE_NVTX})
@@ -387,11 +391,17 @@ if(${TRITON_ENABLE_HTTP}
 
   target_include_directories(
     http-endpoint-library
-    PRIVATE 
-      $<TARGET_PROPERTY:libevhtp::evhtp,INTERFACE_INCLUDE_DIRECTORIES>
-      ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+    PRIVATE $<TARGET_PROPERTY:libevhtp::evhtp,INTERFACE_INCLUDE_DIRECTORIES>
   )
   
+  # FIXME when Triton support of Opentelemetry is available on Windows
+  # add ${OPENTELEMETRY_CPP_INCLUDE_DIRS} to above target_include_directories
+  if (NOT WIN32)
+    target_include_directories(
+      http-endpoint-library
+      PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+    )
+  endif()
 
   if(${TRITON_ENABLE_GPU})
     target_compile_definitions(
@@ -499,15 +509,17 @@ if(${TRITON_ENABLE_TRACING})
     tracer.cc tracer.h
   )
   
-  target_include_directories(
-    tracing-library 
-    PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
-  )
+  if (NOT WIN32)
+    target_include_directories(
+      tracing-library 
+      PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+    )
 
-  target_link_libraries(
-    tracing-library
-    PRIVATE 
-    ${OPENTELEMETRY_CPP_LIBRARIES})
+    target_link_libraries(
+      tracing-library
+      PRIVATE 
+      ${OPENTELEMETRY_CPP_LIBRARIES})
+  endif()
 
   target_link_libraries(
     tracing-library

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -172,6 +172,10 @@ struct TritonServerParameters {
   int32_t trace_rate_{1000};
   int32_t trace_count_{-1};
   int32_t trace_log_frequency_{0};
+  TRITONSERVER_InferenceTraceMode trace_mode_{
+      TRITONSERVER_TRACE_MODE_TRITON};
+  triton::server::TraceConfigMap
+      trace_config_settings_;
 #endif  // TRITON_ENABLE_TRACING
 
 // The configurations for various endpoints (i.e. HTTP, GRPC and metrics)
@@ -283,6 +287,9 @@ class TritonParser {
   ParseGrpcRestrictedProtocolOption(const std::string& arg);
 #ifdef TRITON_ENABLE_TRACING
   TRITONSERVER_InferenceTraceLevel ParseTraceLevelOption(std::string arg);
+  TRITONSERVER_InferenceTraceMode ParseTraceModeOption(std::string arg);
+  std::tuple<std::string, std::string, std::string> ParseTraceConfigOption(
+      const std::string& arg);
 #endif  // TRITON_ENABLE_TRACING
   // Helper function to parse option in
   // "<string>[1st_delim]<string>[2nd_delim]<string>" format

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -40,7 +40,7 @@
 // To avoid ambiguous reference during build
 // grpc headers should be imported first
 // https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/otlp/README.md#additional-notes-regarding-abseil-library
-#include "grpc_server.h"
+#include "grpc/grpc_server.h"
 #endif  // TRITON_ENABLE_GRPC
 #if defined(TRITON_ENABLE_HTTP) || defined(TRITON_ENABLE_METRICS)
 #include "http_server.h"

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -175,7 +175,7 @@ struct TritonServerParameters {
   TRITONSERVER_InferenceTraceMode trace_mode_{
       TRITONSERVER_TRACE_MODE_TRITON};
   triton::server::TraceConfigMap
-      trace_config_settings_;
+      trace_config_map_;
 #endif  // TRITON_ENABLE_TRACING
 
 // The configurations for various endpoints (i.e. HTTP, GRPC and metrics)

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -172,10 +172,8 @@ struct TritonServerParameters {
   int32_t trace_rate_{1000};
   int32_t trace_count_{-1};
   int32_t trace_log_frequency_{0};
-  TRITONSERVER_InferenceTraceMode trace_mode_{
-      TRITONSERVER_TRACE_MODE_TRITON};
-  triton::server::TraceConfigMap
-      trace_config_map_;
+  TRITONSERVER_InferenceTraceMode trace_mode_{TRITONSERVER_TRACE_MODE_TRITON};
+  triton::server::TraceConfigMap trace_config_map_;
 #endif  // TRITON_ENABLE_TRACING
 
 // The configurations for various endpoints (i.e. HTTP, GRPC and metrics)

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -36,6 +36,12 @@
 #include <vector>
 #include "triton/common/logging.h"
 #include "triton/core/tritonserver.h"
+#ifdef TRITON_ENABLE_GRPC
+// To avoid ambiguous reference during build
+// grpc headers should be imported first
+// https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/otlp/README.md#additional-notes-regarding-abseil-library
+#include "grpc_server.h"
+#endif  // TRITON_ENABLE_GRPC
 #if defined(TRITON_ENABLE_HTTP) || defined(TRITON_ENABLE_METRICS)
 #include "http_server.h"
 #endif  // TRITON_ENABLE_HTTP|| TRITON_ENABLE_METRICS
@@ -45,9 +51,6 @@
 #ifdef TRITON_ENABLE_VERTEX_AI
 #include "vertex_ai_server.h"
 #endif  // TRITON_ENABLE_VERTEX_AI
-#ifdef TRITON_ENABLE_GRPC
-#include "grpc/grpc_server.h"
-#endif  // TRITON_ENABLE_GRPC
 
 #ifndef _WIN32
 #include <getopt.h>

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -76,10 +76,17 @@ target_link_libraries(
 
 target_include_directories(
   grpc-endpoint-library
-  PRIVATE
-    $<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>
-    ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  PRIVATE $<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>
 )
+
+# FIXME when Triton support of Opentelemetry is available on Windows
+# add ${OPENTELEMETRY_CPP_INCLUDE_DIRS} to above target_include_directories
+if (NOT WIN32)
+  target_include_directories(
+    grpc-endpoint-library
+    PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  )
+endif()
 
 target_compile_definitions(
   grpc-endpoint-library

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -78,6 +78,7 @@ target_include_directories(
   grpc-endpoint-library
   PRIVATE
     $<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>
+    ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
 )
 
 target_compile_definitions(

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -1378,7 +1378,7 @@ CommonHandler::RegisterTrace()
     // Get current trace setting, this is needed even if the setting
     // has been updated above as some values may not be provided in the request.
     trace_manager_->GetTraceSetting(
-        request.model_name(), &level, &rate, &count, &log_frequency, &filepath, 
+        request.model_name(), &level, &rate, &count, &log_frequency, &filepath,
         &mode);
     // level
     {

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -1232,6 +1232,7 @@ CommonHandler::RegisterTrace()
     int32_t count;
     uint32_t log_frequency;
     std::string filepath;
+    TRITONSERVER_InferenceTraceMode mode = TRITONSERVER_TRACE_MODE_TRITON;
     // Update trace setting
     if (!request.settings().empty()) {
       TraceManager::NewSetting new_setting;
@@ -1377,7 +1378,8 @@ CommonHandler::RegisterTrace()
     // Get current trace setting, this is needed even if the setting
     // has been updated above as some values may not be provided in the request.
     trace_manager_->GetTraceSetting(
-        request.model_name(), &level, &rate, &count, &log_frequency, &filepath);
+        request.model_name(), &level, &rate, &count, &log_frequency, &filepath, 
+        &mode);
     // level
     {
       inference::TraceSettingResponse::SettingValue level_setting;
@@ -1400,6 +1402,8 @@ CommonHandler::RegisterTrace()
     (*response->mutable_settings())["log_frequency"].add_value(
         std::to_string(log_frequency));
     (*response->mutable_settings())["trace_file"].add_value(filepath);
+    (*response->mutable_settings())["trace_mode"].add_value(
+        TRITONSERVER_InferenceTraceModeString(mode));
 
   earlyexit:
     GrpcStatusUtil::Create(status, err);

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1659,6 +1659,7 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
   int32_t count;
   uint32_t log_frequency;
   std::string filepath;
+  TRITONSERVER_InferenceTraceMode mode = TRITONSERVER_TRACE_MODE_TRITON;
 
   // Perform trace setting update if requested
   if (req->method == htp_method_POST) {
@@ -1791,7 +1792,7 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
   // Get current trace setting, this is needed even if the setting
   // has been updated above as some values may not be provided in the request.
   trace_manager_->GetTraceSetting(
-      model_name, &level, &rate, &count, &log_frequency, &filepath);
+      model_name, &level, &rate, &count, &log_frequency, &filepath, &mode);
   triton::common::TritonJson::Value trace_response(
       triton::common::TritonJson::ValueType::OBJECT);
   // level
@@ -1819,6 +1820,11 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
       req,
       trace_response.AddString("log_frequency", std::to_string(log_frequency)));
   HTTP_RESPOND_IF_ERR(req, trace_response.AddString("trace_file", filepath));
+  HTTP_RESPOND_IF_ERR(
+      req, 
+      trace_response.AddString(
+          "trace_mode", 
+          TRITONSERVER_InferenceTraceModeString(mode)));
 
   triton::common::TritonJson::WriteBuffer buffer;
   HTTP_RESPOND_IF_ERR(req, trace_response.Write(&buffer));

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1821,10 +1821,8 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
       trace_response.AddString("log_frequency", std::to_string(log_frequency)));
   HTTP_RESPOND_IF_ERR(req, trace_response.AddString("trace_file", filepath));
   HTTP_RESPOND_IF_ERR(
-      req, 
-      trace_response.AddString(
-          "trace_mode", 
-          TRITONSERVER_InferenceTraceModeString(mode)));
+      req, trace_response.AddString(
+               "trace_mode", TRITONSERVER_InferenceTraceModeString(mode)));
 
   triton::common::TritonJson::WriteBuffer buffer;
   HTTP_RESPOND_IF_ERR(req, trace_response.Write(&buffer));
@@ -2561,7 +2559,8 @@ HTTPAPIServer::EVBufferToInput(
       uint64_t shm_offset;
       const char* shm_region;
       RETURN_IF_ERR(CheckSharedMemoryData(
-          request_input, &use_shm, &shm_region, &shm_offset, reinterpret_cast<uint64_t*>(&byte_size)));
+          request_input, &use_shm, &shm_region, &shm_offset,
+          reinterpret_cast<uint64_t*>(&byte_size)));
       if (use_shm) {
         void* base;
         TRITONSERVER_MemoryType memory_type;

--- a/src/main.cc
+++ b/src/main.cc
@@ -384,7 +384,8 @@ StartTracing(triton::server::TraceManager** trace_manager)
   TRITONSERVER_Error* err = triton::server::TraceManager::Create(
       trace_manager, g_triton_params.trace_level_, g_triton_params.trace_rate_,
       g_triton_params.trace_count_, g_triton_params.trace_log_frequency_,
-      g_triton_params.trace_filepath_);
+      g_triton_params.trace_filepath_, g_triton_params.trace_mode_, 
+      g_triton_params.trace_config_settings_);
 
   if (err != nullptr) {
     LOG_TRITONSERVER_ERROR(err, "failed to configure tracing");

--- a/src/main.cc
+++ b/src/main.cc
@@ -384,7 +384,7 @@ StartTracing(triton::server::TraceManager** trace_manager)
   TRITONSERVER_Error* err = triton::server::TraceManager::Create(
       trace_manager, g_triton_params.trace_level_, g_triton_params.trace_rate_,
       g_triton_params.trace_count_, g_triton_params.trace_log_frequency_,
-      g_triton_params.trace_filepath_, g_triton_params.trace_mode_, 
+      g_triton_params.trace_filepath_, g_triton_params.trace_mode_,
       g_triton_params.trace_config_map_);
 
   if (err != nullptr) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -385,7 +385,7 @@ StartTracing(triton::server::TraceManager** trace_manager)
       trace_manager, g_triton_params.trace_level_, g_triton_params.trace_rate_,
       g_triton_params.trace_count_, g_triton_params.trace_log_frequency_,
       g_triton_params.trace_filepath_, g_triton_params.trace_mode_, 
-      g_triton_params.trace_config_settings_);
+      g_triton_params.trace_config_map_);
 
   if (err != nullptr) {
     LOG_TRITONSERVER_ERROR(err, "failed to configure tracing");

--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -705,6 +705,7 @@ TraceManager::TraceSetting::SampleTrace()
     
     // Setting up exporter
     otlp::OtlpHttpExporterOptions opts;
+    // [FIXME] read from cmd
     opts.url="localhost:4318/v1/traces";
     lts->exporter = otlp::OtlpHttpExporterFactory::Create(opts);
     lts->processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(lts->exporter));
@@ -712,6 +713,7 @@ TraceManager::TraceSetting::SampleTrace()
 
     opentelemetry::trace::StartSpanOptions options;
     options.kind          = opentelemetry::trace::SpanKind::kServer;  // server
+    // [FIXME] think about names
     lts->trace_span_ = lts->provider->GetTracer("triton-http-server")
                       -> StartSpan("HandleInfer", {}, options);
     return lts;

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -52,7 +52,7 @@ namespace otel_trace_api = opentelemetry::trace;
 namespace triton { namespace server {
 
 using TraceConfig = std::vector<std::pair<std::string, std::string>>;
-using TraceConfigMap = std::vector<std::tuple<std::string, std::string, std::string>>;
+using TraceConfigMap = std::unordered_map<std::string, TraceConfig>;
 
 //
 // Manager for tracing to a file.
@@ -72,7 +72,7 @@ class TraceManager {
           rate_(nullptr), clear_count_(false), count_(nullptr),
           clear_log_frequency_(false), log_frequency_(nullptr),
           clear_filepath_(false), filepath_(nullptr), clear_mode_(false),
-          mode_(nullptr)
+          mode_(nullptr), clear_config_map_(false), config_map_(nullptr)
     {
     }
     bool clear_level_;
@@ -92,6 +92,9 @@ class TraceManager {
 
     bool clear_mode_;
     const TRITONSERVER_InferenceTraceMode* mode_;
+
+    bool clear_config_map_;
+    const TraceConfigMap* config_map_; 
   };
 
   struct Trace;
@@ -101,7 +104,7 @@ class TraceManager {
       TraceManager** manager, const TRITONSERVER_InferenceTraceLevel level,
       const uint32_t rate, const int32_t count, const uint32_t log_frequency,
       const std::string& filepath, const TRITONSERVER_InferenceTraceMode mode,
-      const TraceConfigMap trace_config_map);
+      const TraceConfigMap& config_map);
 
   ~TraceManager() = default;
 
@@ -186,7 +189,8 @@ class TraceManager {
   TraceManager(
       const TRITONSERVER_InferenceTraceLevel level, const uint32_t rate,
       const int32_t count, const uint32_t log_frequency,
-      const std::string& filepath, const TRITONSERVER_InferenceTraceMode mode);
+      const std::string& filepath, const TRITONSERVER_InferenceTraceMode mode,
+      const TraceConfigMap& config_map);
 
   static void TraceActivity(
       TRITONSERVER_InferenceTrace* trace,
@@ -241,7 +245,7 @@ class TraceManager {
           log_frequency_(0), mode_(TRITONSERVER_TRACE_MODE_TRITON),
           level_specified_(false), rate_specified_(false),
           count_specified_(false), log_frequency_specified_(false),
-          filepath_specified_(false), mode_specified_(false), sample_(0),
+          filepath_specified_(false), mode_specified_(false), config_map_specified_(false), sample_(0),
           created_(0), collected_(0), sample_in_stream_(0)
     {
       invalid_reason_ = "Setting hasn't been initialized";
@@ -250,10 +254,11 @@ class TraceManager {
         const TRITONSERVER_InferenceTraceLevel level, const uint32_t rate,
         const int32_t count, const uint32_t log_frequency,
         const std::shared_ptr<TraceFile>& file,
-        const TRITONSERVER_InferenceTraceMode mode, const bool level_specified,
+        const TRITONSERVER_InferenceTraceMode mode, const TraceConfigMap& config_map, 
+        const bool level_specified,
         const bool rate_specified, const bool count_specified,
         const bool log_frequency_specified, const bool filepath_specified,
-        const bool mode_specified);
+        const bool mode_specified, const bool config_map_specified);
 
     ~TraceSetting();
 
@@ -272,6 +277,7 @@ class TraceManager {
     const uint32_t log_frequency_;
     const std::shared_ptr<TraceFile> file_;
     const TRITONSERVER_InferenceTraceMode mode_;
+    const TraceConfigMap config_map_;
 
     // Whether the field value is specified or mirror from upper level setting
     const bool level_specified_;
@@ -280,6 +286,7 @@ class TraceManager {
     const bool log_frequency_specified_;
     const bool filepath_specified_;
     const bool mode_specified_;
+    const bool config_map_specified_;
 
    private:
     std::string invalid_reason_;

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -94,7 +94,7 @@ class TraceManager {
     const TRITONSERVER_InferenceTraceMode* mode_;
 
     bool clear_config_map_;
-    const TraceConfigMap* config_map_; 
+    const TraceConfigMap* config_map_;
   };
 
   struct Trace;
@@ -245,8 +245,9 @@ class TraceManager {
           log_frequency_(0), mode_(TRITONSERVER_TRACE_MODE_TRITON),
           level_specified_(false), rate_specified_(false),
           count_specified_(false), log_frequency_specified_(false),
-          filepath_specified_(false), mode_specified_(false), config_map_specified_(false), sample_(0),
-          created_(0), collected_(0), sample_in_stream_(0)
+          filepath_specified_(false), mode_specified_(false),
+          config_map_specified_(false), sample_(0), created_(0), collected_(0),
+          sample_in_stream_(0)
     {
       invalid_reason_ = "Setting hasn't been initialized";
     }
@@ -254,8 +255,8 @@ class TraceManager {
         const TRITONSERVER_InferenceTraceLevel level, const uint32_t rate,
         const int32_t count, const uint32_t log_frequency,
         const std::shared_ptr<TraceFile>& file,
-        const TRITONSERVER_InferenceTraceMode mode, const TraceConfigMap& config_map, 
-        const bool level_specified,
+        const TRITONSERVER_InferenceTraceMode mode,
+        const TraceConfigMap& config_map, const bool level_specified,
         const bool rate_specified, const bool count_specified,
         const bool log_frequency_specified, const bool filepath_specified,
         const bool mode_specified, const bool config_map_specified);

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -34,7 +34,21 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+
+#include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
+#include "opentelemetry/sdk/trace/simple_processor_factory.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/sdk/trace/tracer_provider_factory.h"
+#include "opentelemetry/trace/provider.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/sdk/trace/processor.h"
+namespace otlp = opentelemetry::exporter::otlp;
+namespace trace_sdk = opentelemetry::sdk::trace;
+
+
 #include "triton/core/tritonserver.h"
+
+namespace otel_trace = opentelemetry::trace;
 
 namespace triton { namespace server {
 
@@ -124,6 +138,14 @@ class TraceManager {
     void* trace_userp_;
 
     uint64_t trace_id_;
+
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> trace_span_;
+    
+    std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter;
+
+    std::unique_ptr<trace_sdk::SpanProcessor> processor;
+
+    std::shared_ptr<opentelemetry::trace::TracerProvider> provider;
 
     // Capture a timestamp generated outside of triton and associate it
     // with this trace.


### PR DESCRIPTION
Adding the limited support of Opentelemetry APIs for tracing in triton.

Major Changes:
 - Build with Opentelemetry. Currently there are issues with Windows, so code excludes opentelemetry build and use on Windows
 - TraceManager::Trace has new Opentelemetry related attributes: exporter, processor, provider and span. Exporter and Processor are in charge of exporting collected traces to either default or specified endpoint. This PR adds support for only  OTLP HTTP exporter and SimpleSpanProcessor, which sends every collected span to the endpoint. `provider` and `span`, are in charge of collecting and generating traces.
 - CLI for tracing: new flag is introduced `--trace-config=<<mode>,<setting>=<value>>
    ```
    Specifies global or trace mode specific configuration setting.
	The format of this flag is --tracing-config=<trace
	mode>,<setting>=<value>. Where <trace mode> is either "triton" or "opentelemetry".
	The default is "triton". To specify global trace settings (level,
	rate, count, or mode), the format would be
	--tracing-config=<setting>=<value>. For "triton", the server will use the Triton's trace APIs.
	For "opentelemetry", the server will use the OpenTelemetry's APIs to
	generate, collect and export traces for individual inference
	requests.
```
- Docs are still in process, something may be added
- Tests are on the way
- Opentelemetry tracing does not support bls models and Tensor level tracing