### PR TITLE
Disable developer tools build for In-process API + JavaCPP tests

### DIFF
--- a/docs/customization_guide/inference_protocols.md
+++ b/docs/customization_guide/inference_protocols.md
@@ -476,14 +476,12 @@ JavaCPP-presets. You can do this using the following steps:
 
 1. Create the JNI binaries in your local repository (`/root/.m2/repository`)
    with [`javacpp-presets/tritonserver`](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver)
-   a. For In-Process C-API Java bindings, you can disable the C-API wrapper build by setting
-   ```bash export INCLUDE_DEVELOPER_TOOLS_SERVER=1 ```
-   b. For C-API Wrapper Java bindings, you need to install some build specific dependencies like cmake. You can either do this with:
+   For C-API Wrapper Java bindings, you need to install some build specific dependencies like cmake. You can either do this with:
    ```bash
     $ git clone https://github.com/triton-inference-server/developer_tools.git
     $ bash -x ../install_test_dependencies_and_build.sh
    ```
-    or refer to [developer_tools/server installation script](https://github.com/triton-inference-server/developer_tools/blob/main/qa/install_test_dependencies_and_build.sh) for dependencies and install them yourself.
+    Please refer to [server installation script](https://github.com/triton-inference-server/client/blob/main/src/java-api-bindings/scripts/install_dependencies_and_build.sh) for dependencies you need to install and modifications you need to make for your container.
 After installing dependencies, you can build the tritonserver project on javacpp-presets:
 ```bash
  $ git clone https://github.com/bytedeco/javacpp-presets.git

--- a/docs/customization_guide/inference_protocols.md
+++ b/docs/customization_guide/inference_protocols.md
@@ -476,6 +476,15 @@ JavaCPP-presets. You can do this using the following steps:
 
 1. Create the JNI binaries in your local repository (`/root/.m2/repository`)
    with [`javacpp-presets/tritonserver`](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver)
+   a. For In-Process C-API Java bindings, you can disable the C-API wrapper build by setting
+   ```bash export INCLUDE_DEVELOPER_TOOLS_SERVER=1 ```
+   b. For C-API Wrapper Java bindings, you need to install some build specific dependencies like cmake. You can either do this with:
+   ```bash
+    $ git clone https://github.com/triton-inference-server/developer_tools.git
+    $ bash -x ../install_test_dependencies_and_build.sh
+   ```
+    or refer to [developer_tools/server installation script](https://github.com/triton-inference-server/developer_tools/blob/main/qa/install_test_dependencies_and_build.sh) for dependencies and install them yourself.
+After installing dependencies, you can build the tritonserver project on javacpp-presets:
 ```bash
  $ git clone https://github.com/bytedeco/javacpp-presets.git
  $ cd javacpp-presets

--- a/docs/customization_guide/inference_protocols.md
+++ b/docs/customization_guide/inference_protocols.md
@@ -479,7 +479,7 @@ JavaCPP-presets. You can do this using the following steps:
    For C-API Wrapper Java bindings, you need to install some build specific dependencies like cmake. You can either do this with:
    ```bash
     $ git clone https://github.com/triton-inference-server/developer_tools.git
-    $ bash -x ../install_test_dependencies_and_build.sh
+    $ bash -x developer_tools/server/install_dependencies_and_build.sh
    ```
     Please refer to [server installation script](https://github.com/triton-inference-server/client/blob/main/src/java-api-bindings/scripts/install_dependencies_and_build.sh) for dependencies you need to install and modifications you need to make for your container.
 After installing dependencies, you can build the tritonserver project on javacpp-presets:

--- a/docs/customization_guide/inference_protocols.md
+++ b/docs/customization_guide/inference_protocols.md
@@ -447,8 +447,8 @@ Java program with the Java bindings with the following steps:
       # Run build script
       ## For In-Process C-API Java Bindings
       $ source clientrepo/src/java-api-bindings/scripts/install_dependencies_and_build.sh
-      ## For C-API Wrapper Java Bindings
-      $ source clientrepo/src/java-api-bindings/scripts/install_dependencies_and_build.sh --enable-developer-tools-server`
+      ## For C-API Wrapper (Triton with C++ bindings) Java Bindings
+      $ source clientrepo/src/java-api-bindings/scripts/install_dependencies_and_build.sh --enable-developer-tools-server
       ```
       This will install the Java bindings to `/workspace/install/java-api-bindings/tritonserver-java-bindings.jar`
 
@@ -472,16 +472,15 @@ If you want to make changes to the Java bindings, then you can use Maven to
 build yourself. You can refer to part 1.a of [Run Java program with Java
 bindings Jar](#run-java-program-with-java-bindings-jar) to also build the jar
 yourself without any modifications to the Tritonserver bindings in
-JavaCPP-presets. You can do this using the following steps:
+JavaCPP-presets.
+You can do this using the following steps:
 
 1. Create the JNI binaries in your local repository (`/root/.m2/repository`)
-   with [`javacpp-presets/tritonserver`](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver)
-   For C-API Wrapper Java bindings, you need to install some build specific dependencies like cmake. You can either do this with:
-   ```bash
-    $ git clone https://github.com/triton-inference-server/developer_tools.git
-    $ bash -x developer_tools/server/install_dependencies_and_build.sh
-   ```
-    Please refer to [server installation script](https://github.com/triton-inference-server/client/blob/main/src/java-api-bindings/scripts/install_dependencies_and_build.sh) for dependencies you need to install and modifications you need to make for your container.
+   with [`javacpp-presets/tritonserver`](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver).
+   For C-API Wrapper Java bindings (Triton with C++ bindings), you need to
+   install some build specific dependencies including cmake and rapidjson.
+   Refer to [java installation script](https://github.com/triton-inference-server/client/blob/main/src/java-api-bindings/scripts/install_dependencies_and_build.sh)
+   for dependencies you need to install and modifications you need to make for your container.
 After installing dependencies, you can build the tritonserver project on javacpp-presets:
 ```bash
  $ git clone https://github.com/bytedeco/javacpp-presets.git

--- a/qa/L0_java_memory_growth/test.sh
+++ b/qa/L0_java_memory_growth/test.sh
@@ -27,15 +27,10 @@
 
 # Set up test files based on installation instructions
 # https://github.com/bytedeco/javacpp-presets/blob/master/tritonserver/README.md
-set +e
-export INCLUDE_DEVELOPER_TOOLS_SERVER=1
-rm -r javacpp-presets
-git clone https://github.com/bytedeco/javacpp-presets.git
-cd javacpp-presets
-mvn clean install --projects .,tritonserver
-mvn clean install -f platform --projects ../tritonserver/platform -Djavacpp.platform.host
-cd ..
 set -e
+git clone --single-branch --depth=1 -b ${TRITON_CLIENT_REPO_TAG} https://github.com/triton-inference-server/client.git
+source client/src/java-api-bindings/scripts/install_dependencies_and_build.sh -b $PWD --keep-build-dependencies
+cd ..
 
 export MAVEN_OPTS="-XX:MaxGCPauseMillis=40"
 MODEL_REPO=`pwd`/models

--- a/qa/L0_java_memory_growth/test.sh
+++ b/qa/L0_java_memory_growth/test.sh
@@ -28,6 +28,7 @@
 # Set up test files based on installation instructions
 # https://github.com/bytedeco/javacpp-presets/blob/master/tritonserver/README.md
 set +e
+export INCLUDE_DEVELOPER_TOOLS_SERVER=1
 rm -r javacpp-presets
 git clone https://github.com/bytedeco/javacpp-presets.git
 cd javacpp-presets

--- a/qa/L0_java_resnet/test.sh
+++ b/qa/L0_java_resnet/test.sh
@@ -53,15 +53,10 @@ done
 
 # Set up test files based on installation instructions
 # https://github.com/bytedeco/javacpp-presets/blob/master/tritonserver/README.md
-set +e
-export INCLUDE_DEVELOPER_TOOLS_SERVER=1
-rm -r javacpp-presets
-git clone https://github.com/bytedeco/javacpp-presets.git
-cd javacpp-presets
-mvn clean install --projects .,tritonserver
-mvn clean install -f platform --projects ../tritonserver/platform -Djavacpp.platform.host
-cd ..
 set -e
+git clone --single-branch --depth=1 -b ${TRITON_CLIENT_REPO_TAG} https://github.com/triton-inference-server/client.git
+source client/src/java-api-bindings/scripts/install_dependencies_and_build.sh -b $PWD --keep-build-dependencies
+cd ..
 
 CLIENT_LOG="client.log"
 SAMPLES_REPO=`pwd`/javacpp-presets/tritonserver/samples/simple

--- a/qa/L0_java_resnet/test.sh
+++ b/qa/L0_java_resnet/test.sh
@@ -54,6 +54,7 @@ done
 # Set up test files based on installation instructions
 # https://github.com/bytedeco/javacpp-presets/blob/master/tritonserver/README.md
 set +e
+export INCLUDE_DEVELOPER_TOOLS_SERVER=1
 rm -r javacpp-presets
 git clone https://github.com/bytedeco/javacpp-presets.git
 cd javacpp-presets

--- a/qa/L0_java_sequence_batcher/test.sh
+++ b/qa/L0_java_sequence_batcher/test.sh
@@ -43,15 +43,10 @@ DATADIR=/data/inferenceserver/${REPO_VERSION}
 
 # Set up test files based on installation instructions
 # https://github.com/bytedeco/javacpp-presets/blob/master/tritonserver/README.md
-set +e
-export INCLUDE_DEVELOPER_TOOLS_SERVER=1
-rm -r javacpp-presets
-git clone https://github.com/bytedeco/javacpp-presets.git
-cd javacpp-presets
-mvn clean install --projects .,tritonserver
-mvn clean install -f platform --projects ../tritonserver/platform -Djavacpp.platform.host
-cd ..
 set -e
+git clone --single-branch --depth=1 -b ${TRITON_CLIENT_REPO_TAG} https://github.com/triton-inference-server/client.git
+source client/src/java-api-bindings/scripts/install_dependencies_and_build.sh -b $PWD --keep-build-dependencies
+cd ..
 
 CLIENT_LOG="client.log"
 MODEL_REPO=`pwd`/models

--- a/qa/L0_java_sequence_batcher/test.sh
+++ b/qa/L0_java_sequence_batcher/test.sh
@@ -44,6 +44,7 @@ DATADIR=/data/inferenceserver/${REPO_VERSION}
 # Set up test files based on installation instructions
 # https://github.com/bytedeco/javacpp-presets/blob/master/tritonserver/README.md
 set +e
+export INCLUDE_DEVELOPER_TOOLS_SERVER=1
 rm -r javacpp-presets
 git clone https://github.com/bytedeco/javacpp-presets.git
 cd javacpp-presets

--- a/qa/L0_java_simple_example/test.sh
+++ b/qa/L0_java_simple_example/test.sh
@@ -37,15 +37,10 @@ if [ -z "$REPO_VERSION" ]; then
     exit 1
 fi
 
-set +e
-rm -r javacpp-presets
-export INCLUDE_DEVELOPER_TOOLS_SERVER=1
-git clone https://github.com/bytedeco/javacpp-presets.git
-cd javacpp-presets
-mvn clean install --projects .,tritonserver
-mvn clean install -f platform --projects ../tritonserver/platform -Djavacpp.platform.host
-cd ..
 set -e
+git clone --single-branch --depth=1 -b ${TRITON_CLIENT_REPO_TAG} https://github.com/triton-inference-server/client.git
+source client/src/java-api-bindings/scripts/install_dependencies_and_build.sh -b $PWD --keep-build-dependencies
+cd ..
 
 CLIENT_LOG="client_cpu_only.log"
 DATADIR=/data/inferenceserver/${REPO_VERSION}/qa_model_repository

--- a/qa/L0_java_simple_example/test.sh
+++ b/qa/L0_java_simple_example/test.sh
@@ -39,6 +39,7 @@ fi
 
 set +e
 rm -r javacpp-presets
+export INCLUDE_DEVELOPER_TOOLS_SERVER=1
 git clone https://github.com/bytedeco/javacpp-presets.git
 cd javacpp-presets
 mvn clean install --projects .,tritonserver


### PR DESCRIPTION
closes: https://github.com/triton-inference-server/server/pull/6275
Fixes build for javaCPP-CAPI binding tests. 
Does not fix memory growth test issue.
Related PR: https://github.com/bytedeco/javacpp-presets/pull/1412
