### PR TITLE
Ensure L0_batch_input requests received in order

### DIFF
--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -62,10 +62,11 @@ class BatchInputTest(tu.TestResultCollector):
         model_name = "ragged_io"
 
         # The model is identity model
-        inputs = []
+        test_inputs = []
         for value in [2, 4, 1, 3]:
-            inputs.append([grpcclient.InferInput('INPUT0', [1, value], "FP32")])
-            inputs[-1][0].set_data_from_numpy(
+            test_inputs.append(
+                [grpcclient.InferInput('INPUT0', [1, value], "FP32")])
+            test_inputs[-1][0].set_data_from_numpy(
                 np.full([1, value], value, np.float32))
 
         user_data = queue.Queue()
@@ -77,11 +78,12 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            for inputs in inputs:
+            # Use
+            for input in test_inputs:
                 # Asynchronous inference call.
                 async_requests.append(
                     self.client.async_stream_infer(model_name=model_name,
-                                                   inputs=inputs,
+                                                   inputs=input,
                                                    outputs=outputs))
 
             expected_value_list = [[v] * v for v in [2, 4, 1, 3]]
@@ -115,11 +117,11 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            for inputs in self.inputs:
+            for input in self.inputs:
                 # Asynchronous inference call.
                 async_requests.append(
                     self.client.async_stream_infer(model_name=model_name,
-                                                   inputs=inputs,
+                                                   inputs=input,
                                                    outputs=outputs))
 
             value_lists = [[v] * v for v in [2, 4, 1, 3]]
@@ -152,11 +154,11 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            for inputs in self.inputs:
+            for input in self.inputs:
                 # Asynchronous inference call.
                 async_requests.append(
                     self.client.async_stream_infer(model_name=model_name,
-                                                   inputs=inputs,
+                                                   inputs=input,
                                                    outputs=outputs))
 
             expected_value = np.asarray([[2, 4, 1, 3]], np.float32)
@@ -186,11 +188,11 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            for inputs in self.inputs:
+            for input in self.inputs:
                 # Asynchronous inference call.
                 async_requests.append(
                     self.client.async_stream_infer(model_name=model_name,
-                                                   inputs=inputs,
+                                                   inputs=input,
                                                    outputs=outputs))
 
             expected_value = np.asarray([[2, 6, 7, 10]], np.float32)
@@ -220,11 +222,11 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            for inputs in self.inputs:
+            for input in self.inputs:
                 # Asynchronous inference call.
                 async_requests.append(
                     self.client.async_stream_infer(model_name=model_name,
-                                                   inputs=inputs,
+                                                   inputs=input,
                                                    outputs=outputs))
 
             expected_value = np.asarray([[0, 2, 6, 7, 10]], np.float32)
@@ -254,11 +256,11 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            for inputs in self.inputs:
+            for input in self.inputs:
                 # Asynchronous inference call.
                 async_requests.append(
                     self.client.async_stream_infer(model_name=model_name,
-                                                   inputs=inputs,
+                                                   inputs=input,
                                                    outputs=outputs))
 
             for idx in range(len(async_requests)):
@@ -281,11 +283,11 @@ class BatchInputTest(tu.TestResultCollector):
         # [1, 4, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2]
         # Note that the test only checks the formation of "BATCH_INPUT" where
         # the value of "RAGGED_INPUT" is irrelevant, only the shape matters
-        inputs = []
+        test_inputs = []
         for value in [[1, 4, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2]]:
-            inputs.append(
+            test_inputs.append(
                 [grpcclient.InferInput('RAGGED_INPUT', value, "FP32")])
-            inputs[-1][0].set_data_from_numpy(
+            test_inputs[-1][0].set_data_from_numpy(
                 np.full(value, value[0], np.float32))
 
         model_name = "batch_item_flatten"
@@ -298,11 +300,11 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            for inputs in inputs:
+            for input in test_inputs:
                 # Asynchronous inference call.
                 async_requests.append(
                     self.client.async_stream_infer(model_name=model_name,
-                                                   inputs=inputs,
+                                                   inputs=input,
                                                    outputs=outputs))
 
             expected_value = np.asarray([[4, 1, 1, 2, 1, 2, 2, 2]], np.float32)
@@ -325,11 +327,11 @@ class BatchInputTest(tu.TestResultCollector):
         # Use 3 set of inputs with shape [2, 1, 2], [1, 1, 2], [1, 2, 2]
         # Note that the test only checks the formation of "BATCH_INPUT" where
         # the value of "RAGGED_INPUT" is irrelevant, only the shape matters
-        inputs = []
+        test_inputs = []
         for value in [[2, 1, 2], [1, 1, 2], [1, 2, 2]]:
-            inputs.append(
+            test_inputs.append(
                 [grpcclient.InferInput('RAGGED_INPUT', value, "FP32")])
-            inputs[-1][0].set_data_from_numpy(
+            test_inputs[-1][0].set_data_from_numpy(
                 np.full(value, value[0], np.float32))
 
         expected_outputs = [
@@ -348,11 +350,11 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            for inputs in inputs:
+            for input in test_inputs:
                 # Asynchronous inference call.
                 async_requests.append(
                     self.client.async_stream_infer(model_name=model_name,
-                                                   inputs=inputs,
+                                                   inputs=input,
                                                    outputs=outputs))
 
             for idx in range(len(async_requests)):

--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -33,7 +33,6 @@ import numpy as np
 from functools import partial
 import queue
 import test_util as tu
-import time
 import tritonclient.grpc as grpcclient
 from tritonclient.utils import InferenceServerException
 
@@ -288,7 +287,6 @@ class BatchInputTest(tu.TestResultCollector):
                 [grpcclient.InferInput('RAGGED_INPUT', value, "FP32")])
             inputs[-1][0].set_data_from_numpy(
                 np.full(value, value[0], np.float32))
-        self.client = grpcclient.InferenceServerClient(url="localhost:8001")
 
         model_name = "batch_item_flatten"
         user_data = queue.Queue()
@@ -333,7 +331,6 @@ class BatchInputTest(tu.TestResultCollector):
                 [grpcclient.InferInput('RAGGED_INPUT', value, "FP32")])
             inputs[-1][0].set_data_from_numpy(
                 np.full(value, value[0], np.float32))
-        client = grpcclient.InferenceServerClient(url="localhost:8001")
 
         expected_outputs = [
             np.array([[1.0, 2.0], [1.0, 2.0]]),

--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -53,18 +53,20 @@ class BatchInputTest(tu.TestResultCollector):
     def set_inputs(self, shapes, input_name):
         self.dtype_ = np.float32
         self.inputs = []
-        if len(shapes[0]) == 1:
-            for shape in shapes:
-                self.inputs.append(
-                    [grpcclient.InferInput(input_name, [1, shape[0]], "FP32")])
-                self.inputs[-1][0].set_data_from_numpy(
-                    np.full([1, shape[0]], shape[0], np.float32))
-        else:
-            for shape in shapes:
-                self.inputs.append(
-                    [grpcclient.InferInput(input_name, shape, "FP32")])
-                self.inputs[-1][0].set_data_from_numpy(
-                    np.full(shape, shape[0], np.float32))
+        for shape in shapes:
+            self.inputs.append(
+                [grpcclient.InferInput(input_name, [1, shape[0]], "FP32")])
+            self.inputs[-1][0].set_data_from_numpy(
+                np.full([1, shape[0]], shape[0], np.float32))
+
+    def set_inputs_for_batch_item(self, shapes, input_name):
+        self.dtype_ = np.float32
+        self.inputs = []
+        for shape in shapes:
+            self.inputs.append(
+                [grpcclient.InferInput(input_name, shape, "FP32")])
+            self.inputs[-1][0].set_data_from_numpy(
+                np.full(shape, shape[0], np.float32))
 
     def test_ragged_output(self):
         model_name = "ragged_io"
@@ -287,8 +289,8 @@ class BatchInputTest(tu.TestResultCollector):
         # [1, 4, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2]
         # Note that the test only checks the formation of "BATCH_INPUT" where
         # the value of "RAGGED_INPUT" is irrelevant, only the shape matters
-        self.set_inputs([[1, 4, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2]],
-                        "RAGGED_INPUT")
+        self.set_inputs_for_batch_item(
+            [[1, 4, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2]], "RAGGED_INPUT")
 
         model_name = "batch_item_flatten"
         user_data = queue.Queue()
@@ -327,7 +329,8 @@ class BatchInputTest(tu.TestResultCollector):
         # Use 3 set of inputs with shape [2, 1, 2], [1, 1, 2], [1, 2, 2]
         # Note that the test only checks the formation of "BATCH_INPUT" where
         # the value of "RAGGED_INPUT" is irrelevant, only the shape matters
-        self.set_inputs([[2, 1, 2], [1, 1, 2], [1, 2, 2]], "RAGGED_INPUT")
+        self.set_inputs_for_batch_item([[2, 1, 2], [1, 1, 2], [1, 2, 2]],
+                                       "RAGGED_INPUT")
 
         expected_outputs = [
             np.array([[1.0, 2.0], [1.0, 2.0]]),

--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -35,7 +35,6 @@ import queue
 import test_util as tu
 import time
 import tritonclient.grpc as grpcclient
-import tritonclient.http as httpclient
 from tritonclient.utils import InferenceServerException
 
 
@@ -43,15 +42,14 @@ class BatchInputTest(tu.TestResultCollector):
 
     def setUp(self):
         self.dtype_ = np.float32
-        self.grpc_inputs = [] #replace with inputs
+        self.inputs = []
         # 4 set of inputs with shape [2], [4], [1], [3]
         for value in [2, 4, 1, 3]:
-            self.grpc_inputs.append([
-                grpcclient.InferInput('RAGGED_INPUT', [1, value], "FP32")
-            ])
-            self.grpc_inputs[-1][0].set_data_from_numpy(
+            self.inputs.append(
+                [grpcclient.InferInput('RAGGED_INPUT', [1, value], "FP32")])
+            self.inputs[-1][0].set_data_from_numpy(
                 np.full([1, value], value, np.float32))
-        self.grpc = grpcclient.InferenceServerClient(url='localhost:8001') #Replace with client
+        self.client = grpcclient.InferenceServerClient(url='localhost:8001')
 
         def callback(user_data, result, error):
             if error:
@@ -59,35 +57,33 @@ class BatchInputTest(tu.TestResultCollector):
             else:
                 user_data.put(result)
 
-        self.grpc_callback = callback
+        self.client_callback = callback
 
     def test_ragged_output(self):
-        print("test_ragged_output")
         model_name = "ragged_io"
 
         # The model is identity model
-        self.grpc_inputs = []
+        inputs = []
         for value in [2, 4, 1, 3]:
-            self.grpc_inputs.append(
-                [grpcclient.InferInput('INPUT0', [1, value], "FP32")])
-            self.grpc_inputs[-1][0].set_data_from_numpy(
+            inputs.append([grpcclient.InferInput('INPUT0', [1, value], "FP32")])
+            inputs[-1][0].set_data_from_numpy(
                 np.full([1, value], value, np.float32))
 
         user_data = queue.Queue()
-        self.grpc.start_stream(callback=partial(self.grpc_callback, user_data))
+        self.client.start_stream(
+            callback=partial(self.client_callback, user_data))
 
         output_name = 'OUTPUT0'
         outputs = [grpcclient.InferRequestedOutput(output_name)]
 
         async_requests = []
         try:
-            for inputs in self.grpc_inputs:
+            for inputs in inputs:
                 # Asynchronous inference call.
-                self.grpc.async_infer(model_name=model_name,
-                                            inputs=inputs,
-                                            outputs=outputs,
-                                            callback=partial(self.grpc_callback,
-                                                   user_data))
+                async_requests.append(
+                    self.client.async_stream_infer(model_name=model_name,
+                                                   inputs=inputs,
+                                                   outputs=outputs))
 
             expected_value_list = [[v] * v for v in [2, 4, 1, 3]]
             expected_value_list = [
@@ -95,7 +91,6 @@ class BatchInputTest(tu.TestResultCollector):
                 for expected_value in expected_value_list
             ]
             for idx in range(len(async_requests)):
-                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = user_data.get()
@@ -108,28 +103,25 @@ class BatchInputTest(tu.TestResultCollector):
                         idx, expected_value_list[idx], output_data))
         except InferenceServerException as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
-        self.grpc.stop_stream()
+        self.client.stop_stream()
 
     def test_ragged_input(self):
-        print("test_ragged_input")
         model_name = "ragged_acc_shape"
         user_data = queue.Queue()
-        self.grpc.start_stream(callback=partial(self.grpc_callback, user_data))
+        self.client.start_stream(
+            callback=partial(self.client_callback, user_data))
 
         output_name = 'RAGGED_OUTPUT'
-        outputs = [grpcclient.InferRequestedOutput(output_name),
-        grpcclient.InferRequestedOutput("BATCH_OUTPUT"),
-        grpcclient.InferRequestedOutput("BATCH_AND_SIZE_OUTPUT")]
+        outputs = [grpcclient.InferRequestedOutput(output_name)]
 
         async_requests = []
         try:
-            for inputs in self.grpc_inputs:
+            for inputs in self.inputs:
                 # Asynchronous inference call.
-                self.grpc.async_infer(model_name=model_name,
-                                            inputs=inputs,
-                                            outputs=outputs,
-                                            callback=partial(self.grpc_callback,
-                                                   user_data))
+                async_requests.append(
+                    self.client.async_stream_infer(model_name=model_name,
+                                                   inputs=inputs,
+                                                   outputs=outputs))
 
             value_lists = [[v] * v for v in [2, 4, 1, 3]]
             expected_value = []
@@ -137,14 +129,9 @@ class BatchInputTest(tu.TestResultCollector):
                 expected_value += value_list
             expected_value = np.asarray([expected_value], dtype=np.float32)
             for idx in range(len(async_requests)):
-                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = user_data.get()
-                print("BATCH_AND_SIZE_OUTPUT:")
-                print(result.as_numpy("BATCH_AND_SIZE_OUTPUT"))
-                print("BATCH_OUTPUT:")
-                print(result.as_numpy("BATCH_OUTPUT"))
                 # Validate the results by comparing with precomputed values.
                 output_data = result.as_numpy(output_name)
                 self.assertTrue(
@@ -153,30 +140,28 @@ class BatchInputTest(tu.TestResultCollector):
                         idx, expected_value, output_data))
         except InferenceServerException as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
-        self.grpc.stop_stream()
+        self.client.stop_stream()
 
     def test_element_count(self):
-        print("test_element_count")
         model_name = "ragged_element_count_acc_zero"
         user_data = queue.Queue()
-        self.grpc.start_stream(callback=partial(self.grpc_callback, user_data))
+        self.client.start_stream(
+            callback=partial(self.client_callback, user_data))
 
         output_name = 'BATCH_AND_SIZE_OUTPUT'
         outputs = [grpcclient.InferRequestedOutput(output_name)]
 
         async_requests = []
         try:
-            for inputs in self.grpc_inputs:
+            for inputs in self.inputs:
                 # Asynchronous inference call.
-                self.grpc.async_infer(model_name=model_name,
-                                            inputs=inputs,
-                                            outputs=outputs,
-                                            callback=partial(self.grpc_callback,
-                                                   user_data))
+                async_requests.append(
+                    self.client.async_stream_infer(model_name=model_name,
+                                                   inputs=inputs,
+                                                   outputs=outputs))
 
             expected_value = np.asarray([[2, 4, 1, 3]], np.float32)
             for idx in range(len(async_requests)):
-                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = user_data.get()
@@ -189,40 +174,31 @@ class BatchInputTest(tu.TestResultCollector):
                         idx, expected_value, output_data))
         except InferenceServerException as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
-        self.grpc.stop_stream()
+        self.client.stop_stream()
 
     def test_accumulated_element_count(self):
-        print("test_accumulated_element_count")
         model_name = "ragged_acc_shape"
         user_data = queue.Queue()
-        self.grpc.start_stream(callback=partial(self.grpc_callback, user_data))
+        self.client.start_stream(
+            callback=partial(self.client_callback, user_data))
 
         output_name = 'BATCH_AND_SIZE_OUTPUT'
-        outputs = [grpcclient.InferRequestedOutput(output_name),
-        grpcclient.InferRequestedOutput("RAGGED_OUTPUT"),
-        grpcclient.InferRequestedOutput("BATCH_OUTPUT")]
+        outputs = [grpcclient.InferRequestedOutput(output_name)]
 
         async_requests = []
         try:
-            for inputs in self.grpc_inputs:
+            for inputs in self.inputs:
                 # Asynchronous inference call.
-                self.grpc.async_infer(model_name=model_name,
-                                            inputs=inputs,
-                                            outputs=outputs,
-                                            callback=partial(self.grpc_callback,
-                                                   user_data))
-
+                async_requests.append(
+                    self.client.async_stream_infer(model_name=model_name,
+                                                   inputs=inputs,
+                                                   outputs=outputs))
 
             expected_value = np.asarray([[2, 6, 7, 10]], np.float32)
             for idx in range(len(async_requests)):
-                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = user_data.get()
-                print("RAGGED_OUTPUT:")
-                print(result.as_numpy("RAGGED_OUTPUT"))
-                print("BATCH_OUTPUT:")
-                print(result.as_numpy("BATCH_OUTPUT"))
 
                 # Validate the results by comparing with precomputed values.
                 output_data = result.as_numpy(output_name)
@@ -232,71 +208,61 @@ class BatchInputTest(tu.TestResultCollector):
                         idx, expected_value, output_data))
         except InferenceServerException as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
-        self.grpc.stop_stream()
+        self.client.stop_stream()
 
     def test_accumulated_element_count_with_zero(self):
-        print("test_accumulated_element_count_with_zero")
         model_name = "ragged_element_count_acc_zero"
         user_data = queue.Queue()
-        self.grpc.start_stream(callback=partial(self.grpc_callback, user_data))
-
-        output_name = 'BATCH_OUTPUT'
-        outputs = [grpcclient.InferRequestedOutput(output_name),
-        grpcclient.InferRequestedOutput("RAGGED_OUTPUT"),
-        grpcclient.InferRequestedOutput("BATCH_AND_SIZE_OUTPUT")]
-
-        async_requests = []
-        try:
-            for inputs in self.grpc_inputs:
-                # Asynchronous inference call.
-                self.grpc.async_infer(model_name=model_name,
-                                            inputs=inputs,
-                                            outputs=outputs,
-                                            callback=partial(self.grpc_callback,
-                                                   user_data))
-
-            expected_value = np.asarray([[0, 2, 6, 7, 10]], np.float32)
-            for idx in range(len(async_requests)):
-                print("idx: {}".format(idx))
-                # Get the result from the initiated asynchronous inference request.
-                # Note the call will block till the server responds.
-                result = user_data.get()
-                print("RAGGED_OUTPUT:")
-                print(result.as_numpy("RAGGED_OUTPUT"))
-                print("BATCH_AND_SIZE_OUTPUT:")
-                print(result.as_numpy("BATCH_AND_SIZE_OUTPUT"))
-
-                # Validate the results by comparing with precomputed values.
-                output_data = result.as_numpy(output_name)
-                self.assertTrue(
-                    np.array_equal(output_data, expected_value),
-                    "Expect response {} to have value {}, got {}".format(
-                        idx, expected_value, output_data))
-        except InferenceServerException as ex:
-            self.assertTrue(False, "unexpected error {}".format(ex))
-        self.grpc.stop_stream()
-
-    def test_max_element_count_as_shape(self):
-        print("test_max_element_count_as_shape")
-        model_name = "ragged_acc_shape"
-        user_data = queue.Queue()
-        self.grpc.start_stream(callback=partial(self.grpc_callback, user_data))
+        self.client.start_stream(
+            callback=partial(self.client_callback, user_data))
 
         output_name = 'BATCH_OUTPUT'
         outputs = [grpcclient.InferRequestedOutput(output_name)]
 
         async_requests = []
         try:
-            for inputs in self.grpc_inputs:
+            for inputs in self.inputs:
                 # Asynchronous inference call.
-                self.grpc.async_infer(model_name=model_name,
-                                            inputs=inputs,
-                                            outputs=outputs,
-                                            callback=partial(self.grpc_callback,
-                                                   user_data))
+                async_requests.append(
+                    self.client.async_stream_infer(model_name=model_name,
+                                                   inputs=inputs,
+                                                   outputs=outputs))
+
+            expected_value = np.asarray([[0, 2, 6, 7, 10]], np.float32)
+            for idx in range(len(async_requests)):
+                # Get the result from the initiated asynchronous inference request.
+                # Note the call will block till the server responds.
+                result = user_data.get()
+
+                # Validate the results by comparing with precomputed values.
+                output_data = result.as_numpy(output_name)
+                self.assertTrue(
+                    np.array_equal(output_data, expected_value),
+                    "Expect response {} to have value {}, got {}".format(
+                        idx, expected_value, output_data))
+        except InferenceServerException as ex:
+            self.assertTrue(False, "unexpected error {}".format(ex))
+        self.client.stop_stream()
+
+    def test_max_element_count_as_shape(self):
+        model_name = "ragged_acc_shape"
+        user_data = queue.Queue()
+        self.client.start_stream(
+            callback=partial(self.client_callback, user_data))
+
+        output_name = 'BATCH_OUTPUT'
+        outputs = [grpcclient.InferRequestedOutput(output_name)]
+
+        async_requests = []
+        try:
+            for inputs in self.inputs:
+                # Asynchronous inference call.
+                async_requests.append(
+                    self.client.async_stream_infer(model_name=model_name,
+                                                   inputs=inputs,
+                                                   outputs=outputs))
 
             for idx in range(len(async_requests)):
-                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = user_data.get()
@@ -309,10 +275,9 @@ class BatchInputTest(tu.TestResultCollector):
                     .format(idx, 4, output_data.shape))
         except InferenceServerException as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
-        self.grpc.stop_stream()
+        self.client.stop_stream()
 
     def test_batch_item_shape_flatten(self):
-        print("test_batch_item_shape_flatten")
         # Use 4 set of inputs with shape
         # [1, 4, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2]
         # Note that the test only checks the formation of "BATCH_INPUT" where
@@ -320,31 +285,33 @@ class BatchInputTest(tu.TestResultCollector):
         inputs = []
         for value in [[1, 4, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2]]:
             inputs.append(
-                [httpclient.InferInput('RAGGED_INPUT', value, "FP32")])
+                [grpcclient.InferInput('RAGGED_INPUT', value, "FP32")])
             inputs[-1][0].set_data_from_numpy(
                 np.full(value, value[0], np.float32))
-        client = httpclient.InferenceServerClient(url="localhost:8000",
-                                                        concurrency=len(inputs))
+        self.client = grpcclient.InferenceServerClient(url="localhost:8001")
 
         model_name = "batch_item_flatten"
+        user_data = queue.Queue()
+        self.client.start_stream(
+            callback=partial(self.client_callback, user_data))
 
         output_name = 'BATCH_OUTPUT'
-        outputs = [httpclient.InferRequestedOutput(output_name)]
+        outputs = [grpcclient.InferRequestedOutput(output_name)]
 
         async_requests = []
         try:
-            for request_inputs in inputs:
+            for inputs in inputs:
                 # Asynchronous inference call.
-                client.async_infer(model_name=model_name,
-                                            inputs=request_inputs,
-                                            outputs=outputs)
+                async_requests.append(
+                    self.client.async_stream_infer(model_name=model_name,
+                                                   inputs=inputs,
+                                                   outputs=outputs))
 
             expected_value = np.asarray([[4, 1, 1, 2, 1, 2, 2, 2]], np.float32)
             for idx in range(len(async_requests)):
-                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
-                result = async_requests[idx].get_result()
+                result = user_data.get()
 
                 # Validate the results by comparing with precomputed values.
                 output_data = result.as_numpy(output_name)
@@ -354,6 +321,7 @@ class BatchInputTest(tu.TestResultCollector):
                         idx, expected_value, output_data))
         except InferenceServerException as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
+        self.client.stop_stream()
 
     def test_batch_item_shape(self):
         # Use 3 set of inputs with shape [2, 1, 2], [1, 1, 2], [1, 2, 2]
@@ -362,11 +330,10 @@ class BatchInputTest(tu.TestResultCollector):
         inputs = []
         for value in [[2, 1, 2], [1, 1, 2], [1, 2, 2]]:
             inputs.append(
-                [httpclient.InferInput('RAGGED_INPUT', value, "FP32")])
+                [grpcclient.InferInput('RAGGED_INPUT', value, "FP32")])
             inputs[-1][0].set_data_from_numpy(
                 np.full(value, value[0], np.float32))
-        client = httpclient.InferenceServerClient(url="localhost:8000",
-                                                        concurrency=len(inputs))
+        client = grpcclient.InferenceServerClient(url="localhost:8001")
 
         expected_outputs = [
             np.array([[1.0, 2.0], [1.0, 2.0]]),
@@ -375,23 +342,26 @@ class BatchInputTest(tu.TestResultCollector):
         ]
 
         model_name = "batch_item"
+        user_data = queue.Queue()
+        self.client.start_stream(
+            callback=partial(self.client_callback, user_data))
 
         output_name = 'BATCH_OUTPUT'
-        outputs = [httpclient.InferRequestedOutput(output_name)]
+        outputs = [grpcclient.InferRequestedOutput(output_name)]
 
         async_requests = []
         try:
-            for request_inputs in inputs:
+            for inputs in inputs:
                 # Asynchronous inference call.
                 async_requests.append(
-                    client.async_infer(model_name=model_name,
-                                            inputs=request_inputs,
-                                            outputs=outputs))
+                    self.client.async_stream_infer(model_name=model_name,
+                                                   inputs=inputs,
+                                                   outputs=outputs))
 
             for idx in range(len(async_requests)):
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
-                result = async_requests[idx].get_result()
+                result = user_data.get()
 
                 # Validate the results by comparing with precomputed values.
                 output_data = result.as_numpy(output_name)
@@ -402,6 +372,7 @@ class BatchInputTest(tu.TestResultCollector):
                             np.isclose(expected_outputs[idx], output_data)))
         except InferenceServerException as ex:
             self.assertTrue(False, "unexpected error {}".format(ex))
+        self.client.stop_stream()
 
 
 if __name__ == '__main__':

--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -78,7 +78,6 @@ class BatchInputTest(tu.TestResultCollector):
 
         async_requests = []
         try:
-            # Use
             for input in test_inputs:
                 # Asynchronous inference call.
                 async_requests.append(

--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -31,6 +31,7 @@ sys.path.append("../common")
 import unittest
 import numpy as np
 import test_util as tu
+import time
 import tritonhttpclient
 from tritonclientutils import InferenceServerException
 
@@ -51,6 +52,7 @@ class BatchInputTest(tu.TestResultCollector):
             url="localhost:8000", concurrency=len(self.inputs))
 
     def test_ragged_output(self):
+        print("test_ragged_output")
         model_name = "ragged_io"
 
         # The model is identity model
@@ -78,6 +80,7 @@ class BatchInputTest(tu.TestResultCollector):
                 for expected_value in expected_value_list
             ]
             for idx in range(len(async_requests)):
+                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()
@@ -92,10 +95,13 @@ class BatchInputTest(tu.TestResultCollector):
             self.assertTrue(False, "unexpected error {}".format(ex))
 
     def test_ragged_input(self):
+        print("test_ragged_input")
         model_name = "ragged_acc_shape"
 
         output_name = 'RAGGED_OUTPUT'
-        outputs = [tritonhttpclient.InferRequestedOutput(output_name)]
+        outputs = [tritonhttpclient.InferRequestedOutput(output_name),
+        tritonhttpclient.InferRequestedOutput("BATCH_OUTPUT"),
+        tritonhttpclient.InferRequestedOutput("BATCH_AND_SIZE_OUTPUT")]
 
         async_requests = []
         try:
@@ -112,10 +118,14 @@ class BatchInputTest(tu.TestResultCollector):
                 expected_value += value_list
             expected_value = np.asarray([expected_value], dtype=np.float32)
             for idx in range(len(async_requests)):
+                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()
-
+                print("BATCH_AND_SIZE_OUTPUT:")
+                print(result.as_numpy("BATCH_AND_SIZE_OUTPUT"))
+                print("BATCH_OUTPUT:")
+                print(result.as_numpy("BATCH_OUTPUT"))
                 # Validate the results by comparing with precomputed values.
                 output_data = result.as_numpy(output_name)
                 self.assertTrue(
@@ -126,6 +136,7 @@ class BatchInputTest(tu.TestResultCollector):
             self.assertTrue(False, "unexpected error {}".format(ex))
 
     def test_element_count(self):
+        print("test_element_count")
         model_name = "ragged_element_count_acc_zero"
 
         output_name = 'BATCH_AND_SIZE_OUTPUT'
@@ -142,6 +153,7 @@ class BatchInputTest(tu.TestResultCollector):
 
             expected_value = np.asarray([[2, 4, 1, 3]], np.float32)
             for idx in range(len(async_requests)):
+                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()
@@ -156,6 +168,7 @@ class BatchInputTest(tu.TestResultCollector):
             self.assertTrue(False, "unexpected error {}".format(ex))
 
     def test_accumulated_element_count(self):
+        print("test_accumulated_element_count")
         model_name = "ragged_acc_shape"
 
         output_name = 'BATCH_AND_SIZE_OUTPUT'
@@ -170,8 +183,10 @@ class BatchInputTest(tu.TestResultCollector):
                                             inputs=inputs,
                                             outputs=outputs))
 
+
             expected_value = np.asarray([[2, 6, 7, 10]], np.float32)
             for idx in range(len(async_requests)):
+                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()
@@ -186,6 +201,7 @@ class BatchInputTest(tu.TestResultCollector):
             self.assertTrue(False, "unexpected error {}".format(ex))
 
     def test_accumulated_element_count_with_zero(self):
+        print("test_accumulated_element_count_with_zero")
         model_name = "ragged_element_count_acc_zero"
 
         output_name = 'BATCH_OUTPUT'
@@ -202,6 +218,7 @@ class BatchInputTest(tu.TestResultCollector):
 
             expected_value = np.asarray([[0, 2, 6, 7, 10]], np.float32)
             for idx in range(len(async_requests)):
+                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()
@@ -216,6 +233,7 @@ class BatchInputTest(tu.TestResultCollector):
             self.assertTrue(False, "unexpected error {}".format(ex))
 
     def test_max_element_count_as_shape(self):
+        print("test_max_element_count_as_shape")
         model_name = "ragged_acc_shape"
 
         output_name = 'BATCH_OUTPUT'
@@ -231,6 +249,7 @@ class BatchInputTest(tu.TestResultCollector):
                                             outputs=outputs))
 
             for idx in range(len(async_requests)):
+                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()
@@ -245,6 +264,7 @@ class BatchInputTest(tu.TestResultCollector):
             self.assertTrue(False, "unexpected error {}".format(ex))
 
     def test_batch_item_shape_flatten(self):
+        print("test_batch_item_shape_flatten")
         # Use 4 set of inputs with shape
         # [1, 4, 1], [1, 1, 2], [1, 1, 2], [1, 2, 2]
         # Note that the test only checks the formation of "BATCH_INPUT" where
@@ -274,6 +294,7 @@ class BatchInputTest(tu.TestResultCollector):
 
             expected_value = np.asarray([[4, 1, 1, 2, 1, 2, 2, 2]], np.float32)
             for idx in range(len(async_requests)):
+                print("idx: {}".format(idx))
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()

--- a/qa/L0_batch_input/batch_input_test.py
+++ b/qa/L0_batch_input/batch_input_test.py
@@ -172,7 +172,9 @@ class BatchInputTest(tu.TestResultCollector):
         model_name = "ragged_acc_shape"
 
         output_name = 'BATCH_AND_SIZE_OUTPUT'
-        outputs = [tritonhttpclient.InferRequestedOutput(output_name)]
+        outputs = [tritonhttpclient.InferRequestedOutput(output_name),
+        tritonhttpclient.InferRequestedOutput("RAGGED_OUTPUT"),
+        tritonhttpclient.InferRequestedOutput("BATCH_OUTPUT")]
 
         async_requests = []
         try:
@@ -190,6 +192,10 @@ class BatchInputTest(tu.TestResultCollector):
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()
+                print("RAGGED_OUTPUT:")
+                print(result.as_numpy("RAGGED_OUTPUT"))
+                print("BATCH_OUTPUT:")
+                print(result.as_numpy("BATCH_OUTPUT"))
 
                 # Validate the results by comparing with precomputed values.
                 output_data = result.as_numpy(output_name)
@@ -205,7 +211,9 @@ class BatchInputTest(tu.TestResultCollector):
         model_name = "ragged_element_count_acc_zero"
 
         output_name = 'BATCH_OUTPUT'
-        outputs = [tritonhttpclient.InferRequestedOutput(output_name)]
+        outputs = [tritonhttpclient.InferRequestedOutput(output_name),
+        tritonhttpclient.InferRequestedOutput("RAGGED_OUTPUT"),
+        tritonhttpclient.InferRequestedOutput("BATCH_AND_SIZE_OUTPUT")]
 
         async_requests = []
         try:
@@ -222,6 +230,10 @@ class BatchInputTest(tu.TestResultCollector):
                 # Get the result from the initiated asynchronous inference request.
                 # Note the call will block till the server responds.
                 result = async_requests[idx].get_result()
+                print("RAGGED_OUTPUT:")
+                print(result.as_numpy("RAGGED_OUTPUT"))
+                print("BATCH_AND_SIZE_OUTPUT:")
+                print(result.as_numpy("BATCH_AND_SIZE_OUTPUT"))
 
                 # Validate the results by comparing with precomputed values.
                 output_data = result.as_numpy(output_name)


### PR DESCRIPTION
L0_batch_input has been flaky in passing. It looks like the reason is that the responses rely on the requests being in order. Otherwise, for example, accumulation values will differ (since each request has a different volume and the tests assume that the request volumes will be received in the same order as requests sent).

This PR switches this test to use the GRPC client's streaming capability to ensure requests are received in order.