### PR TITLE
Add Python backend when vLLM backend built

### DIFF
--- a/build.py
+++ b/build.py
@@ -2506,7 +2506,11 @@ if __name__ == "__main__":
 
     if "vllm" in backends:
         if "python" not in backends:
-            log("vLLM backend requires Python backend, adding Python backend with tag {}".format(backends["vllm"]))
+            log(
+                "vLLM backend requires Python backend, adding Python backend with tag {}".format(
+                    backends["vllm"]
+                )
+            )
             backends["python"] = backends["vllm"]
 
     # Initialize map of repo agents to build and repo-tag for each.

--- a/build.py
+++ b/build.py
@@ -2504,6 +2504,11 @@ if __name__ == "__main__":
         log('backend "{}" at tag/branch "{}"'.format(parts[0], parts[1]))
         backends[parts[0]] = parts[1]
 
+    if "vllm" in backends:
+        if "python" not in backends:
+            log("vLLM backend requires Python backend, adding Python backend with tag {}".format(backends["vllm"]))
+            backends["python"] = backends["vllm"]
+
     # Initialize map of repo agents to build and repo-tag for each.
     repoagents = {}
     for be in FLAGS.repoagent:


### PR DESCRIPTION
The vLLM backend is a Python-based backend, so it relies on Python backend existing. Add it as a dependency in the build. If it does not exist, log that and use the vLLM's repo tag as the tag for the Python backend.