### PR TITLE
Document instance naming on reuse

### DIFF
--- a/docs/user_guide/model_management.md
+++ b/docs/user_guide/model_management.md
@@ -224,6 +224,8 @@ request is received under
 'config.pbtxt' is modified in place. The swap file is not part of the model
 configuration, so its presence in the model directory may be detected as a new file
 and cause the model to fully reload when only an update is expected.
+  * The model instance reused might carry a different name than the one provided
+on the 'config.pbtxt', but the instances are equivalent beside their names.
 
 * If a sequence model is updated with in-flight sequence(s), Triton does not
 guarentee any remaining request(s) from the in-flight sequence(s) will be routed

--- a/docs/user_guide/model_management.md
+++ b/docs/user_guide/model_management.md
@@ -224,7 +224,7 @@ request is received under
 'config.pbtxt' is modified in place. The swap file is not part of the model
 configuration, so its presence in the model directory may be detected as a new file
 and cause the model to fully reload when only an update is expected.
-  * The model instance reused might carry a different name than the one provided
+  * When a model configuration is reloaded existing model instances will be checked against the new configuration and be reused if possible. If a model instance is reused it will retain its original name.
 on the 'config.pbtxt', but the instances are equivalent beside their names.
 
 * If a sequence model is updated with in-flight sequence(s), Triton does not

--- a/docs/user_guide/model_management.md
+++ b/docs/user_guide/model_management.md
@@ -224,8 +224,9 @@ request is received under
 'config.pbtxt' is modified in place. The swap file is not part of the model
 configuration, so its presence in the model directory may be detected as a new file
 and cause the model to fully reload when only an update is expected.
-  * When a model configuration is reloaded existing model instances will be checked against the new configuration and be reused if possible. If a model instance is reused it will retain its original name.
-on the 'config.pbtxt', but the instances are equivalent beside their names.
+  * When a model configuration is reloaded existing model instances will be
+checked against the new configuration and be reused if possible. If a model
+instance is reused it will retain its original name.
 
 * If a sequence model is updated with in-flight sequence(s), Triton does not
 guarentee any remaining request(s) from the in-flight sequence(s) will be routed

--- a/qa/L0_model_update/instance_update_test.py
+++ b/qa/L0_model_update/instance_update_test.py
@@ -186,27 +186,6 @@ class TestInstanceUpdate(unittest.TestCase):
         self.__update_instance_count(3, 0, "{\ncount: 7\nkind: KIND_GPU\n}")
         self.__unload_model()
 
-    # Test add/remove multiple CPU/GPU instances at a time
-    def test_gpu_cpu_instance_update(self):
-        # Load model with 1 GPU instance and 2 CPU instance
-        self.__load_model(
-            3,
-            "{\ncount: 2\nkind: KIND_CPU\n},\n{\ncount: 1\nkind: KIND_GPU\n}")
-        # Add 2 GPU instance and remove 1 CPU instance
-        self.__update_instance_count(
-            2, 1,
-            "{\ncount: 1\nkind: KIND_CPU\n},\n{\ncount: 3\nkind: KIND_GPU\n}")
-        # Shuffle the instances
-        self.__update_instance_count(
-            0, 0,
-            "{\ncount: 3\nkind: KIND_GPU\n},\n{\ncount: 1\nkind: KIND_CPU\n}")
-        # Remove 1 GPU instance and add 1 CPU instance
-        self.__update_instance_count(
-            1, 1,
-            "{\ncount: 2\nkind: KIND_GPU\n},\n{\ncount: 2\nkind: KIND_CPU\n}")
-        # Unload model
-        self.__unload_model()
-
     # Test model instance name update
     def test_instance_name_update(self):
         # Load 3 instances with 2 different names
@@ -214,37 +193,45 @@ class TestInstanceUpdate(unittest.TestCase):
             3,
             "{\nname: \"old_1\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"old_2\"\ncount: 2\nkind: KIND_GPU\n}"
         )
-        # Change the instance names
+        # Rename all instances
         self.__update_instance_count(
-            0, 0,
+            3, 3,
             "{\nname: \"new_1\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"new_2\"\ncount: 2\nkind: KIND_GPU\n}"
         )
+        # Shuffle the instances
+        self.__update_instance_count(
+            0, 0,
+            "{\nname: \"new_2\"\ncount: 2\nkind: KIND_GPU\n},\n{\nname: \"new_1\"\ncount: 1\nkind: KIND_CPU\n}"
+        )
+        time.sleep(0.1)  # larger the gap for config.pbtxt timestamp to update
         # Unload model
         self.__unload_model()
 
-    # Test instance signature grouping
-    def test_instance_signature(self):
-        # Load 2 GPU instances and 3 CPU instances
+    # Test multiple model instances with the same name
+    def test_instance_same_name(self):
+        # Load 2 instances with the same name
         self.__load_model(
-            5,
-            "{\nname: \"GPU_group\"\ncount: 2\nkind: KIND_GPU\n},\n{\nname: \"CPU_group\"\ncount: 3\nkind: KIND_CPU\n}"
+            2,
+            "{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n}"
         )
-        # Flatten the instances representation
+        # Remove 1 instance with the same name
+        self.__update_instance_count(
+            0, 1, "{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n}")
+        # Add 2 instances with the same name
+        self.__update_instance_count(
+            2, 0,
+            "{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n}"
+        )
+        # No change
         self.__update_instance_count(
             0, 0,
-            "{\nname: \"CPU_1\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"CPU_2_3\"\ncount: 2\nkind: KIND_CPU\n},\n{\nname: \"GPU_1\"\ncount: 1\nkind: KIND_GPU\n},\n{\nname: \"GPU_2\"\ncount: 1\nkind: KIND_GPU\n}"
+            "{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n}"
         )
         time.sleep(0.1)  # larger the gap for config.pbtxt timestamp to update
-        # Consolidate different representations
+        # Change instance kind but keeping the same name
         self.__update_instance_count(
-            0, 0,
-            "{\nname: \"CPU_group\"\ncount: 3\nkind: KIND_CPU\n},\n{\nname: \"GPU_group\"\ncount: 2\nkind: KIND_GPU\n}"
-        )
-        time.sleep(0.1)  # larger the gap for config.pbtxt timestamp to update
-        # Flatten the instances representation
-        self.__update_instance_count(
-            0, 0,
-            "{\nname: \"GPU_1\"\ncount: 1\nkind: KIND_GPU\n},\n{\nname: \"GPU_2\"\ncount: 1\nkind: KIND_GPU\n},\n{\nname: \"CPU_1\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"CPU_2\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"CPU_3\"\ncount: 1\nkind: KIND_CPU\n}"
+            1, 1,
+            "{\nname: \"n\"\ncount: 1\nkind: KIND_GPU\n},\n{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n},\n{\nname: \"n\"\ncount: 1\nkind: KIND_CPU\n}"
         )
         # Unload model
         self.__unload_model()


### PR DESCRIPTION
core PR: https://github.com/triton-inference-server/core/pull/231

~~The `test_gpu_cpu_instance_update` test is removed, because adding and removing CPU and GPU instances impact the instance name, see the core PR for the naming rules, unless the instance names are explicitly controlled. The two primary goals of the removed `test_gpu_cpu_instance_update` test is to:~~
- ~~Ensure a model with more than one instance kind can be updated, which is covered by the new `test_instance_name_update`.~~
- ~~If the instances are simply shuffled on the config, no instance creation or destruction is performed, which is also covered by the new `test_instance_name_update`.~~

~~The `test_instance_signature` test is removed, because its primary goal is to ensure an instance is reused or not reused only based on the instance configuration, ignoring the name. Now, the name is taken into account, so a new test `test_instance_same_name` is added, which tests for the correct instance reused on instance configuration, with the instance name always explicitly fixed.~~