### PR TITLE
Improve the error message when the number of GPUs is insufficient for L0_io and L0_libtorch_instance_group_kind_model

### DIFF
--- a/qa/L0_io/test.sh
+++ b/qa/L0_io/test.sh
@@ -160,7 +160,7 @@ python3 gen_libtorch_model.py >> $CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     echo -e "\n***\n*** Error when generating libtorch models. \n***"
     cat $CLIENT_LOG
-    RET=1
+    exit 1
 fi
 set -e
 

--- a/qa/L0_libtorch_instance_group_kind_model/gen_models.py
+++ b/qa/L0_libtorch_instance_group_kind_model/gen_models.py
@@ -72,6 +72,9 @@ class TestModel(nn.Module):
         op1 = self.layer2(INPUT0, INPUT1)
         return op0, op1
 
+if torch.cuda.device_count() < 4:
+    print("Need at least 4 GPUs to run this test")
+    exit(1)
 
 devices = [("cuda:2", "cuda:0"), ("cpu", "cuda:3")]
 model_names = ["libtorch_multi_gpu", "libtorch_multi_device"]

--- a/qa/L0_libtorch_instance_group_kind_model/test.sh
+++ b/qa/L0_libtorch_instance_group_kind_model/test.sh
@@ -69,7 +69,7 @@ python3 gen_models.py >> $CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     echo -e "\n***\n*** Error when generating models. \n***"
     cat $CLIENT_LOG
-    RET=1
+    exit 1
 fi
 set -e
 


### PR DESCRIPTION
This PR adds a check and returns a clearer error message when the tests are run on a machine that has less than 4 GPUs.