### PR TITLE
Add test that >1000 model files can be loaded in S3

### DIFF
--- a/qa/L0_storage_S3/test.sh
+++ b/qa/L0_storage_S3/test.sh
@@ -82,7 +82,7 @@ RET=0
 # Test 3 Scenarios:
 # 1. Only AWS ENV vars (Without aws configure)
 # 2. AWS ENV vars + dummy values in aws configure [ENV vars have higher priority]
-# 3. Only aws configured (Without AWS ENV vars)
+# 3. Only AWS configured (Without AWS ENV vars)
 for ENV_VAR in "env" "env_dummy" "config"; do
     SERVER_LOG=$SERVER_LOG_BASE.$ENV_VAR.log
     CLIENT_LOG=$CLIENT_LOG_BASE.$ENV_VAR.log

--- a/qa/L0_storage_S3/test.sh
+++ b/qa/L0_storage_S3/test.sh
@@ -416,9 +416,8 @@ aws configure set default.region $AWS_DEFAULT_REGION && \
     aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID && \
     aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
 
-# Clean up bucket contents and delete bucket
+# Clean up bucket contents
 aws s3 rm "${BUCKET_URL_SLASH}" --recursive --include "*"
-aws s3 rb "${BUCKET_URL}"
 
 if [ $RET -eq 0 ]; then
   echo -e "\n***\n*** Test Passed\n***"
@@ -456,5 +455,9 @@ fi
 
 kill $SERVER_PID
 wait $SERVER_PID
+
+# Clean up bucket contents and delete bucket
+aws s3 rm "${BUCKET_URL_SLASH}" --recursive --include "*"
+aws s3 rb "${BUCKET_URL}"
 
 exit $RET

--- a/qa/L0_storage_S3/test.sh
+++ b/qa/L0_storage_S3/test.sh
@@ -293,6 +293,7 @@ kill $SERVER_PID
 wait $SERVER_PID
 
 # Save models for AWS_SESSION_TOKEN test
+rm -rf tmp_cred_test_models
 mv models tmp_cred_test_models
 # Clean up bucket contents
 aws s3 rm "${BUCKET_URL_SLASH}" --recursive --include "*"
@@ -419,12 +420,6 @@ aws configure set default.region $AWS_DEFAULT_REGION && \
 # Clean up bucket contents
 aws s3 rm "${BUCKET_URL_SLASH}" --recursive --include "*"
 
-if [ $RET -eq 0 ]; then
-  echo -e "\n***\n*** Test Passed\n***"
-else
-  echo -e "\n***\n*** Test FAILED\n***"
-fi
-
 # Test case where S3 folder has >1000 files
 rm -rf models
 
@@ -437,6 +432,7 @@ done
 
 # Provide extended timeout to allow >1000 files to be loaded
 SERVER_ARGS="--model-repository=$BUCKET_URL --exit-timeout-secs=600 --model-control-mode=none"
+SERVER_LOG=$SERVER_LOG_BASE.many_files.log
 
 # copy contents of /models into S3 bucket and wait for them to be loaded.
 aws s3 cp models/ "${BUCKET_URL_SLASH}" --recursive --include "*"
@@ -459,5 +455,11 @@ wait $SERVER_PID
 # Clean up bucket contents and delete bucket
 aws s3 rm "${BUCKET_URL_SLASH}" --recursive --include "*"
 aws s3 rb "${BUCKET_URL}"
+
+if [ $RET -eq 0 ]; then
+  echo -e "\n***\n*** Test Passed\n***"
+else
+  echo -e "\n***\n*** Test FAILED\n***"
+fi
 
 exit $RET


### PR DESCRIPTION
Now that >1000 model files can be loaded, add a test to verify this can be done.

Results of test before changes (model.py is not loaded due to not being one of first 1000 files in ascending order):
![image](https://github.com/triton-inference-server/server/assets/58150256/2d7216f8-b740-407e-a7ee-97f4953b634b)
![image](https://github.com/triton-inference-server/server/assets/58150256/e0c14eb9-a0c7-4798-a61c-d3549ae9a12c)

Results of test after changes:
![image](https://github.com/triton-inference-server/server/assets/58150256/5fbf5855-7575-405c-9985-edce164c4a2d)
![image](https://github.com/triton-inference-server/server/assets/58150256/a49caf15-964f-4aa5-9de2-15b5e83db1bc)

Core: https://github.com/triton-inference-server/core/pull/225