### PR TITLE
adding wget package

### DIFF
--- a/build.py
+++ b/build.py
@@ -1254,12 +1254,14 @@ RUN apt-get update && \
             libgoogle-perftools-dev \
             libnuma-dev \
             curl \
+            wget \
             libjemalloc-dev \
             {backend_dependencies} && \
     rm -rf /var/lib/apt/lists/*
 
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
+
 RUN wget -O /tmp/boost.tar.gz \
         https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz && \
     (cd /tmp && tar xzf boost.tar.gz) && \


### PR DESCRIPTION
wget is missing in the base image

 > [ 4/14] RUN wget -O /tmp/boost.tar.gz         https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz &&     (cd /tmp && tar xzf boost.tar.gz) &&     cd /tmp/boost_1_80_0 && ./bootstrap.sh --prefix=/usr && ./b2 install &&     rm -rf /tmp/boost*:
#0 0.299 /bin/sh: 1: wget: not found