### PR TITLE
Add link to PyTorch platform handler docs

### DIFF
--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -362,6 +362,11 @@ A minimal model repository for a TorchScript model is:
         model.pt
 ```
 
+### PyTorch Models \[Experimental\]
+
+Refer to
+[this documentation](https://github.com/triton-inference-server/python_backend/blob/main/src/resources/platform_handlers/pytorch/README.md).
+
 ### TensorFlow Models
 
 TensorFlow saves models in one of two formats: *GraphDef* or


### PR DESCRIPTION
Add link to docs on PR: https://github.com/triton-inference-server/python_backend/pull/282

The new link is pointing to the resource on the main branch, which will be broken until the Python PR is merged.