### PR TITLE
Test batch input for libtorch

### DIFF
--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -33,9 +33,7 @@ import numpy as np
 import test_util as tu
 import tritonhttpclient
 from tritonclientutils import InferenceServerException
-import os
 
-TEST_BACKEND = os.environ.get("BACKEND", "")
 
 class BatchInputTest(tu.TestResultCollector):
 
@@ -57,18 +55,12 @@ class BatchInputTest(tu.TestResultCollector):
 
         # The model is identity model
         self.inputs = []
-        if TEST_BACKEND == "libtorch":
-            input_name = "INPUT__0"
-            output_name = "OUTPUT__0"
-        else:
-            print("1")
-            input_name = "INPUT0"
-            output_name = "OUTPUT0"
         for value in [2, 4, 1, 3]:
             self.inputs.append(
-                [tritonhttpclient.InferInput(input_name, [1, value], "FP32")])
+                [tritonhttpclient.InferInput('INPUT0', [1, value], "FP32")])
             self.inputs[-1][0].set_data_from_numpy(
                 np.full([1, value], value, np.float32))
+        output_name = 'OUTPUT0'
         outputs = [tritonhttpclient.InferRequestedOutput(output_name)]
 
         async_requests = []

--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -33,7 +33,9 @@ import numpy as np
 import test_util as tu
 import tritonhttpclient
 from tritonclientutils import InferenceServerException
+import os
 
+TEST_BACKEND = os.environ.get("BACKEND", "")
 
 class BatchInputTest(tu.TestResultCollector):
 
@@ -55,12 +57,18 @@ class BatchInputTest(tu.TestResultCollector):
 
         # The model is identity model
         self.inputs = []
+        if TEST_BACKEND == "libtorch":
+            input_name = "INPUT__0"
+            output_name = "OUTPUT__0"
+        else:
+            print("1")
+            input_name = "INPUT0"
+            output_name = "OUTPUT0"
         for value in [2, 4, 1, 3]:
             self.inputs.append(
-                [tritonhttpclient.InferInput('INPUT0', [1, value], "FP32")])
+                [tritonhttpclient.InferInput(input_name, [1, value], "FP32")])
             self.inputs[-1][0].set_data_from_numpy(
                 np.full([1, value], value, np.float32))
-        output_name = 'OUTPUT0'
         outputs = [tritonhttpclient.InferRequestedOutput(output_name)]
 
         async_requests = []

--- a/qa/L0_batch_input/test.sh
+++ b/qa/L0_batch_input/test.sh
@@ -81,14 +81,15 @@ for BACKEND in $BACKENDS; do
     # Use nobatch model to showcase ragged input, identity model to verify
     # batch input is generated properly
     cp -r $IDENTITY_DATADIR/${BACKEND}_nobatch_zero_1_float32 models/ragged_io
-    IO_SUFFIX=$([[ "$BACKEND" == "libtorch" ]] && echo "__0" || echo "0")
     (cd models/ragged_io && \
+          # In case of libtorch, update I/O names
+          sed -i "s/__0/0/" config.pbtxt && \
           sed -i "s/${BACKEND}_nobatch_zero_1_float32/ragged_io/" config.pbtxt && \
           sed -i "s/^max_batch_size:.*/max_batch_size: 4/" config.pbtxt && \
-          sed -i "s/name: \"INPUT${IO_SUFFIX}\"/name: \"INPUT${IO_SUFFIX}\"\\nallow_ragged_batch: true/" config.pbtxt && \
-          echo "batch_output [{target_name: \"OUTPUT${IO_SUFFIX}\" \
+          sed -i "s/name: \"INPUT0\"/name: \"INPUT0\"\\nallow_ragged_batch: true/" config.pbtxt && \
+          echo "batch_output [{target_name: \"OUTPUT0\" \
                                  kind: BATCH_SCATTER_WITH_INPUT_SHAPE \
-                                 source_input: \"INPUT${IO_SUFFIX}\" }] \
+                                 source_input: \"INPUT0\" }] \
                 dynamic_batching { max_queue_delay_microseconds: 1000000 }" >> config.pbtxt)
 
 

--- a/qa/L0_batch_input/test.sh
+++ b/qa/L0_batch_input/test.sh
@@ -99,8 +99,10 @@ for BACKEND in $BACKENDS; do
         exit 1
     fi
 
+    export BACKEND
+
     set +e
-    python $BATCH_INPUT_TEST >$CLIENT_LOG 2>&1
+    python3 $BATCH_INPUT_TEST >$CLIENT_LOG 2>&1
     if [ $? -ne 0 ]; then
         cat $CLIENT_LOG
         echo -e "\n***\n*** Test Failed\n***"

--- a/qa/L0_batch_input/test.sh
+++ b/qa/L0_batch_input/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -54,7 +54,7 @@ SERVER_LOG="./inference_server.log"
 source ../common/util.sh
 
 # If BACKENDS not specified, set to all
-BACKENDS=${BACKENDS:="onnx savedmodel plan"}
+BACKENDS=${BACKENDS:="onnx savedmodel plan libtorch"}
 
 rm -f $SERVER_LOG $CLIENT_LOG
 

--- a/qa/L0_batch_input/test.sh
+++ b/qa/L0_batch_input/test.sh
@@ -81,13 +81,14 @@ for BACKEND in $BACKENDS; do
     # Use nobatch model to showcase ragged input, identity model to verify
     # batch input is generated properly
     cp -r $IDENTITY_DATADIR/${BACKEND}_nobatch_zero_1_float32 models/ragged_io
+    IO_SUFFIX=$([[ "$BACKEND" == "libtorch" ]] && echo "__0" || echo "0")
     (cd models/ragged_io && \
           sed -i "s/${BACKEND}_nobatch_zero_1_float32/ragged_io/" config.pbtxt && \
           sed -i "s/^max_batch_size:.*/max_batch_size: 4/" config.pbtxt && \
-          sed -i "s/name: \"INPUT0\"/name: \"INPUT0\"\\nallow_ragged_batch: true/" config.pbtxt && \
-          echo "batch_output [{target_name: \"OUTPUT0\" \
+          sed -i "s/name: \"INPUT${IO_SUFFIX}\"/name: \"INPUT${IO_SUFFIX}\"\\nallow_ragged_batch: true/" config.pbtxt && \
+          echo "batch_output [{target_name: \"OUTPUT${IO_SUFFIX}\" \
                                  kind: BATCH_SCATTER_WITH_INPUT_SHAPE \
-                                 source_input: \"INPUT0\" }] \
+                                 source_input: \"INPUT${IO_SUFFIX}\" }] \
                 dynamic_batching { max_queue_delay_microseconds: 1000000 }" >> config.pbtxt)
 
 

--- a/qa/L0_batch_input/test.sh
+++ b/qa/L0_batch_input/test.sh
@@ -100,8 +100,6 @@ for BACKEND in $BACKENDS; do
         exit 1
     fi
 
-    export BACKEND
-
     set +e
     python3 $BATCH_INPUT_TEST >$CLIENT_LOG 2>&1
     if [ $? -ne 0 ]; then

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -345,6 +345,8 @@ python3 $SRCDIR/gen_qa_dyna_sequence_models.py --libtorch --models_dir=$DYNASEQD
 chmod -R 777 $DYNASEQDESTDIR
 python3 $SRCDIR/gen_qa_torchtrt_models.py --models_dir=$TORCHTRTDESTDIR
 chmod -R 777 $TORCHTRTDESTDIR
+python3 $SRCDIR/gen_qa_ragged_models.py --libtorch --models_dir=$RAGGEDDESTDIR
+chmod -R 777 $RAGGEDDESTDIR
 EOF
 
 chmod a+x $HOST_SRCDIR/$TORCHSCRIPT

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -364,6 +364,7 @@ docker run $DOCKER_GPU_ARGS --rm --entrypoint $SRCDIR/$TORCHSCRIPT \
        --mount type=bind,source=$HOST_DYNASEQDESTDIR,target=$DYNASEQDESTDIR \
        --mount type=bind,source=$HOST_VARSEQDESTDIR,target=$VARSEQDESTDIR \
        --mount type=bind,source=$HOST_TORCHTRTDESTDIR,target=$TORCHTRTDESTDIR \
+       --mount type=bind,source=$HOST_RAGGEDDESTDIR,target=$RAGGEDDESTDIR \
        $PYTORCH_IMAGE
 if [ $? -ne 0 ]; then
     echo -e "Failed"

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -123,6 +123,7 @@ def np_to_onnx_dtype(np_dtype):
         return onnx.TensorProto.STRING
     return None
 
+
 def create_savedmodel_modelfile(models_dir, model_version, dtype):
     # Create special identity model for batch input testing.
     # Because the ragged input and batch input are one dimensional vector

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -460,7 +460,7 @@ def create_libtorch_modelfile(models_dir, model_version, dtype):
                 RAGGED_INPUT = RAGGED_INPUT.view(1, -1)
                 RAGGED_OUTPUT = torch.matmul(batch_entry, RAGGED_INPUT)
 
-                return BATCH_OUTPUT, BATCH_AND_SIZE_OUTPUT, RAGGED_OUTPUT
+                return RAGGED_OUTPUT, BATCH_AND_SIZE_OUTPUT, BATCH_OUTPUT
 
     identityModel = IdentityNet()
     traced = torch.jit.script(identityModel)

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -446,21 +446,21 @@ def create_libtorch_modelfile(models_dir, model_version, dtype):
             def __init__(self):
                 super(IdentityNet, self).__init__()
 
-            def forward(self, BATCH_INPUT, BATCH_AND_SIZE_INPUT, RAGGED_INPUT):
-                batch_entry = BATCH_AND_SIZE_INPUT / BATCH_AND_SIZE_INPUT
+            def forward(self, batch_input, batch_and_size_input, ragged_input):
+                batch_entry = batch_and_size_input / batch_and_size_input
                 batch_entry = batch_entry.view(-1, 1)
 
-                BATCH_INPUT = BATCH_INPUT.view(1, -1)
-                BATCH_OUTPUT = torch.matmul(batch_entry, BATCH_INPUT)
+                batch_input = batch_input.view(1, -1)
+                batch_output = torch.matmul(batch_entry, batch_input)
 
-                BATCH_AND_SIZE_INPUT = BATCH_AND_SIZE_INPUT.view(1, -1)
-                BATCH_AND_SIZE_OUTPUT = torch.matmul(batch_entry,
-                                                     BATCH_AND_SIZE_INPUT)
+                batch_and_size_input = batch_and_size_input.view(1, -1)
+                batch_and_size_output = torch.matmul(batch_entry,
+                                                     batch_and_size_input)
 
-                RAGGED_INPUT = RAGGED_INPUT.view(1, -1)
-                RAGGED_OUTPUT = torch.matmul(batch_entry, RAGGED_INPUT)
+                ragged_input = ragged_input.view(1, -1)
+                ragged_output = torch.matmul(batch_entry, ragged_input)
 
-                return RAGGED_OUTPUT, BATCH_AND_SIZE_OUTPUT, BATCH_OUTPUT
+                return ragged_output, batch_and_size_output, batch_output
 
     identityModel = IdentityNet()
     traced = torch.jit.script(identityModel)

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -447,21 +447,21 @@ def create_libtorch_modelfile(models_dir, model_version, dtype):
             def __init__(self):
                 super(IdentityNet, self).__init__()
 
-            def forward(self, batch_input, batch_and_size_input, ragged_input):
-                batch_entry = batch_and_size_input / batch_and_size_input
+            def forward(self, BATCH_INPUT, BATCH_AND_SIZE_INPUT, RAGGED_INPUT):
+                batch_entry = BATCH_AND_SIZE_INPUT / BATCH_AND_SIZE_INPUT
                 batch_entry = batch_entry.view(-1, 1)
 
-                batch_input = batch_input.view(1, -1)
-                batch_output = torch.matmul(batch_entry, batch_input)
+                BATCH_INPUT = BATCH_INPUT.view(1, -1)
+                BATCH_OUTPUT = torch.matmul(batch_entry, BATCH_INPUT)
 
-                batch_and_size_input = batch_and_size_input.view(1, -1)
-                batch_and_size_output = torch.matmul(batch_entry,
-                                                     batch_and_size_input)
+                BATCH_AND_SIZE_INPUT = BATCH_AND_SIZE_INPUT.view(1, -1)
+                BATCH_AND_SIZE_OUTPUT = torch.matmul(batch_entry,
+                                                     BATCH_AND_SIZE_INPUT)
 
-                ragged_input = ragged_input.view(1, -1)
-                ragged_output = torch.matmul(batch_entry, ragged_input)
+                RAGGED_INPUT = RAGGED_INPUT.view(1, -1)
+                RAGGED_OUTPUT = torch.matmul(batch_entry, RAGGED_INPUT)
 
-                return ragged_output, batch_and_size_output, batch_output
+                return RAGGED_OUTPUT, BATCH_AND_SIZE_OUTPUT, BATCH_OUTPUT
 
     identityModel = IdentityNet()
     traced = torch.jit.script(identityModel)

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -123,6 +123,7 @@ def np_to_onnx_dtype(np_dtype):
         return onnx.TensorProto.STRING
     return None
 
+
 def np_to_torch_dtype(np_dtype):
     if np_dtype == bool:
         return torch.bool
@@ -470,10 +471,12 @@ def create_libtorch_modelfile(models_dir, model_version, dtype):
 
     if (dtype == np_dtype_string):
 
-        raise Exception("PyTorch ragged model generation for string models not yet implemented")
+        raise Exception(
+            "PyTorch ragged model generation for string models not yet implemented"
+        )
 
     else:
-        
+
         class IdentityNet(nn.Module):
 
             def __init__(self):
@@ -487,15 +490,16 @@ def create_libtorch_modelfile(models_dir, model_version, dtype):
                 BATCH_OUTPUT = torch.matmul(batch_entry, BATCH_INPUT)
 
                 BATCH_AND_SIZE_INPUT = BATCH_AND_SIZE_INPUT.view(1, -1)
-                BATCH_AND_SIZE_OUTPUT = torch.matmul(batch_entry, BATCH_AND_SIZE_INPUT)
+                BATCH_AND_SIZE_OUTPUT = torch.matmul(batch_entry,
+                                                     BATCH_AND_SIZE_INPUT)
 
                 RAGGED_INPUT = RAGGED_INPUT.view(1, -1)
                 RAGGED_OUTPUT = torch.matmul(batch_entry, RAGGED_INPUT)
 
                 return BATCH_OUTPUT, BATCH_AND_SIZE_OUTPUT, RAGGED_OUTPUT
-                
+
     traced = torch.jit.script(identityModel)
-    
+
     graph_proto = onnx.helper.make_graph(onnx_nodes, model_name, onnx_inputs,
                                          onnx_outputs)
 
@@ -505,7 +509,7 @@ def create_libtorch_modelfile(models_dir, model_version, dtype):
         pass  # ignore existing dir
 
     traced.save(model_version_dir + "/model.onnx")
-    
+
 
 def create_modelconfig(models_dir, max_batch, model_version, dtype, backend,
                        platform):
@@ -598,7 +602,7 @@ def create_savedmodel_itemshape_modelfile(models_dir, model_version, dtype):
 
     tf.compat.v1.reset_default_graph()
     tf.compat.v1.placeholder(tf_dtype, tu.shape_to_tf_shape([-1]),
-                                       "TENSOR_RAGGED_INPUT")
+                             "TENSOR_RAGGED_INPUT")
     # Shape is predefined
     batch_node = tf.compat.v1.placeholder(tf_dtype,
                                           tu.shape_to_tf_shape([-1, 2]),
@@ -750,7 +754,9 @@ def create_libtorch_itemshape_modelfile(models_dir, model_version, dtype):
 
     if (dtype == np_dtype_string):
 
-        raise Exception("PyTorch ragged model generation for string models not yet implemented")
+        raise Exception(
+            "PyTorch ragged model generation for string models not yet implemented"
+        )
 
     else:
 
@@ -857,14 +863,15 @@ def create_batch_input_models(models_dir):
         create_itemshape_modelconfig(models_dir, 4, model_version, np.float32,
                                      "onnxruntime", "onnx")
         create_onnx_itemshape_modelfile(models_dir, model_version, np.float32)
-    
+
     if FLAGS.libtorch:
-        # create_modelconfig(models_dir, 4, model_version, np.float32,
-        #                    "pytorch", "pytorch_libtorch")
-        # create_libtorch_modelfile(models_dir, model_version, np.float32)
+        create_modelconfig(models_dir, 4, model_version, np.float32, "pytorch",
+                           "pytorch_libtorch")
+        create_libtorch_modelfile(models_dir, model_version, np.float32)
         create_itemshape_modelconfig(models_dir, 4, model_version, np.float32,
                                      "pytorch", "pytorch_libtorch")
-        create_libtorch_itemshape_modelfile(models_dir, model_version, np.float32)
+        create_libtorch_itemshape_modelfile(models_dir, model_version,
+                                            np.float32)
 
 
 if __name__ == '__main__':

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -433,6 +433,80 @@ def create_onnx_modelfile(models_dir, model_version, dtype):
     onnx.save(model_def, model_version_dir + "/model.onnx")
 
 
+def create_libtorch_modelfile(models_dir, model_version, dtype):
+    # Create special identity model for batch input testing.
+    # Because the ragged input and batch input are one dimensional vector
+    # when passing to the model, the model must generate output with batch
+    # dimension so that Triton can scatter it to different responses along
+    # the batch dimension.
+    # 'BATCH_AND_SIZE_INPUT' is also used as a hint to generate output with
+    # batch dimension, 'BATCH_AND_SIZE_INPUT' must have shape [batch_size].
+    # Each output corresponds to the input with the same name, so if there
+    # are two requests, one has "RAGGED_INPUT" [2, 4] and the other has [1],
+    # since the input is ragged, the model sees the input as [2, 4, 1], and
+    # "BATCH_AND_SIZE_INPUT" will have shape [2]. Then the model output will
+    # be [[2, 4, 1], [2, 4, 1]] and Triton will send responses that each has
+    # value [[2, 4, 1]].
+    # For "BATCH_INPUT", the input tensor must only have one variable dimension
+    # to be broadcasted along the batch dimension properly, thus the currently
+    # allowed batch input types are:
+    # - BATCH_ACCUMULATED_ELEMENT_COUNT
+    # - BATCH_ACCUMULATED_ELEMENT_COUNT_WITH_ZERO
+    # - BATCH_MAX_ELEMENT_COUNT_AS_SHAPE
+    # - BATCH_ITEM_SHAPE_FLATTEN
+
+    torch_dtype = np_to_torch_dtype(dtype)
+
+    # Create the model
+    model_name = "libtorch_batch_input"
+    model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
+
+    in0_shape = [-1]
+    bs_shape = [-1]
+    batch_shape = [-1]
+    out_shape = [-1, -1]
+    bs_out_shape = [-1, -1]
+    batch_out_shape = [-1, -1]
+
+    if (dtype == np_dtype_string):
+
+        raise Exception("PyTorch ragged model generation for string models not yet implemented")
+
+    else:
+        
+        class IdentityNet(nn.Module):
+
+            def __init__(self):
+                super(IdentityNet, self).__init__()
+
+            def forward(self, BATCH_INPUT, BATCH_AND_SIZE_INPUT, RAGGED_INPUT):
+                batch_entry = BATCH_AND_SIZE_INPUT / BATCH_AND_SIZE_INPUT
+                batch_entry = batch_entry.view(-1, 1)
+
+                BATCH_INPUT = BATCH_INPUT.view(1, -1)
+                BATCH_OUTPUT = torch.matmul(batch_entry, BATCH_INPUT)
+
+                BATCH_AND_SIZE_INPUT = BATCH_AND_SIZE_INPUT.view(1, -1)
+                BATCH_AND_SIZE_OUTPUT = torch.matmul(batch_entry, BATCH_AND_SIZE_INPUT)
+
+                RAGGED_INPUT = RAGGED_INPUT.view(1, -1)
+                RAGGED_OUTPUT = torch.matmul(batch_entry, RAGGED_INPUT)
+
+                return BATCH_OUTPUT, BATCH_AND_SIZE_OUTPUT, RAGGED_OUTPUT
+                
+    traced = torch.jit.script(identityModel)
+    
+    graph_proto = onnx.helper.make_graph(onnx_nodes, model_name, onnx_inputs,
+                                         onnx_outputs)
+
+    try:
+        os.makedirs(model_version_dir)
+    except OSError as ex:
+        pass  # ignore existing dir
+
+    traced.save(model_version_dir + "/model.onnx")
+    
+
 def create_modelconfig(models_dir, max_batch, model_version, dtype, backend,
                        platform):
     version_policy_str = "{ latest { num_versions: 1 }}"

--- a/qa/common/gen_qa_ragged_models.py
+++ b/qa/common/gen_qa_ragged_models.py
@@ -123,33 +123,6 @@ def np_to_onnx_dtype(np_dtype):
         return onnx.TensorProto.STRING
     return None
 
-
-def np_to_torch_dtype(np_dtype):
-    if np_dtype == bool:
-        return torch.bool
-    elif np_dtype == np.int8:
-        return torch.int8
-    elif np_dtype == np.int16:
-        return torch.int16
-    elif np_dtype == np.int32:
-        return torch.int
-    elif np_dtype == np.int64:
-        return torch.long
-    elif np_dtype == np.uint8:
-        return torch.uint8
-    elif np_dtype == np.uint16:
-        return None  # Not supported in Torch
-    elif np_dtype == np.float16:
-        return None
-    elif np_dtype == np.float32:
-        return torch.float
-    elif np_dtype == np.float64:
-        return torch.double
-    elif np_dtype == np_dtype_string:
-        return None  # Not supported in Torch
-    return None
-
-
 def create_savedmodel_modelfile(models_dir, model_version, dtype):
     # Create special identity model for batch input testing.
     # Because the ragged input and batch input are one dimensional vector
@@ -456,18 +429,9 @@ def create_libtorch_modelfile(models_dir, model_version, dtype):
     # - BATCH_MAX_ELEMENT_COUNT_AS_SHAPE
     # - BATCH_ITEM_SHAPE_FLATTEN
 
-    torch_dtype = np_to_torch_dtype(dtype)
-
     # Create the model
     model_name = "libtorch_batch_input"
     model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
-
-    in0_shape = [-1]
-    bs_shape = [-1]
-    batch_shape = [-1]
-    out_shape = [-1, -1]
-    bs_out_shape = [-1, -1]
-    batch_out_shape = [-1, -1]
 
     if (dtype == np_dtype_string):
 
@@ -741,14 +705,9 @@ def create_libtorch_itemshape_modelfile(models_dir, model_version, dtype):
     # generated to have matching batch dimension, the output can be produced
     # via identity op and expect Triton will scatter the output properly.
 
-    torch_dtype = np_to_torch_dtype(dtype)
-
     # Create the model
     model_name = "libtorch_batch_item"
     model_version_dir = models_dir + "/" + model_name + "/" + str(model_version)
-
-    input_shape = [-1]
-    batch_shape = [-1, 2]
 
     if (dtype == np_dtype_string):
 


### PR DESCRIPTION
Add test model generation and testing for batch_input for libtorch.

Note that capitalization is used to match the input names in the model configs and output order is important for the PyTorch backend.

Pytorch_backend batch input implementation here: https://github.com/triton-inference-server/pytorch_backend/pull/98