### PR TITLE
added support to intel gpu in a custom build

### DIFF
--- a/build.py
+++ b/build.py
@@ -1099,7 +1099,6 @@ RUN ldconfig && \
 
 ENV LD_LIBRARY_PATH=/usr/local/tensorrt/lib/:/opt/tritonserver/backends/tensorrtllm:$LD_LIBRARY_PATH
 """
-
     with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
         dfile.write(df)
 


### PR DESCRIPTION
Additional build flag --enable-intel-gpu which includes in the docker image required runtime drivers for Intel GPU
Related to https://github.com/triton-inference-server/openvino_backend/pull/74/files