### PR TITLE
nnshah1 stream infer segfault fix

### DIFF
--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -269,9 +269,11 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     }
     // Get request ID for logging in case of error.
     const char* request_id = "";
-    LOG_TRITONSERVER_ERROR(
-        TRITONSERVER_InferenceRequestId(irequest, &request_id),
-        "unable to retrieve request ID string");
+    if (err == nullptr) {
+      LOG_TRITONSERVER_ERROR(
+          TRITONSERVER_InferenceRequestId(irequest, &request_id),
+          "unable to retrieve request ID string");
+    }
     if (!strncmp(request_id, "", 1)) {
       request_id = "<id_unknown>";
     }

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -269,7 +269,7 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     }
     // Get request ID for logging in case of error.
     const char* request_id = "";
-    if (err == nullptr) {
+    if (irequest != nullptr) {
       LOG_TRITONSERVER_ERROR(
           TRITONSERVER_InferenceRequestId(irequest, &request_id),
           "unable to retrieve request ID string");


### PR DESCRIPTION
In stream infer process function, request id was being retrieved even if the request object was not created due to earlier error. 
This was guarded in `infer_handler.cc`, applied same guard in `stream_infer_handler.cc`.

Fix for issue:

https://github.com/triton-inference-server/server/issues/5828 
