### PR TITLE
Run L0_backend_python subtests with virtual environment

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -330,7 +330,8 @@ RUN rm -f /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip3 install --upgrade wheel setuptools && \
-    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil awscli six grpcio-channelz prettytable
+    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil \
+                           awscli six grpcio-channelz prettytable virtualenv
 
 # L0_http_fuzz is hitting similar issue with boofuzz with latest version (0.4.0):
 # https://github.com/jtpereyda/boofuzz/issues/529

--- a/qa/L0_backend_python/decoupled/test.sh
+++ b/qa/L0_backend_python/decoupled/test.sh
@@ -34,6 +34,9 @@ BACKEND_DIR=${TRITON_DIR}/backends
 SERVER_ARGS="--model-repository=`pwd`/models --backend-directory=${BACKEND_DIR} --log-verbose=1"
 SERVER_LOG="./inference_server.log"
 
+pip3 uninstall -y torch
+pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html
+
 RET=0
 source ../../common/util.sh
 

--- a/qa/L0_backend_python/io/test.sh
+++ b/qa/L0_backend_python/io/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ RET=0
 rm -fr *.log ./models
 
 pip3 uninstall -y torch
-pip3 install torch==1.13.0
+pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html
 
 # IOTest.test_ensemble_io
 TRIALS="default decoupled"


### PR DESCRIPTION
This PR updated the subtests in L0_backend_python to be run using a virtual environment. This was done to prevent any dependencies from interfering with each other during the installation of dependencies in each test. Reverted the test order changes in this PR https://github.com/triton-inference-server/server/pull/5607 and the JAX example ran successfully.