### PR TITLE
Exposing trace context to python backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   repo-core
-  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/core.git
+  #GIT_REPOSITORY https://github.com/triton-inference-server/core.git
+  GIT_REPOSITORY oandreeva@172.17.0.1:/home/oandreeva/Code/core
   GIT_TAG ${TRITON_CORE_REPO_TAG}
 )
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,7 @@ include(FetchContent)
 
 FetchContent_Declare(
   repo-core
-  #GIT_REPOSITORY https://github.com/triton-inference-server/core.git
-  GIT_REPOSITORY oandreeva@172.17.0.1:/home/oandreeva/Code/core
+  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/core.git
   GIT_TAG ${TRITON_CORE_REPO_TAG}
 )
 FetchContent_Declare(

--- a/qa/L0_trace/opentelemetry_unittest.py
+++ b/qa/L0_trace/opentelemetry_unittest.py
@@ -41,7 +41,7 @@ import requests
 import test_util as tu
 import tritonclient.grpc as grpcclient
 import tritonclient.http as httpclient
-from tritonclient.utils import InferenceServerException, np_to_triton_dtype
+from tritonclient.utils import InferenceServerException
 
 NO_PARENT_SPAN_ID = ""
 COLLECTOR_TIMEOUT = 10

--- a/qa/L0_trace/test.sh
+++ b/qa/L0_trace/test.sh
@@ -721,7 +721,7 @@ rm collected_traces.json*
 # Unittests then check that produced spans have expected format and events
 OPENTELEMETRY_TEST=opentelemetry_unittest.py
 OPENTELEMETRY_LOG="opentelemetry_unittest.log"
-EXPECTED_NUM_TESTS="13"
+EXPECTED_NUM_TESTS="14"
 
 # Set up repo and args for SageMaker
 export SAGEMAKER_TRITON_DEFAULT_MODEL_NAME="simple"

--- a/qa/L0_trace/test.sh
+++ b/qa/L0_trace/test.sh
@@ -739,7 +739,8 @@ mkdir -p $MODELSDIR/trace_context/1 && cp ./trace_context.py $MODELSDIR/trace_co
 SERVER_ARGS="--allow-sagemaker=true --model-control-mode=explicit \
                 --load-model=simple --load-model=ensemble_add_sub_int32_int32_int32 \
                 --load-model=bls_simple --trace-config=level=TIMESTAMPS \
-                --trace-config=rate=1 --trace-config=count=-1 --trace-config=mode=opentelemetry \
+                --load-model=trace_context --trace-config=rate=1 \
+                --trace-config=count=-1 --trace-config=mode=opentelemetry \
                 --trace-config=opentelemetry,resource=test.key=test.value \
                 --trace-config=opentelemetry,resource=service.name=test_triton \
                 --trace-config=opentelemetry,url=localhost:$OTLP_PORT/v1/traces \

--- a/qa/L0_trace/test.sh
+++ b/qa/L0_trace/test.sh
@@ -722,6 +722,9 @@ cp -r $DATADIR/$MODELBASE/* ${MODEL_PATH} && \
     rm -r ${MODEL_PATH}/2 && rm -r ${MODEL_PATH}/3 && \
         sed -i "s/onnx_int32_int32_int32/simple/" ${MODEL_PATH}/config.pbtxt
 
+# Add model to test trace context exposed to python backend
+mkdir -p $MODELSDIR/trace_context/1 && cp ./trace_context.py $MODELSDIR/trace_context/1/model.py
+
 
 SERVER_ARGS="--allow-sagemaker=true --model-control-mode=explicit \
                 --load-model=simple --load-model=ensemble_add_sub_int32_int32_int32 \

--- a/qa/L0_trace/test.sh
+++ b/qa/L0_trace/test.sh
@@ -131,6 +131,16 @@ function update_trace_setting {
   set -e
 }
 
+function check_pbe_trace_context {
+  model_name="${1}"
+  expect_none="${2}"
+  data='{"inputs":[{"name":"expect_none","datatype":"BOOL","shape":[1],"data":['${expect_none}']}]}'
+  rm -f ./curl.out
+  set +e
+  code=`curl -s -w %{http_code} -o ./curl.out -X POST localhost:8000/v2/models/${model_name}/infer -d ${data}`
+  set -e
+}
+
 function send_inference_requests {
     log_file="${1}"
     upper_bound="${2}"
@@ -1024,6 +1034,49 @@ fi
 set -e
 kill $COLLECTOR_PID
 wait $COLLECTOR_PID
+kill $SERVER_PID
+wait $SERVER_PID
+set +e
+
+# Test that PBE returns None as trace context in trace mode Triton
+SERVER_ARGS="--trace-config=level=TIMESTAMPS --trace-config=rate=1\
+                --trace-config=count=-1 --trace-config=mode=triton \
+                --model-repository=$MODELSDIR --log-verbose=1"
+SERVER_LOG="./inference_server_triton_trace_context.log"
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+check_pbe_trace_context "trace_context" true
+assert_curl_success "PBE trace context is not None"
+
+set -e
+kill $SERVER_PID
+wait $SERVER_PID
+set +e
+
+# Test that PBE returns None as trace context in trace mode OpenTelemetry,
+# but traceing is OFF.
+SERVER_ARGS="--trace-config=level=OFF --trace-config=rate=1\
+                --trace-config=count=-1 --trace-config=mode=opentelemetry \
+                --model-repository=$MODELSDIR --log-verbose=1"
+SERVER_LOG="./inference_server_triton_trace_context.log"
+
+run_server
+if [ "$SERVER_PID" == "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER\n***"
+    cat $SERVER_LOG
+    exit 1
+fi
+
+check_pbe_trace_context "trace_context" true
+assert_curl_success "PBE trace context is not None"
+
+set -e
 kill $SERVER_PID
 wait $SERVER_PID
 set +e

--- a/qa/L0_trace/trace_context.py
+++ b/qa/L0_trace/trace_context.py
@@ -1,0 +1,48 @@
+import json
+import time
+
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+
+class TritonPythonModel:
+    @staticmethod
+    def auto_complete_config(auto_complete_model_config):
+        inputs = [{"name": "INPUT0", "data_type": "TYPE_FP32", "dims": [1]}]
+        outputs = [{"name": "OUTPUT0", "data_type": "TYPE_STRING", "dims": [-1]}]
+
+        config = auto_complete_model_config.as_dict()
+        input_names = []
+        output_names = []
+        for input in config["input"]:
+            input_names.append(input["name"])
+        for output in config["output"]:
+            output_names.append(output["name"])
+
+        for input in inputs:
+            if input["name"] not in input_names:
+                auto_complete_model_config.add_input(input)
+        for output in outputs:
+            if output["name"] not in output_names:
+                auto_complete_model_config.add_output(output)
+
+        auto_complete_model_config.set_max_batch_size(1)
+
+        return auto_complete_model_config
+
+    def initialize(self, args):
+        self.model_config = json.loads(args["model_config"])
+        output_config = pb_utils.get_output_config_by_name(self.model_config, "OUTPUT0")
+        self.output_dtype = pb_utils.triton_string_to_numpy(output_config["data_type"])
+
+    def execute(self, requests):
+        responses = []
+        for request in requests:
+            context = request.trace().get_context(mode="opentelemetry")
+            output_tensor = pb_utils.Tensor(
+                "OUTPUT0", np.array(context).astype(np.bytes_)
+            )
+            inference_response = pb_utils.InferenceResponse([output_tensor])
+            responses.append(inference_response)
+
+        return responses

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,8 +45,7 @@ FetchContent_Declare(
 )
 FetchContent_Declare(
   repo-core
-  #GIT_REPOSITORY https://github.com/triton-inference-server/core.git
-  GIT_REPOSITORY  oandreeva@172.17.0.1:/home/oandreeva/Code/core
+  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/core.git
   GIT_TAG ${TRITON_CORE_REPO_TAG}
 )
 FetchContent_Declare(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,8 @@ FetchContent_Declare(
 )
 FetchContent_Declare(
   repo-core
-  GIT_REPOSITORY ${TRITON_REPO_ORGANIZATION}/core.git
+  #GIT_REPOSITORY https://github.com/triton-inference-server/core.git
+  GIT_REPOSITORY  oandreeva@172.17.0.1:/home/oandreeva/Code/core
   GIT_TAG ${TRITON_CORE_REPO_TAG}
 )
 FetchContent_Declare(
@@ -525,6 +526,7 @@ if(${TRITON_ENABLE_TRACING})
     tracing-library
     PUBLIC
       triton-common-logging    # from repo-common
+      triton-common-json      # from repo-common
       triton-core-serverapi    # from repo-core
       triton-core-serverstub   # from repo-core
   )

--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -38,7 +38,6 @@
 #ifndef _WIN32
 #include "opentelemetry/sdk/resource/semantic_conventions.h"
 #include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
-
 namespace otel_common = opentelemetry::common;
 #endif
 
@@ -563,7 +562,6 @@ TraceManager::Trace::StartSpan(
     if (std::string(request_id) != "") {
       span->SetAttribute("triton.request_id", request_id);
     }
-
     triton::common::TritonJson::WriteBuffer buffer;
     PrepareTraceContext(span, &buffer);
     TRITONSERVER_InferenceTraceSetContext(trace, buffer.Contents().c_str());

--- a/src/tracer.cc
+++ b/src/tracer.cc
@@ -38,6 +38,7 @@
 #ifndef _WIN32
 #include "opentelemetry/sdk/resource/semantic_conventions.h"
 #include "opentelemetry/sdk/trace/batch_span_processor_factory.h"
+
 namespace otel_common = opentelemetry::common;
 #endif
 
@@ -300,7 +301,9 @@ TraceManager::GetTraceStartOptions(
 {
   TraceManager::TraceStartOptions start_options;
   GetTraceSetting(model_name, start_options.trace_setting);
-  if (start_options.trace_setting->mode_ == TRACE_MODE_OPENTELEMETRY) {
+  if (!start_options.trace_setting->level_ ==
+          TRITONSERVER_TRACE_LEVEL_DISABLED &&
+      start_options.trace_setting->mode_ == TRACE_MODE_OPENTELEMETRY) {
 #ifndef _WIN32
     auto prop =
         otel_cntxt::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
@@ -560,6 +563,10 @@ TraceManager::Trace::StartSpan(
     if (std::string(request_id) != "") {
       span->SetAttribute("triton.request_id", request_id);
     }
+
+    triton::common::TritonJson::WriteBuffer buffer;
+    PrepareTraceContext(span, &buffer);
+    TRITONSERVER_InferenceTraceSetContext(trace, buffer.Contents().c_str());
   }
 
   otel_context_ = otel_context_.SetValue(span_key, span);
@@ -701,6 +708,32 @@ TraceManager::Trace::AddEvent(
         otel_context_.GetValue(span_key));
     span->AddEvent(event, time_offset_ + std::chrono::nanoseconds{timestamp});
   }
+}
+
+void
+TraceManager::Trace::PrepareTraceContext(
+    opentelemetry::nostd::shared_ptr<otel_trace_api::Span> span,
+    triton::common::TritonJson::WriteBuffer* buffer)
+{
+  triton::common::TritonJson::Value json(
+      triton::common::TritonJson::ValueType::OBJECT);
+  char trace_id[32] = {0};
+  char span_id[16] = {0};
+  char trace_flags[2] = {0};
+  span->GetContext().span_id().ToLowerBase16(span_id);
+  span->GetContext().trace_id().ToLowerBase16(trace_id);
+  span->GetContext().trace_flags().ToLowerBase16(trace_flags);
+  std::string kTraceParent = std::string("traceparent");
+  std::string kTraceState = std::string("tracestate");
+  std::string traceparent = std::string("00-") + std::string(trace_id, 32) +
+                            std::string("-") + std::string(span_id, 16) +
+                            std::string("-") + std::string(trace_flags, 2);
+  std::string tracestate = span->GetContext().trace_state()->ToHeader();
+  json.SetStringObject(kTraceParent.c_str(), traceparent);
+  if (!tracestate.empty()) {
+    json.SetStringObject(kTraceState.c_str(), tracestate);
+  }
+  json.Write(buffer);
 }
 #endif
 


### PR DESCRIPTION
The purpose of this PR:
This PR is a Stage 1 towards adding an ability for users to create custom traces in python backend. 
This set of PRs is heavily focused on OpenTelemetry trace mode. 

Functionality:
- Prepares OpenTelemetry trace context via `PrepareTraceContext` and attaches it to TRITONSERVER_InferenceTrace instance through `TRITONSERVER_InferenceTraceSetContex` at the moment in time, when `REQUEST_START` callback happens. That one is happening from the core side, so when PBE model starts execution, it should have context attached to its trace.
- Context is passed as a string and for OpenTelemetry is essentially 2 headers `traceparent` : "..." and `tracestate`: "...". Some of you may know about them from OpenTelemetry context propagation discussions. It's the same. 
- We do nothing with trace Context in Triton mode. On the core side `TRITONSERVER_InferenceTrace` is initiated with an empty string as a context, since it is never updated, pbe will get an empty string and return `None` with `request.trace().get_context()` 

Below is a POC illustrated.

`mode=triton` tests are on the way.

Related PRs:
python_be: https://github.com/triton-inference-server/python_backend/pull/346
core: https://github.com/triton-inference-server/core/pull/334
  

POC:
![image](https://github.com/triton-inference-server/server/assets/124622579/9b46386d-cf13-4e83-b6ee-a0092dac4d85)

created with model.py:
```python
import time
import json

import numpy as np
import triton_python_backend_utils as pb_utils

from opentelemetry import trace
from opentelemetry.propagate import inject
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import (
    BatchSpanProcessor
)
from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter



class TritonPythonModel:

    def initialize(self, args):
    	trace.set_tracer_provider(TracerProvider())
    	self.tracer = trace.get_tracer_provider().get_tracer("pbe")
    	trace.get_tracer_provider().add_span_processor(
	    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4318/v1/traces"))
	)

    def execute(self, requests):
        logger = pb_utils.Logger
        logger.log_info(f"got {len(requests)} requests")

        responses = []
        for request in requests:
            inp = pb_utils.get_input_tensor_by_name(request, "INPUT0").as_numpy()
            context = request.trace().get_context()
            if context == None:
            	context = "{}"
            ctx = TraceContextTextMapPropagator().extract(carrier=json.loads(context))

            # emulate some work
            with self.tracer.start_as_current_span('child', context=ctx) as span:
            	time.sleep(3)
            
            time.sleep(3)

            output_tensors = [pb_utils.Tensor("OUTPUT0", inp.astype(np.float32))]
            inference_response = pb_utils.InferenceResponse(output_tensors=output_tensors)
            responses.append(inference_response)

        return responses
```