### PR TITLE
Ensure HPCX dependencies found in container

### DIFF
--- a/build.py
+++ b/build.py
@@ -1214,6 +1214,13 @@ COPY --from=min_container /usr/local/cuda-12.1/targets/{cuda_arch}-linux/lib/lib
 COPY --from=min_container /usr/local/cuda-12.1/targets/{cuda_arch}-linux/lib/libnvToolsExt.so.1 /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
 COPY --from=min_container /usr/local/cuda-12.1/targets/{cuda_arch}-linux/lib/libnvJitLink.so.12 /usr/local/cuda/targets/{cuda_arch}-linux/lib/.
 
+RUN mkdir -p /opt/hpcx/ucc/lib/ /opt/hpcx/ucx/lib/
+COPY --from=min_container /opt/hpcx/ucc/lib/libucc.so.1 /opt/hpcx/ucc/lib/libucc.so.1
+COPY --from=min_container /opt/hpcx/ucx/lib/libucm.so.0 /opt/hpcx/ucx/lib/libucm.so.0
+COPY --from=min_container /opt/hpcx/ucx/lib/libucp.so.0 /opt/hpcx/ucx/lib/libucp.so.0
+COPY --from=min_container /opt/hpcx/ucx/lib/libucs.so.0 /opt/hpcx/ucx/lib/libucs.so.0
+COPY --from=min_container /opt/hpcx/ucx/lib/libuct.so.0 /opt/hpcx/ucx/lib/libuct.so.0
+
 COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.8 /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.8
 
 # patchelf is needed to add deps of libcublasLt.so.12 to libtorch_cuda.so

--- a/build.py
+++ b/build.py
@@ -1105,7 +1105,10 @@ ENV LD_LIBRARY_PATH /opt/tritonserver/backends/onnxruntime:${LD_LIBRARY_PATH}
 '''
 
     # Necessary for libtorch.so to find correct HPCX libraries
-    if enable_gpu and ('pytorch' in backends):
+    if ('pytorch' in backends):
+        if not enable_gpu: '''
+ENV LD_LIBRARY_PATH /opt/hpcx/ucc/lib/:${LD_LIBRARY_PATH}
+'''
         df += '''
 ENV LD_LIBRARY_PATH /opt/hpcx/ucx/lib/:${LD_LIBRARY_PATH}
 '''

--- a/build.py
+++ b/build.py
@@ -1106,12 +1106,8 @@ ENV LD_LIBRARY_PATH /opt/tritonserver/backends/onnxruntime:${LD_LIBRARY_PATH}
 
     # Necessary for libtorch.so to find correct HPCX libraries
     if ('pytorch' in backends):
-        if not enable_gpu:
-            df += '''
-ENV LD_LIBRARY_PATH /opt/hpcx/ucc/lib/:${LD_LIBRARY_PATH}
-'''
         df += '''
-ENV LD_LIBRARY_PATH /opt/hpcx/ucx/lib/:${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH /opt/hpcx/ucc/lib/:/opt/hpcx/ucx/lib/:${LD_LIBRARY_PATH}
 '''
 
     backend_dependencies = ""

--- a/build.py
+++ b/build.py
@@ -1107,7 +1107,7 @@ ENV LD_LIBRARY_PATH /opt/tritonserver/backends/onnxruntime:${LD_LIBRARY_PATH}
     # Necessary for libtorch.so to find correct HPCX libraries
     if ('pytorch' in backends):
         if not enable_gpu:
-            '''
+            df += '''
 ENV LD_LIBRARY_PATH /opt/hpcx/ucc/lib/:${LD_LIBRARY_PATH}
 '''
         df += '''

--- a/build.py
+++ b/build.py
@@ -1104,6 +1104,12 @@ ENV PATH /opt/tritonserver/bin:${PATH}
 ENV LD_LIBRARY_PATH /opt/tritonserver/backends/onnxruntime:${LD_LIBRARY_PATH}
 '''
 
+    # Necessary for libtorch.so to find correct HPCX libraries
+    if enable_gpu and ('pytorch' in backends):
+        df += '''
+ENV LD_LIBRARY_PATH /opt/hpcx/ucx/lib/:${LD_LIBRARY_PATH}
+'''
+
     backend_dependencies = ""
     # libgomp1 is needed by both onnxruntime and pytorch backends
     if ('onnxruntime' in backends) or ('pytorch' in backends):

--- a/build.py
+++ b/build.py
@@ -1106,7 +1106,8 @@ ENV LD_LIBRARY_PATH /opt/tritonserver/backends/onnxruntime:${LD_LIBRARY_PATH}
 
     # Necessary for libtorch.so to find correct HPCX libraries
     if ('pytorch' in backends):
-        if not enable_gpu: '''
+        if not enable_gpu:
+            '''
 ENV LD_LIBRARY_PATH /opt/hpcx/ucc/lib/:${LD_LIBRARY_PATH}
 '''
         df += '''


### PR DESCRIPTION
Prepend HPCX dependencies to LD_LIBRARY_PATH search path so that the correct version is found by PyTorch.

These already exist in the install repo in CPU-only builds, so they are found there. For the GPU build, these need to be on the search paths so that libtorch.so finds them before the versions installed by apt for other packages.

PyTorch: https://github.com/triton-inference-server/pytorch_backend/pull/113