### PR TITLE
Cover all string/datatype combinations

### DIFF
--- a/qa/python_models/string_fixed/model.py
+++ b/qa/python_models/string_fixed/model.py
@@ -48,11 +48,11 @@ class TritonPythonModel:
                 )
             elif self._index == 1:
                 out_tensor_0 = pb_utils.Tensor(
-                    "OUTPUT0", np.array([], dtype=self._dtypes[1])
+                    "OUTPUT0", np.array([], dtype=self._dtypes[0])
                 )
             elif self._index == 2:
                 out_tensor_0 = pb_utils.Tensor(
-                    "OUTPUT0", np.array(["123456"], dtype=self._dtypes[0])
+                    "OUTPUT0", np.array(["123456"], dtype=self._dtypes[1])
                 )
             elif self._index == 3:
                 out_tensor_0 = pb_utils.Tensor(


### PR DESCRIPTION
Previously, case 0 == case 2 and case 1 == case 3 for `string_fixed` example. This PR corrects the returned datatypes to get all combinations of empty-string/fixed-string + bytes/object.