### PR TITLE
Update note on SageMaker MME support for ensemble

### DIFF
--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -947,9 +947,9 @@ SagemakerAPIServer::SageMakerMMELoadModel(
   std::string repo_path = parse_map.at("url");
   std::string model_name = parse_map.at("model_name");
 
-  /* Error out if there's more than one subdir/version within
-   * supplied model repo, as ensemble in MME is not (currently)
-   * supported
+  /* Check subdirs for models and find ensemble model within the repo_path
+   * If only 1 model, that will be selected as model_subdir
+   * Else ensemble model directory is set as model_subdir
    */
   DIR* dir;
   struct dirent* ent;


### PR DESCRIPTION
Small note update in Sagemaker integration. Note explains that Ensemble model is not supported. However code does parse for ensemble correctly and seems to support it as far as the code goes.

Note caused some confusion which led to us having to parse more code to understand what was the behaviour of sagemaker MME when using triton for ensemble models. 

I wrote some update on note to clarify actual code behaviour.