### PR TITLE
Return an error if --load-model is specified without explicit model control mode

### DIFF
--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -1751,6 +1751,14 @@ TritonParser::Parse(int argc, char** argv)
     lparams.repository_poll_secs_ = 0;
   }
 
+  if (lparams.startup_models_.size() > 0 &&
+      lparams.control_mode_ != TRITONSERVER_MODEL_CONTROL_EXPLICIT) {
+    throw ParseException(
+        "Error: Use of '--load-model' requires setting "
+        "'--model-control-mode=explicit' as well.");
+  }
+
+
 #ifdef TRITON_ENABLE_VERTEX_AI
   // Set default model repository if specific flag is set, postpone the
   // check to after parsing so we only monitor the default repository if

--- a/src/main.cc
+++ b/src/main.cc
@@ -439,9 +439,10 @@ main(int argc, char** argv)
     g_triton_params.CheckPortCollision();
   }
   catch (const triton::server::ParseException& pe) {
-    std::cerr << pe.what() << std::endl;
     std::cerr << "Usage: tritonserver [options]" << std::endl;
     std::cerr << tp.Usage() << std::endl;
+    // Show error at bottom for immediate visibility
+    std::cerr << pe.what() << std::endl;
     exit(1);
   }
 


### PR DESCRIPTION
**Before**: Specifying `--load-model` without explicit model control mode will silently not work as expected, and instead load all models with the default model control mode.
```
root@ced35d0-lcedt:/opt/tritonserver# tritonserver --model-repository models --load-model my_model
...
I0522 18:28:47.526658 448 http_server.cc:4692] Started HTTPService at 0.0.0.0:8000
```

**After**: Specifying `--load-model` without explicit model control mode will fail, and prompt you to also set `--model-control-mode=explicit`. **Parsing errors will also be reported at the bottom for immediate visibility.**
```
root@ced35d0-lcedt:/opt/tritonserver# tritonserver --model-repository models --load-model abc
...
LONG
HELP
OUTPUT
...
# NEW: Log error for invalid arg, and log ParseException errors at the bottom as well for easier visibility
Error: Use of '--load-model' requires setting '--model-control-mode=explicit' as well.
```

**NOTE**: This error can be undone if/when we add support for `--load-model` in default model control mode.