### PR TITLE
changing references to concrete instances

### DIFF
--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -298,7 +298,7 @@ class CommonHandler : public HandlerBase {
   ::grpc::health::v1::Health::AsyncService* health_service_;
   ::grpc::ServerCompletionQueue* cq_;
   std::unique_ptr<std::thread> thread_;
-  const RestrictedFeatures& restricted_keys_;
+  RestrictedFeatures restricted_keys_{};
 };
 
 CommonHandler::CommonHandler(

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -362,6 +362,15 @@ class HTTPAPIServer : public HTTPServer {
       const int32_t port, const bool reuse_port, const std::string& address,
       const std::string& header_forward_pattern, const int thread_cnt,
       const RestrictedFeatures& restricted_apis);
+  explicit HTTPAPIServer(
+      const std::shared_ptr<TRITONSERVER_Server>& server,
+      triton::server::TraceManager* trace_manager,
+      const std::shared_ptr<SharedMemoryManager>& shm_manager,
+      const int32_t port, const bool reuse_port, const std::string& address,
+      const std::string& header_forward_pattern, const int thread_cnt)
+      : HTTPAPIServer(
+            server, trace_manager, shm_manager, port, reuse_port, address,
+            header_forward_pattern, thread_cnt, RestrictedFeatures()){};
   virtual void Handle(evhtp_request_t* req) override;
   // [FIXME] extract to "infer" class
   virtual std::unique_ptr<InferRequestClass> CreateInferRequest(
@@ -546,7 +555,7 @@ class HTTPAPIServer : public HTTPServer {
         parameters_field,
         new MappingSchema(MappingSchema::Kind::MAPPING_SCHEMA, true));
   }
-  const RestrictedFeatures& restricted_apis_{};
+  RestrictedFeatures restricted_apis_{};
   bool RespondIfRestricted(
       evhtp_request_t* req, const Restriction& restriction);
 };

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -361,16 +361,8 @@ class HTTPAPIServer : public HTTPServer {
       const std::shared_ptr<SharedMemoryManager>& shm_manager,
       const int32_t port, const bool reuse_port, const std::string& address,
       const std::string& header_forward_pattern, const int thread_cnt,
-      const RestrictedFeatures& restricted_apis);
-  explicit HTTPAPIServer(
-      const std::shared_ptr<TRITONSERVER_Server>& server,
-      triton::server::TraceManager* trace_manager,
-      const std::shared_ptr<SharedMemoryManager>& shm_manager,
-      const int32_t port, const bool reuse_port, const std::string& address,
-      const std::string& header_forward_pattern, const int thread_cnt)
-      : HTTPAPIServer(
-            server, trace_manager, shm_manager, port, reuse_port, address,
-            header_forward_pattern, thread_cnt, RestrictedFeatures()){};
+      const RestrictedFeatures& restricted_apis = {});
+
   virtual void Handle(evhtp_request_t* req) override;
   // [FIXME] extract to "infer" class
   virtual std::unique_ptr<InferRequestClass> CreateInferRequest(

--- a/src/sagemaker_server.h
+++ b/src/sagemaker_server.h
@@ -72,8 +72,7 @@ class SagemakerAPIServer : public HTTPAPIServer {
       const int32_t port, const std::string address, const int thread_cnt)
       : HTTPAPIServer(
             server, trace_manager, shm_manager, port, false /* reuse_port */,
-            address, "" /* header_forward_pattern */, thread_cnt,
-            RestrictedFeatures()),
+            address, "" /* header_forward_pattern */, thread_cnt),
         ping_regex_(R"(/ping)"), invocations_regex_(R"(/invocations)"),
         models_regex_(R"(/models(?:/)?([^/]+)?(/invoke)?)"),
         model_path_regex_(

--- a/src/vertex_ai_server.cc
+++ b/src/vertex_ai_server.cc
@@ -45,8 +45,7 @@ VertexAiAPIServer::VertexAiAPIServer(
     const std::string& default_model_name)
     : HTTPAPIServer(
           server, trace_manager, shm_manager, port, false /* reuse_port */,
-          address, "" /* header_forward_pattern */, thread_cnt,
-          RestrictedFeatures()),
+          address, "" /* header_forward_pattern */, thread_cnt),
       prediction_regex_(prediction_route), health_regex_(health_route),
       health_mode_("ready"), model_name_(default_model_name),
       model_version_str_("")


### PR DESCRIPTION
Underlying issue was the storage of a reference to the RestrictedFeatures object. In general this can be done as long as the lifetime of the object is known to be longer than the holder (similar to a pointer). However in this case for vertex and sagemaker a reference to a temporary was being stored. In http / grpc cases the reference was to an object with longer lifetime and so no issue was present.

Changed to copy the value and store it as this initialization only happens once. 