### PR TITLE
Avoid the HTTP Error 403: rate limit exceeded error

### DIFF
--- a/qa/python_models/torchvision/resnet50/model.py
+++ b/qa/python_models/torchvision/resnet50/model.py
@@ -1,4 +1,4 @@
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -35,6 +35,8 @@ class TritonPythonModel:
         This function initializes pre-trained ResNet50 model.
         """
         self.device = "cuda" if args["model_instance_kind"] == "GPU" else "cpu"
+        # Avoid the "HTTP Error 403: rate limit exceeded" error
+        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
         # Our tests currently depend on torchvision=0.14,
         # to make sure `torch.hub` loads Resnet50 implementation
         # compatible with torchvision=0.14, we need to provide tag


### PR DESCRIPTION
This PR fixes the HTTP errors occurring in the L0_model_control_stress test, which were caused by extensive access to torch.hub during model loading

```
E0423 06:25:10.553733 50667 model_lifecycle.cc:638] failed to load 'resnet50_python' version 1: Internal: HTTPError: HTTP Error 403: rate limit exceeded

At:
  /usr/lib/python3.10/urllib/request.py(643): http_error_default
  /usr/lib/python3.10/urllib/request.py(496): _call_chain
  /usr/lib/python3.10/urllib/request.py(563): error
  /usr/lib/python3.10/urllib/request.py(634): http_response
  /usr/lib/python3.10/urllib/request.py(525): open
  /usr/lib/python3.10/urllib/request.py(216): urlopen
  /usr/local/lib/python3.10/dist-packages/torch/hub.py(164): _read_url
  /usr/local/lib/python3.10/dist-packages/torch/hub.py(181): _validate_not_a_forked_repo
  /usr/local/lib/python3.10/dist-packages/torch/hub.py(222): _get_cache_or_reload
  /usr/local/lib/python3.10/dist-packages/torch/hub.py(555): load
  /opt/tritonserver/qa/L0_model_control_stress/models/resnet50_python/1/model.py(42): initialize
```