### PR TITLE
update openvino to 2024.0.0

### DIFF
--- a/build.py
+++ b/build.py
@@ -73,8 +73,8 @@ TRITON_VERSION_MAP = {
         "24.04dev",  # triton container
         "24.03",  # upstream container
         "1.17.2",  # ORT
-        "2023.3.0",  # ORT OpenVINO
-        "2023.3.0",  # Standalone OpenVINO
+        "2024.0.0",  # ORT OpenVINO
+        "2024.0.0",  # Standalone OpenVINO
         "3.2.6",  # DCGM version
         "0.3.2",  # vLLM version
     )


### PR DESCRIPTION
Updating OpenVINO version to 2024.0.0
Depends on https://github.com/triton-inference-server/openvino_backend/pull/75