### PR TITLE
Reduce default --model-load-thread-count to 4

### DIFF
--- a/docs/user_guide/model_management.md
+++ b/docs/user_guide/model_management.md
@@ -199,8 +199,7 @@ To reduce service downtime, Triton loads new models in the background while
 continuing to serve inferences on existing models. Based on use case and
 performance requirements, the optimal amount of resources dedicated to loading
 models may differ. Triton exposes a `--model-load-thread-count` option to
-configure the number of threads dedicated to loading models, which defaults to
-twice the number of CPU cores (`2*num_cpus`) visible to the server. 
+configure the number of threads dedicated to loading models, which defaults to 4.
 
 To set this parameter with the C API, refer to 
 `TRITONSERVER_ServerOptionsSetModelLoadThreadCount` in 

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -645,7 +645,7 @@ std::vector<Option> TritonParser::recognized_options_
       {OPTION_MODEL_LOAD_THREAD_COUNT, "model-load-thread-count",
        Option::ArgInt,
        "The number of threads used to concurrently load models in "
-       "model repositories. Default is 2*<num_cpu_cores>."},
+       "model repositories. Default is 4."},
       {OPTION_BACKEND_CONFIG, "backend-config", "<string>,<string>=<string>",
        "Specify a backend-specific configuration setting. The format of this "
        "flag is --backend-config=<backend_name>,<setting>=<value>. Where "

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -121,9 +121,8 @@ struct TritonServerParameters {
   std::set<std::string> startup_models_{};
   // Interval, in seconds, when the model repository is polled for changes.
   int32_t repository_poll_secs_{15};
-  // hardware_concurrency() returns 0 if not well defined or not computable.
-  uint32_t model_load_thread_count_{
-      std::max(2u, 2 * std::thread::hardware_concurrency())};
+  // Number of threads to use for concurrently loading models
+  uint32_t model_load_thread_count_{4};
   std::map<int, double> load_gpu_limit_;
 
   // Rate limiter configuration


### PR DESCRIPTION
On systems with large core counts, this default is too large. In fact, it is causing issues on OCI nodes hitting resource limits.

4 should be a comfortable default for the average use case or simple ensemble cases (preprocess, infer, postprocess) - and users who knowingly need high load concurrency can increase via CLI flag. 

Corresponding core PR: https://github.com/triton-inference-server/core/pull/193

We should rel note this change in 23.05 as well. CC @nv-kmcgill53 