### PR TITLE
Update expected error message

### DIFF
--- a/qa/L0_backend_python/decoupled/decoupled_test.py
+++ b/qa/L0_backend_python/decoupled/decoupled_test.py
@@ -243,12 +243,12 @@ class DecoupledTest(unittest.TestCase):
                 client.async_stream_infer(model_name=model_name, inputs=inputs)
                 data_item = user_data._completed_requests.get()
                 if type(data_item) == InferenceServerException:
-                    self.assertEqual(
-                        data_item.message(),
+                    self.assertIn(
                         "Python model 'decoupled_return_response_error_0_0' is using "
                         "the decoupled mode and the execute function must return "
                         "None.",
-                        "Exception message didn't match.",
+                        data_item.message(),
+                        "Exception message didn't show up.",
                     )
 
     def test_decoupled_send_after_close_error(self):

--- a/qa/L0_backend_python/lifecycle/lifecycle_test.py
+++ b/qa/L0_backend_python/lifecycle/lifecycle_test.py
@@ -199,7 +199,7 @@ class LifecycleTest(unittest.TestCase):
                     print(e.message())
                     self.assertTrue(
                         e.message().startswith(
-                            "Failed to process the request(s) for model instance"
+                            "Failed to process the request(s) for model "
                         ),
                         "Exception message is not correct",
                     )
@@ -208,6 +208,7 @@ class LifecycleTest(unittest.TestCase):
                         False, "Wrong exception raised or did not raise an exception"
                     )
 
+    @unittest.skip("Defer response sending test to response_sender tests")
     def test_incorrect_execute_return(self):
         model_name = "execute_return_error"
         shape = [1, 1]

--- a/qa/L0_backend_python/lifecycle/lifecycle_test.py
+++ b/qa/L0_backend_python/lifecycle/lifecycle_test.py
@@ -208,46 +208,6 @@ class LifecycleTest(unittest.TestCase):
                         False, "Wrong exception raised or did not raise an exception"
                     )
 
-    @unittest.skip("Defer response sending test to response_sender tests")
-    def test_incorrect_execute_return(self):
-        model_name = "execute_return_error"
-        shape = [1, 1]
-        with self._shm_leak_detector.Probe() as shm_probe:
-            with httpclient.InferenceServerClient(
-                f"{_tritonserver_ipaddr}:8000"
-            ) as client:
-                input_data = (5 * np.random.randn(*shape)).astype(np.float32)
-                inputs = [
-                    httpclient.InferInput(
-                        "INPUT", input_data.shape, np_to_triton_dtype(input_data.dtype)
-                    )
-                ]
-                inputs[0].set_data_from_numpy(input_data)
-
-                # The first request to this model will return None.
-                with self.assertRaises(InferenceServerException) as e:
-                    client.infer(model_name, inputs)
-
-                self.assertTrue(
-                    "Failed to process the request(s) for model instance "
-                    "'execute_return_error_0_0', message: Expected a list in the "
-                    "execute return" in str(e.exception),
-                    "Exception message is not correct.",
-                )
-
-                # The second inference request will return a list of None object
-                # instead of Python InferenceResponse objects.
-                with self.assertRaises(InferenceServerException) as e:
-                    client.infer(model_name, inputs)
-
-                self.assertTrue(
-                    "Failed to process the request(s) for model instance "
-                    "'execute_return_error_0_0', message: Expected an "
-                    "'InferenceResponse' object in the execute function return"
-                    " list" in str(e.exception),
-                    "Exception message is not correct.",
-                )
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Previous PR: https://github.com/triton-inference-server/python_backend/pull/361
Related PR: https://github.com/triton-inference-server/python_backend/pull/362

Update the error message the test expects, given the decoupled data pipeline reports the same error in a different mechanism, which results in the message to be slightly different.

Next PRs:
* https://github.com/triton-inference-server/server/pull/7292
* https://github.com/triton-inference-server/python_backend/pull/363