### PR TITLE
Use libmamba solver for L0_backend_python env test. Fix pytest not found

### DIFF
--- a/qa/L0_backend_python/common.sh
+++ b/qa/L0_backend_python/common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@ get_shm_pages() {
 
 install_conda() {
   rm -rf ./miniconda
-  file_name="Miniconda3-py310_23.3.1-0-Linux-x86_64.sh"
+  file_name="Miniconda3-py310_23.11.0-2-Linux-x86_64.sh"
   wget https://repo.anaconda.com/miniconda/$file_name
 
   # install miniconda in silent mode

--- a/qa/L0_backend_python/test.sh
+++ b/qa/L0_backend_python/test.sh
@@ -390,8 +390,7 @@ if [ "$TEST_JETSON" == "0" ]; then
     for TEST in ${SUBTESTS}; do
         # Run each subtest in a separate virtual environment to avoid conflicts
         # between dependencies.
-        virtualenv --system-site-packages venv
-        source venv/bin/activate
+        setup_virtualenv
 
         (cd ${TEST} && bash -ex test.sh)
         if [ $? -ne 0 ]; then
@@ -399,8 +398,7 @@ if [ "$TEST_JETSON" == "0" ]; then
         RET=1
         fi
 
-        deactivate
-        rm -fr venv
+        deactivate_virtualenv
     done
 
     if [ ${PYTHON_ENV_VERSION} = "10" ]; then
@@ -418,8 +416,7 @@ SUBTESTS="lifecycle restart model_control examples argument_validation logging c
 for TEST in ${SUBTESTS}; do
     # Run each subtest in a separate virtual environment to avoid conflicts
     # between dependencies.
-    virtualenv --system-site-packages venv
-    source venv/bin/activate
+    setup_virtualenv
 
     (cd ${TEST} && bash -ex test.sh)
 
@@ -428,8 +425,7 @@ for TEST in ${SUBTESTS}; do
         RET=1
     fi
 
-    deactivate
-    rm -fr venv
+    deactivate_virtualenv
 done
 
 if [ $RET -eq 0 ]; then

--- a/qa/L0_backend_python/test.sh
+++ b/qa/L0_backend_python/test.sh
@@ -153,6 +153,8 @@ else
   # GPU tensor tests are disabled on jetson
 fi
 
+pip3 install pytest
+
 prev_num_pages=`get_shm_pages`
 run_server
 if [ "$SERVER_PID" == "0" ]; then

--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -509,3 +509,16 @@ remove_array_outliers() {
 
     arr=("${arr[@]:$start_index:$end_index}")
 }
+
+function setup_virtualenv() {
+    # Create and activate virtual environment
+    virtualenv --system-site-packages venv
+    source venv/bin/activate
+    pip install pytest
+}
+
+function deactivate_virtualenv() {
+    # Deactivate virtual environment and clean up
+    deactivate
+    rm -fr venv
+}


### PR DESCRIPTION
Update the miniconda version to use libmamba solver to speed up the test time. From the output we can see that `conda-libmamba-solver` is used as default solver.
```
(base) root@a2826b5-lcedt:/opt/tritonserver/qa/L0_backend_python/env# conda info

     active environment : base
    active env location : /opt/tritonserver/qa/L0_backend_python/env/miniconda
            shell level : 1
       user config file : /root/.condarc
 populated config files : 
          conda version : 23.11.0
    conda-build version : not installed
         python version : 3.10.13.final.0
                 solver : libmamba (default)
       virtual packages : __archspec=1=skylake_avx512
                          __conda=23.11.0=0
                          __cuda=12.2=0
                          __glibc=2.35=0
                          __linux=6.5.0=0
                          __unix=0=0
       base environment : /opt/tritonserver/qa/L0_backend_python/env/miniconda  (writable)
      conda av data dir : /opt/tritonserver/qa/L0_backend_python/env/miniconda/etc/conda
  conda av metadata url : None
           channel URLs : https://repo.anaconda.com/pkgs/main/linux-64
                          https://repo.anaconda.com/pkgs/main/noarch
                          https://repo.anaconda.com/pkgs/r/linux-64
                          https://repo.anaconda.com/pkgs/r/noarch
          package cache : /opt/tritonserver/qa/L0_backend_python/env/miniconda/pkgs
                          /root/.conda/pkgs
       envs directories : /opt/tritonserver/qa/L0_backend_python/env/miniconda/envs
                          /root/.conda/envs
               platform : linux-64
             user-agent : conda/23.11.0 requests/2.31.0 CPython/3.10.13 Linux/6.5.0-14-generic ubuntu/22.04.3 glibc/2.35 solver/libmamba conda-libmamba-solver/23.12.0 libmambapy/1.5.3
                UID:GID : 0:0
             netrc file : None
           offline mode : False
```

Also fixed the `pytest not found` error in the tests that are using different versions of Python. It's likely due to the Python version used to install `virtualenv`(within Dockerfile.QA) mismatches with the Python version used for the test.