### PR TITLE
TRT-LLM backend build changes

### DIFF
--- a/build.py
+++ b/build.py
@@ -1349,19 +1349,16 @@ RUN ARCH="$(uname -i)" && \
     rm -fr  ${TRT_ROOT}/doc ${TRT_ROOT}/onnx_graphsurgeon ${TRT_ROOT}/python && \
     rm -fr ${TRT_ROOT}/samples  ${TRT_ROOT}/targets/${ARCH}-linux-gnu/samples
 
+# Install required packages for TRT-LLM models
+RUN python3 -m pip install --upgrade pip && \
+        pip3 install transformers && \
+        pip3 install torch
+
 # Uninstall unused nvidia packages
 RUN if pip freeze | grep -q "nvidia.*"; then \
         pip freeze | grep "nvidia.*" | xargs pip uninstall -y; \
     fi
 RUN pip cache purge
-
-# Install required packages for example models
-RUN python3 -m pip install --upgrade pip && \
-        pip3 install transformers && \
-        pip3 install torch && \
-        pip3 install tritonclient[all] && \
-        pip3 install pandas && \
-        pip3 install tabulate
 
 ENV LD_LIBRARY_PATH=/usr/local/tensorrt/lib/:/opt/tritonserver/backends/tensorrtllm:$LD_LIBRARY_PATH
 """

--- a/build.py
+++ b/build.py
@@ -1355,6 +1355,14 @@ RUN if pip freeze | grep -q "nvidia.*"; then \
     fi
 RUN pip cache purge
 
+# Install required packages for example models
+RUN python3 -m pip install --upgrade pip && \
+        pip3 install transformers && \
+        pip3 install torch && \
+        pip3 install tritonclient[all] && \
+        pip3 install pandas && \
+        pip3 install tabulate
+
 ENV LD_LIBRARY_PATH=/usr/local/tensorrt/lib/:/opt/tritonserver/backends/tensorrtllm:$LD_LIBRARY_PATH
 """
 

--- a/build.py
+++ b/build.py
@@ -1319,7 +1319,7 @@ RUN apt-get update && \
     if "tensorrtllm" in backends:
         be = "tensorrtllm"
         # FIXME: Update the url
-        url = "https://gitlab-master.nvidia.com/krish/tensorrtllm_backend/-/raw/{}/tools/gen_trtllm_dockerfile.py".format(
+        url = "https://gitlab-master.nvidia.com/krish/tekit_backend/-/raw/{}/tools/gen_trtllm_dockerfile.py".format(
             backends[be]
         )
 
@@ -1821,7 +1821,7 @@ def backend_build(
     # FIXME: Use GitHub repo
     if be == "tensorrtllm":
         cmake_script.gitclone(
-            backend_repo(be), tag, be, "https://gitlab-master.nvidia.com/krish"
+            backend_repo("tekit"), tag, be, "https://gitlab-master.nvidia.com/krish"
         )
     else:
         cmake_script.gitclone(backend_repo(be), tag, be, github_organization)

--- a/build.py
+++ b/build.py
@@ -78,8 +78,6 @@ TRITON_VERSION_MAP = {
         "2023.0.0",  # Standalone OpenVINO
         "2.4.7",  # DCGM version
         "py310_23.1.0-1",  # Conda version
-        "9.1.0.3",  # TRT version for building TRT-LLM backend
-        "12.2",  # CUDA version for building TRT-LLM backend
         "0.2.0",  # vLLM version
     )
 }
@@ -1331,7 +1329,11 @@ RUN git clone --single-branch --depth=1 -b {} https://{}:{}@gitlab-master.nvidia
 RUN cd tensorrtllm_backend && git submodule update --init --recursive
 RUN cp tensorrtllm_backend/tensorrt_llm/docker/common/install_tensorrt.sh /tmp/
 RUN rm -fr tensorrtllm_backend
-    """.format(backends[be], os.environ["REMOVE_ME_TRTLLM_USERNAME"], os.environ["REMOVE_ME_TRTLLM_TOKEN"])
+    """.format(
+            backends[be],
+            os.environ["REMOVE_ME_TRTLLM_USERNAME"],
+            os.environ["REMOVE_ME_TRTLLM_TOKEN"],
+        )
 
         df += """
 RUN bash /tmp/install_tensorrt.sh && rm /tmp/install_tensorrt.sh
@@ -1359,7 +1361,7 @@ ENV LD_LIBRARY_PATH=/usr/local/tensorrt/lib/:/opt/tritonserver/backends/tensorrt
 # vLLM needed for vLLM backend
 RUN pip3 install vllm=={}
 """.format(
-            TRITON_VERSION_MAP[FLAGS.version][9]
+            TRITON_VERSION_MAP[FLAGS.version][7]
         )
 
     df += """
@@ -1819,11 +1821,14 @@ def tensorrtllm_prebuild(cmake_script):
     # FIXME: Update the file structure to the one Triton expects. This is a temporary fix
     # to get the build working for r23.10.
     cmake_script.cmd("cd tensorrtllm_backend")
-    cmake_script.cmd("patch inflight_batcher_llm/CMakeLists.txt  < inflight_batcher_llm/CMakeLists.txt.patch")
+    cmake_script.cmd(
+        "patch inflight_batcher_llm/CMakeLists.txt  < inflight_batcher_llm/CMakeLists.txt.patch"
+    )
     cmake_script.cmd("mv inflight_batcher_llm/src .")
     cmake_script.cmd("mv inflight_batcher_llm/cmake .")
     cmake_script.cmd("mv inflight_batcher_llm/CMakeLists.txt .")
     cmake_script.cmd("cd ..")
+
 
 def backend_build(
     be,
@@ -1850,7 +1855,13 @@ def backend_build(
         # cmake_script.gitclone(
         #     backend_repo("tekit"), tag, be, "https://gitlab-master.nvidia.com/ftp"
         # )
-        cmake_script.cmd("git clone --single-branch --depth=1 -b {} https://{}:{}@gitlab-master.nvidia.com/ftp/tekit_backend.git tensorrtllm_backend".format(tag, os.environ["REMOVE_ME_TRTLLM_USERNAME"], os.environ["REMOVE_ME_TRTLLM_TOKEN"]))
+        cmake_script.cmd(
+            "git clone --single-branch --depth=1 -b {} https://{}:{}@gitlab-master.nvidia.com/ftp/tekit_backend.git tensorrtllm_backend".format(
+                tag,
+                os.environ["REMOVE_ME_TRTLLM_USERNAME"],
+                os.environ["REMOVE_ME_TRTLLM_TOKEN"],
+            )
+        )
     else:
         cmake_script.gitclone(backend_repo(be), tag, be, github_organization)
 

--- a/build.py
+++ b/build.py
@@ -1323,6 +1323,10 @@ RUN apt-get update && \
         df += """
 WORKDIR /workspace
 
+# Remove previous TRT installation
+RUN apt-get remove --purge -y tensorrt* libnvinfer*
+RUN pip uninstall -y tensorrt
+
 # Install new version of TRT using the script from TRT-LLM
 RUN apt-get update && apt-get install -y --no-install-recommends python-is-python3
 RUN git clone --single-branch --depth=1 -b {} https://{}:{}@gitlab-master.nvidia.com/ftp/tekit_backend.git tensorrtllm_backend

--- a/build.py
+++ b/build.py
@@ -1319,11 +1319,9 @@ RUN apt-get update && \
     if "tensorrtllm" in backends:
         be = "tensorrtllm"
         # FIXME: Update the url
-        # url = "https://gitlab-master.nvidia.com/krish/tekit_backend/-/raw/{}/tools/gen_trtllm_dockerfile.py".format(
-        #     backends[be]
-        # )
-        print("trtllm tag:", backends[be])
-        url = "https://gitlab-master.nvidia.com/krish/tensorrtllm_backend/-/raw/main/tools/gen_trtllm_dockerfile.py"
+        url = "https://gitlab-master.nvidia.com/krish/tekit_backend/-/raw/{}/tools/gen_trtllm_dockerfile.py".format(
+            backends[be]
+        )
 
         response = requests.get(url)
         spec = importlib.util.spec_from_loader(
@@ -1797,6 +1795,11 @@ def core_build(
 def tensorrtllm_prebuild(cmake_script):
     # Export the TRT_ROOT environment variable
     cmake_script.cmd("export TRT_ROOT=/usr/local/tensorrt")
+    cmake_script.cmd("export ARCH=$(uname -m)")
+
+    # FIXME: Update the file structure to the one Triton expects. This is a temporary fix
+    # to get the build working for r23.10.
+    # patch inflight_batcher_llm/CMakeLists.txt  < inflight_batcher_llm/CMakeLists.txt.patch
     cmake_script.cmd("export ARCH=$(uname -m)")
 
 

--- a/build.py
+++ b/build.py
@@ -1319,9 +1319,11 @@ RUN apt-get update && \
     if "tensorrtllm" in backends:
         be = "tensorrtllm"
         # FIXME: Update the url
-        url = "https://gitlab-master.nvidia.com/krish/tekit_backend/-/raw/{}/tools/gen_trtllm_dockerfile.py".format(
-            backends[be]
-        )
+        # url = "https://gitlab-master.nvidia.com/krish/tekit_backend/-/raw/{}/tools/gen_trtllm_dockerfile.py".format(
+        #     backends[be]
+        # )
+        print("trtllm tag:", backends[be])
+        url = "https://gitlab-master.nvidia.com/krish/tekit_backend/-/raw/krish-triton-changes/tools/gen_trtllm_dockerfile.py"
 
         response = requests.get(url)
         spec = importlib.util.spec_from_loader(

--- a/build.py
+++ b/build.py
@@ -1818,9 +1818,10 @@ def tensorrtllm_prebuild(cmake_script):
 
     # FIXME: Update the file structure to the one Triton expects. This is a temporary fix
     # to get the build working for r23.10.
-    cmake_script.cmd(
-        "patch tensorrtllm/inflight_batcher_llm/CMakeLists.txt  < tensorrtllm/inflight_batcher_llm/CMakeLists.txt.patch"
-    )
+    # Uncomment the patch once moving to the GitHub repo
+    # cmake_script.cmd(
+    #     "patch tensorrtllm/inflight_batcher_llm/CMakeLists.txt  < tensorrtllm/inflight_batcher_llm/CMakeLists.txt.patch"
+    # )
     cmake_script.cmd("mv tensorrtllm/inflight_batcher_llm/src tensorrtllm")
     cmake_script.cmd("mv tensorrtllm/inflight_batcher_llm/cmake tensorrtllm")
     cmake_script.cmd("mv tensorrtllm/inflight_batcher_llm/CMakeLists.txt tensorrtllm")

--- a/build.py
+++ b/build.py
@@ -1526,8 +1526,6 @@ def create_build_dockerfiles(
         if FLAGS.version is None or FLAGS.version not in TRITON_VERSION_MAP
         else TRITON_VERSION_MAP[FLAGS.version][6],
     }
-    dockerfileargmap["TRT_LLM_TRT_VERSION"] = TRITON_VERSION_MAP[FLAGS.version][7]
-    dockerfileargmap["TRT_LLM_CUDA_VERSION"] = TRITON_VERSION_MAP[FLAGS.version][8]
 
     # For CPU-only image we need to copy some cuda libraries and dependencies
     # since we are using PyTorch and TensorFlow containers that

--- a/build.py
+++ b/build.py
@@ -1323,7 +1323,7 @@ RUN apt-get update && \
         #     backends[be]
         # )
         print("trtllm tag:", backends[be])
-        url = "https://gitlab-master.nvidia.com/krish/tekit_backend/-/raw/krish-triton-changes/tools/gen_trtllm_dockerfile.py"
+        url = "https://gitlab-master.nvidia.com/krish/tensorrtllm_backend/-/raw/main/tools/gen_trtllm_dockerfile.py"
 
         response = requests.get(url)
         spec = importlib.util.spec_from_loader(

--- a/build.py
+++ b/build.py
@@ -1818,14 +1818,12 @@ def tensorrtllm_prebuild(cmake_script):
 
     # FIXME: Update the file structure to the one Triton expects. This is a temporary fix
     # to get the build working for r23.10.
-    cmake_script.cmd("cd tensorrtllm_backend")
     cmake_script.cmd(
-        "patch inflight_batcher_llm/CMakeLists.txt  < inflight_batcher_llm/CMakeLists.txt.patch"
+        "patch tensorrtllm/inflight_batcher_llm/CMakeLists.txt  < tensorrtllm/inflight_batcher_llm/CMakeLists.txt.patch"
     )
-    cmake_script.cmd("mv inflight_batcher_llm/src .")
-    cmake_script.cmd("mv inflight_batcher_llm/cmake .")
-    cmake_script.cmd("mv inflight_batcher_llm/CMakeLists.txt .")
-    cmake_script.cmd("cd ..")
+    cmake_script.cmd("mv tensorrtllm/inflight_batcher_llm/src tensorrtllm")
+    cmake_script.cmd("mv tensorrtllm/inflight_batcher_llm/cmake tensorrtllm")
+    cmake_script.cmd("mv tensorrtllm/inflight_batcher_llm/CMakeLists.txt tensorrtllm")
 
 
 def backend_build(
@@ -1854,7 +1852,7 @@ def backend_build(
         #     backend_repo("tekit"), tag, be, "https://gitlab-master.nvidia.com/ftp"
         # )
         cmake_script.cmd(
-            "git clone --single-branch --depth=1 -b {} https://{}:{}@gitlab-master.nvidia.com/ftp/tekit_backend.git tensorrtllm_backend".format(
+            "git clone --single-branch --depth=1 -b {} https://{}:{}@gitlab-master.nvidia.com/ftp/tekit_backend.git tensorrtllm".format(
                 tag,
                 os.environ["REMOVE_ME_TRTLLM_USERNAME"],
                 os.environ["REMOVE_ME_TRTLLM_TOKEN"],


### PR DESCRIPTION
For 23.10, we won't bring any changes to the structure of TRT-LLM backend. This PR fixes some path issues so that Triton can build using CMake. Also adding some temporary workaround to solve the repo permission issues. We will update those once the GitHub repo is ready.