### PR TITLE
Fix Dockerfile syntax error in `build.py`

### DIFF
--- a/build.py
+++ b/build.py
@@ -1024,7 +1024,6 @@ RUN apt-get update && \
             libarchive-dev \
             libxml2-dev \
             libnuma-dev && \
-            wget \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --upgrade pip && \


### PR DESCRIPTION
Corrected string concatenation in build.py to resolve a malformed RUN command in Dockerfile.buildbase, which improperly combined 'wget' and 'rm -rf /var/lib/apt/lists/*'.