### PR TITLE
Add test for shutdown while loading model

### DIFF
--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -3347,6 +3347,18 @@ class LifeCycleTest(tu.TestResultCollector):
         # The server will shutdown after this sub-test exits. The server must shutdown
         # without any hang or runtime error.
 
+    def test_shutdown_while_loading(self):
+        triton_client = self._get_client()
+        self.assertTrue(triton_client.is_server_live())
+        self.assertTrue(triton_client.is_server_ready())
+        # Load the model which will load for at least 10 seconds.
+        model_name = "identity_fp32"
+        with concurrent.futures.ThreadPoolExecutor() as pool:
+            pool.submit(triton_client.load_model, model_name)
+        self.assertFalse(triton_client.is_model_ready(model_name))
+        # The server will shutdown after this sub-test exits. The server must shutdown
+        # without any hang or runtime error.
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -3317,6 +3317,7 @@ class LifeCycleTest(tu.TestResultCollector):
 
         # Touch the local config.pbtxt and reload the file to ensure the local config
         # is preferred because it has a more recent mtime.
+        time.sleep(0.1)  # make sure timestamps are different
         Path(os.path.join("models", model_name, "config.pbtxt")).touch()
 
         # Reload the model


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/core/pull/324

Add a new test that starts loading a model, and before the model can finish loading, the server shutdowns. Given a model is still loading while shutting down, the unload must happen after the load is completed. If the test cannot assert there is exactly one load complete and one unload in order, then the test fails.