### PR TITLE
Add test for TensorRT version-compatible model support

### DIFF
--- a/qa/L0_trt_compat/test.sh
+++ b/qa/L0_trt_compat/test.sh
@@ -43,7 +43,6 @@ source ../common/util.sh
 
 rm -fr models && mkdir models
 cp -r $DATADIR/qa_identity_model_repository/plan_compatible_zero_1_float32 models/.
-rm -f *.log
 
 if [ `ps | grep -c "tritonserver"` != "0" ]; then
     echo -e "Tritonserver already running"

--- a/qa/L0_trt_compat/test.sh
+++ b/qa/L0_trt_compat/test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REPO_VERSION=${NVIDIA_TRITON_SERVER_VERSION}
+if [ "$#" -ge 1 ]; then
+    REPO_VERSION=$1
+fi
+if [ -z "$REPO_VERSION" ]; then
+    echo -e "Repository version must be specified"
+    echo -e "\n***\n*** Test Failed\n***"
+    exit 1
+fi
+
+export CUDA_VISIBLE_DEVICES=0
+
+DATADIR=${DATADIR:="/data/inferenceserver/${REPO_VERSION}"}
+SERVER=/opt/tritonserver/bin/tritonserver
+SERVER_ARGS="--model-repository=`pwd`/models --exit-timeout-secs=120"
+SERVER_LOG="./inference_server.log"
+source ../common/util.sh
+
+rm -fr models && mkdir models
+cp -r $DATADIR/qa_identity_model_repository/plan_compatible_zero_1_float32 models/.
+rm -f *.log
+
+if [ `ps | grep -c "tritonserver"` != "0" ]; then
+    echo -e "Tritonserver already running"
+    echo -e `ps | grep tritonserver`
+    exit 1
+fi
+
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** FAILED: unexpected server start (version compatibility disabled): $SERVER\n***" >> $CLIENT_LOG
+    kill $SERVER_PID
+    wait $SERVER_PID
+    exit 1
+fi
+
+SERVER_ARGS="--model-repository=`pwd`/models --exit-timeout-secs=120 --backend-config=tensorrt,version-compatible=true"
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** FAILED: unsuccessful server start (version compatibility enabled): $SERVER\n***"
+    exit 1
+fi
+
+echo -e "\n***\n*** Test Passed\n***"

--- a/qa/L0_trt_compat/test.sh
+++ b/qa/L0_trt_compat/test.sh
@@ -36,7 +36,7 @@ if [ -z "$REPO_VERSION" ]; then
 fi
 
 TEST_RESULT_FILE='test_results.txt'
-COMPATABILITY_TEST_PY=trt_compatibility_test.py
+COMPATIBILITY_TEST_PY=trt_compatibility_test.py
 CLIENT_LOG="client.log"
 DATADIR=${DATADIR:="/data/inferenceserver/${REPO_VERSION}"}
 SERVER=/opt/tritonserver/bin/tritonserver
@@ -64,6 +64,13 @@ if [ "$SERVER_PID" != "0" ]; then
     exit 1
 fi
 
+EXPECTED_ERR="Internal Error (Cannot deserialize engine with lean runtime"
+if ! grep "$EXPECTED_ERR" $SERVER_LOG; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** Failed to find expected error: ${EXPECTED_ERR} \n***"
+    RET=1
+fi
+
 SERVER_ARGS="--model-repository=`pwd`/models --exit-timeout-secs=120 --backend-config=tensorrt,version-compatible=true"
 
 run_server
@@ -75,7 +82,7 @@ fi
 
 set +e
 
-python $COMPATABILITY_TEST_PY TrtCompatabilityTest >$CLIENT_LOG 2>&1
+python $COMPATIBILITY_TEST_PY >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"

--- a/qa/L0_trt_compat/test.sh
+++ b/qa/L0_trt_compat/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_trt_compat/test.sh
+++ b/qa/L0_trt_compat/test.sh
@@ -35,8 +35,6 @@ if [ -z "$REPO_VERSION" ]; then
     exit 1
 fi
 
-export CUDA_VISIBLE_DEVICES=0
-
 DATADIR=${DATADIR:="/data/inferenceserver/${REPO_VERSION}"}
 SERVER=/opt/tritonserver/bin/tritonserver
 SERVER_ARGS="--model-repository=`pwd`/models --exit-timeout-secs=120"

--- a/qa/L0_trt_compat/trt_compatibility_test.py
+++ b/qa/L0_trt_compat/trt_compatibility_test.py
@@ -37,7 +37,7 @@ import numpy as np
 import test_util as tu
 
 
-class TrtCompatabilityTest(tu.TestResultCollector):
+class TrtCompatibilityTest(tu.TestResultCollector):
     def setUp(self):
         self._data_type = np.float32
 

--- a/qa/L0_trt_compat/trt_compatibility_test.py
+++ b/qa/L0_trt_compat/trt_compatibility_test.py
@@ -35,7 +35,6 @@ import unittest
 import infer_util as iu
 import numpy as np
 import test_util as tu
-from tritonclient.utils import np_to_triton_dtype
 
 
 class TrtCompatabilityTest(tu.TestResultCollector):
@@ -44,7 +43,7 @@ class TrtCompatabilityTest(tu.TestResultCollector):
 
     def test_plan(self):
         # plan_compatible_zero_1_float32 is an identity model with input shape [-1]
-        iu.infer_zero(self, "plan_compatible", 2, self._data_type, [[2, 4]], [[2, 4]])
+        iu.infer_zero(self, "plan_compatible", 1, self._data_type, [[2, 4]], [[2, 4]])
 
 
 if __name__ == "__main__":

--- a/qa/L0_trt_compat/trt_compatibility_test.py
+++ b/qa/L0_trt_compat/trt_compatibility_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+sys.path.append("../common")
+
+import unittest
+
+import infer_util as iu
+import numpy as np
+import test_util as tu
+import tritongrpcclient as grpcclient
+import tritonhttpclient as httpclient
+from tritonclient.utils import np_to_triton_dtype
+
+
+class TrtCompatabilityTest(tu.TestResultCollector):
+    def setUp(self):
+        self._data_type = np.float32
+
+    def test_plan(self):
+        # plan_compatible_zero_1_float32 is an identity model with input shape [-1]
+        iu.infer_zero(self, "plan_compatible", 1, self._data_type, [[2, 4]], [[2, 4]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qa/L0_trt_compat/trt_compatibility_test.py
+++ b/qa/L0_trt_compat/trt_compatibility_test.py
@@ -35,8 +35,6 @@ import unittest
 import infer_util as iu
 import numpy as np
 import test_util as tu
-import tritongrpcclient as grpcclient
-import tritonhttpclient as httpclient
 from tritonclient.utils import np_to_triton_dtype
 
 
@@ -46,7 +44,7 @@ class TrtCompatabilityTest(tu.TestResultCollector):
 
     def test_plan(self):
         # plan_compatible_zero_1_float32 is an identity model with input shape [-1]
-        iu.infer_zero(self, "plan_compatible", 1, self._data_type, [[2, 4]], [[2, 4]])
+        iu.infer_zero(self, "plan_compatible", 2, self._data_type, [[2, 4]], [[2, 4]])
 
 
 if __name__ == "__main__":

--- a/qa/common/gen_qa_identity_models.py
+++ b/qa/common/gen_qa_identity_models.py
@@ -1058,9 +1058,12 @@ def create_plan_modelconfig(
 
     shape_str = tu.shape_to_dims_str(shape)
 
-    model_name = tu.get_zero_model_name(
-        "plan_nobatch" if max_batch == 0 else "plan", io_cnt, dtype
-    )
+    model_name_base = "plan"
+    if max_batch == 0:
+        model_name_base += "_nobatch"
+    if FLAGS.tensorrt_compat:
+        model_name_base += "_compatible"
+    model_name = tu.get_zero_model_name(model_name_base, io_cnt, dtype)
     config_dir = os.path.join(models_dir, model_name)
 
     if FLAGS.tensorrt_shape_io:

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -462,6 +462,7 @@ chmod -R 777 $DESTDIR
 python3 $SRCDIR/gen_qa_models.py --tensorrt --variable --models_dir=$VARDESTDIR
 chmod -R 777 $VARDESTDIR
 python3 $SRCDIR/gen_qa_identity_models.py --tensorrt --models_dir=$IDENTITYDESTDIR
+python3 $SRCDIR/gen_qa_identity_models.py --tensorrt-compat --models_dir=$IDENTITYDESTDIR
 chmod -R 777 $IDENTITYDESTDIR
 python3 $SRCDIR/gen_qa_identity_models.py --tensorrt-big --models_dir=$IDENTITYBIGDESTDIR
 chmod -R 777 $IDENTITYBIGDESTDIR

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -735,7 +735,7 @@ def infer_shape_tensor(
         import tritonclient.utils.shared_memory as shm
 
     tester.assertTrue(use_http or use_grpc or use_streaming)
-    tester.assertTrue(pf.startsWith("plan"))
+    tester.assertTrue(pf.startswith("plan"))
     tester.assertEqual(len(input_shape_values), len(dummy_input_shapes))
 
     configs = []

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -735,7 +735,7 @@ def infer_shape_tensor(
         import tritonclient.utils.shared_memory as shm
 
     tester.assertTrue(use_http or use_grpc or use_streaming)
-    tester.assertTrue(pf == "plan" or pf == "plan_nobatch")
+    tester.assertTrue(pf.startsWith("plan"))
     tester.assertEqual(len(input_shape_values), len(dummy_input_shapes))
 
     configs = []


### PR DESCRIPTION
Add testing for TensorRT version-compatible model support.

The feature will be implemented in the TensorRT backend in this pull request: https://github.com/triton-inference-server/tensorrt_backend/pull/74.