### PR TITLE
[draft] PoC of parsing request prompt and converting to Triton infer request

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3078,11 +3078,6 @@ HTTPAPIServer::HandleGenerate(
       req,
       GetModelVersionFromString(model_version_str, &requested_model_version));
 
-  // If tracing is enabled see if this request should be traced.
-  TRITONSERVER_InferenceTrace* triton_trace = nullptr;
-  std::shared_ptr<TraceManager::Trace> trace =
-      StartTrace(req, model_name, &triton_trace);
-
   std::string config_json_str = "";
   RETURN_AND_RESPOND_IF_ERR(
       req,
@@ -3127,7 +3122,8 @@ HTTPAPIServer::HandleGenerate(
   triton::common::TritonJson::Value triton_json(
       triton::common::TritonJson::ValueType::OBJECT);
 
-  // Parse Model Config for candidate input names/keys to compare and populate
+  // TODO: Parse Model Config for candidate input names/keys to compare and
+  // populate
   triton::common::TritonJson::Value config_json;
   RETURN_AND_RESPOND_IF_ERR(
       req, config_json.Parse(config_json_str.c_str(), config_json_str.size()));

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -255,6 +255,10 @@ class HTTPAPIServer : public HTTPServer {
   virtual DataCompressor::Type GetRequestCompressionType(evhtp_request_t* req);
   virtual DataCompressor::Type GetResponseCompressionType(evhtp_request_t* req);
 
+
+  TRITONSERVER_Error* GetModelConfig(
+      const std::string& model_name, int64_t requested_model_version,
+      std::string* config_json);
   TRITONSERVER_Error* GetContentLength(
       evhtp_request_t* req, evbuffer* decompressed_buffer,
       int32_t* content_length);
@@ -318,7 +322,16 @@ class HTTPAPIServer : public HTTPServer {
   void HandleTrace(evhtp_request_t* req, const std::string& model_name = "");
   void HandleLogging(evhtp_request_t* req);
 
-  TRITONSERVER_Error* EVBufferToTritonRequest(
+  // Text Generation / LLM format
+  void HandleGenerate(
+      evhtp_request_t* req, const std::string& model_name,
+      const std::string& model_version_str);
+
+  // Parses full evhtp request and its evbuffers into JSON.
+  TRITONSERVER_Error* EVRequestToJson(
+      evhtp_request_t* req, triton::common::TritonJson::Value* request_json);
+  // Parses evhtp request buffers into Triton Inference Request.
+  TRITONSERVER_Error* EVRequestToTritonRequest(
       evhtp_request_t* req, const std::string& model_name,
       TRITONSERVER_InferenceRequest* irequest, evbuffer* decompressed_buffer,
       InferRequestClass* infer_req, size_t header_length);


### PR DESCRIPTION
PoC converting request only on "identity" like text model

Infer:
```
rmccormick@ced35d0-lcedt:~$ curl -w "\n" -X POST localhost:8000/v2/models/text/infer -d '{"inputs":[{"name":"prompt","datatype":"BYTES","shape":[1,1],"data":["hello"]}]}'
{"model_name":"text","model_version":"1","outputs":[{"name":"text","datatype":"BYTES","shape":[1,1],"data":["hello"]}]}
```
Generate:
```
rmccormick@ced35d0-lcedt:~$ curl -w "\n" -X POST localhost:8000/v2/models/text/generate -d '{"prompt": "hello"}'
{"model_name":"text","model_version":"1","outputs":[{"name":"text","datatype":"BYTES","shape":[1,1],"data":["hello"]}]}
```

TODO:
- [ ] Convert output/response format as well
- [ ] Discuss conversion method
    - Reuse HandleInfer: modify evhtp_request / create new one, then call HandleInfer
    - Just copy-paste or extract inference logic directly in HandleGenerate