### PR TITLE
Fix L0_sagemaker

### DIFF
--- a/qa/L0_sagemaker/test.sh
+++ b/qa/L0_sagemaker/test.sh
@@ -394,8 +394,7 @@ cp ../python_models/add_sub/model.py ${ENSEMBLE_MODEL_PATH}/${model_name}/1/. &&
 cp ../python_models/add_sub/config.pbtxt ${ENSEMBLE_MODEL_PATH}/${model_name}/.
 (cd ${ENSEMBLE_MODEL_PATH}/${model_name} && \
                     sed -i "s/label_filename:.*//" config.pbtxt && \
-                    sed -i "0,/name:.*/{s/name:.*/name: \"${model_name}\"/}" config.pbtxt && \
-                                        echo "max_batch_size: 64" >> config.pbtxt)
+                    echo "max_batch_size: 64" >> config.pbtxt)
 
 # Ensemble part
 mkdir -p ${ENSEMBLE_MODEL_PATH}/fan_${model_name}/1 && \
@@ -404,7 +403,6 @@ mkdir -p ${ENSEMBLE_MODEL_PATH}/fan_${model_name}/1 && \
             (cd ${ENSEMBLE_MODEL_PATH}/fan_${model_name} && \
                     sed -i "s/label_filename:.*//" config.pbtxt && \
                     sed -i "s/model_name: \"ENSEMBLE_MODEL_NAME\"/model_name: \"${model_name}\"/" config.pbtxt && \
-                    sed -i "0,/name:.*/{s/name:.*/name: \"fan_${model_name}\"/}" config.pbtxt && \
                     echo "max_batch_size: 64" >> config.pbtxt)
 
 # # custom float32 component of ensemble

--- a/qa/L0_sagemaker/test.sh
+++ b/qa/L0_sagemaker/test.sh
@@ -403,6 +403,7 @@ mkdir -p ${ENSEMBLE_MODEL_PATH}/fan_${model_name}/1 && \
             (cd ${ENSEMBLE_MODEL_PATH}/fan_${model_name} && \
                     sed -i "s/label_filename:.*//" config.pbtxt && \
                     sed -i "s/model_name: \"ENSEMBLE_MODEL_NAME\"/model_name: \"${model_name}\"/" config.pbtxt && \
+                    sed -i "0,/name:.*/{s/name:.*/name: \"fan_${model_name}\"/}" config.pbtxt && \
                     echo "max_batch_size: 64" >> config.pbtxt)
 
 # # custom float32 component of ensemble


### PR DESCRIPTION
I removed the model name field from add_sub in a different PR so we wouldn't have to keep sed'ing it everywhere, and then some leftover tests having seds with too generic of a regex are matching input names instead of model names now, and editing the input name. This test was another one impacted, similar to this PR: https://github.com/triton-inference-server/server/pull/6510

Just removed the unnecessary sed and test passes now.