### PR TITLE
Bump min cxx standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ project(tritonserver LANGUAGES C CXX)
 
 include(CMakeDependentOption)
 
-# Use C++17 standard as Triton's default.
+# Use C++17 standard as Triton's minimum required.
 set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
 
 set(TRITON_VERSION "0.0.0" CACHE STRING "The version of the Triton shared library" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,24 @@ project(tritonserver LANGUAGES C CXX)
 
 include(CMakeDependentOption)
 
+# Use C++17 standard as Triton's default.
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
+
+# Unset CMAKE_CXX_STANDARD if it's too low and in the CMakeCache.txt
+if($CACHE{CMAKE_CXX_STANDARD} AND $CACHE{CMAKE_CXX_STANDARD} LESS ${TRITON_MIN_CXX_STANDARD})
+  message(WARNING "Resetting cache value for CMAKE_CXX_STANDARD to ${TRITON_MIN_CXX_STANDARD}")
+  unset(CMAKE_CXX_STANDARD CACHE)
+endif()
+
+# Allow manually specified CMAKE_CXX_STANDARD if it's greater than the minimum
+# required C++ version
+if(DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
+  message(FATAL_ERROR "Requested CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} which is less than the minimum C++ standard ${TRITON_MIN_CXX_STANDARD}")
+endif()
+
+set(CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD} CACHE STRING "C++ standard to conform to")
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(TRITON_VERSION "0.0.0" CACHE STRING "The version of the Triton shared library" )
 
 option(TRITON_ENABLE_LOGGING "Include logging support in server" ON)
@@ -106,6 +124,7 @@ endif()
 #
 # Dependencies
 #
+
 include(FetchContent)
 
 FetchContent_Declare(
@@ -260,6 +279,9 @@ ExternalProject_Add(triton-server
     -DTRITON_ENABLE_S3:BOOL=${TRITON_ENABLE_S3}
     -DTRITON_ENABLE_TENSORRT:BOOL=${TRITON_ENABLE_TENSORRT}
     -DTRITON_ENABLE_ENSEMBLE:BOOL=${TRITON_ENABLE_ENSEMBLE}
+    -DTRITON_MIN_CXX_STANDARD:STRING=${TRITON_MIN_CXX_STANDARD}
+    -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
+    -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX:PATH=${TRITON_INSTALL_PREFIX}
     -DTRITON_VERSION:STRING=${TRITON_VERSION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,22 +31,7 @@ project(tritonserver LANGUAGES C CXX)
 include(CMakeDependentOption)
 
 # Use C++17 standard as Triton's default.
-set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard whose features are requested to build this target.")
-
-# Unset CMAKE_CXX_STANDARD if it's too low and in the CMakeCache.txt
-if($CACHE{CMAKE_CXX_STANDARD} AND $CACHE{CMAKE_CXX_STANDARD} LESS ${TRITON_MIN_CXX_STANDARD})
-  message(WARNING "Resetting cache value for CMAKE_CXX_STANDARD to ${TRITON_MIN_CXX_STANDARD}")
-  unset(CMAKE_CXX_STANDARD CACHE)
-endif()
-
-# Allow manually specified CMAKE_CXX_STANDARD if it's greater than the minimum
-# required C++ version
-if(DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD LESS ${TRITON_MIN_CXX_STANDARD})
-  message(FATAL_ERROR "Requested CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} which is less than the minimum C++ standard ${TRITON_MIN_CXX_STANDARD}")
-endif()
-
-set(CMAKE_CXX_STANDARD ${TRITON_MIN_CXX_STANDARD} CACHE STRING "C++ standard to conform to")
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
 
 set(TRITON_VERSION "0.0.0" CACHE STRING "The version of the Triton shared library" )
 
@@ -124,7 +109,6 @@ endif()
 #
 # Dependencies
 #
-
 include(FetchContent)
 
 FetchContent_Declare(
@@ -280,8 +264,6 @@ ExternalProject_Add(triton-server
     -DTRITON_ENABLE_TENSORRT:BOOL=${TRITON_ENABLE_TENSORRT}
     -DTRITON_ENABLE_ENSEMBLE:BOOL=${TRITON_ENABLE_ENSEMBLE}
     -DTRITON_MIN_CXX_STANDARD:STRING=${TRITON_MIN_CXX_STANDARD}
-    -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
-    -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX:PATH=${TRITON_INSTALL_PREFIX}
     -DTRITON_VERSION:STRING=${TRITON_VERSION}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,11 @@ endif() # TRITON_ENABLE_GRPC
 
 FetchContent_MakeAvailable(repo-common repo-core repo-backend)
 
+# C++ standard
+if(DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD)
+  message(STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
+endif()
+
 # CUDA
 #
 if(${TRITON_ENABLE_GPU})
@@ -117,7 +122,6 @@ if (NOT WIN32)
   set_property(TARGET main PROPERTY OUTPUT_NAME tritonserver)
 endif()
 
-target_compile_features(main PRIVATE cxx_std_11)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   message("Using MSVC as compiler, default target on Windows 10. "
     "If the target system is not Windows 10, please update _WIN32_WINNT "
@@ -353,7 +357,6 @@ if(${TRITON_ENABLE_HTTP}
     ${HTTP_ENDPOINT_SRCS} ${HTTP_ENDPOINT_HDRS}
   )
 
-  target_compile_features(http-endpoint-library PRIVATE cxx_std_11)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(
       http-endpoint-library
@@ -508,7 +511,6 @@ if(${TRITON_ENABLE_TRACING})
   )
 
   if (NOT WIN32)
-    target_compile_features(tracing-library PRIVATE cxx_std_17)
 
     target_include_directories(
       tracing-library
@@ -592,7 +594,6 @@ if (NOT WIN32)
     simple.cc
   )
 
-  target_compile_features(simple PRIVATE cxx_std_11)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message("Using MSVC as compiler, default target on Windows 10. "
             "If the target system is not Windows 10, please update _WIN32_WINNT "
@@ -656,7 +657,6 @@ if (NOT WIN32)
     multi_server.cc
   )
 
-  target_compile_features(multi_server PRIVATE cxx_std_11)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message("Using MSVC as compiler, default target on Windows 10. "
             "If the target system is not Windows 10, please update _WIN32_WINNT "
@@ -721,7 +721,6 @@ if (NOT WIN32)
       memory_alloc.cc
     )
 
-    target_compile_features(memory_alloc PRIVATE cxx_std_11)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       message("Using MSVC as compiler, default target on Windows 10. "
               "If the target system is not Windows 10, please update _WIN32_WINNT "

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,11 +61,6 @@ endif() # TRITON_ENABLE_GRPC
 
 FetchContent_MakeAvailable(repo-common repo-core repo-backend)
 
-# C++ standard
-if(DEFINED CMAKE_CXX_STANDARD AND CMAKE_CXX_STANDARD)
-  message(STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
-
 # CUDA
 #
 if(${TRITON_ENABLE_GPU})
@@ -122,6 +117,7 @@ if (NOT WIN32)
   set_property(TARGET main PROPERTY OUTPUT_NAME tritonserver)
 endif()
 
+target_compile_features(main PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   message("Using MSVC as compiler, default target on Windows 10. "
     "If the target system is not Windows 10, please update _WIN32_WINNT "
@@ -357,6 +353,7 @@ if(${TRITON_ENABLE_HTTP}
     ${HTTP_ENDPOINT_SRCS} ${HTTP_ENDPOINT_HDRS}
   )
 
+  target_compile_features(http-endpoint-library PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     target_compile_options(
       http-endpoint-library
@@ -511,6 +508,7 @@ if(${TRITON_ENABLE_TRACING})
   )
 
   if (NOT WIN32)
+    target_compile_features(tracing-library PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 
     target_include_directories(
       tracing-library
@@ -594,6 +592,7 @@ if (NOT WIN32)
     simple.cc
   )
 
+  target_compile_features(simple PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message("Using MSVC as compiler, default target on Windows 10. "
             "If the target system is not Windows 10, please update _WIN32_WINNT "
@@ -657,6 +656,7 @@ if (NOT WIN32)
     multi_server.cc
   )
 
+  target_compile_features(multi_server PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message("Using MSVC as compiler, default target on Windows 10. "
             "If the target system is not Windows 10, please update _WIN32_WINNT "
@@ -721,6 +721,7 @@ if (NOT WIN32)
       memory_alloc.cc
     )
 
+    target_compile_features(memory_alloc PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
     if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
       message("Using MSVC as compiler, default target on Windows 10. "
               "If the target system is not Windows 10, please update _WIN32_WINNT "

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -37,7 +37,6 @@ add_library(
   stream_infer_handler.cc
 )
 
-target_compile_features(grpc-endpoint-library PRIVATE cxx_std_17)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_compile_options(
     grpc-endpoint-library

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   stream_infer_handler.cc
 )
 
+target_compile_features(grpc-endpoint-library PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_compile_options(
     grpc-endpoint-library

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(
   stream_infer_handler.cc
 )
 
-target_compile_features(grpc-endpoint-library PRIVATE cxx_std_11)
+target_compile_features(grpc-endpoint-library PRIVATE cxx_std_17)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_compile_options(
     grpc-endpoint-library


### PR DESCRIPTION
Setting a min required cxx standard for Triton to 17.

Note in our containers default cxx is 17, thus no `-std=..` flag is shown. However, if higher version is desired, the following command:
``` 
cmake -DTRITON_MIN_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install .. && make -j1 VERBOSE=1 install
```
will add `-std=gnu++20` flag during build. 

This PR:

- adds `TRITON_MIN_CXX_STANDARD` cmake variable, which defaults to 17 
- uses the above variable to specify cxx standard in `target_compile_features(... PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})`, to avoid hardcoded values

This way to recompile Triton in higher standard, one can simply specify ` -DTRITON_MIN_CXX_STANDARD=20` option for cmake command, as shown above.

Related PRs:

- core: https://github.com/triton-inference-server/core/pull/303
- common: https://github.com/triton-inference-server/common/pull/110
- backend: https://github.com/triton-inference-server/backend/pull/92
- third-party: https://github.com/triton-inference-server/third_party/pull/50
- client: https://github.com/triton-inference-server/client/pull/450 [will keep as a draft for now per @debermudez request regarding PA]
- checksum_repository_agent: https://github.com/triton-inference-server/checksum_repository_agent/pull/9

Backends:
- openvino_backend: https://github.com/triton-inference-server/openvino_backend/pull/61
- python_backend: https://github.com/triton-inference-server/python_backend/pull/332
- pytorch_backend: https://github.com/triton-inference-server/pytorch_backend/pull/122
- tensorrt_backend : https://github.com/triton-inference-server/tensorrt_backend/pull/79
- tensorflow_backend: https://github.com/triton-inference-server/tensorflow_backend/pull/100
- onnxruntime_backend: https://github.com/triton-inference-server/onnxruntime_backend/pull/230
- square_backend: https://github.com/triton-inference-server/square_backend/pull/15
- repeat_backend: https://github.com/triton-inference-server/repeat_backend/pull/10
- identity_backend: https://github.com/triton-inference-server/identity_backend/pull/27

Note: 
tensorrt_llm_backend and local_cache are already have c++17 standard, redis cache has c++20 standard specified, so these repos can be updated separately 