### PR TITLE
Remove boost::filesystem from builds

### DIFF
--- a/Dockerfile.win10.min
+++ b/Dockerfile.win10.min
@@ -105,7 +105,6 @@ RUN bootstrap-vcpkg.bat
 RUN vcpkg.exe update
 RUN vcpkg.exe install \
       b64:x64-windows \
-      boost-filesystem:x64-windows \
       boost-interprocess:x64-windows \
       boost-stacktrace:x64-windows \
       openssl-windows:x64-windows \

--- a/build.py
+++ b/build.py
@@ -974,7 +974,6 @@ RUN pip3 install --upgrade pip && \
 RUN wget -O /tmp/boost.tar.gz \
         https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz && \
     (cd /tmp && tar xzf boost.tar.gz) && \
-    cd /tmp/boost_1_80_0 && ./bootstrap.sh --prefix=/usr && ./b2 install && \
     mv /tmp/boost_1_80_0/boost /usr/include/boost
 
 # Server build requires recent version of CMake (FetchContent required)
@@ -1221,16 +1220,6 @@ RUN apt-get update \
             wget \
             {backend_dependencies} \
     && rm -rf /var/lib/apt/lists/*
-
-# Install boost version >= 1.78 for boost::span
-# Current libboost-dev apt packages are < 1.78, so install from tar.gz
-RUN wget -O /tmp/boost.tar.gz \
-        https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz \
-      && (cd /tmp && tar xzf boost.tar.gz) \
-      && cd /tmp/boost_1_80_0 \
-      && ./bootstrap.sh --prefix=/usr \
-      && ./b2 install \
-      && rm -rf /tmp/boost*
 
 # Set TCMALLOC_RELEASE_RATE for users setting LD_PRELOAD with tcmalloc
 ENV TCMALLOC_RELEASE_RATE 200


### PR DESCRIPTION
Server: https://github.com/triton-inference-server/server/pull/6810
Core: https://github.com/triton-inference-server/core/pull/319

Fixes: https://github.com/triton-inference-server/server/issues/6745