### PR TITLE
Remove sub directory artifacts collection from test script

### DIFF
--- a/qa/L0_backend_python/argument_validation/test.sh
+++ b/qa/L0_backend_python/argument_validation/test.sh
@@ -75,6 +75,4 @@ else
     echo -e "\n***\n*** Argument validation test PASSED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/bls/test.sh
+++ b/qa/L0_backend_python/bls/test.sh
@@ -411,6 +411,4 @@ else
     echo -e "\n***\n*** BLS test PASSED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/custom_metrics/test.sh
+++ b/qa/L0_backend_python/custom_metrics/test.sh
@@ -82,6 +82,4 @@ else
     echo -e "\n***\n*** Custom Metrics test PASSED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/decoupled/test.sh
+++ b/qa/L0_backend_python/decoupled/test.sh
@@ -123,6 +123,4 @@ else
     echo -e "\n***\n*** Decoupled test PASSED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/ensemble/test.sh
+++ b/qa/L0_backend_python/ensemble/test.sh
@@ -114,6 +114,4 @@ else
     echo -e "\n***\n*** Ensemble test PASSED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/env/test.sh
+++ b/qa/L0_backend_python/env/test.sh
@@ -315,6 +315,4 @@ else
   echo -e "\n***\n*** Env Manager Test FAILED.\n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/examples/test.sh
+++ b/qa/L0_backend_python/examples/test.sh
@@ -450,6 +450,4 @@ else
     echo -e "\n***\n*** Example verification test FAILED.\n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/io/test.sh
+++ b/qa/L0_backend_python/io/test.sh
@@ -172,6 +172,4 @@ else
     echo -e "\n***\n*** IO test FAILED.\n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/lifecycle/test.sh
+++ b/qa/L0_backend_python/lifecycle/test.sh
@@ -213,6 +213,4 @@ else
     echo -e "\n***\n*** Lifecycle test PASSED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/logging/test.sh
+++ b/qa/L0_backend_python/logging/test.sh
@@ -228,6 +228,4 @@ else
     echo -e "\n***\n*** Logging test FAILED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/model_control/test.sh
+++ b/qa/L0_backend_python/model_control/test.sh
@@ -78,6 +78,4 @@ else
     echo -e "\n***\n*** model_control_test PASSED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/L0_backend_python/restart/test.sh
+++ b/qa/L0_backend_python/restart/test.sh
@@ -126,6 +126,4 @@ else
     echo -e "\n***\n*** Restart test PASSED. \n***"
 fi
 
-collect_artifacts_from_subdir
-
 exit $RET

--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -468,12 +468,6 @@ function kill_servers () {
     done
 }
 
-# Collect all logs and core dumps and copy them to an upper-level directory for
-# proper capture on the CI.
-function collect_artifacts_from_subdir () {
-    cp *.*log* core* ../ || true
-}
-
 # Sort an array
 # Call with sort_array <array_name>
 # Example: sort_array array


### PR DESCRIPTION
The test script will exit directly if segfault happens outside the `set +e` scope, hence the function for collecting artifacts will not be called. Move the artifacts collection in the sub directories to the GitLab yaml file so that when coredump happens during the test, the logs/coredumps will still be collected.