### PR TITLE
Remove obsolete mention of image tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -323,13 +323,10 @@ def replace_relpath_with_url(relpath, src_doc_path):
 def replace_hyperlink(m, src_doc_path):
     """
     TODO: Support of HTML tags for future docs.
-    1. Markdown allows <link>, e.g. <a href=[^>]+>. Whether we want to
-       find and replace the link depends on if they link to internal .md files
-       or allows relative paths. I haven't seen one such case in our doc so
-       should be safe for now.
-    2. Broken images have been found in the client repo src/grpc_generated/java/README.md.
-       Sphinx did not compile HTML image tags correctly. Reach out to @yinggeh for more detail.
-       Ex: <img src="images/proto-files.png" width="220" />
+    Markdown allows <link>, e.g. <a href=[^>]+>. Whether we want to
+    find and replace the link depends on if they link to internal .md files
+    or allows relative paths. I haven't seen one such case in our doc so
+    should be safe for now.
     """
 
     hyperlink_str = m.group(2)


### PR DESCRIPTION
Addressing comments from previous [PR](https://github.com/triton-inference-server/server/pull/7084#event-12399356287) here. 