### PR TITLE
install wget in Docker building

### DIFF
--- a/build.py
+++ b/build.py
@@ -998,7 +998,6 @@ RUN apt-get update \
 # scons is needed for armnn_tflite backend build dep
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-            wget \
             ca-certificates \
             autoconf \
             automake \
@@ -1246,6 +1245,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
             software-properties-common \
+            wget \
             libb64-0d \
             libcurl4-openssl-dev \
             libre2-9 \

--- a/build.py
+++ b/build.py
@@ -998,6 +998,7 @@ RUN apt-get update \
 # scons is needed for armnn_tflite backend build dep
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+            wget \
             ca-certificates \
             autoconf \
             automake \


### PR DESCRIPTION
When running `build.py` it seems that `wget` is not installed and fails to download `boost`