### PR TITLE
Fix L0_mlflow

### DIFF
--- a/qa/L0_mlflow/test.sh
+++ b/qa/L0_mlflow/test.sh
@@ -31,6 +31,16 @@ source ../common/util.sh
 
 rm -fr *.log *.json
 
+# The default version of python 3.10.6 included in
+# Ubuntu 22.04 installs blinker 1.4. This doesn't 
+# work with the awscli which we try to install. 
+# Uninstalling blinker and allowing pip to install blinker 1.6 
+# fixes this issue. The alternative to this is to 
+# install a higher version of python which uses blinker 1.6,
+# but it is unknown whether this test should rely on 
+# the default installation of python.
+apt remove -y python3-blinker
+
 RET=0
 
 # Uninstall the python 3.10 version of blinker. This 

--- a/qa/L0_mlflow/test.sh
+++ b/qa/L0_mlflow/test.sh
@@ -43,10 +43,6 @@ apt remove -y python3-blinker
 
 RET=0
 
-# Uninstall the python 3.10 version of blinker. This 
-# causes other dependencies to not install
-apt-get remove python3-blinker
-
 # Set up MLflow and dependencies used by the test
 pip install mlflow onnx onnxruntime boto3
 

--- a/qa/L0_mlflow/test.sh
+++ b/qa/L0_mlflow/test.sh
@@ -33,6 +33,10 @@ rm -fr *.log *.json
 
 RET=0
 
+# Uninstall the python 3.10 version of blinker. This 
+# causes other dependencies to not install
+apt-get remove python3-blinker
+
 # Set up MLflow and dependencies used by the test
 pip install mlflow onnx onnxruntime boto3
 


### PR DESCRIPTION
This PR fixes mlflow failing when installing python test dependencies. The `python3-blinker` default installed version is `1.4` but the python dependencies need version `1.6` installed. Removing the default installed version of blinker which comes with Ubuntu 22.04 allows pip to install the necessary dependencies.