### PR TITLE
Fix L0_java_memory_growth

### DIFF
--- a/qa/L0_java_memory_growth/test.sh
+++ b/qa/L0_java_memory_growth/test.sh
@@ -25,6 +25,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Pre-requisites
+apt-get update && apt-get install -y \
+    cmake \
+    rapidjson-dev
+
 # Set up test files based on installation instructions
 # https://github.com/bytedeco/javacpp-presets/blob/master/tritonserver/README.md
 set +e


### PR DESCRIPTION
Compilation inside the test is failing due to `cmake` and `rapidjson-dev` not being installed. 

Adding these pre-requisites doesn't solve the runtime issue. Once a solution is found, it will need to be implemented before this can be merged.