### PR TITLE
Test Python execute() to return Triton error code

### DIFF
--- a/qa/L0_backend_python/lifecycle/lifecycle_test.py
+++ b/qa/L0_backend_python/lifecycle/lifecycle_test.py
@@ -63,13 +63,13 @@ class LifecycleTest(tu.TestResultCollector):
         shape = [1, 1]
         # [(Triton error, expected gRPC error message starting), ...]
         errors = [
-            ("TRITONSERVER_ERROR_UNKNOWN", "[StatusCode.UNKNOWN]"),
-            ("TRITONSERVER_ERROR_INTERNAL", "[StatusCode.INTERNAL]"),
-            ("TRITONSERVER_ERROR_NOT_FOUND", "[StatusCode.NOT_FOUND]"),
-            ("TRITONSERVER_ERROR_INVALID_ARG", "[StatusCode.INVALID_ARGUMENT]"),
-            ("TRITONSERVER_ERROR_UNAVAILABLE", "[StatusCode.UNAVAILABLE]"),
-            ("TRITONSERVER_ERROR_UNSUPPORTED", "[StatusCode.UNIMPLEMENTED]"),
-            ("TRITONSERVER_ERROR_ALREADY_EXISTS", "[StatusCode.ALREADY_EXISTS]"),
+            ("UNKNOWN", "[StatusCode.UNKNOWN]"),
+            ("INTERNAL", "[StatusCode.INTERNAL]"),
+            ("NOT_FOUND", "[StatusCode.NOT_FOUND]"),
+            ("INVALID_ARG", "[StatusCode.INVALID_ARGUMENT]"),
+            ("UNAVAILABLE", "[StatusCode.UNAVAILABLE]"),
+            ("UNSUPPORTED", "[StatusCode.UNIMPLEMENTED]"),
+            ("ALREADY_EXISTS", "[StatusCode.ALREADY_EXISTS]"),
             ("(default)", "[StatusCode.INTERNAL] unrecognized"),
         ]
         with self._shm_leak_detector.Probe() as shm_probe:

--- a/qa/L0_backend_python/lifecycle/test.sh
+++ b/qa/L0_backend_python/lifecycle/test.sh
@@ -26,7 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CLIENT_LOG="./lifecycle_client.log"
-EXPECTED_NUM_TESTS="3"
+EXPECTED_NUM_TESTS="4"
 TEST_RESULT_FILE='test_results.txt'
 source ../common.sh
 source ../../common/util.sh
@@ -39,6 +39,10 @@ SERVER_LOG="./lifecycle_server.log"
 
 RET=0
 rm -fr *.log ./models
+
+mkdir -p models/error_code/1/
+cp ../../python_models/error_code/model.py ./models/error_code/1/
+cp ../../python_models/error_code/config.pbtxt ./models/error_code/
 
 mkdir -p models/execute_error/1/
 cp ../../python_models/execute_error/model.py ./models/execute_error/1/

--- a/qa/python_models/error_code/config.pbtxt
+++ b/qa/python_models/error_code/config.pbtxt
@@ -1,0 +1,47 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "error_code"
+backend: "python"
+max_batch_size: 4
+
+input [
+  {
+    name: "ERROR_CODE"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
+  }
+]
+
+output [
+  {
+    name: "DUMMY_OUT"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
+  }
+]
+
+instance_group [{ kind: KIND_CPU }]

--- a/qa/python_models/error_code/model.py
+++ b/qa/python_models/error_code/model.py
@@ -30,13 +30,13 @@ import triton_python_backend_utils as pb_utils
 class TritonPythonModel:
     def execute(self, requests):
         error_code_map = {
-            "UNKNOWN": pb_utils.TritonError.ErrorCode.UNKNOWN,
-            "INTERNAL": pb_utils.TritonError.ErrorCode.INTERNAL,
-            "NOT_FOUND": pb_utils.TritonError.ErrorCode.NOT_FOUND,
-            "INVALID_ARG": pb_utils.TritonError.ErrorCode.INVALID_ARG,
-            "UNAVAILABLE": pb_utils.TritonError.ErrorCode.UNAVAILABLE,
-            "UNSUPPORTED": pb_utils.TritonError.ErrorCode.UNSUPPORTED,
-            "ALREADY_EXISTS": pb_utils.TritonError.ErrorCode.ALREADY_EXISTS,
+            "UNKNOWN": pb_utils.TritonError.UNKNOWN,
+            "INTERNAL": pb_utils.TritonError.INTERNAL,
+            "NOT_FOUND": pb_utils.TritonError.NOT_FOUND,
+            "INVALID_ARG": pb_utils.TritonError.INVALID_ARG,
+            "UNAVAILABLE": pb_utils.TritonError.UNAVAILABLE,
+            "UNSUPPORTED": pb_utils.TritonError.UNSUPPORTED,
+            "ALREADY_EXISTS": pb_utils.TritonError.ALREADY_EXISTS,
         }
 
         responses = []

--- a/qa/python_models/error_code/model.py
+++ b/qa/python_models/error_code/model.py
@@ -30,13 +30,13 @@ import triton_python_backend_utils as pb_utils
 class TritonPythonModel:
     def execute(self, requests):
         error_code_map = {
-            "TRITONSERVER_ERROR_UNKNOWN": pb_utils.ErrorCode.TRITONSERVER_ERROR_UNKNOWN,
-            "TRITONSERVER_ERROR_INTERNAL": pb_utils.ErrorCode.TRITONSERVER_ERROR_INTERNAL,
-            "TRITONSERVER_ERROR_NOT_FOUND": pb_utils.ErrorCode.TRITONSERVER_ERROR_NOT_FOUND,
-            "TRITONSERVER_ERROR_INVALID_ARG": pb_utils.ErrorCode.TRITONSERVER_ERROR_INVALID_ARG,
-            "TRITONSERVER_ERROR_UNAVAILABLE": pb_utils.ErrorCode.TRITONSERVER_ERROR_UNAVAILABLE,
-            "TRITONSERVER_ERROR_UNSUPPORTED": pb_utils.ErrorCode.TRITONSERVER_ERROR_UNSUPPORTED,
-            "TRITONSERVER_ERROR_ALREADY_EXISTS": pb_utils.ErrorCode.TRITONSERVER_ERROR_ALREADY_EXISTS,
+            "UNKNOWN": pb_utils.TritonError.ErrorCode.UNKNOWN,
+            "INTERNAL": pb_utils.TritonError.ErrorCode.INTERNAL,
+            "NOT_FOUND": pb_utils.TritonError.ErrorCode.NOT_FOUND,
+            "INVALID_ARG": pb_utils.TritonError.ErrorCode.INVALID_ARG,
+            "UNAVAILABLE": pb_utils.TritonError.ErrorCode.UNAVAILABLE,
+            "UNSUPPORTED": pb_utils.TritonError.ErrorCode.UNSUPPORTED,
+            "ALREADY_EXISTS": pb_utils.TritonError.ErrorCode.ALREADY_EXISTS,
         }
 
         responses = []

--- a/qa/python_models/error_code/model.py
+++ b/qa/python_models/error_code/model.py
@@ -1,0 +1,60 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import triton_python_backend_utils as pb_utils
+
+
+class TritonPythonModel:
+    def execute(self, requests):
+        error_code_map = {
+            "TRITONSERVER_ERROR_UNKNOWN": pb_utils.ErrorCode.TRITONSERVER_ERROR_UNKNOWN,
+            "TRITONSERVER_ERROR_INTERNAL": pb_utils.ErrorCode.TRITONSERVER_ERROR_INTERNAL,
+            "TRITONSERVER_ERROR_NOT_FOUND": pb_utils.ErrorCode.TRITONSERVER_ERROR_NOT_FOUND,
+            "TRITONSERVER_ERROR_INVALID_ARG": pb_utils.ErrorCode.TRITONSERVER_ERROR_INVALID_ARG,
+            "TRITONSERVER_ERROR_UNAVAILABLE": pb_utils.ErrorCode.TRITONSERVER_ERROR_UNAVAILABLE,
+            "TRITONSERVER_ERROR_UNSUPPORTED": pb_utils.ErrorCode.TRITONSERVER_ERROR_UNSUPPORTED,
+            "TRITONSERVER_ERROR_ALREADY_EXISTS": pb_utils.ErrorCode.TRITONSERVER_ERROR_ALREADY_EXISTS,
+        }
+
+        responses = []
+
+        for request in requests:
+            err_code_tensor = pb_utils.get_input_tensor_by_name(
+                request, "ERROR_CODE"
+            ).as_numpy()
+            err_code_str = str(err_code_tensor[0][0], encoding="utf-8")
+            if err_code_str in error_code_map:
+                error = pb_utils.TritonError(
+                    message=("Provided error code: " + err_code_str),
+                    code=error_code_map[err_code_str],
+                )
+            else:
+                error = pb_utils.TritonError(
+                    "On default error code, provided error code: " + err_code_str
+                )
+            responses.append(pb_utils.InferenceResponse(error=error))
+
+        return responses

--- a/qa/python_models/error_code/model.py
+++ b/qa/python_models/error_code/model.py
@@ -48,13 +48,11 @@ class TritonPythonModel:
             err_code_str = str(err_code_tensor[0][0], encoding="utf-8")
             if err_code_str in error_code_map:
                 error = pb_utils.TritonError(
-                    message=("Provided error code: " + err_code_str),
+                    message=("error code: " + err_code_str),
                     code=error_code_map[err_code_str],
                 )
             else:
-                error = pb_utils.TritonError(
-                    "On default error code, provided error code: " + err_code_str
-                )
+                error = pb_utils.TritonError("unrecognized error code: " + err_code_str)
             responses.append(pb_utils.InferenceResponse(error=error))
 
         return responses


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/python_backend/pull/292

This new test ensures the optionally supplied Python `execute()` error code can be picked up on the calling gRPC client.