### PR TITLE
Bumped vLLM version to v0.2.2

### DIFF
--- a/build.py
+++ b/build.py
@@ -78,7 +78,7 @@ TRITON_VERSION_MAP = {
         "2023.0.0",  # Standalone OpenVINO
         "3.2.6",  # DCGM version
         "py310_23.1.0-1",  # Conda version
-        "0.2.1.post1",  # vLLM version
+        "0.2.2",  # vLLM version
     )
 }
 


### PR DESCRIPTION
updated build.py to install current latest version of vLLM (v.0.2.2): https://github.com/vllm-project/vllm/releases