### PR TITLE
Remove the dependency on CUDA driver

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -180,7 +180,6 @@ if(${TRITON_ENABLE_GPU})
     main
     PRIVATE
       CUDA::cudart
-      -lcuda
   )
 endif() # TRITON_ENABLE_GPU
 

--- a/src/shared_memory_manager.cc
+++ b/src/shared_memory_manager.cc
@@ -118,7 +118,6 @@ SharedMemoryManager::UnregisterHelper(
 }
 }}  // namespace triton::server
 #else
-#include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>

--- a/src/shared_memory_manager.cc
+++ b/src/shared_memory_manager.cc
@@ -266,6 +266,10 @@ OpenCudaIPCRegion(
   return nullptr;
 }
 
+// Using `cudaGetDriverEntryPoint` from CUDA runtime API to get CUDA driver
+// entry point. This approach is used to avoid linking against CUDA driver
+// library so that when Triton is built with GPU support, it can still be run on
+// CPU-only environments.
 TRITONSERVER_Error*
 GetCudaDriverEntryPoint(const char* name, void** func_ptr)
 {


### PR DESCRIPTION
This PR fixed the CUDA driver dependency issue on CPU-only system introduced in the previous PR https://github.com/triton-inference-server/server/pull/7178.