### PR TITLE
Add test for Python BLS parameters

### DIFF
--- a/qa/L0_backend_python/bls/bls_parameters_test.py
+++ b/qa/L0_backend_python/bls/bls_parameters_test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import unittest
+
+import numpy as np
+import tritonclient.grpc as grpcclient
+from tritonclient.utils import np_to_triton_dtype
+
+
+class TestBlsParameters(unittest.TestCase):
+    def test_bls_parameters(self):
+        model_name = "bls_parameters"
+        shape = [1]
+        num_params = 3
+
+        # Based on the num_params specified, the model will generate a JSON response
+        # containing all the supported parameter types for num_params times recursively.
+        # Make sure the model has at least num_params + 1 instances.
+        expected_params = {}
+        for i in range(1, num_params + 1):
+            expected_params["bool_" + str(i)] = bool(i)
+            expected_params["int_" + str(i)] = i
+            expected_params["str_" + str(i)] = str(i)
+
+        with grpcclient.InferenceServerClient("localhost:8001") as client:
+            input_data = np.array([num_params], dtype=np.ubyte)
+            inputs = [
+                grpcclient.InferInput(
+                    "NUMBER_PARAMETERS", shape, np_to_triton_dtype(input_data.dtype)
+                )
+            ]
+            inputs[0].set_data_from_numpy(input_data)
+            outputs = [grpcclient.InferRequestedOutput("PARAMETERS_AGGREGATED")]
+            result = client.infer(model_name, inputs, outputs=outputs)
+            params_json = str(
+                result.as_numpy("PARAMETERS_AGGREGATED")[0], encoding="utf-8"
+            )
+
+        params = json.loads(params_json)
+        self.assertEqual(params, expected_params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qa/L0_backend_python/bls/test.sh
+++ b/qa/L0_backend_python/bls/test.sh
@@ -365,6 +365,34 @@ if [ $SUB_TEST_RET -eq 1 ]; then
     cat $SERVER_LOG
 fi
 
+# Test BLS parameters
+rm -rf params_models && mkdir -p params_models/bls_parameters/1
+cp ../../python_models/bls_parameters/model.py ./params_models/bls_parameters/1
+cp ../../python_models/bls_parameters/config.pbtxt ./params_models/bls_parameters
+
+TEST_LOG="./bls_parameters.log"
+SERVER_LOG="./bls_parameters.server.log"
+
+SERVER_ARGS="--model-repository=`pwd`/params_models --backend-directory=${BACKEND_DIR} --log-verbose=1"
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+set +e
+python3 bls_parameters_test.py > $TEST_LOG 2>&1
+if [ $? -ne 0 ]; then
+    echo -e "\n***\n*** bls_parameters_test.py FAILED. \n***"
+    cat $TEST_LOG
+    RET=1
+fi
+set -e
+
+kill $SERVER_PID
+wait $SERVER_PID
+
 if [ $RET -eq 1 ]; then
     echo -e "\n***\n*** BLS test FAILED. \n***"
 else

--- a/qa/python_models/bls_parameters/config.pbtxt
+++ b/qa/python_models/bls_parameters/config.pbtxt
@@ -1,0 +1,52 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "bls_parameters"
+backend: "python"
+max_batch_size: 0
+
+input [
+  {
+    name: "NUMBER_PARAMETERS"
+    data_type: TYPE_UINT8
+    dims: [ 1 ]
+  }
+]
+
+output [
+  {
+    name: "PARAMETERS_AGGREGATED"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
+  }
+]
+
+instance_group [
+  {
+    count: 4
+    kind: KIND_CPU
+  }
+]

--- a/qa/python_models/bls_parameters/model.py
+++ b/qa/python_models/bls_parameters/model.py
@@ -1,0 +1,77 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+
+class TritonPythonModel:
+    def execute(self, requests):
+        responses = []
+
+        for request in requests:
+            num_params = int(
+                pb_utils.get_input_tensor_by_name(
+                    request, "NUMBER_PARAMETERS"
+                ).as_numpy()[0]
+            )
+            params = json.loads(request.parameters())
+
+            if num_params == 0:
+                # Base case where the received parameters are returned as JSON
+                response = json.dumps(params)
+                response_tensors = [
+                    pb_utils.Tensor(
+                        "PARAMETERS_AGGREGATED", np.array([response], dtype=np.object_)
+                    )
+                ]
+            else:
+                # Add the parameters of num_params step to the received parameters
+                params["bool_" + str(num_params)] = bool(num_params)
+                params["int_" + str(num_params)] = num_params
+                params["str_" + str(num_params)] = str(num_params)
+                # Complete any remaining steps [1, num_params - 1] by calling self
+                # recursively via BLS
+                bls_request_tensor = pb_utils.Tensor(
+                    "NUMBER_PARAMETERS", np.array([num_params - 1], dtype=np.ubyte)
+                )
+                bls_request = pb_utils.InferenceRequest(
+                    model_name="bls_parameters",
+                    inputs=[bls_request_tensor],
+                    requested_output_names=["PARAMETERS_AGGREGATED"],
+                    parameters=params,
+                )
+                bls_response = bls_request.exec()
+                response_tensors = bls_response.output_tensors()
+
+            inference_response = pb_utils.InferenceResponse(
+                output_tensors=response_tensors
+            )
+            responses.append(inference_response)
+
+        return responses


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/python_backend/pull/313

Add a new test on BLS parameters. The model call itself recursively via BLS to completes the requested number of parameters. Each recursive level only completes the parameters, on 3 different supported data type `str` `int` `bool`, of its level. For example, at the initial `num_params = 3`, the parameters is changed from `{}` to
```
"bool_3": True, "int_3": 3, "str_3": "3"
```
Then, the remaining as completed by calling itself recursively with `num_params - 1`.
At `num_params = 2`, the parameters become
```
"bool_3": True, "int_3": 3, "str_3": "3",
"bool_2": True, "int_2": 2, "str_2": "2"
```
At `num_params = 1`, the parameters become
```
"bool_3": True, "int_3": 3, "str_3": "3",
"bool_2": True, "int_2": 2, "str_2": "2",
"bool_1": True, "int_1": 1, "str_1": "1"
```
At `num_params = 0`, it is the base case where no new parameters are added, so the received parameters are converted into its JSON representation and returned, which completes the recursive BLS call.