### PR TITLE
Reduce instance count to 1 for python bls model loading test

### DIFF
--- a/qa/python_models/bls_model_loading/config.pbtxt
+++ b/qa/python_models/bls_model_loading/config.pbtxt
@@ -37,7 +37,7 @@ output [
 
 instance_group [
   {
-    count: 3
+    count: 1
     kind: KIND_CPU
   }
 ]

--- a/qa/python_models/bls_model_loading/model.py
+++ b/qa/python_models/bls_model_loading/model.py
@@ -35,6 +35,8 @@ class PBBLSModelLoadingTest(unittest.TestCase):
         self.model_name = "onnx_int32_int32_int32"
 
     def tearDown(self):
+        # The unload call does not wait for the requested model to be fully
+        # unloaded before returning.
         pb_utils.unload_model(self.model_name)
 
     def test_load_unload_model(self):


### PR DESCRIPTION
To avoid unsafely using the model loading API, reduce the model instance count to 1.