### PR TITLE
Fix gRPC frontend race condition

### DIFF
--- a/qa/L0_grpc_state_cleanup/cleanup_test.py
+++ b/qa/L0_grpc_state_cleanup/cleanup_test.py
@@ -554,6 +554,15 @@ class CleanUpTest(tu.TestResultCollector):
                 infer_helper_map=[False, True],
             )
 
+    def test_decoupled_infer_complete(self):
+        # Test if the Process() thread could release the state object before
+        # the StreamInferResponseComplete() thread is done accessing it.
+        self._decoupled_infer(request_count=1, repeat_count=1, stream_timeout=16)
+        # Check no error is printed to the log.
+        with open(os.environ["SERVER_LOG"]) as f:
+            server_log = f.read()
+        self.assertNotIn("Should not print this", server_log)
+
 
 if __name__ == "__main__":
     CleanUpTest.SERVER_PID = os.environ.get("SERVER_PID", CleanUpTest.SERVER_PID)

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -1013,12 +1013,18 @@ class InferHandlerState {
       const std::shared_ptr<Context>& context, Steps start_step = Steps::START)
       : tritonserver_(tritonserver), async_notify_state_(false)
   {
-    // For debugging and testing,
+    // For debugging and testing
     const char* dstr = getenv("TRITONSERVER_DELAY_GRPC_RESPONSE");
     delay_response_ms_ = 0;
     if (dstr != nullptr) {
       delay_response_ms_ = atoi(dstr);
     }
+    const char* cstr = getenv("TRITONSERVER_DELAY_GRPC_COMPLETE");
+    delay_complete_ms_ = 0;
+    if (cstr != nullptr) {
+      delay_complete_ms_ = atoi(cstr);
+    }
+
     response_queue_.reset(new ResponseQueue<ResponseType>());
     Reset(context, start_step);
   }
@@ -1113,6 +1119,7 @@ class InferHandlerState {
 
   // For testing and debugging
   int delay_response_ms_;
+  int delay_complete_ms_;
 
   // For inference requests the allocator payload, unused for other
   // requests.


### PR DESCRIPTION
There is a race condition with the `InferHandlerState::complete_` variable. When `ModelStreamInferHandler::StreamInferResponseComplete()` function is called with `TRITONSERVER_RESPONSE_COMPLETE_FINAL` flag, the `InferHandlerState::complete_` variable is updated to `true` before the function returns. Simultaneously, the executing `ModelStreamInferHandler::Process()` function will see the `InferHandlerState::complete_ == true` and instruct its caller `InferHandler::Start()` function to release the `InferHandlerState` object, which is required by the `ModelStreamInferHandler::StreamInferResponseComplete()` function to finish its execution, for instance, checking for `InferHandlerState::IsGrpcContextCancelled()`.

A possible sequence of actions, 
1. `ModelStreamInferHandler::StreamInferResponseComplete()` is called.
2. `ModelStreamInferHandler::StreamInferResponseComplete()` set `InferHandlerState::complete_ = true`.
4. `InferHandler::Start()` begin its next iteration.
5. Since `InferHandlerState::complete_ == true`, `InferHandlerState` object is released.
7. `ModelStreamInferHandler::StreamInferResponseComplete()` continue execution without knowing `InferHandlerState` object is released.
8. `InferHandlerState` object is dereferenced and this action resulted in a segmentation fault.

The issue is easily fixable by having the `ModelStreamInferHandler::StreamInferResponseComplete()` function to update the `InferHandlerState::complete_` variable at the end of its execution, after all accesses to the `InferHandlerState` object are completed.

Before fix:
```
I0412 19:57:10.187564 1474 grpc_server.cc:2470] Started GRPCInferenceService at 0.0.0.0:8001
I0412 19:57:10.187729 1474 http_server.cc:4693] Started HTTPService at 0.0.0.0:8000
I0412 19:57:10.228720 1474 http_server.cc:362] Started Metrics Service at 0.0.0.0:8002
Signal (11) received.
 0# 0x0000564C107D8B43 in tritonserver
 1# 0x00007FD194BA9520 in /usr/lib/x86_64-linux-gnu/libc.so.6
 2# 0x0000564C10839564 in tritonserver
 3# 0x00007FD19560720C in /opt/tritonserver/bin/../lib/libtritonserver.so
 4# TRITONBACKEND_ResponseFactorySendFlags in /opt/tritonserver/bin/../lib/libtritonserver.so
 5# 0x00007FD180736728 in /opt/tritonserver/backends/python/libtriton_python.so
 6# 0x00007FD180737134 in /opt/tritonserver/backends/python/libtriton_python.so
 7# 0x00007FD18074624D in /opt/tritonserver/backends/python/libtriton_python.so
 8# 0x00007FD194C00EE8 in /usr/lib/x86_64-linux-gnu/libc.so.6
 9# 0x00007FD18072DCD0 in /opt/tritonserver/backends/python/libtriton_python.so
10# 0x00007FD18075B55B in /opt/tritonserver/backends/python/libtriton_python.so
11# 0x00007FD18074B997 in /opt/tritonserver/backends/python/libtriton_python.so
12# 0x00007FD18072FBC1 in /opt/tritonserver/backends/python/libtriton_python.so
13# 0x00007FD18074F59D in /opt/tritonserver/backends/python/libtriton_python.so
14# 0x00007FD180745484 in /opt/tritonserver/backends/python/libtriton_python.so
15# 0x00007FD194BFBAC3 in /usr/lib/x86_64-linux-gnu/libc.so.6
16# clone in /usr/lib/x86_64-linux-gnu/libc.so.6

Segmentation fault (core dumped)
root@tritonserver_qa:/opt/tritonserver# I0412 19:57:13.289491 1637 pb_stub.cc:2119]  Non-graceful termination detected. 
I0412 19:57:13.295702 1644 pb_stub.cc:2119]  Non-graceful termination detected.
```

After fix:
```
I0412 19:53:56.744054 612 grpc_server.cc:2470] Started GRPCInferenceService at 0.0.0.0:8001
I0412 19:53:56.744225 612 http_server.cc:4693] Started HTTPService at 0.0.0.0:8000
I0412 19:53:56.785186 612 http_server.cc:362] Started Metrics Service at 0.0.0.0:8002
^CSignal (2) received.
...
```