### PR TITLE
Parse reuse-grpc-port and reuse-http-port as booleans

### DIFF
--- a/qa/L0_socket/test.sh
+++ b/qa/L0_socket/test.sh
@@ -310,12 +310,12 @@ SERVER2_LOG="./inference_server2.log"
 for p in http grpc; do
     # error if servers bind to the same http/grpc port without setting the reuse flag
     if [ "$p" == "http" ]; then
-        SERVER_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-grpc-port=1"
-        SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8003 --reuse-grpc-port=1"
+        SERVER_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-grpc-port=true"
+        SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8003 --reuse-grpc-port=true"
         SERVER1_ARGS="--model-repository=$DATADIR --metrics-port 8004 --reuse-grpc-port=true"
     else
-        SERVER_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=1"
-        SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8003 --reuse-http-port=1"
+        SERVER_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=true"
+        SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8003 --reuse-http-port=true"
         SERVER1_ARGS="--model-repository=$DATADIR --metrics-port 8004 --reuse-http-port=true"
     fi
     # make sure the first server is launched successfully, then run the other

--- a/qa/L0_socket/test.sh
+++ b/qa/L0_socket/test.sh
@@ -359,7 +359,7 @@ for p in http grpc; do
     #   (c) Test setting metrics-address explicitly to 127.0.0.1
     SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=true --reuse-grpc-port=true"
     SERVER1_ARGS="--model-repository=$DATADIR --metrics-address 0.0.0.0 --metrics-port 8003 --reuse-http-port=true --reuse-grpc-port=true"
-    SERVER2_ARGS="--model-repository=$DATADIR --metrics-address 127.0.0.2 --metrics-port 8004 --reuse-http-port=1 --reuse-grpc-port=true"
+    SERVER2_ARGS="--model-repository=$DATADIR --metrics-address 127.0.0.2 --metrics-port 8004 --reuse-http-port=true --reuse-grpc-port=true"
     run_multiple_servers_nowait 3
     sleep 15
     if [ "$SERVER0_PID" == "0" ]; then

--- a/qa/L0_socket/test.sh
+++ b/qa/L0_socket/test.sh
@@ -357,9 +357,9 @@ for p in http grpc; do
     #   (a) Test default metrics-address being same as http-address
     #   (b) Test setting metrics-address explicitly to 0.0.0.0
     #   (c) Test setting metrics-address explicitly to 127.0.0.1
-    SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=1 --reuse-grpc-port=1"
-    SERVER1_ARGS="--model-repository=$DATADIR --metrics-address 0.0.0.0 --metrics-port 8003 --reuse-http-port=1 --reuse-grpc-port=1"
-    SERVER2_ARGS="--model-repository=$DATADIR --metrics-address 127.0.0.2 --metrics-port 8004 --reuse-http-port=1 --reuse-grpc-port=1"
+    SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=true --reuse-grpc-port=true"
+    SERVER1_ARGS="--model-repository=$DATADIR --metrics-address 0.0.0.0 --metrics-port 8003 --reuse-http-port=1 --reuse-grpc-port=true"
+    SERVER2_ARGS="--model-repository=$DATADIR --metrics-address 127.0.0.2 --metrics-port 8004 --reuse-http-port=1 --reuse-grpc-port=true"
     run_multiple_servers_nowait 3
     sleep 15
     if [ "$SERVER0_PID" == "0" ]; then

--- a/qa/L0_socket/test.sh
+++ b/qa/L0_socket/test.sh
@@ -312,11 +312,11 @@ for p in http grpc; do
     if [ "$p" == "http" ]; then
         SERVER_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-grpc-port=1"
         SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8003 --reuse-grpc-port=1"
-        SERVER1_ARGS="--model-repository=$DATADIR --metrics-port 8004 --reuse-grpc-port=1"
+        SERVER1_ARGS="--model-repository=$DATADIR --metrics-port 8004 --reuse-grpc-port=true"
     else
         SERVER_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=1"
         SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8003 --reuse-http-port=1"
-        SERVER1_ARGS="--model-repository=$DATADIR --metrics-port 8004 --reuse-http-port=1"
+        SERVER1_ARGS="--model-repository=$DATADIR --metrics-port 8004 --reuse-http-port=true"
     fi
     # make sure the first server is launched successfully, then run the other
     # two servers and expect them to fail

--- a/qa/L0_socket/test.sh
+++ b/qa/L0_socket/test.sh
@@ -358,7 +358,7 @@ for p in http grpc; do
     #   (b) Test setting metrics-address explicitly to 0.0.0.0
     #   (c) Test setting metrics-address explicitly to 127.0.0.1
     SERVER0_ARGS="--model-repository=$DATADIR --metrics-port 8002 --reuse-http-port=true --reuse-grpc-port=true"
-    SERVER1_ARGS="--model-repository=$DATADIR --metrics-address 0.0.0.0 --metrics-port 8003 --reuse-http-port=1 --reuse-grpc-port=true"
+    SERVER1_ARGS="--model-repository=$DATADIR --metrics-address 0.0.0.0 --metrics-port 8003 --reuse-http-port=true --reuse-grpc-port=true"
     SERVER2_ARGS="--model-repository=$DATADIR --metrics-address 127.0.0.2 --metrics-port 8004 --reuse-http-port=1 --reuse-grpc-port=true"
     run_multiple_servers_nowait 3
     sleep 15

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -1330,7 +1330,7 @@ TritonParser::Parse(int argc, char** argv)
           lgrpc_options.socket_.port_ = ParseOption<int>(optarg);
           break;
         case OPTION_REUSE_GRPC_PORT:
-          lgrpc_options.socket_.reuse_port_ = ParseOption<int>(optarg);
+          lgrpc_options.socket_.reuse_port_ = ParseOption<bool>(optarg);
           break;
         case OPTION_GRPC_ADDRESS:
           lgrpc_options.socket_.address_ = optarg;

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -1276,7 +1276,7 @@ TritonParser::Parse(int argc, char** argv)
           lparams.http_port_ = ParseOption<int>(optarg);
           break;
         case OPTION_REUSE_HTTP_PORT:
-          lparams.reuse_http_port_ = ParseOption<int>(optarg);
+          lparams.reuse_http_port_ = ParseOption<bool>(optarg);
           break;
         case OPTION_HTTP_ADDRESS:
           lparams.http_address_ = optarg;


### PR DESCRIPTION
The reuse-grpc-port and reuse-http-port flags are documented in the options as booleans but parsed as integers. This PR makes it so they are parsed as booleans.

Addresses [6481](https://github.com/triton-inference-server/server/issues/6481).