### PR TITLE
Fix the L0_simple_go_client

### DIFF
--- a/qa/L0_simple_go_client/test.sh
+++ b/qa/L0_simple_go_client/test.sh
@@ -31,7 +31,6 @@ TRITON_REPO_ORGANIZATION=${TRITON_REPO_ORGANIZATION:="http://github.com/triton-i
 TRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG:="main"}
 
 GO_CLIENT_DIR=client/src/grpc_generated/go
-SIMPLE_GO_CLIENT=${GO_CLIENT_DIR}/grpc_simple_client.go
 
 SERVER=/opt/tritonserver/bin/tritonserver
 SERVER_ARGS=--model-repository=`pwd`/models

--- a/qa/L0_simple_go_client/test.sh
+++ b/qa/L0_simple_go_client/test.sh
@@ -55,26 +55,23 @@ git clone ${TRITON_REPO_ORGANIZATION}/client.git
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
 pushd ${GO_CLIENT_DIR}
+
 git clone --single-branch --depth=1 -b $TRITON_COMMON_REPO_TAG \
     ${TRITON_REPO_ORGANIZATION}/common.git
 bash gen_go_stubs.sh
-popd
-
-# Copy packages to GOPATH, where Go expects to find packages.
-PACKAGE_PATH="${GOPATH}/src/github.com/triton-inference-server"
-rm -rf ${PACKAGE_PATH}/client
-mkdir -p ${PACKAGE_PATH}
-cp -r client $PACKAGE_PATH
 
 set +e
 
-# Run test for GRPC variant of go client
-GO111MODULE=off go run $SIMPLE_GO_CLIENT >>client.log 2>&1
+# Run test for GRPC variant of go client within go.mod path
+go run grpc_simple_client.go >>client.log 2>&1
 if [ $? -ne 0 ]; then
     RET=1
 fi
 
-if [ `grep -c "Checking Inference Outputs" client.log` != "1" ]; then
+popd
+
+
+if [ `grep -c "Checking Inference Outputs" ${GO_CLIENT_DIR}/client.log` != "1" ]; then
     echo -e "\n***\n*** Failed. Unable to run inference.\n***"
     RET=1
 fi


### PR DESCRIPTION
The client should run at the same location as go.mod.
This is needed because go has moved to module only execution system.

Client PR: https://github.com/triton-inference-server/client/pull/663