### PR TITLE
Allow non-decoupled model to send response and FINAL flag separately

### DIFF
--- a/qa/L0_decoupled/decoupled_test.py
+++ b/qa/L0_decoupled/decoupled_test.py
@@ -591,5 +591,57 @@ class DecoupledTest(tu.TestResultCollector):
         )
 
 
+class NonDecoupledTest(tu.TestResultCollector):
+    def setUp(self):
+        self.model_name_ = "repeat_int32"
+        self.input_data = {
+            "IN": np.array([1], dtype=np.int32),
+            "DELAY": np.array([0], dtype=np.uint32),
+            "WAIT": np.array([0], dtype=np.uint32),
+        }
+
+    def test_grpc(self):
+        inputs = [
+            grpcclient.InferInput("IN", [1], "INT32").set_data_from_numpy(
+                self.input_data["IN"]
+            ),
+            grpcclient.InferInput("DELAY", [1], "UINT32").set_data_from_numpy(
+                self.input_data["DELAY"]
+            ),
+            grpcclient.InferInput("WAIT", [1], "UINT32").set_data_from_numpy(
+                self.input_data["WAIT"]
+            ),
+        ]
+
+        triton_client = grpcclient.InferenceServerClient(
+            url="localhost:8001", verbose=True
+        )
+        # Expect the inference is successful
+        res = triton_client.infer(model_name=self.model_name_, inputs=inputs)
+        self.assertEqual(1, res.as_numpy("OUT")[0])
+        self.assertEqual(0, res.as_numpy("IDX")[0])
+
+    def test_http(self):
+        inputs = [
+            httpclient.InferInput("IN", [1], "INT32").set_data_from_numpy(
+                self.input_data["IN"]
+            ),
+            httpclient.InferInput("DELAY", [1], "UINT32").set_data_from_numpy(
+                self.input_data["DELAY"]
+            ),
+            httpclient.InferInput("WAIT", [1], "UINT32").set_data_from_numpy(
+                self.input_data["WAIT"]
+            ),
+        ]
+
+        triton_client = httpclient.InferenceServerClient(
+            url="localhost:8000", verbose=True
+        )
+        # Expect the inference is successful
+        res = triton_client.infer(model_name=self.model_name_, inputs=inputs)
+        self.assertEqual(1, res.as_numpy("OUT")[0])
+        self.assertEqual(0, res.as_numpy("IDX")[0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/qa/L0_decoupled/decoupled_test.py
+++ b/qa/L0_decoupled/decoupled_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_decoupled/test.sh
+++ b/qa/L0_decoupled/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -1,4 +1,4 @@
-// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -992,11 +992,6 @@ ModelInferHandler::InferResponseComplete(
     state->context_->EraseInflightState(state);
   }
 
-#ifdef TRITON_ENABLE_TRACING
-  state->trace_timestamps_.emplace_back(std::make_pair(
-      "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
-#endif  // TRITON_ENABLE_TRACING
-
   // If gRPC Stream is cancelled then no need of forming and returning
   // a response.
   if (state->IsGrpcContextCancelled()) {
@@ -1063,6 +1058,11 @@ ModelInferHandler::InferResponseComplete(
   if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
     return;
   }
+
+#ifdef TRITON_ENABLE_TRACING
+  state->trace_timestamps_.emplace_back(std::make_pair(
+      "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
+#endif  // TRITON_ENABLE_TRACING
 
 #ifdef TRITON_ENABLE_TRACING
   state->trace_timestamps_.emplace_back(

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -1051,8 +1051,7 @@ ModelInferHandler::InferResponseComplete(
     response->Clear();
   }
 
-  ::grpc::Status status;
-  GrpcStatusUtil::Create(&status, err);
+  GrpcStatusUtil::Create(&state->status_, err);
   TRITONSERVER_ErrorDelete(err);
 
   LOG_TRITONSERVER_ERROR(
@@ -1061,7 +1060,7 @@ ModelInferHandler::InferResponseComplete(
 
   // Defer sending the response until FINAL flag is seen or
   // there is error
-  if (status.ok() && (flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
+  if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
     return;
   }
 
@@ -1071,7 +1070,7 @@ ModelInferHandler::InferResponseComplete(
 #endif  // TRITON_ENABLE_TRACING
 
   state->step_ = COMPLETE;
-  state->context_->responder_->Finish(*response, status, state);
+  state->context_->responder_->Finish(*response, state->status_, state);
   if (response_created) {
     delete response;
   }

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -1040,6 +1040,10 @@ ModelInferHandler::InferResponseComplete(
   } else if (iresponse != nullptr) {
     err = InferResponseCompleteCommon<inference::ModelInferResponse>(
         state->tritonserver_, iresponse, *response, state->alloc_payload_);
+#ifdef TRITON_ENABLE_TRACING
+    state->trace_timestamps_.emplace_back(std::make_pair(
+        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
+#endif  // TRITON_ENABLE_TRACING
   }
 
   if (err != nullptr) {
@@ -1059,10 +1063,6 @@ ModelInferHandler::InferResponseComplete(
     return;
   }
 
-#ifdef TRITON_ENABLE_TRACING
-  state->trace_timestamps_.emplace_back(std::make_pair(
-      "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
-#endif  // TRITON_ENABLE_TRACING
 
 #ifdef TRITON_ENABLE_TRACING
   state->trace_timestamps_.emplace_back(

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -1032,6 +1032,7 @@ class InferHandlerState {
     unique_id_ = NEXT_UNIQUE_ID;
     context_ = context;
     step_ = start_step;
+    status_ = ::grpc::Status{};
     cb_count_ = 0;
     is_decoupled_ = false;
     complete_ = false;
@@ -1100,6 +1101,7 @@ class InferHandlerState {
   bool is_decoupled_ = false;
   StateParameters parameters_;
 
+  ::grpc::Status status_;
   std::atomic<uint32_t> cb_count_;
   bool complete_;
 

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3745,12 +3745,6 @@ HTTPAPIServer::InferRequestClass::InferResponseComplete(
     err = infer_request->FinalizeResponse(response);
   }
 
-#ifdef TRITON_ENABLE_TRACING
-  if (infer_request->trace_ != nullptr) {
-    infer_request->trace_->CaptureTimestamp(
-        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
-  }
-#endif  // TRITON_ENABLE_TRACING
 
   LOG_TRITONSERVER_ERROR(
       TRITONSERVER_InferenceResponseDelete(response),
@@ -3766,6 +3760,12 @@ HTTPAPIServer::InferRequestClass::InferResponseComplete(
   if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
     return;
   }
+#ifdef TRITON_ENABLE_TRACING
+  if (infer_request->trace_ != nullptr) {
+    infer_request->trace_->CaptureTimestamp(
+        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
+  }
+#endif  // TRITON_ENABLE_TRACING
   evthr_defer(
       infer_request->thread_, InferRequestClass::ReplyCallback, infer_request);
 }

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3743,6 +3743,12 @@ HTTPAPIServer::InferRequestClass::InferResponseComplete(
             .c_str());
   } else if (response != nullptr) {
     err = infer_request->FinalizeResponse(response);
+#ifdef TRITON_ENABLE_TRACING
+    if (infer_request->trace_ != nullptr) {
+      infer_request->trace_->CaptureTimestamp(
+          "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
+    }
+#endif  // TRITON_ENABLE_TRACING
   }
 
 
@@ -3760,12 +3766,6 @@ HTTPAPIServer::InferRequestClass::InferResponseComplete(
   if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
     return;
   }
-#ifdef TRITON_ENABLE_TRACING
-  if (infer_request->trace_ != nullptr) {
-    infer_request->trace_->CaptureTimestamp(
-        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
-  }
-#endif  // TRITON_ENABLE_TRACING
   evthr_defer(
       infer_request->thread_, InferRequestClass::ReplyCallback, infer_request);
 }

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3756,16 +3756,15 @@ HTTPAPIServer::InferRequestClass::InferResponseComplete(
       TRITONSERVER_InferenceResponseDelete(response),
       "deleting inference response");
 
-  // Defer sending the response until FINAL flag is seen or
-  // there is error
-  if ((err == nullptr) && (flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
-    return;
-  }
-
   if (err != nullptr) {
     EVBufferAddErrorJson(infer_request->req_->buffer_out, err);
     infer_request->response_code_ = HttpCodeFromError(err);
     TRITONSERVER_ErrorDelete(err);
+  }
+
+  // Defer sending the response until FINAL flag is seen
+  if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
+    return;
   }
   evthr_defer(
       infer_request->thread_, InferRequestClass::ReplyCallback, infer_request);

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -293,14 +293,15 @@ class HTTPAPIServer : public HTTPServer {
     static void ReplyCallback(evthr_t* thr, void* arg, void* shared);
 
    protected:
-    TRITONSERVER_Server* server_;
-    evhtp_request_t* req_;
-    evthr_t* thread_;
+    TRITONSERVER_Server* server_{nullptr};
+    evhtp_request_t* req_{nullptr};
+    evthr_t* thread_{nullptr};
 
-    DataCompressor::Type response_compression_type_;
+    DataCompressor::Type response_compression_type_{
+        DataCompressor::Type::IDENTITY};
 
     // Counter to keep track of number of responses generated.
-    std::atomic<uint32_t> response_count_;
+    std::atomic<uint32_t> response_count_{0};
 
     // Event hook for called before request deletion
     static evhtp_res RequestFiniHook(evhtp_request* req, void* arg);

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -406,11 +406,6 @@ SagemakerAPIServer::SagemakeInferRequestClass::InferResponseComplete(
       TRITONSERVER_InferenceResponseDelete(response),
       "deleting inference response");
 
-  // Defer sending the response until FINAL flag is seen or
-  // there is error
-  if ((err == nullptr) && (flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
-    return;
-  }
 
   if (err != nullptr) {
     EVBufferAddErrorJson(infer_request->req_->buffer_out, err);
@@ -425,6 +420,11 @@ SagemakerAPIServer::SagemakeInferRequestClass::InferResponseComplete(
       infer_request->response_code_ = 507;
     }
     TRITONSERVER_ErrorDelete(err);
+  }
+
+  // Defer sending the response until FINAL flag is seen
+  if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
+    return;
   }
   evthr_defer(infer_request->thread_, ReplyCallback, infer_request);
 }

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -392,6 +392,12 @@ SagemakerAPIServer::SagemakeInferRequestClass::InferResponseComplete(
             .c_str());
   } else if (response != nullptr) {
     err = infer_request->FinalizeResponse(response);
+#ifdef TRITON_ENABLE_TRACING
+    if (infer_request->trace_ != nullptr) {
+      infer_request->trace_->CaptureTimestamp(
+          "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
+    }
+#endif  // TRITON_ENABLE_TRACING
   }
 
 
@@ -419,12 +425,6 @@ SagemakerAPIServer::SagemakeInferRequestClass::InferResponseComplete(
   if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
     return;
   }
-#ifdef TRITON_ENABLE_TRACING
-  if (infer_request->trace_ != nullptr) {
-    infer_request->trace_->CaptureTimestamp(
-        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
-  }
-#endif  // TRITON_ENABLE_TRACING
   evthr_defer(infer_request->thread_, ReplyCallback, infer_request);
 }
 

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -394,13 +394,6 @@ SagemakerAPIServer::SagemakeInferRequestClass::InferResponseComplete(
     err = infer_request->FinalizeResponse(response);
   }
 
-#ifdef TRITON_ENABLE_TRACING
-  if (infer_request->trace_ != nullptr) {
-    infer_request->trace_->CaptureTimestamp(
-        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
-  }
-#endif  // TRITON_ENABLE_TRACING
-
 
   LOG_TRITONSERVER_ERROR(
       TRITONSERVER_InferenceResponseDelete(response),
@@ -426,6 +419,12 @@ SagemakerAPIServer::SagemakeInferRequestClass::InferResponseComplete(
   if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
     return;
   }
+#ifdef TRITON_ENABLE_TRACING
+  if (infer_request->trace_ != nullptr) {
+    infer_request->trace_->CaptureTimestamp(
+        "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp());
+  }
+#endif  // TRITON_ENABLE_TRACING
   evthr_defer(infer_request->thread_, ReplyCallback, infer_request);
 }
 


### PR DESCRIPTION
Follow up on https://github.com/triton-inference-server/core/pull/229
For custom backend, one may call send response in the following style, even for "non-decoupled" model
```
TRITONBACKEND_ResponseSend(response, 0, nullptr /* success */);
TRITONBACKEND_ResponseFactorySendFlags(factory, TRITONSERVER_RESPONSE_COMPLETE_FINAL);
```
This yields single response of the request from the client's perspective and would expect a successful inference through HTTP / non-streaming GRPC as it is "non-decoupled". The previous implementation is restricted that it simply assume decoupled use case when response complete callback is invoked multiple time. The change is to relax the restriction and collapse the above into single response to the client.