### PR TITLE
Fixes on the gRPC frontend to handle AsyncNotifyWhenDone() API

### DIFF
--- a/src/grpc/grpc_utils.cc
+++ b/src/grpc/grpc_utils.cc
@@ -28,6 +28,48 @@
 
 namespace triton { namespace server { namespace grpc {
 
+std::ostream&
+operator<<(std::ostream& out, const Steps& step)
+{
+  switch (step) {
+    case START:
+      out << "START";
+      break;
+    case COMPLETE:
+      out << "COMPLETE";
+      break;
+    case FINISH:
+      out << "FINISH";
+      break;
+    case ISSUED:
+      out << "ISSUED";
+      break;
+    case READ:
+      out << "READ";
+      break;
+    case WRITEREADY:
+      out << "WRITEREADY";
+      break;
+    case WRITTEN:
+      out << "WRITTEN";
+      break;
+    case WAITING_NOTIFICATION:
+      out << "WAITING_NOTIFICATION";
+      break;
+    case CANCELLATION_ISSUED:
+      out << "CANCELLATION_ISSUED";
+      break;
+    case CANCELLED:
+      out << "CANCELLED";
+      break;
+    case PARTIAL_COMPLETION:
+      out << "PARTIAL_COMPLETION";
+      break;
+  }
+
+  return out;
+}
+
 void
 GrpcStatusUtil::Create(::grpc::Status* status, TRITONSERVER_Error* err)
 {

--- a/src/grpc/grpc_utils.h
+++ b/src/grpc/grpc_utils.h
@@ -38,6 +38,25 @@
 
 namespace triton { namespace server { namespace grpc {
 
+// The step of processing that the state is in. Every state must
+// recognize START, COMPLETE and FINISH and the others are optional.
+typedef enum {
+  START,
+  COMPLETE,
+  FINISH,
+  ISSUED,
+  READ,
+  WRITEREADY,
+  WRITTEN,
+  WAITING_NOTIFICATION,
+  CANCELLATION_ISSUED,
+  CANCELLED,
+  PARTIAL_COMPLETION
+} Steps;
+
+// Debugging helper
+std::ostream& operator<<(std::ostream& out, const Steps& step);
+
 //
 // GrpcStatusUtil
 //

--- a/src/grpc/grpc_utils.h
+++ b/src/grpc/grpc_utils.h
@@ -41,16 +41,38 @@ namespace triton { namespace server { namespace grpc {
 // The step of processing that the state is in. Every state must
 // recognize START, COMPLETE and FINISH and the others are optional.
 typedef enum {
+  // This marks the starting stage of the RPC
   START,
+  // This marks that RPC is complete.
   COMPLETE,
+  // This marks the stage where all the notifications from the gRPC
+  // completion queue is received and state can be safely released.
   FINISH,
+  // This stage means that RPC has been issued to Triton for inference
+  // and is waiting for the server callbacks or cancellation to be
+  // invokded.
   ISSUED,
+  // This stage means the request has been read from the network and
+  // can be sent to Triton for execution.
   READ,
+  // This stage means that the response is ready to be written back to
+  // the network.
   WRITEREADY,
+  // This stage means that response has been written completely to the
+  // network.
   WRITTEN,
+  // This marks the special stage for the state object to differentiate
+  // the tag delivered from AsyncNotifyWhenDone() method.
   WAITING_NOTIFICATION,
+  // This stage means that the cancellation for the RPC has been issued
+  // to the server.
   CANCELLATION_ISSUED,
+  // This stage marks that the state has been successfully cancelled.
   CANCELLED,
+  // This is intermediary stage where the state has been been partially
+  // completed by grpc responder Finish call or AsyncNotifyWhenDone()
+  // notification. The other next call will move the stage to fully
+  // complete.
   PARTIAL_COMPLETION
 } Steps;
 

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -37,45 +37,6 @@ NextUniqueId()
 
 namespace triton { namespace server { namespace grpc {
 
-std::ostream&
-operator<<(std::ostream& out, const Steps& step)
-{
-  switch (step) {
-    case START:
-      out << "START";
-      break;
-    case COMPLETE:
-      out << "COMPLETE";
-      break;
-    case FINISH:
-      out << "FINISH";
-      break;
-    case ISSUED:
-      out << "ISSUED";
-      break;
-    case READ:
-      out << "READ";
-      break;
-    case WRITEREADY:
-      out << "WRITEREADY";
-      break;
-    case WRITTEN:
-      out << "WRITTEN";
-      break;
-    case WAITING_NOTIFICATION:
-      out << "WAITING_NOTIFICATION";
-      break;
-    case CANCELLATION_ISSUED:
-      out << "CANCELLATION_ISSUED";
-      break;
-    case CANCELLED:
-      out << "CANCELLED";
-      break;
-  }
-
-  return out;
-}
-
 TRITONSERVER_Error*
 OutputBufferAttributesHelper(
     TRITONSERVER_ResponseAllocator* allocator, const char* tensor_name,

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -62,6 +62,9 @@ operator<<(std::ostream& out, const Steps& step)
     case WRITTEN:
       out << "WRITTEN";
       break;
+    case WAITING_NOTIFICATION:
+      out << "WAITING_NOTIFICATION";
+      break;
     case CANCELLATION_ISSUED:
       out << "CANCELLATION_ISSUED";
       break;
@@ -785,6 +788,7 @@ ModelInferHandler::Process(InferHandler::State* state, bool rpc_ok)
 #endif  // TRITON_ENABLE_TRACING
 
     state->step_ = Steps::FINISH;
+  } else if (state->step_ == Steps::FINISH) {
     finished = true;
   }
 

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -979,6 +979,10 @@ class InferHandlerState {
     bool received_notification_;
   };
 
+  // This constructor is used to build a wrapper state object
+  // pointing to the actual state object. The wrapper state
+  // object is used to distinguish a tag from AsyncNotifyWhenDone()
+  // signal.
   explicit InferHandlerState(Steps start_step, InferHandlerState* state)
       : step_(start_step), state_ptr_(state)
   {
@@ -1019,6 +1023,8 @@ class InferHandlerState {
     // Clear trace_timestamps_ here so they do not grow indefinitely since
     // states are re-used for performance.
     ClearTraceTimestamps();
+    // The pointer should be nullptr for all state objects instead of
+    // wrapper state object in WAITING_NOTIFICATION step.
     state_ptr_ = nullptr;
   }
 
@@ -1083,9 +1089,9 @@ class InferHandlerState {
   // requests.
   AllocPayload<ResponseType> alloc_payload_;
 
-  // The below pointer is only set when the state object is being
-  // fed to the completion queue using AsyncNotifyWhenDone function.
-  // Otherwise it is nullptr.
+  // The below pointer is only set when using this state object as a
+  // wrapper over actual state when being sent to completion queue
+  // using AsyncNotifyWhenDone function. Otherwise it is nullptr.
   InferHandlerState* state_ptr_;
 };
 

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -140,17 +140,14 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
   // This means that we only need to take care of
   // synchronizing this thread and the ResponseComplete
   // threads.
-  {
+  if (state->context_->ReceivedNotification()) {
     std::lock_guard<std::recursive_mutex> lock(state->step_mtx_);
-    if (state->context_->ReceivedNotification()) {
-      if (state->IsGrpcContextCancelled()) {
-        bool resume =
-            state->context_->HandleCancellation(state, rpc_ok, Name());
-        return resume;
-      } else {
-        if (state->context_->HandleCompletion()) {
-          return true;
-        }
+    if (state->IsGrpcContextCancelled()) {
+      bool resume = state->context_->HandleCancellation(state, rpc_ok, Name());
+      return resume;
+    } else {
+      if (state->context_->HandleCompletion()) {
+        return true;
       }
     }
   }

--- a/src/grpc/stream_infer_handler.h
+++ b/src/grpc/stream_infer_handler.h
@@ -112,7 +112,7 @@ class ModelStreamInferHandler
   static void StreamInferResponseComplete(
       TRITONSERVER_InferenceResponse* response, const uint32_t flags,
       void* userp);
-  void Finish(State* state);
+  bool Finish(State* state);
 
   TraceManager* trace_manager_;
   std::shared_ptr<SharedMemoryManager> shm_manager_;

--- a/src/grpc/stream_infer_handler.h
+++ b/src/grpc/stream_infer_handler.h
@@ -112,7 +112,7 @@ class ModelStreamInferHandler
   static void StreamInferResponseComplete(
       TRITONSERVER_InferenceResponse* response, const uint32_t flags,
       void* userp);
-  bool Finish(State* state);
+  void Finish(State* state);
 
   TraceManager* trace_manager_;
   std::shared_ptr<SharedMemoryManager> shm_manager_;


### PR DESCRIPTION
There are few items that have been identified and fixed:
1. It is unsafe to call ctx_->IsCancelled() if the tag from AsyncNotifyWhenDone(). I am using a dummy State object that points to the first state object of ongoing context tracking the bidi grpc streaming RPC.
2. Introduced a new state step called PARTIAL_COMPLETE. We would need to handle the lifetimes of the state objects ourselves so that State is released only when all the RPC is complete. This means that callbacks have been processed, all the standard loops from the state->steps_ are complete and Done notification has been processed. The sad thing is there is no order guarantee on the standard CQ delivery and Done notification delivery.
3. There is a possibility that server when shutting down might not receive the Done() event. Exploring more on this,

I am adding some tests on the gRPC state cleanup logic for the following permutations and combinations.
[non-streaming, streaming non-decoupled, streaming decoupled][normal infer, cancelled, timeout, kill server, restricted API error].
I think if these tests pass. We should be confident on our end. 

There are some open gaps that got identified in the process of this work:

The server shutdown and handler are asynchronously invoked which might lead to certain race condition. Specifically, when calling Finish() on a listening RPC within handler. There are several points where it can occur. See [here](https://github.com/triton-inference-server/server/pull/6345#discussion_r1341666326). I will fix them in a separate PR as it is going out-of-context with this PR and the issue is already seem to be present in the current implementation. Opened a ticket here to track this: [DLIS-5563](https://jirasw.nvidia.com/browse/DLIS-5563)