### PR TITLE
OpenTelemetry context propagation PoC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,8 @@ FetchContent_Declare(
 )
 FetchContent_Declare(
   repo-third-party
-  GIT_REPOSITORY https://github.com/triton-inference-server/third_party.git
-  GIT_TAG ${TRITON_THIRD_PARTY_REPO_TAG}
+  GIT_REPOSITORY https://github.com/HennerM/third_party.git
+  GIT_TAG HennerM-patch-1
 )
 
 # Some libs are installed to ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/{LIB}/lib64 instead

--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -36,6 +36,8 @@
 #include <cuda_runtime_api.h>
 #endif  // TRITON_ENABLE_GPU
 #ifndef _WIN32
+#include "opentelemetry/context/propagation/global_propagator.h"
+#include "opentelemetry/trace/propagation/http_trace_context.h"
 #include "opentelemetry/exporters/ostream/span_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #include "opentelemetry/sdk/resource/semantic_conventions.h"
@@ -290,7 +292,7 @@ TraceManager::GetTraceSetting(
 }
 
 std::shared_ptr<TraceManager::Trace>
-TraceManager::SampleTrace(const std::string& model_name)
+TraceManager::SampleTrace(const std::string& model_name, otel_trace_api::SpanContext *span_context)
 {
   std::shared_ptr<TraceSetting> trace_setting;
   {
@@ -299,7 +301,7 @@ TraceManager::SampleTrace(const std::string& model_name)
     trace_setting =
         (m_it == model_settings_.end()) ? global_setting_ : m_it->second;
   }
-  std::shared_ptr<Trace> ts = trace_setting->SampleTrace();
+  std::shared_ptr<Trace> ts = trace_setting->SampleTrace(span_context);
   if (ts != nullptr) {
     ts->setting_ = trace_setting;
   }
@@ -361,9 +363,7 @@ TraceManager::InitTracer(const triton::server::TraceConfigMap& config_map)
     case TRACE_MODE_OPENTELEMETRY: {
 #if !defined(_WIN32) && defined(TRITON_ENABLE_TRACING)
       otlp::OtlpHttpExporterOptions opts;
-      otel_resource::ResourceAttributes attributes = {};
-      attributes[otel_resource::SemanticConventions::kServiceName] =
-          "triton-inference-server";
+      otel_resource::ResourceAttributes attributes = {{otel_resource::SemanticConventions::kServiceName, "triton-inference-server"}};
       auto mode_key = std::to_string(TRACE_MODE_OPENTELEMETRY);
       auto otel_options_it = config_map.find(mode_key);
       if (otel_options_it != config_map.end()) {
@@ -376,7 +376,7 @@ TraceManager::InitTracer(const triton::server::TraceConfigMap& config_map)
             auto pos = setting.second.find('=');
             auto key = setting.second.substr(0, pos);
             auto value = setting.second.substr(pos + 1);
-            attributes[key] = value;
+            attributes.SetAttribute(key, value);
           }
         }
       }
@@ -395,6 +395,11 @@ TraceManager::InitTracer(const triton::server::TraceConfigMap& config_map)
               std::move(processor), resource);
 
       otel_trace_api::Provider::SetTracerProvider(provider);
+
+      // set global propagator
+      opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+      opentelemetry::nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
+          new opentelemetry::trace::propagation::HttpTraceContext()));
       break;
 #else
       LOG_ERROR << "Unsupported trace mode: "
@@ -512,6 +517,23 @@ TraceManager::Trace::StartSpan(
   auto provider = opentelemetry::trace::Provider::GetTracerProvider();
   return provider->GetTracer(kTritonTracer)->StartSpan(display_name, options);
 }
+
+opentelemetry::nostd::shared_ptr<otel_trace_api::Span>
+TraceManager::Trace::StartServerSpan(
+    std::string display_name, const uint64_t& raw_timestamp_ns,
+    const otel_trace_api::SpanContext& span_context)
+{
+  otel_trace_api::StartSpanOptions options;
+  options.kind = otel_trace_api::SpanKind::kServer;
+  options.start_system_time =
+      time_offset_ + std::chrono::nanoseconds{raw_timestamp_ns};
+  options.start_steady_time =
+      otel_common::SteadyTimestamp{std::chrono::nanoseconds{raw_timestamp_ns}};
+  options.parent = span_context;
+  auto provider = opentelemetry::trace::Provider::GetTracerProvider();
+  return provider->GetTracer(kTritonTracer)->StartSpan(display_name, options);
+}
+
 
 void
 TraceManager::Trace::EndSpan(std::string span_key)
@@ -1015,7 +1037,7 @@ TraceManager::TraceFile::SaveTraces(
 }
 
 std::shared_ptr<TraceManager::Trace>
-TraceManager::TraceSetting::SampleTrace()
+TraceManager::TraceSetting::SampleTrace(otel_trace_api::SpanContext *span_context)
 {
   bool create_trace = false;
   {
@@ -1055,7 +1077,12 @@ TraceManager::TraceSetting::SampleTrace()
           std::chrono::duration_cast<std::chrono::nanoseconds>(
               std::chrono::steady_clock::now().time_since_epoch())
               .count();
-      auto root_span = lts->StartSpan("InferRequest", steady_timestamp_ns);
+      opentelemetry::nostd::shared_ptr<otel_trace_api::Span> root_span;
+      if (span_context) {
+        root_span = lts->StartServerSpan("InferRequest", steady_timestamp_ns, *span_context);
+      } else {
+        root_span = lts->StartSpan("InferRequest", steady_timestamp_ns);
+      }
       // Initializing OTel context and storing "InferRequest" span as a root
       // span to keep it alive for the duration of the request.
       lts->otel_context_ =

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -125,7 +125,7 @@ class TraceManager {
 
   // Return a trace that should be used to collected trace activities
   // for an inference request. Return nullptr if no tracing should occur.
-  std::shared_ptr<Trace> SampleTrace(const std::string& model_name);
+  std::shared_ptr<Trace> SampleTrace(const std::string& model_name, otel_trace_api::SpanContext *span_context = nullptr);
 
   // Update global setting if 'model_name' is empty, otherwise, model setting is
   // updated.
@@ -222,6 +222,10 @@ class TraceManager {
     opentelemetry::nostd::shared_ptr<otel_trace_api::Span> StartSpan(
         std::string display_name, const uint64_t& raw_timestamp_ns,
         std::string parent_span_key = "");
+
+    opentelemetry::nostd::shared_ptr<otel_trace_api::Span> StartServerSpan(
+        std::string display_name, const uint64_t& raw_timestamp_ns,
+        const opentelemetry::trace::SpanContext &span_context);
 
     // OTel context to store spans, created in the current trace
     opentelemetry::context::Context otel_context_;
@@ -396,7 +400,7 @@ class TraceManager {
         const std::unordered_map<uint64_t, std::unique_ptr<std::stringstream>>&
             streams);
 
-    std::shared_ptr<Trace> SampleTrace();
+    std::shared_ptr<Trace> SampleTrace(otel_trace_api::SpanContext *span_context = nullptr);
 
     const TRITONSERVER_InferenceTraceLevel level_;
     const uint32_t rate_;


### PR DESCRIPTION
One of OpenTelemetry's core functionality is to pass trace information throughout an entire system. 
This is done through context propagation: https://opentelemetry.io/docs/instrumentation/js/propagation/

Triton recently added support for OpenTelemetry tracing, but it's still missing context propagation capabilities.
A full implementation of the context propagation for both HTTP and gRPC (streaming/non-streaming) fixes #5853.

This Draft PR adds a fix as a prototype to the gRPC stream handler, which roughly follows the gRPC sample in open-telemetry-grpc: https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples/grpc
This only adds support to one server interface, to pass through the context one also needs to instrument the client, which is a simple matter of adding an appropriate header to the gRPC call.

When adding this functionality to the server, I encountered an issue with open-telemetry-cpp, specially a bug in the custom abseil map implementation, I solved this by setting `WITH_ABSEIL=OFF` in the third party build: https://github.com/triton-inference-server/third_party/compare/main...HennerM:third_party:HennerM-patch-1


E.g. to include them on the Triton C++ client:

```cpp
#include <opentelemetry/context/propagation/global_propagator.h>
#include <opentelemetry/context/propagation/text_map_propagator.h>
#include <opentelemetry/context/runtime_context.h>
#include <opentelemetry/trace/span.h>

// create custom context propagation carrier
class GrpcClientCarrier : public opentelemetry::context::propagation::TextMapCarrier {
 public:
  explicit GrpcClientCarrier(triton::client::Headers *triton_headers) : triton_headers_(triton_headers) {}
  GrpcClientCarrier() = default;
  [[nodiscard]] opentelemetry::nostd::string_view Get(
      opentelemetry::nostd::string_view /* key */) const noexcept override {
    // not required for client
    return "";
  }

  void Set(opentelemetry::nostd::string_view key, opentelemetry::nostd::string_view value) noexcept override {
    (*triton_headers_)[std::string(key)] = std::string(value);
  }

 private:
  triton::client::Headers *triton_headers_;
};

inline void InjectOpenTelemetry(triton::client::Headers *headers) {
  auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
  GrpcClientCarrier carrier(headers);
  auto prop = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
  prop->Inject(carrier, current_ctx);
}
``

```
triton::client::Headers headers;
InjectOpenTelemetry(headers);
// call StartStream
triton_client_->StartStream(std::move(tc_callback),
                                                           /* enable_stats */ false,
                                                           /* stream_timeout us */ stream_timeout_.count(),
                                                           headers));
```

Eventually this could be added to the upstream TritonClient implementation as well.