### PR TITLE
Refactor HandleInfer into more readable chunks

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1009,7 +1009,7 @@ HTTPAPIServer::HTTPAPIServer(
       server_(server), trace_manager_(trace_manager), shm_manager_(shm_manager),
       allocator_(nullptr), server_regex_(R"(/v2(?:/health/(live|ready))?)"),
       model_regex_(
-          R"(/v2/models/([^/]+)(?:/versions/([0-9]+))?(?:/(infer|generate|ready|config|stats|trace/setting))?)"),
+          R"(/v2/models/([^/]+)(?:/versions/([0-9]+))?(?:/(infer|ready|config|stats|trace/setting))?)"),
       modelcontrol_regex_(
           R"(/v2/repository(?:/([^/]+))?/(index|models/([^/]+)/(load|unload)))"),
       systemsharedmemory_regex_(
@@ -3160,19 +3160,6 @@ HTTPAPIServer::HandleInfer(
 }
 
 void
-HTTPAPIServer::HandleGenerate(
-    evhtp_request_t* req, const std::string& model_name,
-    const std::string& model_version_str)
-{
-  if (req->method != htp_method_POST) {
-    RETURN_AND_RESPOND_WITH_ERR(
-        req, EVHTP_RES_METHNALLOWED, "Method Not Allowed");
-  }
-
-  RETURN_AND_RESPOND_WITH_ERR(req, EVHTP_RES_BADREQ, "Not Implemented Yet");
-}
-
-void
 HTTPAPIServer::OKReplyCallback(evthr_t* thr, void* arg, void* shared)
 {
   HTTPAPIServer::InferRequestClass* infer_request =
@@ -3636,10 +3623,6 @@ HTTPAPIServer::Handle(evhtp_request_t* req)
     } else if (kind == "infer") {
       // model infer
       HandleInfer(req, model_name, version);
-      return;
-    } else if (kind == "generate") {
-      // LLM infer format converter
-      HandleGenerate(req, model_name, version);
       return;
     } else if (kind == "config") {
       // model configuration

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2312,7 +2312,6 @@ TRITONSERVER_Error*
 HTTPAPIServer::GetInferenceHeaderLength(
     evhtp_request_t* req, int32_t content_length, size_t* header_length)
 {
-  // Find Inference-Header-Content-Length in header.
   // Set to content length in case that the header is not specified
   *header_length = content_length;
 

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -322,7 +322,7 @@ class HTTPAPIServer : public HTTPServer {
   void HandleTrace(evhtp_request_t* req, const std::string& model_name = "");
   void HandleLogging(evhtp_request_t* req);
 
-  TRITONSERVER_Error* EVBufferToTritonInput(
+  TRITONSERVER_Error* EVBufferToTritonRequest(
       evhtp_request_t* req, const std::string& model_name,
       TRITONSERVER_InferenceRequest* irequest, evbuffer* decompressed_buffer,
       InferRequestClass* infer_req, size_t header_length);

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -209,9 +209,8 @@ class HTTPAPIServer : public HTTPServer {
 
     uint32_t IncrementResponseCount();
 
-#ifdef TRITON_ENABLE_TRACING
+    // Only used if tracing enabled
     std::shared_ptr<TraceManager::Trace> trace_;
-#endif  // TRITON_ENABLE_TRACING
 
     AllocPayload alloc_payload_;
 
@@ -252,9 +251,24 @@ class HTTPAPIServer : public HTTPServer {
   // Get the inference header length. Return 0 if the whole request body is
   // the inference header.
   virtual TRITONSERVER_Error* GetInferenceHeaderLength(
-      evhtp_request_t* req, int32_t content_length, size_t* header_length);
+      evhtp_request_t* req, evbuffer* decompressed_buffer,
+      size_t* header_length);
+  virtual TRITONSERVER_Error* GetContentLength(
+      evhtp_request_t* req, evbuffer* decompressed_buffer,
+      int32_t* content_length);
   virtual DataCompressor::Type GetRequestCompressionType(evhtp_request_t* req);
   virtual DataCompressor::Type GetResponseCompressionType(evhtp_request_t* req);
+
+  TRITONSERVER_Error* DecompressBuffer(
+      evhtp_request_t* req, evbuffer** decompressed_buffer);
+  TRITONSERVER_Error* CheckTransactionPolicy(
+      evhtp_request_t* req, const std::string& model_name,
+      int64_t requested_model_version);
+  std::shared_ptr<TraceManager::Trace> StartTrace(
+      evhtp_request_t* req, const std::string& model_name,
+      TRITONSERVER_InferenceTrace** triton_trace);
+  TRITONSERVER_Error* ForwardHeaders(
+      evhtp_request_t* req, TRITONSERVER_InferenceRequest* irequest);
 
   static TRITONSERVER_Error* InferResponseAlloc(
       TRITONSERVER_ResponseAllocator* allocator, const char* tensor_name,
@@ -288,6 +302,9 @@ class HTTPAPIServer : public HTTPServer {
   void HandleInfer(
       evhtp_request_t* req, const std::string& model_name,
       const std::string& model_version_str);
+  void HandleGenerate(
+      evhtp_request_t* req, const std::string& model_name,
+      const std::string& model_version_str);
   void HandleModelStats(
       evhtp_request_t* req, const std::string& model_name = "",
       const std::string& model_version_str = "");
@@ -305,6 +322,10 @@ class HTTPAPIServer : public HTTPServer {
   void HandleTrace(evhtp_request_t* req, const std::string& model_name = "");
   void HandleLogging(evhtp_request_t* req);
 
+  TRITONSERVER_Error* EVBufferToTritonInput(
+      evhtp_request_t* req, const std::string& model_name,
+      TRITONSERVER_InferenceRequest* irequest, evbuffer* decompressed_buffer,
+      InferRequestClass* infer_req, size_t header_length);
   TRITONSERVER_Error* EVBufferToInput(
       const std::string& model_name, TRITONSERVER_InferenceRequest* irequest,
       evbuffer* input_buffer, InferRequestClass* infer_req,

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -251,14 +251,13 @@ class HTTPAPIServer : public HTTPServer {
   // Get the inference header length. Return 0 if the whole request body is
   // the inference header.
   virtual TRITONSERVER_Error* GetInferenceHeaderLength(
-      evhtp_request_t* req, evbuffer* decompressed_buffer,
-      size_t* header_length);
-  virtual TRITONSERVER_Error* GetContentLength(
-      evhtp_request_t* req, evbuffer* decompressed_buffer,
-      int32_t* content_length);
+      evhtp_request_t* req, int32_t content_length, size_t* header_length);
   virtual DataCompressor::Type GetRequestCompressionType(evhtp_request_t* req);
   virtual DataCompressor::Type GetResponseCompressionType(evhtp_request_t* req);
 
+  TRITONSERVER_Error* GetContentLength(
+      evhtp_request_t* req, evbuffer* decompressed_buffer,
+      int32_t* content_length);
   TRITONSERVER_Error* DecompressBuffer(
       evhtp_request_t* req, evbuffer** decompressed_buffer);
   TRITONSERVER_Error* CheckTransactionPolicy(

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -302,9 +302,6 @@ class HTTPAPIServer : public HTTPServer {
   void HandleInfer(
       evhtp_request_t* req, const std::string& model_name,
       const std::string& model_version_str);
-  void HandleGenerate(
-      evhtp_request_t* req, const std::string& model_name,
-      const std::string& model_version_str);
   void HandleModelStats(
       evhtp_request_t* req, const std::string& model_name = "",
       const std::string& model_version_str = "");


### PR DESCRIPTION
1. Compartmentalize `HandleInfer` into logical helpers for better readability and re-usabilty for different inference handlers
2. Replace nested `if (err == nullptr)` logic with early return macro style for better readability. Added a callback helper to cleanup on error and resume the request if `connection_paused`. Currently it will always be paused when inference request is created, but left the variable in for clarity.
3. Set JSON content type before early returns so it's properly set on early errors, and add a helper to condense the code a bit.
4. Remove some unnecessary ifdefs around `trace` usage to remove some noise, as we already have [TraceManager](https://github.com/triton-inference-server/server/blob/5dd9398dd76a90a117ce6b3052e15561337fe88b/src/http_server.h#L340) in the code without any guards. The trace will just be `nullptr` when tracing isn't enabled, and the main trace logic is still protected by ifdefs. 