### PR TITLE
Fix L0_backend_python expected instance name

### DIFF
--- a/qa/python_models/init_args/model.py
+++ b/qa/python_models/init_args/model.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/python_models/init_args/model.py
+++ b/qa/python_models/init_args/model.py
@@ -34,7 +34,7 @@ def check_init_args(args):
         'model_name':
             'init_args',
         'model_instance_name':
-            'init_args_0',
+            'init_args_0_0',
         'model_instance_kind':
             'CPU',
         'model_instance_device_id':


### PR DESCRIPTION
After merging https://github.com/triton-inference-server/core/pull/231 PR, the default instance name no longer varies based on the instance group count.

For example, in the past, if `count = 1`, the default instance name is `init_args_0`. If `count > 1`, the default instance names are `init_args_0_0`, `init_args_0_1`, ... After the change, the default instance names will always be `init_args_0_0`, `init_args_0_1`, ... regardless of `count`.