### PR TITLE
Fix notify state destruction and inflight states tracking

### DIFF
--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -973,6 +973,8 @@ ModelInferHandler::InferResponseComplete(
     return;
   }
 
+  state->context_->EraseInflightState(state);
+
 #ifdef TRITON_ENABLE_TRACING
   state->trace_timestamps_.emplace_back(std::make_pair(
       "INFER_RESPONSE_COMPLETE", TraceManager::CaptureTimestamp()));
@@ -987,7 +989,6 @@ ModelInferHandler::InferResponseComplete(
         "deleting GRPC inference response");
 
     state->step_ = Steps::CANCELLED;
-    state->context_->EraseInflightState(state);
 
     LOG_VERBOSE(1) << "ModelInferHandler::InferResponseComplete, "
                    << state->unique_id_

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -673,8 +673,12 @@ class InferHandlerState {
       all_states_.insert(state);
     }
 
-    // Adds the state object created on this context
-    void EraseState(InferHandlerStateType* state) { all_states_.erase(state); }
+    // Erases the state object created on this context
+    void EraseState(InferHandlerStateType* state)
+    {
+      EraseInflightState(state);
+      all_states_.erase(state);
+    }
 
     bool HandleCompletion()
     {

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -987,7 +987,7 @@ class InferHandlerState {
     std::atomic<bool> ongoing_write_;
 
     // The state object that is sent to grpc async notification
-    // for tracking the gRPC stream associated wth
+    // for tracking the gRPC stream.
     InferHandlerState* notify_state_;
 
     // Tracks whether the async notification has been delivered by

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -578,7 +578,10 @@ ModelStreamInferHandler::StreamInferResponseComplete(
 
   // If receiving the final callback then erase the state from the inflight
   // state data structure to prevent cancellation being called on the request.
-  if (state->complete_) {
+  // Also make sure that if this state was sent to gRPC async notification
+  // mechanism then the state is not removed as it would be needed for handling
+  // the cancellation if detected.
+  if (state->complete_ && (!state->IsAsyncNotifyState())) {
     state->context_->EraseInflightState(state);
   }
 


### PR DESCRIPTION
For the cases where gRPC doesn't deliver notification, we have moved the notify_state_ ~delete to the context  destructor~ to the unique_ptr.
This should fix the valgrind failures on CI.

Fixing the tracking of inflight states to erase the states as and when they complete or run into an error. This should fix the L0_perf_analyzer under heavy streaming load case.
