### PR TITLE
Remove Python backend double unit test

### DIFF
--- a/qa/L0_backend_python/python_unittest.py
+++ b/qa/L0_backend_python/python_unittest.py
@@ -75,8 +75,6 @@ class PythonUnittest(tu.TestResultCollector):
                 # call so that the probe can detect the leak correctly.
                 self._run_unittest(model_name)
 
-                # [FIXME] See DLIS-3684
-                self._run_unittest(model_name)
                 with self._shm_leak_detector.Probe() as shm_probe:
                     self._run_unittest(model_name)
             else:


### PR DESCRIPTION
The issue appears fixed by #302, so the double unit test before checking for memory leak can be reduced down to a single unit test.