### PR TITLE
Mlflow Plugin Fix

### DIFF
--- a/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
+++ b/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
@@ -338,8 +338,9 @@ class TritonPlugin(BaseDeploymentClient):
             # with proper model versions and version strategy, which may differ from
             # the versioning in MLFlow
             for file in artifact_path.iterdir():
-                if file.name not in ["MLmodel", "conda.yaml", "registered_model_meta"]:
+                if file.is_dir():
                     copy_paths["model_path"]["from"] = file
+                    break
             copy_paths["model_path"]["to"] = triton_deployment_dir
         elif flavor == "onnx":
             # Look for model file via MLModel metadata or iterating dir

--- a/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
+++ b/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
@@ -338,7 +338,7 @@ class TritonPlugin(BaseDeploymentClient):
             # with proper model versions and version strategy, which may differ from
             # the versioning in MLFlow
             for file in artifact_path.iterdir():
-                if file.name not in ["MLmodel", "conda.yaml"]:
+                if file.name not in ["MLmodel", "conda.yaml", "registered_model_meta"]:
                     copy_paths["model_path"]["from"] = file
             copy_paths["model_path"]["to"] = triton_deployment_dir
         elif flavor == "onnx":


### PR DESCRIPTION
[This ](https://github.com/mlflow/mlflow/pull/9402/files) PR introduced a new YAML file to the artifact/triton directory called 'registered_model_meta'. Because our _get_copy_paths function in the mlflow_deploy folder overwrites the copy path per item in the folder, we end up copying this file to the model_repo instead of the model folder.

The contents of this new file were:
```
model_name: onnx_float32_int32_int32
model_version: '1'
```
Which is similar to the `mlflow-meta.json` already produced by our plugin which contains:
```
{
    "name": "onnx_float32_int32_int32",
    "triton_model_path": "models/onnx_float32_int32_int32",
    "mlflow_model_uri": "models:/onnx_float32_int32_int32/1",
    "flavor": "triton"
}
```
Due to the style of existing code, I simply appended the new file to not be copied. However, provided there will only ever be a single model directory stored at this location, perhaps a more lasting solution would be to only copy over the file that is actually a directory? E.g.,:
```
for file in artifact_path.iterdir():
    if file.is_dir():
        copy_paths["model_path"]["from"] = file
        break
```
In my testing the storage location has only ever included the single model directory. Hopefully someone on the team with more context can let me know whether multiple directories could exist here.