### PR TITLE
Add test on rate limiter max resource decrease update

### DIFF
--- a/qa/L0_model_update/instance_update_test.py
+++ b/qa/L0_model_update/instance_update_test.py
@@ -338,10 +338,10 @@ class TestInstanceUpdate(unittest.TestCase):
         # Unload model
         self.__unload_model()
 
-    # Test instance resource requirement increase
+    # Test instance resource requirement update
     @unittest.skipUnless(os.environ["RATE_LIMIT_MODE"] == "execution_count",
                          "Rate limiter precondition not met for this test")
-    def test_instance_resource_increase(self):
+    def test_instance_resource_update(self):
         # Load model
         self.__load_model(
             1,
@@ -365,6 +365,20 @@ class TestInstanceUpdate(unittest.TestCase):
             time.sleep(infer_count / 2)  # each infer should take < 0.5 seconds
             self.assertNotIn(False, infer_complete, "Infer possibly stuck")
             infer_thread.result()
+        # Decrease the resource requirement
+        self.__update_instance_count(
+            1, 1,
+            "{\ncount: 1\nkind: KIND_CPU\nrate_limiter {\nresources [\n{\nname: \"R1\"\ncount: 6\n}\n]\n}\n}"
+        )
+        # Further decrease the resource requirement. The previous decrease
+        # should have lower the max resource in the rate limiter, which the
+        # error "Should not print this ..." should not be printed into the
+        # server log because the max resource is above the previously set limit
+        # and it will be checked by the main bash test script.
+        self.__update_instance_count(
+            1, 1,
+            "{\ncount: 1\nkind: KIND_CPU\nrate_limiter {\nresources [\n{\nname: \"R1\"\ncount: 4\n}\n]\n}\n}"
+        )
         # Unload model
         self.__unload_model()
 

--- a/qa/L0_model_update/test.sh
+++ b/qa/L0_model_update/test.sh
@@ -83,6 +83,15 @@ for RATE_LIMIT_MODE in "off" "execution_count"; do
     kill $SERVER_PID
     wait $SERVER_PID
 
+    set +e
+    grep "Should not print this" $SERVER_LOG
+    if [ $? -eq 0 ]; then
+        echo -e "\n***\n*** Found \"Should not print this\" on \"$SERVER_LOG\"\n***"
+        cat $SERVER_LOG
+        RET=1
+    fi
+    set -e
+
 done
 
 if [ $RET -eq 0 ]; then

--- a/qa/L0_model_update/test.sh
+++ b/qa/L0_model_update/test.sh
@@ -55,15 +55,20 @@ function setup_models() {
 
 RET=0
 
-# Test model instance update with and without rate limiting enabled
-for RATE_LIMIT_MODE in "off" "execution_count"; do
+# Test model instance update with rate limiting on/off and explicit resource
+for RATE_LIMIT_MODE in "off" "execution_count" "execution_count_with_explicit_resource"; do
+
+    RATE_LIMIT_ARGS="--rate-limit=$RATE_LIMIT_MODE"
+    if [ "$RATE_LIMIT_MODE" == "execution_count_with_explicit_resource" ]; then
+        RATE_LIMIT_ARGS="--rate-limit=execution_count --rate-limit-resource=R1:10"
+    fi
 
     export RATE_LIMIT_MODE=$RATE_LIMIT_MODE
     TEST_LOG="instance_update_test.rate_limit_$RATE_LIMIT_MODE.log"
     SERVER_LOG="./instance_update_test.rate_limit_$RATE_LIMIT_MODE.server.log"
 
     setup_models
-    SERVER_ARGS="--model-repository=models --model-control-mode=explicit --rate-limit=$RATE_LIMIT_MODE --log-verbose=2"
+    SERVER_ARGS="--model-repository=models --model-control-mode=explicit $RATE_LIMIT_ARGS --log-verbose=2"
     run_server
     if [ "$SERVER_PID" == "0" ]; then
         echo -e "\n***\n*** Failed to start $SERVER\n***"


### PR DESCRIPTION
Add the test to decrease the rate limiter max resource limit, by updating instances to a lower resource count. If the rate limiter sees a instance is being removed that specifies a higher resource count than the max resource, then the "Should not print this" warning is printed, and the test script is also updated to capture the phrase "Should not print this" and report test failure if found.

Core PR: https://github.com/triton-inference-server/core/pull/208