### PR TITLE
support parameters object in generate route

### DIFF
--- a/qa/L0_http/generate_endpoint_test.py
+++ b/qa/L0_http/generate_endpoint_test.py
@@ -363,6 +363,18 @@ class GenerateEndpointTest(tu.TestResultCollector):
         inputs = {"PROMPT": [text], "STREAM": True, "parameters":{"REPETITION": rep_count}}
         self.generate_stream_expect_success(self._model_name, inputs, text, rep_count)
 
+        # non object parameters
+        inputs = {"PROMPT": [text], "STREAM": True, "parameters": 1}
+
+        r = self.generate(self._model_name, inputs)
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            self.assertIn(
+                "Expected JSON object for keyword: 'parameters'", r.json()["error"]
+            )
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qa/L0_http/generate_endpoint_test.py
+++ b/qa/L0_http/generate_endpoint_test.py
@@ -360,7 +360,11 @@ class GenerateEndpointTest(tu.TestResultCollector):
         # Test reserved nested object for parameters
         text = "hello world"
         rep_count = 3
-        inputs = {"PROMPT": [text], "STREAM": True, "parameters":{"REPETITION": rep_count}}
+        inputs = {
+            "PROMPT": [text],
+            "STREAM": True,
+            "parameters": {"REPETITION": rep_count},
+        }
         self.generate_stream_expect_success(self._model_name, inputs, text, rep_count)
 
         # parameters keyword is not an object
@@ -375,16 +379,20 @@ class GenerateEndpointTest(tu.TestResultCollector):
             )
 
         # parameters contains complex object
-        inputs = {"PROMPT": [text], "STREAM": True, "parameters": {"nested":{"twice":1}}}
+        inputs = {
+            "PROMPT": [text],
+            "STREAM": True,
+            "parameters": {"nested": {"twice": 1}},
+        }
 
         r = self.generate(self._model_name, inputs)
         try:
             r.raise_for_status()
         except requests.exceptions.HTTPError as e:
             self.assertIn(
-                "Converting keyword: 'parameters': parameter 'nested' has invalid type.", r.json()["error"]
+                "Converting keyword: 'parameters': parameter 'nested' has invalid type.",
+                r.json()["error"],
             )
-
 
 
 if __name__ == "__main__":

--- a/qa/L0_http/generate_endpoint_test.py
+++ b/qa/L0_http/generate_endpoint_test.py
@@ -363,7 +363,7 @@ class GenerateEndpointTest(tu.TestResultCollector):
         inputs = {"PROMPT": [text], "STREAM": True, "parameters":{"REPETITION": rep_count}}
         self.generate_stream_expect_success(self._model_name, inputs, text, rep_count)
 
-        # non object parameters
+        # parameters keyword is not an object
         inputs = {"PROMPT": [text], "STREAM": True, "parameters": 1}
 
         r = self.generate(self._model_name, inputs)
@@ -372,6 +372,17 @@ class GenerateEndpointTest(tu.TestResultCollector):
         except requests.exceptions.HTTPError as e:
             self.assertIn(
                 "Expected JSON object for keyword: 'parameters'", r.json()["error"]
+            )
+
+        # parameters contains complex object
+        inputs = {"PROMPT": [text], "STREAM": True, "parameters": {"nested":{"twice":1}}}
+
+        r = self.generate(self._model_name, inputs)
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            self.assertIn(
+                "Converting keyword: 'parameters': parameter 'nested' has invalid type.", r.json()["error"]
             )
 
 

--- a/qa/L0_http/generate_endpoint_test.py
+++ b/qa/L0_http/generate_endpoint_test.py
@@ -356,6 +356,13 @@ class GenerateEndpointTest(tu.TestResultCollector):
                 "attempt to access JSON non-string as string", r.json()["error"]
             )
 
+    def test_parameters(self):
+        # Test reserved nested object for parameters
+        text = "hello world"
+        rep_count = 3
+        inputs = {"PROMPT": [text], "STREAM": True, "parameters":{"REPETITION": rep_count}}
+        self.generate_stream_expect_success(self._model_name, inputs, text, rep_count)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -648,7 +648,7 @@ fi
 ## Python Unit Tests
 TEST_RESULT_FILE='test_results.txt'
 PYTHON_TEST=generate_endpoint_test.py
-EXPECTED_NUM_TESTS=12
+EXPECTED_NUM_TESTS=13
 set +e
 python $PYTHON_TEST >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3286,8 +3286,10 @@ HTTPAPIServer::GenerateRequestClass::ConvertGenerateRequest(
               generate_request.MemberAsObject(
                   m.c_str(), &nested_generate_request),
               "Expected JSON object for keyword: '" + m + "'");
-          RETURN_IF_ERR(ConvertGenerateRequest(
-              input_metadata, it->second.get(), nested_generate_request));
+          RETURN_MSG_IF_ERR(
+              ConvertGenerateRequest(
+                  input_metadata, it->second.get(), nested_generate_request),
+              "Converting keyword: '" + m + "'");
           break;
         }
         default:

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3282,8 +3282,10 @@ HTTPAPIServer::GenerateRequestClass::ConvertGenerateRequest(
         case MappingSchema::Kind::MAPPING_SCHEMA: {
           // The key is nested schema
           triton::common::TritonJson::Value nested_generate_request;
-          RETURN_IF_ERR(generate_request.MemberAsObject(
-              m.c_str(), &nested_generate_request));
+          RETURN_MSG_IF_ERR(
+              generate_request.MemberAsObject(
+                  m.c_str(), &nested_generate_request),
+              "Expected JSON object for keyword: '" + m + "'");
           RETURN_IF_ERR(ConvertGenerateRequest(
               input_metadata, it->second.get(), nested_generate_request));
           break;

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1082,6 +1082,17 @@ HTTPAPIServer::HTTPAPIServer(
       TRITONSERVER_ResponseAllocatorSetBufferAttributesFunction(
           allocator_, OutputBufferAttributes),
       "setting allocator's buffer attributes function");
+
+  // Reserved field parameters for generate
+  // If present, parameters will be converted to tensors
+  // or parameters based on model config
+  
+  // Note: may change in future versions
+  const std::string parameters_field = "parameters";
+  generate_stream_request_schema_->children_.emplace(parameters_field,
+						     new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
+  generate_request_schema_->children_.emplace(parameters_field,
+					      new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
 }
 
 HTTPAPIServer::~HTTPAPIServer()

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1086,13 +1086,15 @@ HTTPAPIServer::HTTPAPIServer(
   // Reserved field parameters for generate
   // If present, parameters will be converted to tensors
   // or parameters based on model config
-  
+
   // Note: may change in future versions
   const std::string parameters_field = "parameters";
-  generate_stream_request_schema_->children_.emplace(parameters_field,
-						     new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
-  generate_request_schema_->children_.emplace(parameters_field,
-					      new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
+  generate_stream_request_schema_->children_.emplace(
+      parameters_field,
+      new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
+  generate_request_schema_->children_.emplace(
+      parameters_field,
+      new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
 }
 
 HTTPAPIServer::~HTTPAPIServer()

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -62,6 +62,14 @@ class MappingSchema {
   const bool allow_unspecified_{true};
   const Kind kind_{Kind::EXACT_MAPPING};
 
+  explicit MappingSchema(
+      const MappingSchema::Kind& kind = Kind::EXACT_MAPPING,
+      const bool& allow_unspecified = true)
+      : allow_unspecified_(allow_unspecified), kind_(kind)
+  {
+  }
+
+
  private:
 };
 

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -524,6 +524,25 @@ class HTTPAPIServer : public HTTPServer {
       new MappingSchema()};
   std::unique_ptr<MappingSchema> generate_stream_request_schema_{
       new MappingSchema()};
+
+  // Provisional definition of generate mapping schema
+  // to allow for parameters passing
+  //
+  // Note: subject to change
+  void ConfigureGenerateMappingSchema()
+  {
+    // Reserved field parameters for generate
+    // If present, parameters will be converted to tensors
+    // or parameters based on model config
+
+    const std::string parameters_field = "parameters";
+    generate_stream_request_schema_->children_.emplace(
+        parameters_field,
+        new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
+    generate_request_schema_->children_.emplace(
+        parameters_field,
+        new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
+  }
 };
 
 }}  // namespace triton::server


### PR DESCRIPTION
Adding a specific key word for generate endpoint to support passing parameters such as:

curl -s localhost:8000/v2/models/mock_llm/generate_stream -d '{"PROMPT":"hello","STREAM":true, "parameters"\
        :{"REPETITION":5}}'
