### PR TITLE
Fix count check in L0_batcher

### DIFF
--- a/qa/L0_batcher/batcher_test.py
+++ b/qa/L0_batcher/batcher_test.py
@@ -214,7 +214,7 @@ class BatcherTest(tu.TestResultCollector):
                 model_name, "1")
             self.assertEqual(len(stats.model_stats), 1, "expect 1 model stats")
             actual_exec_cnt = stats.model_stats[0].execution_count
-            if actual_exec_cnt == exec_count:
+            if actual_exec_cnt in exec_count:
                 break
             print("WARNING: expect {} executions, got {} (attempt {})".format(
                 exec_count, actual_exec_cnt, i))
@@ -254,7 +254,7 @@ class BatcherTest(tu.TestResultCollector):
         self.assertIn(
             actual_exec_cnt, exec_count,
             "expected model-exec-count {}, got {}".format(
-                request_cnt, actual_exec_cnt))
+                exec_count, actual_exec_cnt))
 
         actual_infer_cnt = stats.model_stats[0].inference_count
         self.assertEqual(


### PR DESCRIPTION
Unlike the sequence batcher's check_status function, L0_batcher's check_status expects the execution count to be provided as a set. This allows one of the tests to provide two execution values. As a result, it gets checked via AssertIn. To be consistent in the stability check and allow it to pass when the batch is ready, L0_batcher needs to check that the actual execution count is in the expected execution count.

- Use "in" check rather than equality check for consistency
- Correct error message when execution count fails