### PR TITLE
Give sufficient time to get inference statistics for batcher tests

### DIFF
--- a/qa/L0_batcher/batcher_test.py
+++ b/qa/L0_batcher/batcher_test.py
@@ -205,8 +205,20 @@ class BatcherTest(tu.TestResultCollector):
 
     def check_status(self, model_name, batch_exec, request_cnt, infer_cnt,
                      exec_count):
-        stats = self.triton_client_.get_inference_statistics(model_name, "1")
-        self.assertEqual(len(stats.model_stats), 1, "expect 1 model stats")
+        # There is a time window between when responses are returned and statistics are updated.
+        # To prevent intermittent test failure during that window, wait up to 10 seconds for the
+        # inference statistics to be ready.
+        num_tries = 10
+        for i in range(num_tries):
+            stats = self.triton_client_.get_inference_statistics(model_name, "1")
+            self.assertEqual(len(stats.model_stats), 1, "expect 1 model stats")
+            actual_exec_cnt = stats.model_stats[0].execution_count
+            if actual_exec_cnt == exec_count:
+                break
+            print("WARNING: expect {} executions, got {} (attempt {})".format(
+                exec_count, actual_exec_cnt, i))
+            time.sleep(1)
+
         self.assertEqual(stats.model_stats[0].name, model_name,
                          "expect model stats for model {}".format(model_name))
         self.assertEqual(

--- a/qa/L0_batcher/batcher_test.py
+++ b/qa/L0_batcher/batcher_test.py
@@ -210,7 +210,8 @@ class BatcherTest(tu.TestResultCollector):
         # inference statistics to be ready.
         num_tries = 10
         for i in range(num_tries):
-            stats = self.triton_client_.get_inference_statistics(model_name, "1")
+            stats = self.triton_client_.get_inference_statistics(
+                model_name, "1")
             self.assertEqual(len(stats.model_stats), 1, "expect 1 model stats")
             actual_exec_cnt = stats.model_stats[0].execution_count
             if actual_exec_cnt == exec_count:


### PR DESCRIPTION
L0_batcher occasionally fails with a similar error to that seen in L0_sequence_batcher seen [here](https://github.com/triton-inference-server/server/pull/5670). Proposing a similar fix to ensure the test does not check statistics before they are ready.