### PR TITLE
Fixing L0_io

### DIFF
--- a/qa/L0_io/test.sh
+++ b/qa/L0_io/test.sh
@@ -67,9 +67,7 @@ for trial in graphdef savedmodel onnx libtorch plan python python_dlpack; do
             cp ../python_models/add_sub/model.py $MODELSDIR/${full}/1/. && \
             cp ../python_models/add_sub/config.pbtxt $MODELSDIR/${full}/. && \
             (cd $MODELSDIR/${full} && \
-                    sed -i "s/label_filename:.*//" config.pbtxt && \
-                    sed -i "0,/name:.*/{s/name:.*/name: \"${full}\"/}" config.pbtxt && \
-                                        echo "max_batch_size: 64" >> config.pbtxt)
+                    sed -i "s/label_filename:.*//" config.pbtxt)
 
         # ensemble version of the model.
         mkdir -p $MODELSDIR/fan_${full}/1 && \


### PR DESCRIPTION
Recent PR removed `name` from `add_sub` config file, so this line was changing `INPUT0` name, and not model's name, Thus L0_io was failing 