### PR TITLE
Exclude extra TRT version-compatible models from tests

### DIFF
--- a/qa/L0_infer_zero/test.sh
+++ b/qa/L0_infer_zero/test.sh
@@ -57,7 +57,7 @@ cp -r /data/inferenceserver/${REPO_VERSION}/qa_identity_model_repository/* model
 
 # Remove version-compatible TensorRT models, as they require version-compatibility
 # mode to be turned on when starting the server.
-rm -r models/plan_compatible*
+rm -rf models/plan_compatible*
 
 create_nop_version_dir `pwd`/models
 

--- a/qa/L0_infer_zero/test.sh
+++ b/qa/L0_infer_zero/test.sh
@@ -55,6 +55,10 @@ rm -fr models && mkdir models
 cp -r /data/inferenceserver/${REPO_VERSION}/qa_identity_model_repository/* models/. && \
     cp -r /data/inferenceserver/${REPO_VERSION}/qa_ensemble_model_repository/qa_identity_model_repository/* models/.
 
+# Remove version-compatible TensorRT models, as they require version-compatibility
+# mode to be turned on when starting the server.
+rm -r models/plan_compatible*
+
 create_nop_version_dir `pwd`/models
 
 RET=0


### PR DESCRIPTION
Some QA tests do not need the version-compatible models. Including them will result in the tests failing if the server is started with version compatibility disabled. Remove these models from those tests.