### PR TITLE
Add higher --max-trials to L0_perf tests with configurable PA_MAX_TRIALS var

### DIFF
--- a/qa/L0_perf_deeprecommender/run_test.sh
+++ b/qa/L0_perf_deeprecommender/run_test.sh
@@ -86,14 +86,21 @@ for STATIC_BATCH in $STATIC_BATCH_SIZES; do
             $PERF_CLIENT -v -i ${PERF_CLIENT_PROTOCOL} -m $MODEL_NAME -p5000 \
                          -b${STATIC_BATCH} --concurrency-range ${CONCURRENCY}
 
+            set -o pipefail
+            PA_MAX_TRIALS=${PA_MAX_TRIALS:-"50"}
             $PERF_CLIENT -v -i ${PERF_CLIENT_PROTOCOL} -m $MODEL_NAME -p5000 \
                          -b${STATIC_BATCH} --concurrency-range ${CONCURRENCY} \
+                         --max-trials "${PA_MAX_TRIALS}" \
                          -f ${NAME}.csv 2>&1 | tee ${NAME}.log
             if (( $? != 0 )); then
+                echo -e "\n***\n*** FAILED Perf Analyzer measurement\n***"
                 RET=1
             fi
+            set +o pipefail
+
             curl localhost:8002/metrics -o ${NAME}.metrics >> ${NAME}.log 2>&1
             if (( $? != 0 )); then
+                echo -e "\n***\n*** FAILED to get metrics\n***"
                 RET=1
             fi
 

--- a/qa/L0_perf_deeprecommender/run_test.sh
+++ b/qa/L0_perf_deeprecommender/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_perf_deeprecommender/run_test.sh
+++ b/qa/L0_perf_deeprecommender/run_test.sh
@@ -70,6 +70,7 @@ for STATIC_BATCH in $STATIC_BATCH_SIZES; do
                         echo "dynamic_batching { preferred_batch_size: [ ${DYNAMIC_BATCH} ] }" >> config.pbtxt)
             fi
 
+            echo "Time before starting server: $(date)"
             SERVER_LOG="${NAME}.server.log"
             run_server
             if (( $SERVER_PID == 0 )); then
@@ -79,6 +80,7 @@ for STATIC_BATCH in $STATIC_BATCH_SIZES; do
             fi
 
             set +e
+            echo "Time before perf analyzer trials: $(date)"
 
             # Run the model once to warm up. Some frameworks do
             # optimization on the first requests.  Must warmup similar
@@ -96,6 +98,7 @@ for STATIC_BATCH in $STATIC_BATCH_SIZES; do
                 echo -e "\n***\n*** FAILED Perf Analyzer measurement\n***"
                 RET=1
             fi
+            echo "Time after perf analyzer trials: $(date)"
             set +o pipefail
 
             curl localhost:8002/metrics -o ${NAME}.metrics >> ${NAME}.log 2>&1

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -179,18 +179,23 @@ for BACKEND in $BACKENDS; do
     fi
 
     set +e
+    set -o pipefail
+    PA_MAX_TRIALS=${PA_MAX_TRIALS:-"50"}
     $PERF_CLIENT -v \
                  -p${PERF_CLIENT_STABILIZE_WINDOW} \
                  -s${PERF_CLIENT_STABILIZE_THRESHOLD} \
                  ${PERF_CLIENT_EXTRA_ARGS} \
                  -m ${MODEL_NAME} \
                  -b${STATIC_BATCH} -t${CONCURRENCY} \
+                 --max-trials "${PA_MAX_TRIALS}" \
                  --shape ${INPUT_NAME}:${SHAPE} \
                  ${SERVICE_ARGS} \
                  -f ${RESULTDIR}/${NAME}.csv 2>&1 | tee ${RESULTDIR}/${NAME}.log
     if [ $? -ne 0 ]; then
+        echo -e "\n***\n*** FAILED Perf Analyzer measurement\n***"
         RET=1
     fi
+    set +o pipefail
     set -e
 
     echo -e "[{\"s_benchmark_kind\":\"benchmark_perf\"," >> ${RESULTDIR}/${NAME}.tjson

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -167,6 +167,7 @@ for BACKEND in $BACKENDS; do
                 echo "dynamic_batching { preferred_batch_size: [ ${DYNAMIC_BATCH} ] }" >> config.pbtxt)
     fi
 
+    echo "Time before starting server: $(date)"
     # Only start separate server if not using C API, since C API runs server in-process
     if [[ "${PERF_CLIENT_PROTOCOL}" != "triton_c_api" ]]; then
         SERVER_LOG="${RESULTDIR}/${NAME}.server.log"
@@ -178,6 +179,7 @@ for BACKEND in $BACKENDS; do
         fi
     fi
 
+    echo "Time before perf analyzer trials: $(date)"
     set +e
     set -o pipefail
     PA_MAX_TRIALS=${PA_MAX_TRIALS:-"50"}
@@ -195,6 +197,7 @@ for BACKEND in $BACKENDS; do
         echo -e "\n***\n*** FAILED Perf Analyzer measurement\n***"
         RET=1
     fi
+    echo "Time after perf analyzer trials: $(date)"
     set +o pipefail
     set -e
 

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -93,15 +93,21 @@ else
                     ${SERVICE_ARGS}
     set -e
 fi
+
 set +e
+set -o pipefail
+PA_MAX_TRIALS=${PA_MAX_TRIALS:-"50"}
 # Measure perf client results and write them to a file for reporting
 $PERF_CLIENT -v -m $MODEL_NAME -p${MEASUREMENT_WINDOW} \
                 -b${STATIC_BATCH} --concurrency-range ${CONCURRENCY} \
+                --max-trials "${PA_MAX_TRIALS}" \
                 ${SERVICE_ARGS} \
                 -f ${NAME}.csv 2>&1 | tee ${NAME}.log
 if (( $? != 0 )); then
+    echo -e "\n***\n*** FAILED Perf Analyzer measurement\n***"
     RET=1
 fi
+set +o pipefail
 set -e
 
 echo -e "[{\"s_benchmark_kind\":\"benchmark_perf\"," >> ${NAME}.tjson


### PR DESCRIPTION
- Add higher --max-trials default with configurable env var
- Print timestamps periodically to help debug timeouts

Per https://github.com/triton-inference-server/server/pull/5673#discussion_r1173179521