### PR TITLE
Fix TensorRT expected model instance name

### DIFF
--- a/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_dims/expected
+++ b/qa/L0_model_config/autofill_noplatform/tensorrt/bad_input_dims/expected
@@ -1,1 +1,1 @@
-model 'bad_input_dims', tensor 'INPUT1': the model expects 1 dimensions (shape \[16\]) but the model configuration specifies 2 dimensions (shape \[16,1\])
+model 'bad_input_dims_0', tensor 'INPUT1': the model expects 1 dimensions (shape \[16\]) but the model configuration specifies 2 dimensions (shape \[16,1\])


### PR DESCRIPTION
After merging https://github.com/triton-inference-server/core/pull/231 PR, the default instance name no longer varies based on the instance group count.

For example, in the past, if `count = 1`, the default instance name is `bad_input_dims`. If `count > 1`, the default instance names are `bad_input_dims_0, bad_input_dims_1, ...`. After the change, the default instance names will always be `bad_input_dims_0, bad_input_dims_1, ...` regardless of count.