### PR TITLE
HTTP live connections on server shutdown

### DIFF
--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -2662,6 +2662,7 @@ class LifeCycleTest(tu.TestResultCollector):
 
         # Send signal to shutdown the server
         os.kill(int(os.environ["SERVER_PID"]), signal.SIGINT)
+        time.sleep(0.5)
 
         # Send more requests and should be rejected
         try:
@@ -2721,6 +2722,7 @@ class LifeCycleTest(tu.TestResultCollector):
 
         # Send signal to shutdown the server
         os.kill(int(os.environ["SERVER_PID"]), signal.SIGINT)
+        time.sleep(0.5)
 
         # Send requests with different characteristic
         # 1: New sequence with new sequence ID
@@ -2808,6 +2810,7 @@ class LifeCycleTest(tu.TestResultCollector):
 
         # Send signal to shutdown the server
         os.kill(int(os.environ["SERVER_PID"]), signal.SIGINT)
+        time.sleep(0.5)
 
         # Send more requests and should be rejected
         try:

--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -2120,7 +2120,7 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 
 set +e
-SERVER_PID=$SERVER_PID python $LC_TEST LifeCycleTest.test_shutdown_with_live_connection >>$CLIENT_LOG 2>&1
+SERVER_PID=$SERVER_PID SERVER_LOG=$SERVER_LOG python $LC_TEST LifeCycleTest.test_shutdown_with_live_connection >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
     echo -e "\n***\n*** Test Failed\n***"

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -238,8 +238,6 @@ HTTPServer::Start()
 TRITONSERVER_Error*
 HTTPServer::Stop(uint32_t* exit_timeout_secs, const std::string& service_name)
 {
-  accept_new_conn_ = false;
-
   if (exit_timeout_secs != nullptr) {
     while (*exit_timeout_secs > 0) {
       uint32_t conn_cnt = conn_cnt_;
@@ -285,9 +283,6 @@ HTTPServer::Dispatch(evhtp_request_t* req, void* arg)
 evhtp_res
 HTTPServer::NewConnection(evhtp_connection_t* conn, void* arg)
 {
-  if ((static_cast<HTTPServer*>(arg))->accept_new_conn_ == false) {
-    return EVHTP_RES_SERVUNAVAIL;
-  }
   evhtp_connection_set_hook(
       conn, evhtp_hook_on_connection_fini,
       (evhtp_hook)(void*)HTTPServer::EndConnection, arg);

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -243,10 +243,8 @@ HTTPServer::Stop(uint32_t* exit_timeout_secs, const std::string& service_name)
     accepting_new_conn_ = false;
   }
   if (exit_timeout_secs != nullptr) {
-    while (*exit_timeout_secs > 0) {
-      if (conn_cnt_ == 0) {  // conn_cnt_ can only decrease
-        break;
-      }
+    // Note: conn_cnt_ can only decrease
+    while (*exit_timeout_secs > 0 && conn_cnt_ > 0) {
       LOG_INFO << "Timeout " << *exit_timeout_secs << ": Found " << conn_cnt_
                << " " << service_name << " service connections";
       std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -212,6 +212,7 @@ HTTPServer::Start()
       evhtp_enable_flag(htp_, EVHTP_FLAG_ENABLE_REUSEPORT);
     }
     evhtp_set_gencb(htp_, HTTPServer::Dispatch, this);
+    evhtp_set_pre_accept_cb(htp_, HTTPServer::NewConnection, this);
     evhtp_use_threads_wexit(htp_, NULL, NULL, thread_cnt_, NULL);
     if (evhtp_bind_socket(htp_, address_.c_str(), port_, 1024) != 0) {
       return TRITONSERVER_ErrorNew(
@@ -265,6 +266,26 @@ void
 HTTPServer::Dispatch(evhtp_request_t* req, void* arg)
 {
   (static_cast<HTTPServer*>(arg))->Handle(req);
+}
+
+evhtp_res
+HTTPServer::NewConnection(evhtp_connection_t* conn, void* arg)
+{
+  if ((static_cast<HTTPServer*>(arg))->accept_new_conn_ == false) {
+    return EVHTP_RES_SERVUNAVAIL;
+  }
+  evhtp_connection_set_hook(
+      conn, evhtp_hook_on_connection_fini,
+      (evhtp_hook)(void*)HTTPServer::EndConnection, arg);
+  (static_cast<HTTPServer*>(arg))->conn_cnt_++;
+  return EVHTP_RES_OK;
+}
+
+evhtp_res
+HTTPServer::EndConnection(evhtp_connection_t* conn, void* arg)
+{
+  (static_cast<HTTPServer*>(arg))->conn_cnt_--;
+  return EVHTP_RES_OK;
 }
 
 #ifdef TRITON_ENABLE_METRICS

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -92,7 +92,7 @@ class HTTPServer {
       : port_(port), reuse_port_(reuse_port), address_(address),
         header_forward_pattern_(header_forward_pattern),
         thread_cnt_(thread_cnt), header_forward_regex_(header_forward_pattern_),
-        accept_new_conn_(true), conn_cnt_(0)
+        conn_cnt_(0)
   {
   }
 
@@ -120,7 +120,6 @@ class HTTPServer {
   evutil_socket_t fds_[2];
   event* break_ev_;
 
-  std::atomic<bool> accept_new_conn_;
   std::atomic<uint32_t> conn_cnt_;
 };
 

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -81,10 +81,9 @@ class HTTPServer {
   virtual ~HTTPServer() { IGNORE_ERR(Stop()); }
 
   TRITONSERVER_Error* Start();
-  TRITONSERVER_Error* Stop();
-
-  void StopAcceptingNewConnections() { accept_new_conn_ = false; }
-  uint32_t ConnectionCount() { return conn_cnt_; }
+  TRITONSERVER_Error* Stop(
+      uint32_t* exit_timeout_secs = nullptr,
+      const std::string& service_name = "HTTP");
 
  protected:
   explicit HTTPServer(

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -28,10 +28,10 @@
 #include <evhtp/evhtp.h>
 #include <re2/re2.h>
 
-#include <atomic>
 #include <list>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <string>
 #include <thread>
@@ -92,7 +92,7 @@ class HTTPServer {
       : port_(port), reuse_port_(reuse_port), address_(address),
         header_forward_pattern_(header_forward_pattern),
         thread_cnt_(thread_cnt), header_forward_regex_(header_forward_pattern_),
-        conn_cnt_(0)
+        conn_cnt_(0), stop_accepting_new_conn_(false)
   {
   }
 
@@ -120,7 +120,9 @@ class HTTPServer {
   evutil_socket_t fds_[2];
   event* break_ev_;
 
-  std::atomic<uint32_t> conn_cnt_;
+  std::mutex conn_mu_;
+  uint32_t conn_cnt_;
+  bool stop_accepting_new_conn_;
 };
 
 #ifdef TRITON_ENABLE_METRICS

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -92,7 +92,7 @@ class HTTPServer {
       : port_(port), reuse_port_(reuse_port), address_(address),
         header_forward_pattern_(header_forward_pattern),
         thread_cnt_(thread_cnt), header_forward_regex_(header_forward_pattern_),
-        conn_cnt_(0), stop_accepting_new_conn_(false)
+        conn_cnt_(0), accepting_new_conn_(true)
   {
   }
 
@@ -122,7 +122,7 @@ class HTTPServer {
 
   std::mutex conn_mu_;
   uint32_t conn_cnt_;
-  bool stop_accepting_new_conn_;
+  bool accepting_new_conn_;
 };
 
 #ifdef TRITON_ENABLE_METRICS

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -83,7 +83,7 @@ class HTTPServer {
   TRITONSERVER_Error* Start();
   TRITONSERVER_Error* Stop();
 
-  void StopAcceptingNewConnection() { accept_new_conn_ = false; }
+  void StopAcceptingNewConnections() { accept_new_conn_ = false; }
   uint32_t ConnectionCount() { return conn_cnt_; }
 
  protected:

--- a/src/main.cc
+++ b/src/main.cc
@@ -301,12 +301,12 @@ StartEndpoints(
 }
 
 uint32_t
-PrepareStopEndpoints(uint32_t timeout_secs)
+WaitForExistingConnections(uint32_t timeout_secs)
 {
   // Instruct endpoints to stop accepting new connections
 #ifdef TRITON_ENABLE_HTTP
   if (g_http_service) {
-    g_http_service->StopAcceptingNewConnection();
+    g_http_service->StopAcceptingNewConnections();
   }
 #endif  // TRITON_ENABLE_HTTP
 
@@ -547,7 +547,7 @@ main(int argc, char** argv)
   }
 
   uint32_t exit_timeout_secs =
-      PrepareStopEndpoints(g_triton_params.exit_timeout_secs_);
+      WaitForExistingConnections(g_triton_params.exit_timeout_secs_);
   TRITONSERVER_ServerSetExitTimeout(server_ptr, exit_timeout_secs);
 
   TRITONSERVER_Error* stop_err = TRITONSERVER_ServerStop(server_ptr);

--- a/src/main.cc
+++ b/src/main.cc
@@ -316,6 +316,17 @@ StopEndpoints(uint32_t* exit_timeout_secs)
   }
 #endif  // TRITON_ENABLE_HTTP
 
+  return ret;
+}
+
+bool
+StopEndpoints()
+{
+  bool ret = true;
+
+  // TODO: Add support for 'exit_timeout_secs' to the endpoints below and move
+  // them to the 'StopEndpoints(uint32_t* exit_timeout_secs)' function above.
+
 #ifdef TRITON_ENABLE_GRPC
   if (g_grpc_service) {
     TRITONSERVER_Error* err = g_grpc_service->Stop();
@@ -509,7 +520,7 @@ main(int argc, char** argv)
     triton::server::signal_exit_cv_.wait_for(lock, wait_timeout);
   }
 
-  // Stop HTTP, gRPC and metrics endpoints, and update exit timeout.
+  // Stop the HTTP[, gRPC, and metrics] endpoints, and update exit timeout.
   uint32_t exit_timeout_secs = g_triton_params.exit_timeout_secs_;
   StopEndpoints(&exit_timeout_secs);
   TRITONSERVER_ServerSetExitTimeout(server_ptr, exit_timeout_secs);
@@ -523,6 +534,9 @@ main(int argc, char** argv)
     LOG_TRITONSERVER_ERROR(stop_err, "failed to stop server");
     exit(1);
   }
+
+  // Stop gRPC and metrics endpoints that do not yet support exit timeout.
+  StopEndpoints();
 
   // Stop tracing.
   StopTracing(&trace_manager);

--- a/src/main.cc
+++ b/src/main.cc
@@ -548,9 +548,9 @@ main(int argc, char** argv)
 
   uint32_t exit_timeout_secs =
       PrepareStopEndpoints(g_triton_params.exit_timeout_secs_);
+  TRITONSERVER_ServerSetExitTimeout(server_ptr, exit_timeout_secs);
 
-  TRITONSERVER_Error* stop_err =
-      TRITONSERVER_ServerStopWithTimeout(server_ptr, exit_timeout_secs);
+  TRITONSERVER_Error* stop_err = TRITONSERVER_ServerStop(server_ptr);
 
   // If unable to gracefully stop the server then Triton threads and
   // state are potentially in an invalid state, so just exit

--- a/src/main.cc
+++ b/src/main.cc
@@ -45,7 +45,6 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <string>
 #include <thread>
 
 #include "triton_signal.h"


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/core/pull/335

When graceful shutdown begin, 
1. The HTTP endpoints stop accepting new connections (existing connections may continue).
2. The server will poll until all connections on the HTTP endpoints end, or `exit_timeout_secs_` expires, whichever is earlier.
3. The server passes the remaining timeout to the core and initiates core shutdown.
4. The core begins its shutdown routine as it is currently.

Example shutdown:
```
I0315 19:34:17.024361 101974 main.cc:329] Timeout 30: Found 1 HTTP connections
I0315 19:34:18.024569 101974 main.cc:329] Timeout 29: Found 1 HTTP connections
I0315 19:34:19.024747 101974 main.cc:329] Timeout 28: Found 1 HTTP connections
I0315 19:34:20.025022 101974 server.cc:307] Waiting for in-flight requests to complete.
I0315 19:34:20.025078 101974 server.cc:323] Timeout 27: Found 0 model versions that have in-flight inferences
I0315 19:34:20.025321 101974 server.cc:338] All models are stopped, unloading models
I0315 19:34:20.025461 101974 server.cc:347] Timeout 27: Found 1 live models and 0 in-flight non-inference requests
I0315 19:34:21.025611 101974 server.cc:347] Timeout 26: Found 1 live models and 0 in-flight non-inference requests
I0315 19:34:21.440670 101974 model_lifecycle.cc:620] successfully unloaded 'add_sub' version 1
I0315 19:34:22.025764 101974 server.cc:347] Timeout 25: Found 0 live models and 0 in-flight non-inference requests
```