### PR TITLE
Omit registered_model_meta file when uploading to registry.

### DIFF
--- a/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
+++ b/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
@@ -338,7 +338,7 @@ class TritonPlugin(BaseDeploymentClient):
             # with proper model versions and version strategy, which may differ from
             # the versioning in MLFlow
             for file in artifact_path.iterdir():
-                if file.name not in ["MLmodel", "conda.yaml"]:
+                if file.name not in ["MLmodel", "conda.yaml", "registered_model_meta"]:
                     copy_paths["model_path"]["from"] = file
             copy_paths["model_path"]["to"] = triton_deployment_dir
         elif flavor == "onnx":

--- a/deploy/mlflow-triton-plugin/setup.py
+++ b/deploy/mlflow-triton-plugin/setup.py
@@ -29,7 +29,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="mlflow-triton",
-    version="0.2.0",
+    version="0.2.1",
     description="Triton Mlflow Deployment",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
It seems that MLFLow broke backwards compatibility with this plugin by introducing a new meta file to keep traceability of the models [#9402](https://github.com/mlflow/mlflow/commit/85037652d6caf4a78d8ac73ca734e433e86b1fd9). The file intent is good, but it's still less informative for our use case (it only contains name and version, although it might replace our `mlflow-meta.json` in the future). 