### PR TITLE
Downgrade vcpkg version to WAR RE2 library inconsistency

### DIFF
--- a/Dockerfile.win10.min
+++ b/Dockerfile.win10.min
@@ -92,7 +92,7 @@ WORKDIR /
 #
 # Installing Vcpkg
 #
-ARG VCPGK_VERSION=2023.07.21
+ARG VCPGK_VERSION=2022.11.14
 RUN git clone --single-branch --depth=1 -b %VCPGK_VERSION% https://github.com/microsoft/vcpkg.git
 WORKDIR /vcpkg
 RUN bootstrap-vcpkg.bat


### PR DESCRIPTION
Windows build with newer vcpkg results in HTTP server not properly parse URL with regex (provided by RE2), combining with the segfault from GRPC server suggests that a different version of the library is dynamically linked. GRPC itself brings an older version of RE2 and builds against that, while HTTP server links a newer RE2 shared library installed by vcpkg.

This PR is WAR to use a different but compatible library at runtime, the long-term fix is to isolate the dependency between HTTP and GRPC so they may use different version of the library.  