### PR TITLE
Fix L0_backend_python default instance name when count = 1

### DIFF
--- a/qa/L0_backend_python/decoupled/decoupled_test.py
+++ b/qa/L0_backend_python/decoupled/decoupled_test.py
@@ -220,7 +220,7 @@ class DecoupledTest(tu.TestResultCollector):
             if type(data_item) == InferenceServerException:
                 self.assertEqual(
                     data_item.message(),
-                    "Python model 'decoupled_return_response_error_0' is using "
+                    "Python model 'decoupled_return_response_error_0_0' is using "
                     "the decoupled mode and the execute function must return "
                     "None.",
                     "Exception message didn't match.",

--- a/qa/L0_backend_python/test.sh
+++ b/qa/L0_backend_python/test.sh
@@ -346,7 +346,7 @@ mkdir -p models/init_exit/1/
 cp ../python_models/init_exit/model.py ./models/init_exit/1/model.py
 cp ../python_models/init_exit/config.pbtxt ./models/init_exit/config.pbtxt
 
-ERROR_MESSAGE="Stub process 'init_exit_0' is not healthy."
+ERROR_MESSAGE="Stub process 'init_exit_0_0' is not healthy."
 
 prev_num_pages=`get_shm_pages`
 run_server


### PR DESCRIPTION
After merging https://github.com/triton-inference-server/core/pull/231 PR, the default instance name no longer varies based on the instance group count.

For example, in the past, if `count = 1`, the default instance name is `model_name_0`. If `count > 1`, the default instance names are `model_name_0_0, model_name_0_1, ...` After the change, the default instance names will always be `model_name_0_0, model_name_0_1, ...` regardless of count.