### PR TITLE
Fix inference command sample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ docker run --gpus=1 --rm --net=host -v ${PWD}/model_repository:/models nvcr.io/n
 
 # Step 3: Sending an Inference Request
 # In a separate console, launch the image_client example from the NGC Triton SDK container
-docker run -it --rm --net=host nvcr.io/nvidia/tritonserver:24.01-py3-sdk
+docker run -it --rm --net=host nvcr.io/nvidia/tritonserver:24.01-py3-sdk \
 /workspace/install/bin/image_client -m densenet_onnx -c 3 -s INCEPTION /workspace/images/mug.jpg
 
 # Inference should return the following


### PR DESCRIPTION
The inference sample in README.md did not work for me and I noticed there was a missing line continuation in the command line.