### PR TITLE
Add --metrics-address and testing

### DIFF
--- a/qa/L0_socket/test.sh
+++ b/qa/L0_socket/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -46,8 +46,8 @@ for address in default explicit; do
         SAME_EXPLICIT_ADDRESS=""
         DIFF_EXPLICIT_ADDRESS_ARGS=""
     else
-        SAME_EXPLICIT_ADDRESS="--http-address 127.0.0.1 --grpc-address 127.0.0.1"
-        DIFF_EXPLICIT_ADDRESS="--http-address 127.0.0.1 --grpc-address 127.0.0.2"
+        SAME_EXPLICIT_ADDRESS="--http-address 127.0.0.1 --grpc-address 127.0.0.1 --metrics-address 127.0.0.1"
+        DIFF_EXPLICIT_ADDRESS="--http-address 127.0.0.1 --grpc-address 127.0.0.2 --metrics-address 127.0.0.3"
     fi
 
     for p in http grpc; do
@@ -352,10 +352,14 @@ for p in http grpc; do
     fi
     kill_server
 
-    # allow multiple servers bind to the same http/grpc port with setting the reuse flag
+    # 1. Allow multiple servers bind to the same http/grpc port with setting the reuse flag
+    # 2. Test different forms of setting --metrics-address and verify metrics are queryable
+    #   (a) Test default metrics-address being same as http-address
+    #   (b) Test setting metrics-address explicitly to 0.0.0.0
+    #   (c) Test setting metrics-address explicitly to 127.0.0.1
     SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=1 --reuse-grpc-port=1"
-    SERVER1_ARGS="--model-repository=$DATADIR --metrics-port 8003 --reuse-http-port=1 --reuse-grpc-port=1"
-    SERVER2_ARGS="--model-repository=$DATADIR --metrics-port 8004 --reuse-http-port=1 --reuse-grpc-port=1"
+    SERVER1_ARGS="--model-repository=$DATADIR --metrics-address 0.0.0.0 --metrics-port 8003 --reuse-http-port=1 --reuse-grpc-port=1"
+    SERVER2_ARGS="--model-repository=$DATADIR --metrics-address 127.0.0.1 --metrics-port 8004 --reuse-http-port=1 --reuse-grpc-port=1"
     run_multiple_servers_nowait 3
     sleep 15
     if [ "$SERVER0_PID" == "0" ]; then

--- a/qa/L0_socket/test.sh
+++ b/qa/L0_socket/test.sh
@@ -359,7 +359,7 @@ for p in http grpc; do
     #   (c) Test setting metrics-address explicitly to 127.0.0.1
     SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=1 --reuse-grpc-port=1"
     SERVER1_ARGS="--model-repository=$DATADIR --metrics-address 0.0.0.0 --metrics-port 8003 --reuse-http-port=1 --reuse-grpc-port=1"
-    SERVER2_ARGS="--model-repository=$DATADIR --metrics-address 127.0.0.1 --metrics-port 8004 --reuse-http-port=1 --reuse-grpc-port=1"
+    SERVER2_ARGS="--model-repository=$DATADIR --metrics-address 127.0.0.2 --metrics-port 8004 --reuse-http-port=1 --reuse-grpc-port=1"
     run_multiple_servers_nowait 3
     sleep 15
     if [ "$SERVER0_PID" == "0" ]; then
@@ -398,7 +398,7 @@ for p in http grpc; do
 
     server0_request_count=`curl -s localhost:8002/metrics | awk '/nv_inference_request_success{/ {print $2}'`
     server1_request_count=`curl -s localhost:8003/metrics | awk '/nv_inference_request_success{/ {print $2}'`
-    server2_request_count=`curl -s localhost:8004/metrics | awk '/nv_inference_request_success{/ {print $2}'`
+    server2_request_count=`curl -s 127.0.0.2:8004/metrics | awk '/nv_inference_request_success{/ {print $2}'`
     if [ ${server0_request_count%.*} -eq 0 ] || \
        [ ${server1_request_count%.*} -eq 0 ] || \
        [ ${server2_request_count%.*} -eq 0 ]; then

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -296,6 +296,7 @@ enum TritonOptionId {
   OPTION_ALLOW_METRICS,
   OPTION_ALLOW_GPU_METRICS,
   OPTION_ALLOW_CPU_METRICS,
+  OPTION_METRICS_ADDRESS,
   OPTION_METRICS_PORT,
   OPTION_METRICS_INTERVAL_MS,
   OPTION_METRICS_CONFIG,
@@ -409,21 +410,22 @@ TritonParser::SetupOptions()
   http_options_.push_back({OPTION_ALLOW_HTTP, "allow-http", Option::ArgBool,
                            "Allow the server to listen for HTTP requests."});
   http_options_.push_back(
-      {OPTION_HTTP_PORT, "http-port", Option::ArgInt,
-       "The port for the server to listen on for HTTP requests."});
-  http_options_.push_back(
-      {OPTION_HTTP_HEADER_FORWARD_PATTERN, "http-header-forward-pattern",
-       Option::ArgStr,
-       "The regular expression pattern that will be used for forwarding HTTP "
-       "headers as inference request parameters."});
+      {OPTION_HTTP_ADDRESS, "http-address", Option::ArgStr,
+       "The address for the http server to bind to. Default is 0.0.0.0"});
+  http_options_.push_back({OPTION_HTTP_PORT, "http-port", Option::ArgInt,
+                           "The port for the server to listen on for HTTP "
+                           "requests. Default is 8000."});
   http_options_.push_back(
       {OPTION_REUSE_HTTP_PORT, "reuse-http-port", Option::ArgBool,
        "Allow multiple servers to listen on the same HTTP port when every "
        "server has this option set. If you plan to use this option as a way to "
        "load balance between different Triton servers, the same model "
        "repository or set of models must be used for every server."});
-  http_options_.push_back({OPTION_HTTP_ADDRESS, "http-address", Option::ArgStr,
-                           "The address for the http server to binds to."});
+  http_options_.push_back(
+      {OPTION_HTTP_HEADER_FORWARD_PATTERN, "http-header-forward-pattern",
+       Option::ArgStr,
+       "The regular expression pattern that will be used for forwarding HTTP "
+       "headers as inference request parameters."});
   http_options_.push_back({OPTION_HTTP_THREAD_COUNT, "http-thread-count",
                            Option::ArgInt,
                            "Number of threads handling HTTP requests."});
@@ -432,22 +434,22 @@ TritonParser::SetupOptions()
 #if defined(TRITON_ENABLE_GRPC)
   grpc_options_.push_back({OPTION_ALLOW_GRPC, "allow-grpc", Option::ArgBool,
                            "Allow the server to listen for GRPC requests."});
-  grpc_options_.push_back(
-      {OPTION_GRPC_HEADER_FORWARD_PATTERN, "grpc-header-forward-pattern",
-       Option::ArgStr,
-       "The regular expression pattern that will be used for forwarding GRPC "
-       "headers as inference request parameters."});
-  grpc_options_.push_back(
-      {OPTION_GRPC_PORT, "grpc-port", Option::ArgInt,
-       "The port for the server to listen on for GRPC requests."});
+  grpc_options_.push_back({OPTION_GRPC_ADDRESS, "grpc-address", Option::ArgStr,
+                           "The address for the grpc server to binds to. Default is 0.0.0.0"});
+  grpc_options_.push_back({OPTION_GRPC_PORT, "grpc-port", Option::ArgInt,
+                           "The port for the server to listen on for GRPC "
+                           "requests. Default is 8001."});
   grpc_options_.push_back(
       {OPTION_REUSE_GRPC_PORT, "reuse-grpc-port", Option::ArgBool,
        "Allow multiple servers to listen on the same GRPC port when every "
        "server has this option set. If you plan to use this option as a way to "
        "load balance between different Triton servers, the same model "
        "repository or set of models must be used for every server."});
-  grpc_options_.push_back({OPTION_GRPC_ADDRESS, "grpc-address", Option::ArgStr,
-                           "The address for the grpc server to binds to."});
+  grpc_options_.push_back(
+      {OPTION_GRPC_HEADER_FORWARD_PATTERN, "grpc-header-forward-pattern",
+       Option::ArgStr,
+       "The regular expression pattern that will be used for forwarding GRPC "
+       "headers as inference request parameters."});
   grpc_options_.push_back(
       {OPTION_GRPC_INFER_ALLOCATION_POOL_SIZE,
        "grpc-infer-allocation-pool-size", Option::ArgInt,
@@ -602,9 +604,14 @@ TritonParser::SetupOptions()
       {OPTION_ALLOW_CPU_METRICS, "allow-cpu-metrics", Option::ArgBool,
        "Allow the server to provide CPU metrics. Ignored unless "
        "--allow-metrics is true."});
-  metric_options_.push_back({OPTION_METRICS_PORT, "metrics-port",
-                             Option::ArgInt,
-                             "The port reporting prometheus metrics."});
+  metric_options_.push_back(
+      {OPTION_METRICS_ADDRESS, "metrics-address", Option::ArgStr,
+       "The address for the metrics server to bind to. Default is the same as "
+       "--http-address if built with HTTP support. Otherwise, default is "
+       "0.0.0.0"});
+  metric_options_.push_back(
+      {OPTION_METRICS_PORT, "metrics-port", Option::ArgInt,
+       "The port reporting prometheus metrics. Default is 8002."});
   metric_options_.push_back(
       {OPTION_METRICS_INTERVAL_MS, "metrics-interval-ms", Option::ArgFloat,
        "Metrics will be collected once every <metrics-interval-ms> "
@@ -1231,9 +1238,6 @@ TritonParser::Parse(int argc, char** argv)
         break;
       case OPTION_HTTP_ADDRESS:
         lparams.http_address_ = optarg;
-#ifdef TRITON_ENABLE_METRICS
-        lparams.metrics_address_ = optarg;
-#endif  // TRITON_ENABLE_METRICS
         break;
       case OPTION_HTTP_HEADER_FORWARD_PATTERN:
         lparams.http_forward_header_pattern_ = optarg;
@@ -1376,6 +1380,9 @@ TritonParser::Parse(int argc, char** argv)
         break;
       case OPTION_ALLOW_CPU_METRICS:
         lparams.allow_cpu_metrics_ = ParseOption<bool>(optarg);
+        break;
+      case OPTION_METRICS_ADDRESS:
+        lparams.metrics_address_ = optarg;
         break;
       case OPTION_METRICS_PORT:
         lparams.metrics_port_ = ParseOption<int>(optarg);
@@ -1601,6 +1608,16 @@ TritonParser::Parse(int argc, char** argv)
 #ifdef TRITON_ENABLE_METRICS
   lparams.allow_gpu_metrics_ &= lparams.allow_metrics_;
   lparams.allow_cpu_metrics_ &= lparams.allow_metrics_;
+  // Set metrics_address to default if never specified
+  if (lparams.metrics_address_.empty()) {
+#ifdef TRITON_ENABLE_HTTP
+    // If built with HTTP support, default to HTTP address
+    lparams.metrics_address_ = lparams.http_address_;
+#else
+    // Otherwise have default for builds without HTTP support
+    lparams.metrics_address_ = "0.0.0.0";
+#endif  // TRITON_ENABLE_HTTP
+  }
 #endif  // TRITON_ENABLE_METRICS
 
 #ifdef TRITON_ENABLE_TRACING

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -197,14 +197,9 @@ struct TritonServerParameters {
 
 #ifdef TRITON_ENABLE_METRICS
   bool allow_metrics_{true};
-  // Note that socket address is not part of metrics config,
-  // current implementation enforce metric to use the same address as in
-  // HTTP endpoint.
-  // [FIXME] server can be built with metrics ON and HTTP OFF, but we are
-  // not exposing metrics address configuration (currently only set along with
-  // HTTP address), which causes metrics will always listen on localhost in this
-  // build setting.
-  std::string metrics_address_{"0.0.0.0"};
+  // Defaults to http_address_ if TRITON_ENABLE_HTTP is enabled for backwards,
+  // otherwise defaults to "0.0.0.0" for TRITON_ENABLE_HTTP is disabled.
+  std::string metrics_address_{""};
   int32_t metrics_port_{8002};
   // Metric settings for Triton core
   float metrics_interval_ms_{2000};


### PR DESCRIPTION
1. Add `--metrics-address` to support configuring a unique metrics address, even with TRITON_ENABLE_HTTP=OFF in the build. 

Note I made a conscious choice here to add `--metrics-address` as a new CLI arg rather than adding it to `--metrics-config` such as `--metrics-config address=<address>`. 

This is because:
- (a) I think for now, `--metrics-config` will be for Core-side metrics configuration, whereas the `--metrics-address` are server-side configurations.
- (b) This more intuitively matches existing `--metrics-port`, `--http-address`, `--grpc-address` args for users.

Down the line I think we should deprecate and move any non-server-side metrics configs like `--metrics-interval-ms` to be part of `--metrics-config`.

---

2. This PR also reorganizes some of the other similar args to be in a consistent order of address followed by port, and adds notes about their default values to the Usage() output:
```
HTTP
  --http-address ...
  --http-port ...

GRPC
  --grpc-address ...
  --grpc-port ...

Metrics
  --metrics-address ...
  --metrics-port ...
```

