### PR TITLE
Upgrade ORT version

### DIFF
--- a/build.py
+++ b/build.py
@@ -73,7 +73,7 @@ TRITON_VERSION_MAP = {
     "2.41.0dev": (
         "23.12dev",  # triton container
         "23.10",  # upstream container
-        "1.16.2",  # ORT
+        "1.16.3",  # ORT
         "2023.0.0",  # ORT OpenVINO
         "2023.0.0",  # Standalone OpenVINO
         "3.2.6",  # DCGM version


### PR DESCRIPTION
r23.11 is already using this patch release of ORT-TRT with memory leak fix.