### PR TITLE
Pin aiohttp to 3.8.4 to avoid installing error in Python 3.10

### DIFF
--- a/deploy/mlflow-triton-plugin/setup.py
+++ b/deploy/mlflow-triton-plugin/setup.py
@@ -32,6 +32,6 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    install_requires=["mlflow>=2.2.1,<3.0", "tritonclient[all]", "boto3"],
+    install_requires=["mlflow>=2.2.1,<3.0", "tritonclient[all]", "boto3", "aiohttp==3.8.4"],
     entry_points={"mlflow.deployments": "triton=mlflow_triton.deployments"},
 )


### PR DESCRIPTION
Fix: #5666