### PR TITLE
Updated handling for uint64 request priority

### DIFF
--- a/qa/L0_config_json/max_priority_level.pbtxt
+++ b/qa/L0_config_json/max_priority_level.pbtxt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_config_json/max_priority_level.pbtxt
+++ b/qa/L0_config_json/max_priority_level.pbtxt
@@ -1,0 +1,62 @@
+# Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "max_priority_level"
+backend: "identity"
+max_batch_size: 1
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_FP32
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_FP32
+    dims: [ 1 ]
+  }
+]
+
+dynamic_batching:
+{
+    # Max uint64
+    priority_levels: 18446744073709551615
+    # Max uint32
+    default_priority_level: 4294967295
+    # Max uint32 + 1
+    priority_queue_policy: [
+       {key: 4294967296
+        value: {
+          timeout_action: REJECT
+	  default_timeout_microseconds: 18446744073709551615
+	  allow_timeout_override: true
+	  max_queue_size: 10
+       }
+    }
+]
+}

--- a/qa/L0_config_json/test.sh
+++ b/qa/L0_config_json/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_config_json/test.sh
+++ b/qa/L0_config_json/test.sh
@@ -373,6 +373,52 @@ fi
 kill $SERVER_PID
 wait $SERVER_PID
 
+# Test max_priority_level
+TRIAL=max_priority_level
+
+rm -fr models && mkdir models
+mkdir -p models/max_priority_level/1 && cp max_priority_level.pbtxt models/max_priority_level/config.pbtxt
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+code=`curl -s -w %{http_code} -o ./$TRIAL.out localhost:8000/v2/models/max_priority_level/config`
+set -e
+if [ "$code" != "200" ]; then
+    cat $TRIAL.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+declare -A expected_values
+
+MAX_UINT64=18446744073709551615
+MAX_UINT32=4294967295
+MAX_UINT32_PLUS_1=4294967296
+
+expected_values["priority_levels"]=$MAX_UINT64
+expected_values["default_priority_level"]=$MAX_UINT32
+expected_values[$MAX_UINT32_PLUS_1]=\{\"timeout_action\":\"REJECT\",\"default_timeout_microseconds\":18446744073709551615,\"allow_timeout_override\":true,\"max_queue_size\":10\}
+expected_values["default_timeout_microseconds"]=$MAX_UINT64
+
+for key in "${!expected_values[@]}"; do
+    value=${expected_values[$key]}
+    matches=`grep -o "\"$key\":$value" $TRIAL.out | wc -l`
+    if [ $matches -ne 1 ]; then
+	cat $TRIAL.out
+	echo -e "\n***\n*** Expected 1 $key == $value, got $matches\n***"
+	RET=1
+    fi
+done
+
+kill $SERVER_PID
+wait $SERVER_PID
+
 if [ $RET -eq 0 ]; then
     echo -e "\n***\n*** Test Passed\n***"
 else

--- a/qa/L0_model_queue/model_queue_test.py
+++ b/qa/L0_model_queue/model_queue_test.py
@@ -396,6 +396,42 @@ class ModelQueueTest(tu.TestResultCollector):
             except InferenceServerException as ex:
                 self.assertTrue(False, "unexpected error {}".format(ex))
 
+    def test_max_priority_levels(self):
+        # Send 2 requests with batch sizes 2, 1 in default priority (MAX_UINT32+1). Then send
+        # 1 request with batch size 2 in priority 1. Expect the third request is
+        # place in the front of the queue and form a preferred batch with the
+        # first request.
+        dtype = np.float32
+        shapes = ([16],)
+        for trial in self.trials_:
+            threads = []
+            threads.append(
+                threading.Thread(target=self.check_response,
+                                 args=(2, dtype, shapes, 0, 0, (500, 200)),
+                                 kwargs=trial))
+            threads.append(
+                threading.Thread(target=self.check_response,
+                                 args=(1, dtype, shapes, 0, 0, (15000, 10000)),
+                                 kwargs=trial))
+            threads.append(
+                threading.Thread(target=self.check_response,
+                                 args=(2, dtype, shapes, 1, 0, (100, 0)),
+                                 kwargs=trial))
+            threads[0].start()
+            # wait to make sure the order is correct
+            time.sleep(0.1)
+            threads[1].start()
+            time.sleep(0.2)
+            threads[2].start()
+
+            for t in threads:
+                t.join()
+
+            try:
+                self.check_deferred_exception()
+            except InferenceServerException as ex:
+                self.assertTrue(False, "unexpected error {}".format(ex))
+
     def test_priority_with_policy(self):
         # Two set of requests are being sent at different priority levels
         # in sequence:

--- a/qa/L0_model_queue/model_queue_test.py
+++ b/qa/L0_model_queue/model_queue_test.py
@@ -403,6 +403,7 @@ class ModelQueueTest(tu.TestResultCollector):
         # first request.
         dtype = np.float32
         shapes = ([16],)
+        MAX_UINT32_PLUS_1 = 4294967296
         for trial in self.trials_:
             threads = []
             threads.append(
@@ -411,7 +412,7 @@ class ModelQueueTest(tu.TestResultCollector):
                                  kwargs=trial))
             threads.append(
                 threading.Thread(target=self.check_response,
-                                 args=(1, dtype, shapes, 0, 0, (15000, 10000)),
+                                 args=(1, dtype, shapes, MAX_UINT32_PLUS_1, 0, (15000, 10000)),
                                  kwargs=trial))
             threads.append(
                 threading.Thread(target=self.check_response,

--- a/qa/L0_model_queue/model_queue_test.py
+++ b/qa/L0_model_queue/model_queue_test.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_model_queue/test.sh
+++ b/qa/L0_model_queue/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_model_queue/test.sh
+++ b/qa/L0_model_queue/test.sh
@@ -283,6 +283,50 @@ set -e
 kill $SERVER_PID
 wait $SERVER_PID
 
+MAX_UINT64=18446744073709551615
+MAX_UINT32_PLUS_1=4294967296
+
+# test_max_priority_levels
+rm -fr models && mkdir models && \
+    cp -r ensemble_zero_1_float32 models/. && \
+    cp -r custom_zero_1_float32 models/. && \
+    (cd models/custom_zero_1_float32 && \
+        echo "dynamic_batching { " >> config.pbtxt && \
+        echo "    preferred_batch_size: [ 4, 8 ]" >> config.pbtxt && \
+        echo "    max_queue_delay_microseconds: 10000000" >> config.pbtxt && \
+        echo "    priority_levels: $MAX_UINT64" >> config.pbtxt && \
+        echo "    default_priority_level: $MAX_UINT32_PLUS_1" >> config.pbtxt && \
+        echo "}" >> config.pbtxt)
+
+TEST_CASE=test_max_priority_levels
+SERVER_LOG="./$TEST_CASE.server.log"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+echo "Test: $TEST_CASE" >>$CLIENT_LOG
+
+set +e
+python $MODEL_QUEUE_TEST ModelQueueTest.$TEST_CASE >>$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+else
+    check_test_results $TEST_RESULT_FILE 1
+    if [ $? -ne 0 ]; then
+        cat $CLIENT_LOG
+        echo -e "\n***\n*** Test Result Verification Failed\n***"
+        RET=1
+    fi
+fi
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
 # test_priority_with_policy
 # 2 levels and 2 policies:
 #     priority 1: delay

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -297,22 +297,24 @@ SetInferenceRequestMetadata(
     } else if (param.first.compare("priority") == 0) {
       const auto& infer_param = param.second;
       if (infer_param.parameter_choice_case() ==
-	  inference::InferParameter::ParameterChoiceCase::kInt64Param) {
-	if (infer_param.int64_param() < 0) {
-	  return TRITONSERVER_ErrorNew(
-				       TRITONSERVER_ERROR_INVALID_ARG,
-				       "invalid value for 'priority', expected value >= 0.");
-	}
-	RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(inference_request, infer_param.int64_param()));
-      }
-      else if (infer_param.parameter_choice_case() ==
-	       inference::InferParameter::ParameterChoiceCase::kUint64Param) {
-	RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(inference_request, infer_param.uint64_param()));
+          inference::InferParameter::ParameterChoiceCase::kInt64Param) {
+        if (infer_param.int64_param() < 0) {
+          return TRITONSERVER_ErrorNew(
+              TRITONSERVER_ERROR_INVALID_ARG,
+              "invalid value for 'priority', expected value >= 0.");
+        }
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(
+            inference_request, infer_param.int64_param()));
+      } else if (
+          infer_param.parameter_choice_case() ==
+          inference::InferParameter::ParameterChoiceCase::kUint64Param) {
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(
+            inference_request, infer_param.uint64_param()));
       } else {
-	return TRITONSERVER_ErrorNew(
-				     TRITONSERVER_ERROR_INVALID_ARG,
-				     "invalid value type for 'priority' parameter, expected "
-				     "int64_param or uint64_param.");	
+        return TRITONSERVER_ErrorNew(
+            TRITONSERVER_ERROR_INVALID_ARG,
+            "invalid value type for 'priority' parameter, expected "
+            "int64_param or uint64_param.");
       }
     } else if (param.first.compare("timeout") == 0) {
       const auto& infer_param = param.second;

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -296,16 +296,24 @@ SetInferenceRequestMetadata(
       }
     } else if (param.first.compare("priority") == 0) {
       const auto& infer_param = param.second;
-      if (infer_param.parameter_choice_case() !=
-          inference::InferParameter::ParameterChoiceCase::kInt64Param) {
-        return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INVALID_ARG,
-            "invalid value type for 'priority' parameter, expected "
-            "int64_param.");
+      if (infer_param.parameter_choice_case() ==
+	  inference::InferParameter::ParameterChoiceCase::kInt64Param) {
+	if (infer_param.int64_param() < 0) {
+	  return TRITONSERVER_ErrorNew(
+				       TRITONSERVER_ERROR_INVALID_ARG,
+				       "invalid value for 'priority', expected value >= 0.");
+	}
+	RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(inference_request, infer_param.int64_param()));
       }
-      RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriority(
-          inference_request, infer_param.int64_param()));
-
+      else if (infer_param.parameter_choice_case() ==
+	       inference::InferParameter::ParameterChoiceCase::kUint64Param) {
+	RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(inference_request, infer_param.uint64_param()));
+      } else {
+	return TRITONSERVER_ErrorNew(
+				     TRITONSERVER_ERROR_INVALID_ARG,
+				     "invalid value type for 'priority' parameter, expected "
+				     "int64_param or uint64_param.");	
+      }
     } else if (param.first.compare("timeout") == 0) {
       const auto& infer_param = param.second;
       if (infer_param.parameter_choice_case() !=

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -303,12 +303,12 @@ SetInferenceRequestMetadata(
               TRITONSERVER_ERROR_INVALID_ARG,
               "invalid value for 'priority', expected value >= 0.");
         }
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityUInt64(
             inference_request, infer_param.int64_param()));
       } else if (
           infer_param.parameter_choice_case() ==
           inference::InferParameter::ParameterChoiceCase::kUint64Param) {
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityUInt64(
             inference_request, infer_param.uint64_param()));
       } else {
         return TRITONSERVER_ErrorNew(

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2403,7 +2403,7 @@ HTTPAPIServer::EVBufferToInput(
         RETURN_MSG_IF_ERR(
             params_json.MemberAsUInt(parameter.c_str(), &p),
             "Unable to parse 'priority'");
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriority(irequest, p));
+        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(irequest, p));
       } else if (parameter == "timeout") {
         uint64_t t;
         RETURN_MSG_IF_ERR(

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2403,7 +2403,8 @@ HTTPAPIServer::EVBufferToInput(
         RETURN_MSG_IF_ERR(
             params_json.MemberAsUInt(parameter.c_str(), &p),
             "Unable to parse 'priority'");
-        RETURN_IF_ERR(TRITONSERVER_InferenceRequestSetPriorityU64(irequest, p));
+        RETURN_IF_ERR(
+            TRITONSERVER_InferenceRequestSetPriorityUInt64(irequest, p));
       } else if (parameter == "timeout") {
         uint64_t t;
         RETURN_MSG_IF_ERR(


### PR DESCRIPTION
Updating request priority apis to support uint64.

See discussion here https://github.com/triton-inference-server/common/pull/82#issuecomment-1547650136.

Major changes:
- Added test to L0_config_json to ensure large unsigned integers recovered correctly
- Added test to L0_model_queue to ensure large unsigned integer priority levels and default handled correctly
- changed grpc server to accept both U64 and int64 parameter for priority (error handling on negative priority)
- changed http server to use TRITONSERVER_InferenceRequestSetPriority64