### PR TITLE
Remove only MPI libraries in HPCX in L0_perf_analyzer

### DIFF
--- a/qa/L0_perf_analyzer/test.sh
+++ b/qa/L0_perf_analyzer/test.sh
@@ -968,7 +968,7 @@ set -e
 
 ## Test perf_analyzer without MPI library (`libmpi.so`) available
 
-rm -rf /opt/hpcx
+rm -rf /opt/hpcx/ompi/lib/libmpi*
 
 set +e
 $PERF_ANALYZER -v -m graphdef_int32_int32_int32 -s ${STABILITY_THRESHOLD} >$CLIENT_LOG 2>&1


### PR DESCRIPTION
Cherry-pick #5967 to allow L0_perf_analyzer to pass on release branch