### PR TITLE
fix windows build for shared memory fix

### DIFF
--- a/qa/L0_grpc/test.sh
+++ b/qa/L0_grpc/test.sh
@@ -312,8 +312,8 @@ for i in \
             cat $CLIENT_LOG.c++.${SUFFIX}
             RET=1
         fi
-        if [ `grep -c "${CACHED_CHANNEL_STRING_ONE}" ${CLIENT_LOG}.c++.${SUFFIX}` != "2" ]; then
-            echo -e "\n***\n*** Failed. Expected 1 cached channel\n***"
+        if [ `grep -c "${CACHED_CHANNEL_STRING_NONE}" ${CLIENT_LOG}.c++.${SUFFIX}` != "2" ]; then
+            echo -e "\n***\n*** Failed. Expected 0 cached channels\n***"
             cat $CLIENT_LOG.c++.${SUFFIX}
             RET=1
         fi
@@ -328,8 +328,8 @@ for i in \
             cat $CLIENT_LOG.c++.${SUFFIX}
             RET=1
         fi
-        if [ `grep -c "${CACHED_CHANNEL_STRING_NONE}" ${CLIENT_LOG}.c++.${SUFFIX}` != "2" ]; then
-            echo -e "\n***\n*** Failed. Expected 0 cached channels\n***"
+        if [ `grep -c "${CACHED_CHANNEL_STRING_ONE}" ${CLIENT_LOG}.c++.${SUFFIX}` != "2" ]; then
+            echo -e "\n***\n*** Failed. Expected 1 cached channels\n***"
             cat $CLIENT_LOG.c++.${SUFFIX}
             RET=1
         fi

--- a/qa/L0_grpc/test.sh
+++ b/qa/L0_grpc/test.sh
@@ -312,8 +312,8 @@ for i in \
             cat $CLIENT_LOG.c++.${SUFFIX}
             RET=1
         fi
-        if [ `grep -c "${CACHED_CHANNEL_STRING_NONE}" ${CLIENT_LOG}.c++.${SUFFIX}` != "2" ]; then
-            echo -e "\n***\n*** Failed. Expected 0 cached channels\n***"
+        if [ `grep -c "${CACHED_CHANNEL_STRING_ONE}" ${CLIENT_LOG}.c++.${SUFFIX}` != "2" ]; then
+            echo -e "\n***\n*** Failed. Expected 1 cached channel\n***"
             cat $CLIENT_LOG.c++.${SUFFIX}
             RET=1
         fi
@@ -328,8 +328,8 @@ for i in \
             cat $CLIENT_LOG.c++.${SUFFIX}
             RET=1
         fi
-        if [ `grep -c "${CACHED_CHANNEL_STRING_ONE}" ${CLIENT_LOG}.c++.${SUFFIX}` != "2" ]; then
-            echo -e "\n***\n*** Failed. Expected 1 cached channels\n***"
+        if [ `grep -c "${CACHED_CHANNEL_STRING_NONE}" ${CLIENT_LOG}.c++.${SUFFIX}` != "2" ]; then
+            echo -e "\n***\n*** Failed. Expected 0 cached channels\n***"
             cat $CLIENT_LOG.c++.${SUFFIX}
             RET=1
         fi

--- a/src/shared_memory_manager.cc
+++ b/src/shared_memory_manager.cc
@@ -67,8 +67,9 @@ SharedMemoryManager::GetCUDAHandle(
 
 TRITONSERVER_Error*
 SharedMemoryManager::GetMemoryInfo(
-    const std::string& name, size_t offset, void** shm_mapped_addr,
-    TRITONSERVER_MemoryType* memory_type, int64_t* device_id)
+    const std::string& name, size_t offset, size_t byte_size,
+    void** shm_mapped_addr, TRITONSERVER_MemoryType* memory_type,
+    int64_t* device_id)
 {
   return TRITONSERVER_ErrorNew(
       TRITONSERVER_ERROR_UNSUPPORTED,


### PR DESCRIPTION
Fixes windows build caused by: https://github.com/triton-inference-server/server/pull/7083