### PR TITLE
Adding safe string to number conversions

### DIFF
--- a/qa/L0_trace/test.sh
+++ b/qa/L0_trace/test.sh
@@ -481,36 +481,20 @@ if [ -f ./global_trace.log.0 ]; then
     RET=1
 fi
 
-# Check out of range errors
-rm -f ./curl.out
-set +e
-code=`curl -s -w %{http_code} -o ./curl.out -d'{"trace_count":"10000000000"}' localhost:8000/v2/models/simple/trace/setting`
-set -e
-if [ "$code" != "400" ]; then
-    cat ./curl.out
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-fi
+SETTINGS="trace_count trace_rate log_frequency"
 
-rm -f ./curl.out
-set +e
-code=`curl -s -w %{http_code} -o ./curl.out -d'{"trace_rate":"10000000000"}' localhost:8000/v2/models/simple/trace/setting`
-set -e
-if [ "$code" != "400" ]; then
-    cat ./curl.out
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-fi
-
-rm -f ./curl.out
-set +e
-code=`curl -s -w %{http_code} -o ./curl.out -d'{"log_frequency":"10000000000"}' localhost:8000/v2/models/simple/trace/setting`
-set -e
-if [ "$code" != "400" ]; then
-    cat ./curl.out
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-fi
+for SETTING in $SETTINGS; do
+    # Check `out of range` errors
+    rm -f ./curl.out
+    set +e
+    code=`curl -s -w %{http_code} -o ./curl.out -d'{"'${SETTING}'":"10000000000"}' localhost:8000/v2/models/simple/trace/setting`
+    set -e
+    if [ "$code" != "400" ]; then
+        cat ./curl.out
+        echo -e "\n***\n*** Test Failed\n***"
+        RET=1
+    fi
+done
 
 set -e
 

--- a/qa/L0_trace/test.sh
+++ b/qa/L0_trace/test.sh
@@ -485,15 +485,8 @@ SETTINGS="trace_count trace_rate log_frequency"
 
 for SETTING in $SETTINGS; do
     # Check `out of range` errors
-    rm -f ./curl.out
-    set +e
-    code=`curl -s -w %{http_code} -o ./curl.out -d'{"'${SETTING}'":"10000000000"}' localhost:8000/v2/models/simple/trace/setting`
-    set -e
-    if [ "$code" != "400" ]; then
-        cat ./curl.out
-        echo -e "\n***\n*** Test Failed\n***"
-        RET=1
-    fi
+    update_trace_setting "simple" '{"'${SETTING}'":"10000000000"}'
+    assert_curl_failure "Server modified '${SETTING}' with an out of range value."
 done
 
 set -e
@@ -714,7 +707,7 @@ OTEL_COLLECTOR_LOG="./trace_collector_http_exporter.log"
 # Building the latest version of the OpenTelemetry collector.
 # Ref: https://opentelemetry.io/docs/collector/getting-started/#local
 if [ -d "$OTEL_COLLECTOR_DIR" ]; then rm -Rf $OTEL_COLLECTOR_DIR; fi
-git clone https://github.com/open-telemetry/opentelemetry-collector.git
+git clone --depth 1 --branch v0.82.0 https://github.com/open-telemetry/opentelemetry-collector.git
 cd $OTEL_COLLECTOR_DIR
 make install-tools
 make otelcorecol

--- a/qa/L0_trace/test.sh
+++ b/qa/L0_trace/test.sh
@@ -481,6 +481,37 @@ if [ -f ./global_trace.log.0 ]; then
     RET=1
 fi
 
+# Check out of range errors
+rm -f ./curl.out
+set +e
+code=`curl -s -w %{http_code} -o ./curl.out -d'{"trace_count":"10000000000"}' localhost:8000/v2/models/simple/trace/setting`
+set -e
+if [ "$code" != "400" ]; then
+    cat ./curl.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+rm -f ./curl.out
+set +e
+code=`curl -s -w %{http_code} -o ./curl.out -d'{"trace_rate":"10000000000"}' localhost:8000/v2/models/simple/trace/setting`
+set -e
+if [ "$code" != "400" ]; then
+    cat ./curl.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+rm -f ./curl.out
+set +e
+code=`curl -s -w %{http_code} -o ./curl.out -d'{"log_frequency":"10000000000"}' localhost:8000/v2/models/simple/trace/setting`
+set -e
+if [ "$code" != "400" ]; then
+    cat ./curl.out
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
 set -e
 
 kill $SERVER_PID

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -114,32 +114,32 @@ namespace {
 // A wrapper around std::stoi, std::stoull, std::stoll, std::stod
 // to catch `invalid argument` and `out of range` exceptions
 template <typename T>
-T StoX(const std::string& arg);
+T StringTo(const std::string& arg);
 
 template <>
 int
-StoX(const std::string& arg)
+StringTo(const std::string& arg)
 {
   return std::stoi(arg);
 }
 
 template <>
 uint64_t
-StoX(const std::string& arg)
+StringTo(const std::string& arg)
 {
   return std::stoull(arg);
 }
 
 template <>
 int64_t
-StoX(const std::string& arg)
+StringTo(const std::string& arg)
 {
   return std::stoll(arg);
 }
 
 template <>
 double
-StoX(const std::string& arg)
+StringTo(const std::string& arg)
 {
   return std::stod(arg);
 }
@@ -153,7 +153,7 @@ T
 ParseOption(const std::string& arg, const std::string& opt_name = "")
 {
   try {
-    return StoX<T>(arg);
+    return StringTo<T>(arg);
   }
   catch (const std::invalid_argument& ia) {
     std::stringstream ss;

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -1206,8 +1206,7 @@ TritonParser::Parse(int argc, char** argv)
     }
     auto port = triton::server::GetEnvironmentVariableOrDefault(
         "AIP_HTTP_PORT", "8080");
-    lparams.vertex_ai_port_ =
-        ParseOption<int>(port, long_options[option_index].name);
+    lparams.vertex_ai_port_ = ParseOption<int>(port);
   }
 #endif  // TRITON_ENABLE_VERTEX_AI
 

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -36,8 +36,8 @@ bool
 end_of_long_opts(const struct option* longopts)
 {
   return (
-      (longopts->name_ == nullptr) && (longopts->has_arg_ == 0) &&
-      (longopts->flag_ == nullptr) && (longopts->val_ == 0));
+      (longopts->name == nullptr) && (longopts->has_arg == 0) &&
+      (longopts->flag == nullptr) && (longopts->val == 0));
 }
 
 /// Implementation of `getopt_long` for Windows.
@@ -67,8 +67,8 @@ getopt_long(
   std::string key = argv_str.substr(
       2, (found == std::string::npos) ? std::string::npos : (found - 2));
   while (!end_of_long_opts(curr_longopt)) {
-    if (key == curr_longopt->name_) {
-      if (curr_longopt->has_arg_ == required_argument) {
+    if (key == curr_longopt->name) {
+      if (curr_longopt->has_arg == required_argument) {
         if (found == std::string::npos) {
           if (longind != NULL) {
             *longind = optind - 1;
@@ -88,7 +88,7 @@ getopt_long(
         *longind = optind - 1;
       }
       optind++;
-      return curr_longopt->val_;
+      return curr_longopt->val;
     }
     curr_longopt++;
   }

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -93,7 +93,6 @@ getopt_long(
 #endif
 
 #include <algorithm>
-#include <functional>
 #include <iomanip>
 #include <iostream>
 #include <string>

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -45,7 +45,7 @@ getopt_long(
     int argc, char* const argv[], const char* optstring,
     const struct option* longopts, int* longindex)
 {
-  if ((longindex != NULL) || (optind >= argc)) {
+  if (optind >= argc) {
     return -1;
   }
   const struct option* curr_longopt = longopts;
@@ -57,6 +57,7 @@ getopt_long(
     if (key == curr_longopt->name_) {
       if (curr_longopt->has_arg_ == required_argument) {
         if (found == std::string::npos) {
+          *longindex = optind - 1;
           optind++;
           if (optind >= argc) {
             std::cerr << argv[0] << ": option '" << argv_str
@@ -68,6 +69,7 @@ getopt_long(
           optarg = (argv[optind] + found + 1);
         }
       }
+      *longindex = optind - 1;
       optind++;
       return curr_longopt->val_;
     }

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -102,7 +102,7 @@ namespace {
 template <typename T>
 T
 SafeConvertion(
-    const std::string& arg, std::function<int(const std::string&)> stox,
+    const std::string& arg, std::function<T(const std::string&)> stox,
     const std::string& opt_name = "")
 {
   try {

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -1163,6 +1163,19 @@ TritonServerParameters::BuildTritonServerOptions()
   return managed_ptr;
 }
 
+std::string
+TritonParser::GetOptionName(const struct option* long_option)
+{
+  if (long_option != nullptr) {
+#ifdef _WIN32
+    return long_option->name_;
+#else
+    return long_option->name;
+#endif
+  }
+  return "";
+}
+
 std::pair<TritonServerParameters, std::vector<char*>>
 TritonParser::Parse(int argc, char** argv)
 {
@@ -1233,8 +1246,8 @@ TritonParser::Parse(int argc, char** argv)
         throw ParseException();
 #ifdef TRITON_ENABLE_LOGGING
       case OPTION_LOG_VERBOSE:
-        lparams.log_verbose_ =
-            ParseIntBoolOption(optarg, long_options[option_index].name);
+        lparams.log_verbose_ = ParseIntBoolOption(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_LOG_INFO:
         lparams.log_info_ = ParseOption<bool>(optarg);
@@ -1289,12 +1302,12 @@ TritonParser::Parse(int argc, char** argv)
         lparams.allow_http_ = ParseOption<bool>(optarg);
         break;
       case OPTION_HTTP_PORT:
-        lparams.http_port_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.http_port_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_REUSE_HTTP_PORT:
-        lparams.reuse_http_port_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.reuse_http_port_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_HTTP_ADDRESS:
         lparams.http_address_ = optarg;
@@ -1304,8 +1317,8 @@ TritonParser::Parse(int argc, char** argv)
         break;
         break;
       case OPTION_HTTP_THREAD_COUNT:
-        lparams.http_thread_cnt_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.http_thread_cnt_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
 #endif  // TRITON_ENABLE_HTTP
 
@@ -1314,17 +1327,17 @@ TritonParser::Parse(int argc, char** argv)
         lparams.allow_sagemaker_ = ParseOption<bool>(optarg);
         break;
       case OPTION_SAGEMAKER_PORT:
-        lparams.sagemaker_port_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.sagemaker_port_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_SAGEMAKER_SAFE_PORT_RANGE:
         lparams.sagemaker_safe_range_set_ = true;
         lparams.sagemaker_safe_range_ = ParsePairOption<int, int>(
-            optarg, "-", long_options[option_index].name);
+            optarg, "-", GetOptionName(&long_options[option_index]));
         break;
       case OPTION_SAGEMAKER_THREAD_COUNT:
-        lparams.sagemaker_thread_cnt_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.sagemaker_thread_cnt_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
 #endif  // TRITON_ENABLE_SAGEMAKER
 
@@ -1333,12 +1346,12 @@ TritonParser::Parse(int argc, char** argv)
         lparams.allow_vertex_ai_ = ParseOption<bool>(optarg);
         break;
       case OPTION_VERTEX_AI_PORT:
-        lparams.vertex_ai_port_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.vertex_ai_port_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_VERTEX_AI_THREAD_COUNT:
-        lparams.vertex_ai_thread_cnt_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.vertex_ai_thread_cnt_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_VERTEX_AI_DEFAULT_MODEL:
         lparams.vertex_ai_default_model_ = optarg;
@@ -1350,19 +1363,19 @@ TritonParser::Parse(int argc, char** argv)
         lparams.allow_grpc_ = ParseOption<bool>(optarg);
         break;
       case OPTION_GRPC_PORT:
-        lgrpc_options.socket_.port_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lgrpc_options.socket_.port_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_REUSE_GRPC_PORT:
-        lgrpc_options.socket_.reuse_port_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lgrpc_options.socket_.reuse_port_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_GRPC_ADDRESS:
         lgrpc_options.socket_.address_ = optarg;
         break;
       case OPTION_GRPC_INFER_ALLOCATION_POOL_SIZE:
-        lgrpc_options.infer_allocation_pool_size_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lgrpc_options.infer_allocation_pool_size_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_GRPC_USE_SSL:
         lgrpc_options.ssl_.use_ssl_ = ParseOption<bool>(optarg);
@@ -1399,12 +1412,12 @@ TritonParser::Parse(int argc, char** argv)
         break;
       }
       case OPTION_GRPC_ARG_KEEPALIVE_TIME_MS:
-        lgrpc_options.keep_alive_.keepalive_time_ms_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lgrpc_options.keep_alive_.keepalive_time_ms_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_GRPC_ARG_KEEPALIVE_TIMEOUT_MS:
-        lgrpc_options.keep_alive_.keepalive_timeout_ms_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lgrpc_options.keep_alive_.keepalive_timeout_ms_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS:
         lgrpc_options.keep_alive_.keepalive_permit_without_calls_ =
@@ -1412,16 +1425,17 @@ TritonParser::Parse(int argc, char** argv)
         break;
       case OPTION_GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA:
         lgrpc_options.keep_alive_.http2_max_pings_without_data_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+            ParseOption<int>(
+                optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS:
         lgrpc_options.keep_alive_
-            .http2_min_recv_ping_interval_without_data_ms_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+            .http2_min_recv_ping_interval_without_data_ms_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_GRPC_ARG_HTTP2_MAX_PING_STRIKES:
-        lgrpc_options.keep_alive_.http2_max_ping_strikes_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lgrpc_options.keep_alive_.http2_max_ping_strikes_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_GRPC_RESTRICTED_PROTOCOL: {
         const auto& parsed_tuple = ParseGrpcRestrictedProtocolOption(optarg);
@@ -1455,12 +1469,12 @@ TritonParser::Parse(int argc, char** argv)
         lparams.metrics_address_ = optarg;
         break;
       case OPTION_METRICS_PORT:
-        lparams.metrics_port_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.metrics_port_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_METRICS_INTERVAL_MS:
-        lparams.metrics_interval_ms_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.metrics_interval_ms_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_METRICS_CONFIG:
         lparams.metrics_config_settings_.push_back(
@@ -1497,8 +1511,8 @@ TritonParser::Parse(int argc, char** argv)
                      "'--trace-config rate=<rate value> instead."
                   << std::endl;
         trace_rate_present = true;
-        lparams.trace_rate_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.trace_rate_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
 
       case OPTION_TRACE_COUNT:
@@ -1507,8 +1521,8 @@ TritonParser::Parse(int argc, char** argv)
                      "'--trace-config count=<count value> instead."
                   << std::endl;
         trace_count_present = true;
-        lparams.trace_count_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.trace_count_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_TRACE_LOG_FREQUENCY:
         std::cerr << "Warning: '--trace-log-frequency' has been deprecated and "
@@ -1518,8 +1532,8 @@ TritonParser::Parse(int argc, char** argv)
                      "value> instead."
                   << std::endl;
         trace_log_frequency_present = true;
-        lparams.trace_log_frequency_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.trace_log_frequency_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_TRACE_CONFIG: {
         auto trace_config_setting = ParseTraceConfigOption(optarg);
@@ -1534,8 +1548,8 @@ TritonParser::Parse(int argc, char** argv)
 #endif  // TRITON_ENABLE_TRACING
 
       case OPTION_POLL_REPO_SECS:
-        lparams.repository_poll_secs_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.repository_poll_secs_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_STARTUP_MODEL:
         lparams.startup_models_.insert(optarg);
@@ -1587,17 +1601,17 @@ TritonParser::Parse(int argc, char** argv)
         break;
       }
       case OPTION_PINNED_MEMORY_POOL_BYTE_SIZE:
-        lparams.pinned_memory_pool_byte_size_ =
-            ParseOption<int64_t>(optarg, long_options[option_index].name);
+        lparams.pinned_memory_pool_byte_size_ = ParseOption<int64_t>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_CUDA_MEMORY_POOL_BYTE_SIZE:
         lparams.cuda_pools_.push_back(ParsePairOption<int, uint64_t>(
-            optarg, ":", long_options[option_index].name));
+            optarg, ":", GetOptionName(&long_options[option_index])));
         break;
       case OPTION_RESPONSE_CACHE_BYTE_SIZE: {
         cache_size_present = true;
-        const auto byte_size = std::to_string(
-            ParseOption<int64_t>(optarg, long_options[option_index].name));
+        const auto byte_size = std::to_string(ParseOption<int64_t>(
+            optarg, GetOptionName(&long_options[option_index])));
         lparams.cache_config_settings_["local"] = {{"size", byte_size}};
         std::cerr
             << "Warning: '--response-cache-byte-size' has been deprecated! "
@@ -1623,12 +1637,12 @@ TritonParser::Parse(int argc, char** argv)
         lparams.cache_dir_ = optarg;
         break;
       case OPTION_MIN_SUPPORTED_COMPUTE_CAPABILITY:
-        lparams.min_supported_compute_capability_ =
-            ParseOption<double>(optarg, long_options[option_index].name);
+        lparams.min_supported_compute_capability_ = ParseOption<double>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_EXIT_TIMEOUT_SECS:
-        lparams.exit_timeout_secs_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.exit_timeout_secs_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_BACKEND_DIR:
         lparams.backend_dir_ = optarg;
@@ -1637,12 +1651,12 @@ TritonParser::Parse(int argc, char** argv)
         lparams.repoagent_dir_ = optarg;
         break;
       case OPTION_BUFFER_MANAGER_THREAD_COUNT:
-        lparams.buffer_manager_thread_count_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.buffer_manager_thread_count_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_MODEL_LOAD_THREAD_COUNT:
-        lparams.model_load_thread_count_ =
-            ParseOption<int>(optarg, long_options[option_index].name);
+        lparams.model_load_thread_count_ = ParseOption<int>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
       case OPTION_BACKEND_CONFIG:
         lparams.backend_config_settings_.push_back(
@@ -1653,11 +1667,11 @@ TritonParser::Parse(int argc, char** argv)
         break;
       case OPTION_MODEL_LOAD_GPU_LIMIT:
         lparams.load_gpu_limit_.emplace(ParsePairOption<int, double>(
-            optarg, ":", long_options[option_index].name));
+            optarg, ":", GetOptionName(&long_options[option_index])));
         break;
       case OPTION_MODEL_NAMESPACING:
-        lparams.enable_model_namespacing_ =
-            ParseOption<bool>(optarg, long_options[option_index].name);
+        lparams.enable_model_namespacing_ = ParseOption<bool>(
+            optarg, GetOptionName(&long_options[option_index]));
         break;
     }
   }

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -315,6 +315,9 @@ class TritonParser {
   // Initialize option group mappings
   void SetupOptionGroups();
 
+  // Retrieve option name
+  std::string GetOptionName(const struct option* long_option);
+
   // Sum of option groups: vector to maintain insertion order for Usage()
   std::vector<std::pair<std::string, std::vector<Option>&>> option_groups_;
   // Individual option groups

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -62,13 +62,13 @@
 #define no_argument 2
 struct option {
   option(const char* name, int has_arg, int* flag, int val)
-      : name_(name), has_arg_(has_arg), flag_(flag), val_(val)
+      : name(name), has_arg(has_arg), flag(flag), val(val)
   {
   }
-  const char* name_;
-  int has_arg_;
-  int* flag_;
-  int val_;
+  const char* name;
+  int has_arg;
+  int* flag;
+  int val;
 };
 #endif
 #ifdef TRITON_ENABLE_TRACING
@@ -314,9 +314,6 @@ class TritonParser {
   void SetupOptions();
   // Initialize option group mappings
   void SetupOptionGroups();
-
-  // Retrieve option name
-  std::string GetOptionName(const struct option* long_option);
 
   // Sum of option groups: vector to maintain insertion order for Usage()
   std::vector<std::pair<std::string, std::vector<Option>&>> option_groups_;

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -1324,6 +1324,18 @@ CommonHandler::RegisterTrace()
                       .c_str());
               GOTO_IF_ERR(err, earlyexit);
             }
+            catch (const std::out_of_range& oor) {
+              err = TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("Unable to parse '") + setting_name +
+                   "', value is out of range [ " +
+                   std::to_string(std::numeric_limits<std::uint32_t>::min()) +
+                   ", " +
+                   std::to_string(std::numeric_limits<std::uint32_t>::max()) +
+                   " ], got: " + it->second.value()[0])
+                      .c_str());
+              GOTO_IF_ERR(err, earlyexit);
+            }
           } else {
             err = TRITONSERVER_ErrorNew(
                 TRITONSERVER_ERROR_INVALID_ARG,
@@ -1342,6 +1354,14 @@ CommonHandler::RegisterTrace()
           } else if (it->second.value().size() == 1) {
             try {
               count = std::stoi(it->second.value()[0]);
+              if (count < TraceManager::MIN_TRACE_COUNT_VALUE) {
+                err = TRITONSERVER_ErrorNew(
+                    TRITONSERVER_ERROR_INVALID_ARG,
+                    (std::string("Unable to parse '") + setting_name +
+                     "'. Expecting value >= -1, got: " + it->second.value()[0])
+                        .c_str());
+                GOTO_IF_ERR(err, earlyexit);
+              }
               new_setting.count_ = &count;
             }
             catch (const std::invalid_argument& ia) {
@@ -1349,6 +1369,16 @@ CommonHandler::RegisterTrace()
                   TRITONSERVER_ERROR_INVALID_ARG,
                   (std::string("Unable to parse '") + setting_name +
                    "', got: " + it->second.value()[0])
+                      .c_str());
+              GOTO_IF_ERR(err, earlyexit);
+            }
+            catch (const std::out_of_range& oor) {
+              err = TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("Unable to parse '") + setting_name +
+                   "', value is out of range [ -1, " +
+                   std::to_string(std::numeric_limits<std::int32_t>::max()) +
+                   " ], got: " + it->second.value()[0])
                       .c_str());
               GOTO_IF_ERR(err, earlyexit);
             }
@@ -1377,6 +1407,18 @@ CommonHandler::RegisterTrace()
                   TRITONSERVER_ERROR_INVALID_ARG,
                   (std::string("Unable to parse '") + setting_name +
                    "', got: " + it->second.value()[0])
+                      .c_str());
+              GOTO_IF_ERR(err, earlyexit);
+            }
+            catch (const std::out_of_range& oor) {
+              err = TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("Unable to parse '") + setting_name +
+                   "', value is out of range [ " +
+                   std::to_string(std::numeric_limits<std::uint32_t>::min()) +
+                   ", " +
+                   std::to_string(std::numeric_limits<std::uint32_t>::max()) +
+                   " ], got: " + it->second.value()[0])
                       .c_str());
               GOTO_IF_ERR(err, earlyexit);
             }

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -1358,7 +1358,9 @@ CommonHandler::RegisterTrace()
                 err = TRITONSERVER_ErrorNew(
                     TRITONSERVER_ERROR_INVALID_ARG,
                     (std::string("Unable to parse '") + setting_name +
-                     "'. Expecting value >= -1, got: " + it->second.value()[0])
+                     "'. Expecting value >= " +
+                     std::to_string(TraceManager::MIN_TRACE_COUNT_VALUE) +
+                     ", got: " + it->second.value()[0])
                         .c_str());
                 GOTO_IF_ERR(err, earlyexit);
               }
@@ -1376,7 +1378,8 @@ CommonHandler::RegisterTrace()
               err = TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_INVALID_ARG,
                   (std::string("Unable to parse '") + setting_name +
-                   "', value is out of range [ -1, " +
+                   "', value is out of range [ " +
+                   std::to_string(TraceManager::MIN_TRACE_COUNT_VALUE) + ", " +
                    std::to_string(std::numeric_limits<std::int32_t>::max()) +
                    " ], got: " + it->second.value()[0])
                       .c_str());

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1785,7 +1785,9 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
                 req, TRITONSERVER_ErrorNew(
                          TRITONSERVER_ERROR_INVALID_ARG,
                          (std::string("Unable to parse 'trace_count'.") +
-                          " Expecting value >= -1, got:" + count_str)
+                          " Expecting value >= " +
+                          std::to_string(TraceManager::MIN_TRACE_COUNT_VALUE) +
+                          ", got:" + count_str)
                              .c_str()));
           }
           new_setting.count_ = &count;
@@ -1804,7 +1806,8 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_INVALID_ARG,
                   (std::string("Unable to parse 'trace_count', value is out of "
-                               "range [ -1, ") +
+                               "range [ ") +
+                   std::to_string(TraceManager::MIN_TRACE_COUNT_VALUE) + ", " +
                    std::to_string(std::numeric_limits<std::int32_t>::max()) +
                    " ], got: " + count_str)
                       .c_str()));

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1757,6 +1757,19 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
                         rate_str)
                            .c_str()));
         }
+        catch (const std::out_of_range& oor) {
+          HTTP_RESPOND_IF_ERR(
+              req,
+              TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("Unable to parse 'trace_rate', value is out of "
+                               "range [ ") +
+                   std::to_string(std::numeric_limits<std::uint32_t>::min()) +
+                   ", " +
+                   std::to_string(std::numeric_limits<std::uint32_t>::max()) +
+                   " ], got: " + rate_str)
+                      .c_str()));
+        }
       }
     }
     if (request.Find("trace_count", &setting_json)) {
@@ -1767,6 +1780,14 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
         HTTP_RESPOND_IF_ERR(req, setting_json.AsString(&count_str));
         try {
           count = std::stoi(count_str);
+          if (count < TraceManager::MIN_TRACE_COUNT_VALUE) {
+            HTTP_RESPOND_IF_ERR(
+                req, TRITONSERVER_ErrorNew(
+                         TRITONSERVER_ERROR_INVALID_ARG,
+                         (std::string("Unable to parse 'trace_count'.") +
+                          " Expecting value >= -1, got:" + count_str)
+                             .c_str()));
+          }
           new_setting.count_ = &count;
         }
         catch (const std::invalid_argument& ia) {
@@ -1776,6 +1797,17 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
                        (std::string("Unable to parse 'trace_count', got: ") +
                         count_str)
                            .c_str()));
+        }
+        catch (const std::out_of_range& oor) {
+          HTTP_RESPOND_IF_ERR(
+              req,
+              TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("Unable to parse 'trace_count', value is out of "
+                               "range [ -1, ") +
+                   std::to_string(std::numeric_limits<std::int32_t>::max()) +
+                   " ], got: " + count_str)
+                      .c_str()));
         }
       }
     }
@@ -1796,6 +1828,19 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
                        (std::string("Unable to parse 'log_frequency', got: ") +
                         frequency_str)
                            .c_str()));
+        }
+        catch (const std::out_of_range& oor) {
+          HTTP_RESPOND_IF_ERR(
+              req,
+              TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("Unable to parse 'trace_rate', value is out of "
+                               "range [ ") +
+                   std::to_string(std::numeric_limits<std::uint32_t>::min()) +
+                   ", " +
+                   std::to_string(std::numeric_limits<std::uint32_t>::max()) +
+                   " ], got: " + frequency_str)
+                      .c_str()));
         }
       }
     }

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1834,8 +1834,9 @@ HTTPAPIServer::HandleTrace(evhtp_request_t* req, const std::string& model_name)
               req,
               TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_INVALID_ARG,
-                  (std::string("Unable to parse 'trace_rate', value is out of "
-                               "range [ ") +
+                  (std::string(
+                       "Unable to parse 'log_frequency', value is out of "
+                       "range [ ") +
                    std::to_string(std::numeric_limits<std::uint32_t>::min()) +
                    ", " +
                    std::to_string(std::numeric_limits<std::uint32_t>::max()) +

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -79,6 +79,7 @@ class TraceManager {
   class TraceSetting;
 
  public:
+  static constexpr int32_t MIN_TRACE_COUNT_VALUE{-1};
   // The new field values for a setting, 'clear_xxx_' indicates
   // whether to clear the previously specified filed value.
   // If false, 'xxx_' will be used as the new field value.


### PR DESCRIPTION
Related issue: https://github.com/triton-inference-server/server/issues/6153

Issue fix is in files `http_server` and `grpc_server` - added catch for out of range exception .

I've also added a wrapper to `ParseOptions` in `command_line_parser` to handle `stoi`, `stoull`, `stoll` exceptions + report option, for which conversion didn't work.

