### PR TITLE
Update the L0_model_config test to align with the auto-complete changes made to the TensorFlow backend

### DIFF
--- a/qa/L0_model_config/autofill_noplatform/tensorflow_savedmodel/too_many_inputs/config.pbtxt
+++ b/qa/L0_model_config/autofill_noplatform/tensorflow_savedmodel/too_many_inputs/config.pbtxt
@@ -11,7 +11,7 @@ input [
     dims: [ 16 ]
   },
   {
-    name: "INPUT_EXTRA"
+    name: "INPUT1"
     data_type: TYPE_INT32
     dims: [ 16 ]
   }

--- a/qa/L0_model_config/autofill_noplatform/tensorflow_savedmodel/unknown_input/expected
+++ b/qa/L0_model_config/autofill_noplatform/tensorflow_savedmodel/unknown_input/expected
@@ -1,1 +1,1 @@
-Invalid argument: unable to load model 'unknown_input', configuration expects 3 inputs, model provides 2
+Invalid argument: unexpected inference input 'INPUT_UNKNOWN', allowed inputs are: INPUT0, INPUT1


### PR DESCRIPTION
TensorFlow backend changes: https://github.com/triton-inference-server/tensorflow_backend/pull/92