### PR TITLE
Fix L0_backend_python lifecycle default instance name

### DIFF
--- a/qa/L0_backend_python/lifecycle/lifecycle_test.py
+++ b/qa/L0_backend_python/lifecycle/lifecycle_test.py
@@ -146,7 +146,7 @@ class LifecycleTest(tu.TestResultCollector):
 
                 self.assertTrue(
                     "Failed to process the request(s) for model instance "
-                    "'execute_return_error_0', message: Expected a list in the "
+                    "'execute_return_error_0_0', message: Expected a list in the "
                     "execute return" in str(e.exception),
                     "Exception message is not correct.",
                 )
@@ -158,7 +158,7 @@ class LifecycleTest(tu.TestResultCollector):
 
                 self.assertTrue(
                     "Failed to process the request(s) for model instance "
-                    "'execute_return_error_0', message: Expected an "
+                    "'execute_return_error_0_0', message: Expected an "
                     "'InferenceResponse' object in the execute function return"
                     " list" in str(e.exception),
                     "Exception message is not correct.",


### PR DESCRIPTION
After merging https://github.com/triton-inference-server/core/pull/231 PR, the default instance name no longer varies based on the instance group count.

For example, in the past, if `count = 1`, the default instance name is `model_name_0`. If `count > 1`, the default instance names are `model_name_0_0, model_name_0_1, ...` After the change, the default instance names will always be `model_name_0_0, model_name_0_1, ...` regardless of count.