### PR TITLE
Move from jfrog artifactory to archives.boost.io to fix boost download

### DIFF
--- a/build.py
+++ b/build.py
@@ -972,7 +972,7 @@ RUN pip3 install --upgrade pip && \
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
 RUN wget -O /tmp/boost.tar.gz \
-        https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz && \
+        https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && \
     (cd /tmp && tar xzf boost.tar.gz) && \
     cd /tmp/boost_1_80_0 && ./bootstrap.sh --prefix=/usr && ./b2 install && \
     mv /tmp/boost_1_80_0/boost /usr/include/boost
@@ -1225,7 +1225,7 @@ RUN apt-get update \
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
 RUN wget -O /tmp/boost.tar.gz \
-        https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz \
+        https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && \
       && (cd /tmp && tar xzf boost.tar.gz) \
       && cd /tmp/boost_1_80_0 \
       && ./bootstrap.sh --prefix=/usr \

--- a/build.py
+++ b/build.py
@@ -1225,7 +1225,7 @@ RUN apt-get update \
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
 RUN wget -O /tmp/boost.tar.gz \
-        https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && \
+        https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz \
       && (cd /tmp && tar xzf boost.tar.gz) \
       && cd /tmp/boost_1_80_0 \
       && ./bootstrap.sh --prefix=/usr \


### PR DESCRIPTION
Server: https://github.com/triton-inference-server/server/pull/6775
Python Backend: https://github.com/triton-inference-server/python_backend/pull/334
Gitlab: !1027

Based on issues with jfrog similar to this: https://github.com/boostorg/boost/issues/849#issue-2069720679