### PR TITLE
Fix the error message for L0_http

### DIFF
--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -110,7 +110,7 @@ class HttpTest(tu.TestResultCollector):
             ),
         )
         self.assertIn(
-            "For BYTE datatype raw input, the model must have input shape [1]",
+            "For BYTE datatype raw input 'INPUT0', the model must have input shape [1]",
             r.content.decode(),
         )
 


### PR DESCRIPTION
With [adding the input name to the log message](https://github.com/triton-inference-server/core/pull/243), need to update the error message in the test.

Error from L0_http:
```
AssertionError: 'For BYTE datatype raw input, the model must have input shape [1]' not found in '{"error":"[request id: <id_unknown>] For BYTE datatype raw input \'INPUT0\', the model must have input shape [1]"}'
```