### PR TITLE
Upgrade the golang version to 1.22.3

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -368,9 +368,8 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
     fi
 ENV GOPATH /root/go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin
-RUN GO111MODULE=off go get github.com/golang/protobuf/protoc-gen-go && \
-    GO111MODULE=off go get google.golang.org/grpc
-
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest && \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 # CI expects tests in /opt/tritonserver/qa. The triton-server (1000)
 # user should own all artifacts in case CI is run using triton-server
 # user.

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -1,4 +1,4 @@
-# Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -358,13 +358,13 @@ RUN pip3 install --upgrade wheel setuptools && \
 
 # go needed for example go client test.
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-      wget https://golang.org/dl/go1.19.1.linux-arm64.tar.gz && \
-      rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.1.linux-arm64.tar.gz && \
-      rm -f go1.19.1.linux-arm64.tar.gz; \
+      wget https://golang.org/dl/go1.22.3.linux-arm64.tar.gz && \
+      rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.3.linux-arm64.tar.gz && \
+      rm -f go1.22.3.linux-arm64.tar.gz; \
     else \
-      wget https://golang.org/dl/go1.19.1.linux-amd64.tar.gz && \
-      rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.1.linux-amd64.tar.gz && \
-      rm -f go1.19.1.linux-amd64.tar.gz; \
+      wget https://golang.org/dl/go1.22.3.linux-amd64.tar.gz && \
+      rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.3.linux-amd64.tar.gz && \
+      rm -f go1.22.3.linux-amd64.tar.gz; \
     fi
 ENV GOPATH /root/go
 ENV PATH $PATH:/usr/local/go/bin:$GOPATH/bin


### PR DESCRIPTION
We need this to install go-grpc which is a dependency in our L0_grpc test.

This is needed to fix the test.

### Before

```
+ go install github.com/grpc-ecosystem/grpc-health-probe@latest
go: downloading github.com/grpc-ecosystem/grpc-health-probe v0.4.26
go: downloading google.golang.org/grpc v1.63.2
go: downloading github.com/spiffe/go-spiffe/v2 v2.2.0
go: downloading github.com/zeebo/errs v1.3.0
go: downloading google.golang.org/protobuf v1.33.0
go: downloading github.com/go-jose/go-jose/v4 v4.0.1
go: downloading golang.org/x/crypto v0.22.0
go: downloading golang.org/x/sys v0.19.0
go: downloading golang.org/x/sync v0.7.0
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda
go: downloading golang.org/x/net v0.24.0
go: downloading golang.org/x/text v0.14.0
# github.com/go-jose/go-jose/v4
/root/go/pkg/mod/github.com/go-jose/go-jose/v4@v4.0.1/encoding.go:109:23: undefined: max
note: module requires Go 1.21
```