### PR TITLE
Updating vllm version to 0.3.0

### DIFF
--- a/build.py
+++ b/build.py
@@ -78,7 +78,7 @@ TRITON_VERSION_MAP = {
         "2023.0.0",  # Standalone OpenVINO
         "3.2.6",  # DCGM version
         "py310_23.1.0-1",  # Conda version
-        "0.2.3",  # vLLM version
+        "0.3.0",  # vLLM version
     )
 }
 


### PR DESCRIPTION
This update resolves a compromised vllm install of v0.2.3, possibly due to some issues with intermediate dependencies.
Relevant import error:
`ImportError: /usr/local/lib/python3.10/dist-packages/vllm/_C.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZN2at4_ops15to_dtype_layout4callERKNS_6TensorEN3c108optionalINS5_10ScalarTypeEEENS6_INS5_6LayoutEEENS6_INS5_6DeviceEEENS6_IbEEbbNS6_INS5_12MemoryFormatEEE`
Should be merged with https://github.com/triton-inference-server/vllm_backend/pull/30