### PR TITLE
Refactor StreamInferHandler for better readability

### DIFF
--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -186,7 +186,7 @@ CommonCallData<ResponderType, RequestType, ResponseType>::Process(bool rpc_ok)
     step_ = Steps::FINISH;
   }
 
-  return step_ != Steps::FINISH;
+  return step_ == Steps::FINISH;
 }
 
 template <typename ResponderType, typename RequestType, typename ResponseType>

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -338,7 +338,8 @@ CommonHandler::Start()
 
     while (cq_->Next(&tag, &ok)) {
       ICallData* call_data = static_cast<ICallData*>(tag);
-      if (!call_data->Process(ok)) {
+      const bool tag_finished = call_data->Process(ok);
+      if (tag_finished) {
         LOG_VERBOSE(1) << "Done for " << call_data->Name() << ", "
                        << call_data->Id();
         delete call_data;

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -767,7 +767,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     finished = true;
   }
 
-  return !finished;
+  return finished;
 }
 
 TRITONSERVER_Error*

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -958,6 +958,7 @@ class InferHandler : public HandlerBase {
   }
 
   virtual void StartNewRequest() = 0;
+  // Returns whether the request is finished being processed or not.
   virtual bool Process(State* state, bool rpc_ok) = 0;
   bool ExecutePrecondition(InferHandler::State* state);
 

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -1038,7 +1038,8 @@ InferHandler<
 
     while (cq_->Next(&tag, &ok)) {
       State* state = static_cast<State*>(tag);
-      if (!Process(state, ok)) {
+      const bool tag_finished = Process(state, ok);
+      if (tag_finished) {
         LOG_VERBOSE(1) << "Done for " << Name() << ", " << state->unique_id_;
         StateRelease(state);
       }

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -158,8 +158,6 @@ ModelStreamInferHandler::RequestStartStep(
         std::string("This protocol is restricted, expecting header '") +
             restricted_kv_.first + "'");
     state->context_->responder_->Finish(status, state);
-    // Request finished due to error.
-    return true;
   }
 
   // Not finished with a request on the start step unless an error occurs above.
@@ -322,18 +320,7 @@ ModelStreamInferHandler::RequestReadStep(
   // entire stream. Otherwise just finish this state.
   if (!rpc_ok) {
     state->context_->step_ = Steps::WRITEREADY;
-    if (state->context_->IsRequestsCompleted()) {
-      state->context_->step_ = Steps::COMPLETE;
-      state->step_ = Steps::COMPLETE;
-      state->context_->responder_->Finish(
-          state->context_->finish_ok_ ? ::grpc::Status::OK
-                                      : ::grpc::Status::CANCELLED,
-          state);
-    } else {
-      state->step_ = Steps::FINISH;
-      finished = true;
-    }
-
+    finished = Finish(state);
     return finished;
   }
 

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -558,8 +558,6 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
     finished = RequestWrittenStep(state, rpc_ok);
   } else if (state->step_ == Steps::WRITEREADY) {
     finished = RequestWriteReadyStep(state);
-  } else {
-    LOG_WARNING << "IN ELSE STATE OF PROCESS()";
   }
 
   return finished;

--- a/src/grpc/stream_infer_handler.h
+++ b/src/grpc/stream_infer_handler.h
@@ -106,6 +106,7 @@ class ModelStreamInferHandler
 
  protected:
   void StartNewRequest() override;
+  // Returns whether the request is finished being processed or not.
   bool Process(State* state, bool rpc_ok) override;
 
  private:
@@ -113,6 +114,11 @@ class ModelStreamInferHandler
       TRITONSERVER_InferenceResponse* response, const uint32_t flags,
       void* userp);
   bool Finish(State* state);
+
+  // Step helpers
+  bool RequestStartStep(State* state, bool rpc_ok);
+  bool RequestReadStep(State* state, bool rpc_ok);
+  bool RequestCompleteStep(State* state);
 
   TraceManager* trace_manager_;
   std::shared_ptr<SharedMemoryManager> shm_manager_;

--- a/src/grpc/stream_infer_handler.h
+++ b/src/grpc/stream_infer_handler.h
@@ -119,10 +119,8 @@ class ModelStreamInferHandler
   bool RequestStartStep(State* state, bool rpc_ok);
   bool RequestReadStep(State* state, bool rpc_ok);
   bool RequestCompleteStep(State* state);
-  bool RequestWrittenStep(State* state, bool rpc_ok);
   bool RequestWrittenStepDecoupled(State* state, bool rpc_ok);
   bool RequestWrittenStepNonDecoupled(State* state, bool rpc_ok);
-  bool RequestWriteReadyStep(State* state);
   bool RequestWriteReadyStepDecoupled(State* state);
   void PrepareAndSendTritonRequest(State* state);
   void EnqueueErrorResponse(

--- a/src/grpc/stream_infer_handler.h
+++ b/src/grpc/stream_infer_handler.h
@@ -119,6 +119,15 @@ class ModelStreamInferHandler
   bool RequestStartStep(State* state, bool rpc_ok);
   bool RequestReadStep(State* state, bool rpc_ok);
   bool RequestCompleteStep(State* state);
+  bool RequestWrittenStep(State* state, bool rpc_ok);
+  bool RequestWrittenStepDecoupled(State* state, bool rpc_ok);
+  bool RequestWrittenStepNonDecoupled(State* state, bool rpc_ok);
+  bool RequestWriteReadyStep(State* state);
+  bool RequestWriteReadyStepDecoupled(State* state);
+  void PrepareAndSendTritonRequest(State* state);
+  void EnqueueErrorResponse(
+      State* state, TRITONSERVER_InferenceRequest* irequest,
+      TRITONSERVER_Error* err);
 
   TraceManager* trace_manager_;
   std::shared_ptr<SharedMemoryManager> shm_manager_;


### PR DESCRIPTION
This PR does two things:
1. Refactor the handling of every `step` in `StreamInferHandler::Process` from one large ~400 line function into helper functions for each state.
2. Replace the "double negative" logic of `if not not_finished` into just `if finished` in Common/InferHandler/StreamInferHandler `Process()` functions. I found the double negative logic confusing that the function did:
```cpp
bool Process(...) {
  ...
  finished = true; 
  // (not finished)
  return !finished;
}
``` 
and then the caller checks the negation of that:
```cpp
// if (not (not finished) )
if (  !Process(...) )
```
So instead if's more direct to be:
```cpp
bool Process(...) {
  finished = true;
  return finished;
}

if ( Process(...) {
  ...
}
```