### PR TITLE
Add TRT-LLM backend build to Triton

### DIFF
--- a/build.py
+++ b/build.py
@@ -1714,13 +1714,14 @@ def core_build(
             os.path.join(repo_install_dir, "lib", "libtritonserver.so"),
             os.path.join(install_dir, "lib"),
         )
+    # FIXME: Uncomment this part when using the latest branch
     # [FIXME] Placing the Triton server wheel file in 'python' for now, should
     # have been upload to pip registry and be able to install directly
-    cmake_script.mkdir(os.path.join(install_dir, "python"))
-    cmake_script.cp(
-        os.path.join(repo_install_dir, "python", "tritonserver*.whl"),
-        os.path.join(install_dir, "python"),
-    )
+    # cmake_script.mkdir(os.path.join(install_dir, "python"))
+    # cmake_script.cp(
+    #     os.path.join(repo_install_dir, "python", "tritonserver*.whl"),
+    #     os.path.join(install_dir, "python"),
+    # )
 
     cmake_script.mkdir(os.path.join(install_dir, "include", "triton"))
     cmake_script.cpdir(
@@ -1803,6 +1804,11 @@ def backend_build(
 
     cmake_script.mkdir(os.path.join(install_dir, "backends"))
     cmake_script.rmdir(os.path.join(install_dir, "backends", be))
+    
+    # FIXME: Align the backend name
+    if be == "tensorrtllm":
+        be = "inflight_batcher_llm"
+
     cmake_script.cpdir(
         os.path.join(repo_install_dir, "backends", be),
         os.path.join(install_dir, "backends"),

--- a/build.py
+++ b/build.py
@@ -872,7 +872,7 @@ def fastertransformer_cmake_args():
 def tensorrtllm_cmake_args(images):
     cargs = [
         cmake_backend_arg(
-            "tensorrtllm", "TRT_LIB_DIR", None, "${TRT_ROOT}/targets/x86_64-linux-gnu/lib"
+            "tensorrtllm", "TRT_LIB_DIR", None, "${TRT_ROOT}/targets/${ARCH}-linux-gnu/lib"
         ),
         cmake_backend_arg("tensorrtllm", "TRT_INCLUDE_DIR", None, "${TRT_ROOT}/include"),
         cmake_backend_arg(
@@ -1771,6 +1771,7 @@ def core_build(
 def tensorrtllm_prebuild(cmake_script):
     # Export the TRT_ROOT environment variable
     cmake_script.cmd("export TRT_ROOT=/usr/local/tensorrt")
+    cmake_script.cmd("export ARCH=$(uname -m)")
 
 def backend_build(
     be,

--- a/build.py
+++ b/build.py
@@ -574,7 +574,7 @@ def backend_cmake_args(images, components, be, install_dir, library_paths):
     elif be == "tensorrt":
         args = tensorrt_cmake_args()
     elif be == "tensorrtllm":
-        args = tensorrtllm_cmake_args()
+        args = tensorrtllm_cmake_args(images)
     else:
         args = []
 
@@ -869,7 +869,7 @@ def fastertransformer_cmake_args():
     ]
     return cargs
 
-def tensorrtllm_cmake_args():
+def tensorrtllm_cmake_args(images):
     cargs = [
         cmake_backend_arg(
             "tensorrtllm", "TRT_LIB_DIR", None, "${TRT_ROOT}/targets/x86_64-linux-gnu/lib"
@@ -877,9 +877,9 @@ def tensorrtllm_cmake_args():
         cmake_backend_arg("tensorrtllm", "TRT_INCLUDE_DIR", None, "${TRT_ROOT}/include"),
         cmake_backend_arg(
             "tensorrtllm",
-            "TRITON_BUILD_CONTAINER_VERSION",
+            "TRTLLM_BUILD_CONTAINER",
             None,
-            FLAGS.container_version,
+            images["base"],
         )
     ]
     return cargs

--- a/build.py
+++ b/build.py
@@ -76,6 +76,7 @@ TRITON_VERSION_MAP = {
         "2.4.7",  # DCGM version
         "py310_23.1.0-1",  # Conda version.
     ),
+    # FIXME: Remove this section after using the latest branch
     '2.36.0': (
         '23.07',  # triton container
         '23.07',  # upstream container
@@ -1305,7 +1306,7 @@ RUN apt-get update && \
     # Add dependencies needed for tensorrtllm backend
     if "tensorrtllm" in backends:
         df += """
-# python3, python3-pip and some pip installs required for the tensorrtllm backend
+# Required for TRT-LLM python tests
 RUN pip3 install https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/secure/9.0.1/tars/polygraphy-0.48.1-py2.py3-none-any.whl && \
     rm -rf /var/lib/apt/lists/*
 """
@@ -1758,7 +1759,7 @@ def core_build(
     cmake_script.blankln()
 
 def tensorrtllm_prebuild(cmake_script):
-    # Update submodule
+    # Export the TRT_ROOT environment variable
     cmake_script.cmd("export TRT_ROOT=/usr/local/tensorrt")
 
 def backend_build(
@@ -1786,7 +1787,7 @@ def backend_build(
     cmake_script.comment()
     cmake_script.mkdir(build_dir)
     cmake_script.cwd(build_dir)
-    # FIXME: Use regular repo
+    # FIXME: Use GitHub repo
     if be == "tensorrtllm":
         cmake_script.gitclone(backend_repo(be), tag, be, "https://gitlab-master.nvidia.com/krish")
     else:

--- a/build.py
+++ b/build.py
@@ -75,16 +75,7 @@ TRITON_VERSION_MAP = {
         "2023.0.0",  # Standalone OpenVINO
         "2.4.7",  # DCGM version
         "py310_23.1.0-1",  # Conda version.
-    ),
-    # FIXME: Remove this section after using the latest branch
-    '2.36.0': (
-        '23.07',  # triton container
-        '23.07',  # upstream container
-        '1.15.1',  # ORT
-        '2023.0.0',  # ORT OpenVINO
-        '2023.0.0',  # Standalone OpenVINO
-        '2.4.7',  # DCGM version
-        'py310_23.1.0-1')  # Conda version.
+    )
 }
 
 CORE_BACKENDS = ["ensemble"]
@@ -869,20 +860,27 @@ def fastertransformer_cmake_args():
     ]
     return cargs
 
+
 def tensorrtllm_cmake_args(images):
     cargs = [
         cmake_backend_arg(
-            "tensorrtllm", "TRT_LIB_DIR", None, "${TRT_ROOT}/targets/${ARCH}-linux-gnu/lib"
+            "tensorrtllm",
+            "TRT_LIB_DIR",
+            None,
+            "${TRT_ROOT}/targets/${ARCH}-linux-gnu/lib",
         ),
-        cmake_backend_arg("tensorrtllm", "TRT_INCLUDE_DIR", None, "${TRT_ROOT}/include"),
+        cmake_backend_arg(
+            "tensorrtllm", "TRT_INCLUDE_DIR", None, "${TRT_ROOT}/include"
+        ),
         cmake_backend_arg(
             "tensorrtllm",
             "TRTLLM_BUILD_CONTAINER",
             None,
             images["base"],
-        )
+        ),
     ]
     return cargs
+
 
 def install_dcgm_libraries(dcgm_version, target_machine):
     if dcgm_version == "":
@@ -1307,7 +1305,9 @@ RUN apt-get update && \
     if "tensorrtllm" in backends:
         be = "tensorrtllm"
         import importlib.util
+
         import requests
+
         # FIXME: Update the url
         url = "https://gitlab-master.nvidia.com/krish/tensorrtllm_backend/-/raw/{}/tools/gen_trtllm_dockerfile.py".format(
             backends[be]
@@ -1725,14 +1725,13 @@ def core_build(
             os.path.join(repo_install_dir, "lib", "libtritonserver.so"),
             os.path.join(install_dir, "lib"),
         )
-    # FIXME: Uncomment this part when using the latest branch
     # [FIXME] Placing the Triton server wheel file in 'python' for now, should
     # have been upload to pip registry and be able to install directly
-    # cmake_script.mkdir(os.path.join(install_dir, "python"))
-    # cmake_script.cp(
-    #     os.path.join(repo_install_dir, "python", "tritonserver*.whl"),
-    #     os.path.join(install_dir, "python"),
-    # )
+    cmake_script.mkdir(os.path.join(install_dir, "python"))
+    cmake_script.cp(
+        os.path.join(repo_install_dir, "python", "tritonserver*.whl"),
+        os.path.join(install_dir, "python"),
+    )
 
     cmake_script.mkdir(os.path.join(install_dir, "include", "triton"))
     cmake_script.cpdir(
@@ -1768,10 +1767,12 @@ def core_build(
     cmake_script.commentln(8)
     cmake_script.blankln()
 
+
 def tensorrtllm_prebuild(cmake_script):
     # Export the TRT_ROOT environment variable
     cmake_script.cmd("export TRT_ROOT=/usr/local/tensorrt")
     cmake_script.cmd("export ARCH=$(uname -m)")
+
 
 def backend_build(
     be,
@@ -1784,7 +1785,6 @@ def backend_build(
     components,
     library_paths,
 ):
-    
     repo_build_dir = os.path.join(build_dir, be, "build")
     repo_install_dir = os.path.join(build_dir, be, "install")
 
@@ -1796,7 +1796,9 @@ def backend_build(
     cmake_script.cwd(build_dir)
     # FIXME: Use GitHub repo
     if be == "tensorrtllm":
-        cmake_script.gitclone(backend_repo(be), tag, be, "https://gitlab-master.nvidia.com/krish")
+        cmake_script.gitclone(
+            backend_repo(be), tag, be, "https://gitlab-master.nvidia.com/krish"
+        )
     else:
         cmake_script.gitclone(backend_repo(be), tag, be, github_organization)
 
@@ -1926,8 +1928,7 @@ def cibase_build(
             os.path.join(repo_install_dir, "lib", "libtritonrepoagent_relocation.so"),
             os.path.join(ci_dir, "lib"),
         )
-        # FIXME: Uncomment this part when using the latest branch
-        # cmake_script.cpdir(os.path.join(repo_install_dir, "python"), ci_dir)
+        cmake_script.cpdir(os.path.join(repo_install_dir, "python"), ci_dir)
 
     # Some of the backends are needed for CI testing
     cmake_script.mkdir(os.path.join(ci_dir, "backends"))

--- a/build.py
+++ b/build.py
@@ -75,7 +75,15 @@ TRITON_VERSION_MAP = {
         "2023.0.0",  # Standalone OpenVINO
         "2.4.7",  # DCGM version
         "py310_23.1.0-1",  # Conda version.
-    )
+    ),
+    '2.36.0': (
+        '23.07',  # triton container
+        '23.07',  # upstream container
+        '1.15.1',  # ORT
+        '2023.0.0',  # ORT OpenVINO
+        '2023.0.0',  # Standalone OpenVINO
+        '2.4.7',  # DCGM version
+        'py310_23.1.0-1')  # Conda version.
 }
 
 CORE_BACKENDS = ["ensemble"]

--- a/build.py
+++ b/build.py
@@ -1308,7 +1308,7 @@ RUN apt-get update && \
         be = "tensorrtllm"
         import importlib.util
         import requests
-
+        # FIXME: Update the url
         url = "https://gitlab-master.nvidia.com/krish/tensorrtllm_backend/-/raw/{}/tools/gen_trtllm_dockerfile.py".format(
             backends[be]
         )
@@ -1784,12 +1784,8 @@ def backend_build(
     library_paths,
 ):
     
-    if be == "tensorrtllm":
-        repo_build_dir = os.path.join(build_dir, be, "inflight_batcher_llm", "build")
-        repo_install_dir = os.path.join(build_dir, be, "inflight_batcher_llm", "install")
-    else:
-        repo_build_dir = os.path.join(build_dir, be, "build")
-        repo_install_dir = os.path.join(build_dir, be, "install")
+    repo_build_dir = os.path.join(build_dir, be, "build")
+    repo_install_dir = os.path.join(build_dir, be, "install")
 
     cmake_script.commentln(8)
     cmake_script.comment(f"'{be}' backend")
@@ -1815,10 +1811,6 @@ def backend_build(
 
     cmake_script.mkdir(os.path.join(install_dir, "backends"))
     cmake_script.rmdir(os.path.join(install_dir, "backends", be))
-    
-    # FIXME: Align the backend name
-    if be == "tensorrtllm":
-        be = "inflight_batcher_llm"
 
     cmake_script.cpdir(
         os.path.join(repo_install_dir, "backends", be),

--- a/build.py
+++ b/build.py
@@ -1923,7 +1923,8 @@ def cibase_build(
             os.path.join(repo_install_dir, "lib", "libtritonrepoagent_relocation.so"),
             os.path.join(ci_dir, "lib"),
         )
-        cmake_script.cpdir(os.path.join(repo_install_dir, "python"), ci_dir)
+        # FIXME: Uncomment this part when using the latest branch
+        # cmake_script.cpdir(os.path.join(repo_install_dir, "python"), ci_dir)
 
     # Some of the backends are needed for CI testing
     cmake_script.mkdir(os.path.join(ci_dir, "backends"))


### PR DESCRIPTION
Currently the build is using internal GitLab repo for both TRT-LLM backend and TRT-LLM repositories. Will switch the link to the GitHub repo once they're ready.

TRT-LLM backend: https://github.com/triton-inference-server/tensorrtllm_backend/pull/3