### PR TITLE
Allow Jetson build and testing in Docker container

### DIFF
--- a/build.py
+++ b/build.py
@@ -670,8 +670,13 @@ def onnxruntime_cmake_args(images, library_paths):
                               None, ort_include_path),
             cmake_backend_arg('onnxruntime', 'TRITON_ONNXRUNTIME_LIB_PATHS',
                               None, ort_lib_path),
+            cmake_backend_arg('onnxruntime', 'TRITON_BUILD_PLATFORM',
+                                    None, 'jetpack')
+            # Jetson build needs the CUDA compiler to be found
+            cmake_backend_arg('onnxruntime', 'CMAKE_CUDA_COMPILER',
+                                      None, '$(which nvcc)')
             cmake_backend_enable('onnxruntime',
-                                 'TRITON_ENABLE_ONNXRUNTIME_OPENVINO', False)
+                                 'TRITON_ENABLE_ONNXRUNTIME_OPENVINO', False),
         ]
     else:
         if target_platform() == 'windows':

--- a/build.py
+++ b/build.py
@@ -670,11 +670,12 @@ def onnxruntime_cmake_args(images, library_paths):
                               None, ort_include_path),
             cmake_backend_arg('onnxruntime', 'TRITON_ONNXRUNTIME_LIB_PATHS',
                               None, ort_lib_path),
-            cmake_backend_arg('onnxruntime', 'TRITON_BUILD_PLATFORM',
-                                    None, 'jetpack')
+            cmake_backend_arg('onnxruntime', 'TRITON_BUILD_PLATFORM', None,
+                              'jetpack'),
+            # TODO: Remove if not needed, else put back if arch_90 error
             # Jetson build needs the CUDA compiler to be found
-            cmake_backend_arg('onnxruntime', 'CMAKE_CUDA_COMPILER',
-                                      None, '$(which nvcc)')
+            # cmake_backend_arg('onnxruntime', 'CMAKE_CUDA_COMPILER', None,
+            #                   '$(which nvcc)'),
             cmake_backend_enable('onnxruntime',
                                  'TRITON_ENABLE_ONNXRUNTIME_OPENVINO', False),
         ]

--- a/build.py
+++ b/build.py
@@ -672,10 +672,6 @@ def onnxruntime_cmake_args(images, library_paths):
                               None, ort_lib_path),
             cmake_backend_arg('onnxruntime', 'TRITON_BUILD_PLATFORM', None,
                               'jetpack'),
-            # TODO: Remove if not needed, else put back if arch_90 error
-            # Jetson build needs the CUDA compiler to be found
-            # cmake_backend_arg('onnxruntime', 'CMAKE_CUDA_COMPILER', None,
-            #                   '$(which nvcc)'),
             cmake_backend_enable('onnxruntime',
                                  'TRITON_ENABLE_ONNXRUNTIME_OPENVINO', False),
         ]

--- a/qa/L0_backend_python/python_test.py
+++ b/qa/L0_backend_python/python_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_backend_python/test.sh
+++ b/qa/L0_backend_python/test.sh
@@ -131,9 +131,6 @@ cp ../python_models/string_fixed/config.pbtxt ./models/string_fixed
 # Skip torch install on Jetson since it is already installed.
 if [ "$TEST_JETSON" == "0" ]; then
   pip3 install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-else
-  # test_growth_error is skipped on jetson
-  EXPECTED_NUM_TESTS=8
 fi
 
 prev_num_pages=`get_shm_pages`

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -70,6 +70,10 @@ if [[ $BACKENDS == *"python"* ]]; then
         sed -i "s/^name:.*/name: \"python_zero_1_float32\"/" config.pbtxt)
 fi
 
+if [[ $BACKENDS == *"custom"* ]]; then
+    mkdir -p "custom_models/custom_zero_1_float32/1"
+fi
+
 PERF_CLIENT_PERCENTILE_ARGS="" &&
     (( ${PERF_CLIENT_PERCENTILE} != 0 )) &&
     PERF_CLIENT_PERCENTILE_ARGS="--percentile=${PERF_CLIENT_PERCENTILE}"

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -47,18 +47,12 @@ TRITON_DIR=${TRITON_DIR:="/opt/tritonserver"}
 ARCH=${ARCH:="x86_64"}
 SERVER=${TRITON_DIR}/bin/tritonserver
 BACKEND_DIR=${TRITON_DIR}/backends
+DATADIR=${DATADIR:="/data/inferenceserver/${REPO_VERSION}"}
 MODEL_REPO="${PWD}/models"
+PERF_CLIENT=../clients/perf_client
 TF_VERSION=${TF_VERSION:=2}
 SERVER_ARGS="--model-repository=${MODEL_REPO} --backend-directory=${BACKEND_DIR} --backend-config=tensorflow,version=${TF_VERSION}"
 source ../common/util.sh
-
-# DATADIR is already set in environment variable for aarch64
-if [ "$ARCH" == "aarch64" ]; then
-    PERF_CLIENT=${TRITON_DIR}/clients/bin/perf_client
-else
-    PERF_CLIENT=../clients/perf_client
-    DATADIR=/data/inferenceserver/${REPO_VERSION}
-fi
 
 # Select the single GPU that will be available to the inference server
 export CUDA_VISIBLE_DEVICES=0

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -54,15 +54,13 @@ rm -fr models && mkdir -p models && \
             sed -i "s/^max_batch_size:.*/max_batch_size: ${MAX_BATCH}/" config.pbtxt && \
             echo "instance_group [ { count: ${INSTANCE_CNT} }]")
 
-# Onnx and onnx-trt models are very slow on Jetson.
 MEASUREMENT_WINDOW=5000
+PERF_CLIENT=../clients/perf_client
+# Onnx and onnx-trt models are very slow on Jetson.
 if [ "$ARCH" == "aarch64" ]; then
-    PERF_CLIENT=${TRITON_DIR}/clients/bin/perf_client
     if [ "$MODEL_FRAMEWORK" == "onnx" ] || [ "$MODEL_FRAMEWORK" == "onnx_trt" ]; then
         MEASUREMENT_WINDOW=20000
     fi
-else
-    PERF_CLIENT=../clients/perf_client
 fi
 
 # Overload use of PERF_CLIENT_PROTOCOL for convenience with existing test and 


### PR DESCRIPTION
This PR pushes the following changes to facilitate the new Jetson Docker container build and tests:

- Add new jetpack flag to Onnxruntime build for Jetson
- Re-enable test_growth_error test for Jetson now that testing in Docker container
- Use standard path for PERF_CLIENT for Jetson testing
- Make missing custom model directory if needed
- Auto-formatting

Onnxruntime PR: https://github.com/triton-inference-server/onnxruntime_backend/pull/179
Tensorflow PR: https://github.com/triton-inference-server/tensorflow_backend/pull/89