### PR TITLE
Adding OpenTelemetry Batch Span Processor

### DIFF
--- a/docs/user_guide/trace.md
+++ b/docs/user_guide/trace.md
@@ -487,7 +487,15 @@ Default parameters for the Batch Span Processor are provided in
 As a general recommendation, make sure that `bsp_max_queue_size` is large enough
 to hold all collected spans, and `bsp_schedule_delay` does not cause frequent
 exports, which will affect Triton Server's latency. Also, users should keep
-in mind that minimal number of produced spans on Trton Server side is 3:
+in mind that at minimum Triton collects 3 levels of spans:
+
+* Top level. The top-level span collects timestamps for when request was received
+by Triton, and when the response was sent.
+* Mid level
+* Low level
+
+
+minimal number of produced spans on Trton Server side is 3:
 The `InferRequest` span, which collects timestamps for when request was received
 by Triton, and when the response was sent; the request span, which is named
 after the model the request was sent to and records when request was started and

--- a/docs/user_guide/trace.md
+++ b/docs/user_guide/trace.md
@@ -486,20 +486,26 @@ Default parameters for the Batch Span Processor are provided in
 [`OpenTelemetry trace APIs settings`](#opentelemetry-trace-apis-settings).
 As a general recommendation, make sure that `bsp_max_queue_size` is large enough
 to hold all collected spans, and `bsp_schedule_delay` does not cause frequent
-exports, which will affect Triton Server's latency. Also, users should keep
-in mind that at minimum Triton collects 3 levels of spans:
+exports, which will affect Triton Server's latency. A minimal Triton trace
+consists of 3 spans: top level span, model span, and compute span.
 
-* Top level. The top-level span collects timestamps for when request was received
-by Triton, and when the response was sent.
-* Mid level
-* Low level
+* __Top level span__. The top-level span collects timestamps for when
+request was received by Triton, and when the response was sent. Any Triton
+trace contains only 1 top level span.
+* __Model span__. Model spans collect information, when request for
+this model was started, when it was placed in a queue, and when it was ended.
+A minimal Triton trace contains 1 model span.
+* __Compute span__. Compute spans record compute timestamps. A minimal
+Triton trace contains 1 compute span.
 
+The total amount of spans depends on the complexity of your model.
+A general rule is any base model - a single model that performs computations -
+produces 1 model span and one compute span. For ensembles, every composing
+model produces model and compute spans in addition to one model span for the
+ensemble. [BLS](#tracing-for-bls-models) models produce the same number of
+model an compute spans as the total amount of involved in BLS request models,
+including the main BLS model.
 
-minimal number of produced spans on Trton Server side is 3:
-The `InferRequest` span, which collects timestamps for when request was received
-by Triton, and when the response was sent; the request span, which is named
-after the model the request was sent to and records when request was started and
-ended; the `compute` span, which records compute timestamps.
 
 ### Differences in trace contents from Triton's trace [output](#json-trace-output)
 

--- a/docs/user_guide/trace.md
+++ b/docs/user_guide/trace.md
@@ -489,7 +489,7 @@ to hold all collected spans, and `bsp_schedule_delay` does not cause frequent
 exports, which will affect Triton Server's latency. Also, users should keep
 in mind that minimal number of produced spans on Trton Server side is 3:
 The `InferRequest` span, which collects timestamps for when request was received
-by Triton, and when the request was sent; the request span, which is named
+by Triton, and when the response was sent; the request span, which is named
 after the model the request was sent to and records when request was started and
 ended; the `compute` span, which records compute timestamps.
 

--- a/docs/user_guide/trace.md
+++ b/docs/user_guide/trace.md
@@ -520,6 +520,45 @@ The following table shows available OpenTelemetry trace APIs settings for
       environment variable.
     </td>
     </tr>
+    <tr>
+    <td><a href="https://opentelemetry.io/docs/specs/otel/trace/sdk/#batching-processor">
+      Batch Span Processor</a>
+    </td>
+    <td></td><td></td>
+    </tr>
+    <tr>
+    <td><code>bsp_max_queue_size</code></td>
+    <td align="center">2048</td>
+    <td>
+      Maximum queue size. <br/>
+      This setting can also be specified through <br/>
+      <a href="https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor">
+      OTEL_BSP_MAX_QUEUE_SIZE</a>
+      environment variable.
+    </td>
+    </tr>
+    <tr>
+    <td><code>bsp_schedule_delay</code></td>
+    <td align="center">5000</td>
+    <td>
+      Delay interval (in milliseconds) between two consecutive exports. <br/>
+      This setting can also be specified through <br/>
+      <a href="https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor">
+      OTEL_BSP_SCHEDULE_DELAY</a>
+      environment variable.
+    </td>
+    </tr>
+    <tr>
+    <td><code>bsp_max_export_batch_size</code></td>
+    <td align="center">512</td>
+    <td>
+      Maximum batch size. Must be less than or equal to `bsp_max_queue_size`.<br/>
+      This setting can also be specified through <br/>
+      <a href="https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#batch-span-processor">
+      OTEL_BSP_MAX_EXPORT_BATCH_SIZE</a>
+      environment variable.
+    </td>
+    </tr>
   </tbody>
 </table>
 

--- a/docs/user_guide/trace.md
+++ b/docs/user_guide/trace.md
@@ -489,13 +489,13 @@ to hold all collected spans, and `bsp_schedule_delay` does not cause frequent
 exports, which will affect Triton Server's latency. A minimal Triton trace
 consists of 3 spans: top level span, model span, and compute span.
 
-* __Top level span__. The top-level span collects timestamps for when
+* __Top level span__: The top-level span collects timestamps for when
 request was received by Triton, and when the response was sent. Any Triton
 trace contains only 1 top level span.
-* __Model span__. Model spans collect information, when request for
+* __Model span__: Model spans collect information, when request for
 this model was started, when it was placed in a queue, and when it was ended.
 A minimal Triton trace contains 1 model span.
-* __Compute span__. Compute spans record compute timestamps. A minimal
+* __Compute span__: Compute spans record compute timestamps. A minimal
 Triton trace contains 1 compute span.
 
 The total amount of spans depends on the complexity of your model.

--- a/docs/user_guide/trace.md
+++ b/docs/user_guide/trace.md
@@ -503,7 +503,7 @@ A general rule is any base model - a single model that performs computations -
 produces 1 model span and one compute span. For ensembles, every composing
 model produces model and compute spans in addition to one model span for the
 ensemble. [BLS](#tracing-for-bls-models) models produce the same number of
-model an compute spans as the total amount of involved in BLS request models,
+model and compute spans as the total amount of models involved in the BLS request,
 including the main BLS model.
 
 

--- a/qa/L0_cmdline_trace/test.sh
+++ b/qa/L0_cmdline_trace/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_cmdline_trace/test.sh
+++ b/qa/L0_cmdline_trace/test.sh
@@ -688,25 +688,6 @@ fi
 
 unset OTEL_BSP_MAX_EXPORT_BATCH_SIZE
 
-SERVER_ARGS="--model-repository=$MODELSDIR"
-SERVER_LOG="./inference_server_trace_config_flag.log"
-run_server
-if [ "$SERVER_PID" != "0" ]; then
-    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
-    cat $SERVER_LOG
-    set -e
-    kill $SERVER_PID
-    wait $SERVER_PID
-    set +e
-    exit 1
-fi
-
-if [ `grep -c "Bad option: \"OTEL_BSP_MAX_QUEUE_SIZE\"" $SERVER_LOG` != "1" ]; then
-    cat $SERVER_LOG
-    echo -e "\n***\n*** Test Failed\n***"
-    RET=1
-fi
-
 SERVER_ARGS="--model-repository=$MODELSDIR --trace-config mode=opentelemetry \
              --trace-config opentelemetry,bsp_max_queue_size=bad_value"
 SERVER_LOG="./inference_server_trace_config_flag.log"

--- a/qa/L0_cmdline_trace/test.sh
+++ b/qa/L0_cmdline_trace/test.sh
@@ -618,11 +618,159 @@ set -e
 kill $SERVER_PID
 wait $SERVER_PID
 
+set +e
+
+################################################################################
+# The following set of tests checks that tritonserver gracefully handles       #
+# bad OpenTelemetry BatchSpanProcessor parameters, provided through            #
+# environment variables, or tritonserver's options.                            #
+################################################################################
+export OTEL_BSP_MAX_QUEUE_SIZE="bad_value"
+
+SERVER_ARGS="--trace-config mode=opentelemetry --model-repository=$MODELSDIR"
+SERVER_LOG="./inference_server_trace_config_flag.log"
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
+    cat $SERVER_LOG
+    set -e
+    kill $SERVER_PID
+    wait $SERVER_PID
+    set +e
+    exit 1
+fi
+
+if [ `grep -c "Bad option: \"OTEL_BSP_MAX_QUEUE_SIZE\"" $SERVER_LOG` != "1" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+unset OTEL_BSP_MAX_QUEUE_SIZE
+
+export OTEL_BSP_SCHEDULE_DELAY="bad_value"
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
+    cat $SERVER_LOG
+    set -e
+    kill $SERVER_PID
+    wait $SERVER_PID
+    set +e
+    exit 1
+fi
+
+if [ `grep -c "Bad option: \"OTEL_BSP_SCHEDULE_DELAY\"" $SERVER_LOG` != "1" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+unset OTEL_BSP_SCHEDULE_DELAY
+
+export OTEL_BSP_MAX_EXPORT_BATCH_SIZE="bad_value"
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
+    cat $SERVER_LOG
+    set -e
+    kill $SERVER_PID
+    wait $SERVER_PID
+    set +e
+    exit 1
+fi
+
+if [ `grep -c "Bad option: \"OTEL_BSP_MAX_EXPORT_BATCH_SIZE\"" $SERVER_LOG` != "1" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+unset OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+
+SERVER_ARGS="--model-repository=$MODELSDIR"
+SERVER_LOG="./inference_server_trace_config_flag.log"
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
+    cat $SERVER_LOG
+    set -e
+    kill $SERVER_PID
+    wait $SERVER_PID
+    set +e
+    exit 1
+fi
+
+if [ `grep -c "Bad option: \"OTEL_BSP_MAX_QUEUE_SIZE\"" $SERVER_LOG` != "1" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+SERVER_ARGS="--model-repository=$MODELSDIR --trace-config mode=opentelemetry \
+             --trace-config opentelemetry,bsp_max_queue_size=bad_value"
+SERVER_LOG="./inference_server_trace_config_flag.log"
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
+    cat $SERVER_LOG
+    set -e
+    kill $SERVER_PID
+    wait $SERVER_PID
+    set +e
+    exit 1
+fi
+
+if [ `grep -c "Bad option: \"--trace-config opentelemetry,bsp_max_queue_size\"" $SERVER_LOG` != "1" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+SERVER_ARGS="--model-repository=$MODELSDIR --trace-config mode=opentelemetry \
+             --trace-config opentelemetry,bsp_schedule_delay=bad_value"
+SERVER_LOG="./inference_server_trace_config_flag.log"
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
+    cat $SERVER_LOG
+    set -e
+    kill $SERVER_PID
+    wait $SERVER_PID
+    set +e
+    exit 1
+fi
+
+if [ `grep -c "Bad option: \"--trace-config opentelemetry,bsp_schedule_delay\"" $SERVER_LOG` != "1" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
+SERVER_ARGS="--model-repository=$MODELSDIR --trace-config mode=opentelemetry \
+             --trace-config opentelemetry,bsp_max_export_batch_size=bad_value"
+SERVER_LOG="./inference_server_trace_config_flag.log"
+run_server
+if [ "$SERVER_PID" != "0" ]; then
+    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
+    cat $SERVER_LOG
+    set -e
+    kill $SERVER_PID
+    wait $SERVER_PID
+    set +e
+    exit 1
+fi
+
+if [ `grep -c "Bad option: \"--trace-config opentelemetry,bsp_max_export_batch_size\"" $SERVER_LOG` != "1" ]; then
+    cat $SERVER_LOG
+    echo -e "\n***\n*** Test Failed\n***"
+    RET=1
+fi
+
 if [ $RET -eq 0 ]; then
     echo -e "\n***\n*** Test Passed\n***"
 else
     echo -e "\n***\n*** Test FAILED\n***"
 fi
-
 
 exit $RET

--- a/qa/L0_cmdline_trace/test.sh
+++ b/qa/L0_cmdline_trace/test.sh
@@ -25,6 +25,19 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# ============================= Helpers =======================================
+function assert_server_startup_failed() {
+  if [ "$SERVER_PID" != "0" ]; then
+      echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
+      cat $SERVER_LOG
+      set -e
+      kill $SERVER_PID
+      wait $SERVER_PID
+      set +e
+      exit 1
+  fi
+}
+
 TRACE_SUMMARY=../common/trace_summary.py
 CLIENT_SCRIPT=trace_client.py
 
@@ -630,15 +643,7 @@ export OTEL_BSP_MAX_QUEUE_SIZE="bad_value"
 SERVER_ARGS="--trace-config mode=opentelemetry --model-repository=$MODELSDIR"
 SERVER_LOG="./inference_server_trace_config_flag.log"
 run_server
-if [ "$SERVER_PID" != "0" ]; then
-    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
-    cat $SERVER_LOG
-    set -e
-    kill $SERVER_PID
-    wait $SERVER_PID
-    set +e
-    exit 1
-fi
+assert_server_startup_failed
 
 if [ `grep -c "Bad option: \"OTEL_BSP_MAX_QUEUE_SIZE\"" $SERVER_LOG` != "1" ]; then
     cat $SERVER_LOG
@@ -650,15 +655,7 @@ unset OTEL_BSP_MAX_QUEUE_SIZE
 
 export OTEL_BSP_SCHEDULE_DELAY="bad_value"
 run_server
-if [ "$SERVER_PID" != "0" ]; then
-    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
-    cat $SERVER_LOG
-    set -e
-    kill $SERVER_PID
-    wait $SERVER_PID
-    set +e
-    exit 1
-fi
+assert_server_startup_failed
 
 if [ `grep -c "Bad option: \"OTEL_BSP_SCHEDULE_DELAY\"" $SERVER_LOG` != "1" ]; then
     cat $SERVER_LOG
@@ -670,15 +667,7 @@ unset OTEL_BSP_SCHEDULE_DELAY
 
 export OTEL_BSP_MAX_EXPORT_BATCH_SIZE="bad_value"
 run_server
-if [ "$SERVER_PID" != "0" ]; then
-    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
-    cat $SERVER_LOG
-    set -e
-    kill $SERVER_PID
-    wait $SERVER_PID
-    set +e
-    exit 1
-fi
+assert_server_startup_failed
 
 if [ `grep -c "Bad option: \"OTEL_BSP_MAX_EXPORT_BATCH_SIZE\"" $SERVER_LOG` != "1" ]; then
     cat $SERVER_LOG
@@ -692,15 +681,7 @@ SERVER_ARGS="--model-repository=$MODELSDIR --trace-config mode=opentelemetry \
              --trace-config opentelemetry,bsp_max_queue_size=bad_value"
 SERVER_LOG="./inference_server_trace_config_flag.log"
 run_server
-if [ "$SERVER_PID" != "0" ]; then
-    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
-    cat $SERVER_LOG
-    set -e
-    kill $SERVER_PID
-    wait $SERVER_PID
-    set +e
-    exit 1
-fi
+assert_server_startup_failed
 
 if [ `grep -c "Bad option: \"--trace-config opentelemetry,bsp_max_queue_size\"" $SERVER_LOG` != "1" ]; then
     cat $SERVER_LOG
@@ -712,15 +693,7 @@ SERVER_ARGS="--model-repository=$MODELSDIR --trace-config mode=opentelemetry \
              --trace-config opentelemetry,bsp_schedule_delay=bad_value"
 SERVER_LOG="./inference_server_trace_config_flag.log"
 run_server
-if [ "$SERVER_PID" != "0" ]; then
-    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
-    cat $SERVER_LOG
-    set -e
-    kill $SERVER_PID
-    wait $SERVER_PID
-    set +e
-    exit 1
-fi
+assert_server_startup_failed
 
 if [ `grep -c "Bad option: \"--trace-config opentelemetry,bsp_schedule_delay\"" $SERVER_LOG` != "1" ]; then
     cat $SERVER_LOG
@@ -732,15 +705,7 @@ SERVER_ARGS="--model-repository=$MODELSDIR --trace-config mode=opentelemetry \
              --trace-config opentelemetry,bsp_max_export_batch_size=bad_value"
 SERVER_LOG="./inference_server_trace_config_flag.log"
 run_server
-if [ "$SERVER_PID" != "0" ]; then
-    echo -e "\n***\n***Fail: Server start should have failed $SERVER\n***"
-    cat $SERVER_LOG
-    set -e
-    kill $SERVER_PID
-    wait $SERVER_PID
-    set +e
-    exit 1
-fi
+assert_server_startup_failed
 
 if [ `grep -c "Bad option: \"--trace-config opentelemetry,bsp_max_export_batch_size\"" $SERVER_LOG` != "1" ]; then
     cat $SERVER_LOG

--- a/qa/L0_trace/opentelemetry_unittest.py
+++ b/qa/L0_trace/opentelemetry_unittest.py
@@ -1,4 +1,4 @@
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_trace/opentelemetry_unittest.py
+++ b/qa/L0_trace/opentelemetry_unittest.py
@@ -250,9 +250,9 @@ class OpenTelemetryTest(tu.TestResultCollector):
         span_names = []
         for span in spans:
             # Check that collected spans have proper events recorded
-            span_name = span[0]["name"]
+            span_name = span["name"]
             span_names.append(span_name)
-            span_events = span[0]["events"]
+            span_events = span["events"]
             event_names_only = [event["name"] for event in span_events]
             self._check_events(span_name, event_names_only)
 
@@ -283,13 +283,13 @@ class OpenTelemetryTest(tu.TestResultCollector):
         """
         seen_spans = {}
         for span in spans:
-            cur_span = span[0]["spanId"]
-            seen_spans[cur_span] = span[0]["name"]
+            cur_span = span["spanId"]
+            seen_spans[cur_span] = span["name"]
 
         parent_child_dict = {}
         for span in spans:
-            cur_parent = span[0]["parentSpanId"]
-            cur_span = span[0]["name"]
+            cur_parent = span["parentSpanId"]
+            cur_span = span["name"]
             if cur_parent in seen_spans.keys():
                 parent_name = seen_spans[cur_parent]
                 if parent_name not in parent_child_dict:
@@ -377,16 +377,21 @@ class OpenTelemetryTest(tu.TestResultCollector):
         """
         time.sleep(COLLECTOR_TIMEOUT)
         traces = self._parse_trace_log(self.filename)
-        self.assertEqual(len(traces), 1, "Unexpected number of traces collected")
+        expected_traces_number = 1
+        self.assertEqual(
+            len(traces),
+            expected_traces_number,
+            "Unexpected number of traces collected. Expected {}, but got {}".format(
+                expected_traces_number, len(traces)
+            ),
+        )
         self._test_resource_attributes(
             traces[0]["resourceSpans"][0]["resource"]["attributes"]
         )
 
-        parsed_spans = [
-            entry["scopeSpans"][0]["spans"] for entry in traces[0]["resourceSpans"]
-        ]
+        parsed_spans = traces[0]["resourceSpans"][0]["scopeSpans"][0]["spans"]
         root_span = [
-            entry[0] for entry in parsed_spans if entry[0]["name"] == "InferRequest"
+            entry for entry in parsed_spans if entry["name"] == "InferRequest"
         ][0]
         self.assertEqual(len(parsed_spans), expected_number_of_spans)
 

--- a/qa/L0_trace/test.sh
+++ b/qa/L0_trace/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/command_line_parser.h
+++ b/src/command_line_parser.h
@@ -302,13 +302,16 @@ class TritonParser {
   void SetTritonTraceArgs(
       TritonServerParameters& lparams, bool trace_filepath_present,
       bool trace_log_frequency_present);
-  void VerifyOpentelemetryTraceArgs(
-      bool trace_filepath_present, bool trace_log_frequency_present);
+  void SetOpenTelemetryTraceArgs(
+      TritonServerParameters& lparams, bool trace_filepath_present,
+      bool trace_log_frequency_present);
   void PostProcessTraceArgs(
       TritonServerParameters& lparams, bool trace_level_present,
       bool trace_rate_present, bool trace_count_present,
       bool trace_filepath_present, bool trace_log_frequency_present,
       bool explicit_disable_trace);
+  void ProcessOpenTelemetryBatchSpanProcessorArgs(
+      TraceConfig& otel_trace_settings);
 #endif  // TRITON_ENABLE_TRACING
   // Helper function to parse option in
   // "<string>[1st_delim]<string>[2nd_delim]<string>" format

--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -471,30 +471,30 @@ TraceManager::ProcessOpenTelemetryParameters(
       std::string("triton-inference-server");
   auto mode_key = std::to_string(TRACE_MODE_OPENTELEMETRY);
   auto otel_options_it = config_map.find(mode_key);
-  if (otel_options_it != config_map.end()) {
-    for (const auto& setting : otel_options_it->second) {
-      // FIXME add more configuration options of OTLP HTTP Exporter
-      if (setting.first == "url") {
-        exporter_options.url = std::get<std::string>(setting.second);
-      }
-      if (setting.first == "resource") {
-        auto user_setting = std::get<std::string>(setting.second);
-        auto pos = user_setting.find('=');
-        auto key = user_setting.substr(0, pos);
-        auto value = user_setting.substr(pos + 1);
-        attributes[key] = value;
-      }
-      if (setting.first == "bsp_max_queue_size") {
-        processor_options.max_queue_size = std::get<uint32_t>(setting.second);
-      }
-      if (setting.first == "bsp_schedule_delay") {
-        processor_options.schedule_delay_millis =
-            std::chrono::milliseconds(std::get<uint32_t>(setting.second));
-      }
-      if (setting.first == "bsp_max_export_batch_size") {
-        processor_options.max_export_batch_size =
-            std::get<uint32_t>(setting.second);
-      }
+  if (otel_options_it == config_map.end()) {
+    return;
+  }
+  for (const auto& [setting, value] : otel_options_it->second) {
+    // FIXME add more configuration options of OTLP HTTP Exporter
+    if (setting == "url") {
+      exporter_options.url = std::get<std::string>(value);
+    }
+    if (setting == "resource") {
+      auto user_setting = std::get<std::string>(value);
+      auto pos = user_setting.find('=');
+      auto key = user_setting.substr(0, pos);
+      auto value = user_setting.substr(pos + 1);
+      attributes[key] = value;
+    }
+    if (setting == "bsp_max_queue_size") {
+      processor_options.max_queue_size = std::get<uint32_t>(value);
+    }
+    if (setting == "bsp_schedule_delay") {
+      processor_options.schedule_delay_millis =
+          std::chrono::milliseconds(std::get<uint32_t>(value));
+    }
+    if (setting == "bsp_max_export_batch_size") {
+      processor_options.max_export_batch_size = std::get<uint32_t>(value);
     }
   }
 }

--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -36,19 +36,12 @@
 #include <cuda_runtime_api.h>
 #endif  // TRITON_ENABLE_GPU
 #ifndef _WIN32
-#include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #include "opentelemetry/sdk/resource/semantic_conventions.h"
-namespace otlp = opentelemetry::exporter::otlp;
-namespace otel_trace_sdk = opentelemetry::sdk::trace;
-namespace otel_trace_api = opentelemetry::trace;
+#include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
 namespace otel_common = opentelemetry::common;
-namespace otel_resource = opentelemetry::sdk::resource;
 #endif
 
 namespace triton { namespace server {
-
-static const int EXPORT_QUEUE_SIZE = 5000;
-static const int EXPORT_DELAY_MS = 2000;
 
 TRITONSERVER_Error*
 TraceManager::Create(
@@ -412,32 +405,14 @@ TraceManager::InitTracer(const triton::server::TraceConfigMap& config_map)
   switch (global_setting_->mode_) {
     case TRACE_MODE_OPENTELEMETRY: {
 #ifndef _WIN32
-      otlp::OtlpHttpExporterOptions opts;
+      otlp::OtlpHttpExporterOptions exporter_options;
       otel_resource::ResourceAttributes attributes = {};
-      attributes[otel_resource::SemanticConventions::kServiceName] =
-          std::string("triton-inference-server");
-      auto mode_key = std::to_string(TRACE_MODE_OPENTELEMETRY);
-      auto otel_options_it = config_map.find(mode_key);
-      if (otel_options_it != config_map.end()) {
-        for (const auto& setting : otel_options_it->second) {
-          // FIXME add more configuration options of OTLP HTTP Exporter
-          if (setting.first == "url") {
-            opts.url = setting.second;
-          }
-          if (setting.first == "resource") {
-            auto pos = setting.second.find('=');
-            auto key = setting.second.substr(0, pos);
-            auto value = setting.second.substr(pos + 1);
-            attributes[key] = value;
-          }
-        }
-      }
-      auto exporter = otlp::OtlpHttpExporterFactory::Create(opts);
       otel_trace_sdk::BatchSpanProcessorOptions processor_options;
-      processor_options.max_queue_size = EXPORT_QUEUE_SIZE;
-      processor_options.max_export_batch_size = EXPORT_QUEUE_SIZE;
-      processor_options.schedule_delay_millis =
-          std::chrono::milliseconds(EXPORT_DELAY_MS);
+
+      ProcessOpenTelemetryParameters(
+          config_map, exporter_options, attributes, processor_options);
+
+      auto exporter = otlp::OtlpHttpExporterFactory::Create(exporter_options);
       auto processor = otel_trace_sdk::BatchSpanProcessorFactory::Create(
           std::move(exporter), processor_options);
       auto resource = otel_resource::Resource::Create(attributes);
@@ -485,6 +460,56 @@ TraceManager::CleanupTracer()
 }
 
 #ifndef _WIN32
+void
+TraceManager::ProcessOpenTelemetryParameters(
+    const triton::server::TraceConfigMap& config_map,
+    otlp::OtlpHttpExporterOptions& exporter_options,
+    otel_resource::ResourceAttributes& attributes,
+    otel_trace_sdk::BatchSpanProcessorOptions& processor_options)
+{
+  processor_options.max_queue_size =
+      std::stoi(triton::server::GetEnvironmentVariableOrDefault(
+          "OTEL_BSP_MAX_QUEUE_SIZE", "2048"));
+  processor_options.max_export_batch_size =
+      std::stoi(triton::server::GetEnvironmentVariableOrDefault(
+          "OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "512"));
+  processor_options.schedule_delay_millis = std::chrono::milliseconds(
+      std::stoi(triton::server::GetEnvironmentVariableOrDefault(
+          "OTEL_BSP_SCHEDULE_DELAY", "5000")));
+
+  attributes[otel_resource::SemanticConventions::kServiceName] =
+      std::string("triton-inference-server");
+  auto mode_key = std::to_string(TRACE_MODE_OPENTELEMETRY);
+  auto otel_options_it = config_map.find(mode_key);
+  if (otel_options_it != config_map.end()) {
+    for (const auto& setting : otel_options_it->second) {
+      // FIXME add more configuration options of OTLP HTTP Exporter
+      if (setting.first == "url") {
+        exporter_options.url = setting.second;
+      }
+      if (setting.first == "resource") {
+        auto pos = setting.second.find('=');
+        auto key = setting.second.substr(0, pos);
+        auto value = setting.second.substr(pos + 1);
+        attributes[key] = value;
+      }
+      if (setting.first == "batch-span-processor") {
+        auto pos = setting.second.find('=');
+        auto key = setting.second.substr(0, pos);
+        auto value = setting.second.substr(pos + 1);
+        if (key == "max_queue_size") {
+          processor_options.max_queue_size = std::stoi(value);
+        } else if (key == "schedule_delay_millis") {
+          processor_options.schedule_delay_millis =
+              std::chrono::milliseconds(std::stoi(value));
+        } else if (key == "max_export_batch_size") {
+          processor_options.max_export_batch_size = std::stoi(value);
+        }
+      }
+    }
+  }
+}
+
 void
 TraceManager::Trace::StartSpan(
     std::string span_key, TRITONSERVER_InferenceTrace* trace,

--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -47,6 +47,9 @@ namespace otel_resource = opentelemetry::sdk::resource;
 
 namespace triton { namespace server {
 
+static const int EXPORT_QUEUE_SIZE = 5000;
+static const int EXPORT_DELAY_MS = 2000;
+
 TRITONSERVER_Error*
 TraceManager::Create(
     TraceManager** manager, const TRITONSERVER_InferenceTraceLevel level,
@@ -430,8 +433,13 @@ TraceManager::InitTracer(const triton::server::TraceConfigMap& config_map)
         }
       }
       auto exporter = otlp::OtlpHttpExporterFactory::Create(opts);
-      auto processor = otel_trace_sdk::SimpleSpanProcessorFactory::Create(
-          std::move(exporter));
+      otel_trace_sdk::BatchSpanProcessorOptions processor_options;
+      processor_options.max_queue_size = EXPORT_QUEUE_SIZE;
+      processor_options.max_export_batch_size = EXPORT_QUEUE_SIZE;
+      processor_options.schedule_delay_millis =
+          std::chrono::milliseconds(EXPORT_DELAY_MS);
+      auto processor = otel_trace_sdk::BatchSpanProcessorFactory::Create(
+          std::move(exporter), processor_options);
       auto resource = otel_resource::Resource::Create(attributes);
       std::shared_ptr<otel_trace_api::TracerProvider> provider =
           otel_trace_sdk::TracerProviderFactory::Create(

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -41,6 +41,8 @@
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/sdk/trace/simple_processor_factory.h"
+#include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
+#include "opentelemetry/sdk/trace/batch_span_processor_options.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/context.h"
 #include "opentelemetry/trace/propagation/http_trace_context.h"

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -37,19 +37,20 @@
 
 #if !defined(_WIN32) && defined(TRITON_ENABLE_TRACING)
 #include "opentelemetry/context/propagation/global_propagator.h"
+#include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/sdk/resource/resource.h"
-#include "opentelemetry/sdk/trace/processor.h"
-#include "opentelemetry/sdk/trace/simple_processor_factory.h"
-#include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
 #include "opentelemetry/sdk/trace/batch_span_processor_options.h"
+#include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/context.h"
 #include "opentelemetry/trace/propagation/http_trace_context.h"
 #include "opentelemetry/trace/provider.h"
+namespace otlp = opentelemetry::exporter::otlp;
 namespace otel_trace_sdk = opentelemetry::sdk::trace;
 namespace otel_trace_api = opentelemetry::trace;
 namespace otel_cntxt = opentelemetry::context;
+namespace otel_resource = opentelemetry::sdk::resource;
 #endif
 #include "triton/core/tritonserver.h"
 
@@ -191,6 +192,13 @@ class TraceManager {
   /// set by InitTracer.
   /// In Triton trace mode is a no-op.
   void CleanupTracer();
+#if !defined(_WIN32) && defined(TRITON_ENABLE_TRACING)
+  void ProcessOpenTelemetryParameters(
+      const triton::server::TraceConfigMap& config_map,
+      otlp::OtlpHttpExporterOptions& exporter_options,
+      otel_resource::ResourceAttributes& attributes,
+      otel_trace_sdk::BatchSpanProcessorOptions& processor_options);
+#endif
 
   struct Trace {
     Trace() : trace_(nullptr), trace_id_(0) {}
@@ -225,8 +233,8 @@ class TraceManager {
     /// it starts a new request or compute span. For the request span it
     /// adds some triton related attributes, and adds this span to
     /// `otel_context_`. Alternatively, if activity is
-    /// `TRITONSERVER_TRACE_REQUEST_END` or `TRITONSERVER_TRACE_COMPUTE_END`,
-    /// it ends the corresponding span.
+    /// `TRITONSERVER_TRACE_REQUEST_END` or
+    /// `TRITONSERVER_TRACE_COMPUTE_END`, it ends the corresponding span.
     ///
     /// \param trace TRITONSERVER_InferenceTrace instance.
     /// \param activity  Trace activity.

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -34,6 +34,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <variant>
 
 #if !defined(_WIN32) && defined(TRITON_ENABLE_TRACING)
 #include "opentelemetry/context/propagation/global_propagator.h"
@@ -56,7 +57,8 @@ namespace otel_resource = opentelemetry::sdk::resource;
 
 namespace triton { namespace server {
 
-using TraceConfig = std::vector<std::pair<std::string, std::string>>;
+using TraceConfig = std::vector<
+    std::pair<std::string, std::variant<std::string, int, uint32_t>>>;
 using TraceConfigMap = std::unordered_map<std::string, TraceConfig>;
 #if !defined(_WIN32) && defined(TRITON_ENABLE_TRACING)
 using AbstractCarrier = otel_cntxt::propagation::TextMapCarrier;


### PR DESCRIPTION
Fixes issue: https://github.com/triton-inference-server/server/issues/6693
Picked up work from [this PR](https://github.com/triton-inference-server/server/pull/6733) by @theoclark , he has CLA : https://github.com/triton-inference-server/server/pull/6733#issuecomment-1874349122

Currently, OpenTelemetry Trace API uses SimpleSpanProcessor, which send spans one by one, when they are ready. This impacts Triton's performance, when tracing is on and mode is `opentelemetry`. To mitigate this issue, SimpleSpanProcessor was replaced by a BatchSpanProcessor(https://opentelemetry.io/docs/specs/otel/trace/sdk/#batching-processor), which collects spans in batches of a specified size and sends them out to the endpoint periodically. 

There are 3 customization parameters:
`bsp_max_queue_size` - the maximum queue size. After the size is reached spans are dropped. The default value is 2048.
`bsp_schedule_delay` - the maximum delay interval in milliseconds between two consecutive exports. The default value is 5000.
`bsp_max_export_batch_size` - the maximum batch size of every export. It must be smaller or equal to `bsp_max_queue_size`. If the queue reaches `bsp_max_export_batch_size`  a batch will be exported even if `bsp_schedule_delay` milliseconds have not elapsed. The default value is 512.

Note, that specification has 4 parameters, but [opentelemetry-cpp](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/sdk/include/opentelemetry/sdk/trace/batch_span_processor_options.h) client only supports 3 at the moment.

In this PR:
- I add an ability to specify `bsp_max_queue_size`, `bsp_schedule_delay` and `bsp_max_export_batch_size` through cmd line arguments. Alternatively, these parameters could also be specified from the environment variables.
- I verify these arguments in `command_line_parser` and throw exception if argument is specified incorrectly.
- I've also adjusted `TraceConfig` to store pairs, where second element can be one of `std::string`,`int`, `uint32_t`. Note, that cmdline parser will always collect strings of arguments' values. During the validation process I convert numerical values to integers and store integers instead of strings. This is done for multiple reasons: 1) We need to validate args 2) Since validation makes sure that `StringToInt` runs successfully, we can store converted value in `trace_config_map` and pass to TraceManager with valid parameters and proper types.
- I've added docs
- I've added tests
