### PR TITLE
Give sufficient time to get inference statistics for sequence tests

### DIFF
--- a/qa/L0_sequence_batcher/test.sh
+++ b/qa/L0_sequence_batcher/test.sh
@@ -112,7 +112,7 @@ else
     fi
 fi
 
-SERVER_ARGS_EXTRA="--backend-directory=${BACKEND_DIR} --backend-config=tensorflow,version=${TF_VERSION}"
+SERVER_ARGS_EXTRA="--backend-directory=${BACKEND_DIR} --backend-config=tensorflow,version=${TF_VERSION} --log-verbose=1"
 
 source ../common/util.sh
 

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -986,9 +986,9 @@ class SequenceBatcherTestUtil(tu.TestResultCollector):
     def check_status(self, model_name, batch_exec, exec_cnt, infer_cnt):
         start_time = time.time()
         # There is a time window between when responses are returned and statistics are updated.
-        # To prevent intermittent test failure during that window, wait up to 5 seconds for the
+        # To prevent intermittent test failure during that window, wait up to 10 seconds for the
         # inference statistics to be ready.
-        num_tries = 10
+        num_tries = 20
         for i in range(num_tries):
             stats = self.triton_client_.get_inference_statistics(
                 model_name, "1")

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -988,7 +988,7 @@ class SequenceBatcherTestUtil(tu.TestResultCollector):
         # There is a time window between when responses are returned and statistics are updated.
         # To prevent intermittent test failure during that window, wait up to 10 seconds for the
         # inference statistics to be ready.
-        num_tries = 20
+        num_tries = 10
         for i in range(num_tries):
             stats = self.triton_client_.get_inference_statistics(
                 model_name, "1")
@@ -998,7 +998,7 @@ class SequenceBatcherTestUtil(tu.TestResultCollector):
                 break
             print("WARNING: expect {} executions, got {} (attempt {})".format(
                 exec_cnt, actual_exec_cnt, i))
-            time.sleep(0.5)
+            time.sleep(1)
 
         self.assertEqual(stats.model_stats[0].name, model_name,
                          "expect model stats for model {}".format(model_name))

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -993,6 +993,8 @@ class SequenceBatcherTestUtil(tu.TestResultCollector):
             actual_exec_cnt = stats.model_stats[0].execution_count
             if actual_exec_cnt == exec_cnt:
                 break
+            print("Waiting: expect {} executions, got {}".format(exec_cnt,
+                                                          actual_exec_cnt))
             time.sleep(0.5)
 
         self.assertEqual(stats.model_stats[0].name, model_name,

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -984,7 +984,6 @@ class SequenceBatcherTestUtil(tu.TestResultCollector):
                              _max_sequence_idle_ms * 1000)  # 5 secs
 
     def check_status(self, model_name, batch_exec, exec_cnt, infer_cnt):
-        start_time = time.time()
         # There is a time window between when responses are returned and statistics are updated.
         # To prevent intermittent test failure during that window, wait up to 10 seconds for the
         # inference statistics to be ready.

--- a/qa/common/sequence_util.py
+++ b/qa/common/sequence_util.py
@@ -986,10 +986,10 @@ class SequenceBatcherTestUtil(tu.TestResultCollector):
     def check_status(self, model_name, batch_exec, exec_cnt, infer_cnt):
         start_time = time.time()
         # There is a time window between when responses are returned and statistics are updated.
-        # To prevent intermittent test failure during that window, wait up to 10 seconds for the
+        # To prevent intermittent test failure during that window, wait up to 5 seconds for the
         # inference statistics to be ready.
-        loop_count = 0
-        while (time.time() - start_time) < 10:
+        num_tries = 10
+        for i in range(num_tries):
             stats = self.triton_client_.get_inference_statistics(
                 model_name, "1")
             self.assertEqual(len(stats.model_stats), 1, "expect 1 model stats")
@@ -997,7 +997,7 @@ class SequenceBatcherTestUtil(tu.TestResultCollector):
             if actual_exec_cnt == exec_cnt:
                 break
             print("WARNING: expect {} executions, got {} (attempt {})".format(
-                exec_cnt, actual_exec_cnt, loop_count))
+                exec_cnt, actual_exec_cnt, i))
             time.sleep(0.5)
 
         self.assertEqual(stats.model_stats[0].name, model_name,


### PR DESCRIPTION
Since responses are sent before inference statistics are reported, there is the risk that statistics are checked before they are ready. This may be the cause of L0_sequence_batcher failing infrequently with statistics missing one request, with messages like:

```
Traceback (most recent call last):
  File "sequence_batcher_test.py", line 577, in test_no_sequence_end
    self.check_status(model_name, {1: 4 * (idx + 1)},
AssertionError: 7 != 8 : expected model-execution-count 8 for batch size 1, got 7
```

Only in the case that sequence batcher is going to fail due to not having enough requests ready, this change will provide up to 10 seconds in .5 second increments for the requests to be ready.