### PR TITLE
Use OTEL_SERVICE_NAME environment variable if set

### DIFF
--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -363,7 +363,7 @@ TraceManager::InitTracer(const triton::server::TraceConfigMap& config_map)
       otlp::OtlpHttpExporterOptions opts;
       otel_resource::ResourceAttributes attributes = {};
       attributes[otel_resource::SemanticConventions::kServiceName] =
-          "triton-inference-server";
+          triton::server::GetEnvironmentVariableOrDefault("OTEL_SERVICE_NAME", "triton-inference-server");
       auto mode_key = std::to_string(TRACE_MODE_OPENTELEMETRY);
       auto otel_options_it = config_map.find(mode_key);
       if (otel_options_it != config_map.end()) {


### PR DESCRIPTION
`triton-inference-server` is the default OpenTelemetry service name if none other is set. Most libraries and applications read the `OTEL_SERVICE_NAME` environment variable though to get the name. This is override by the explicit setting of `triton-inference-server`.

Fixes #5987 