### PR TITLE
Exclude Jax example from Python 3.8

### DIFF
--- a/qa/L0_backend_python/examples/test.sh
+++ b/qa/L0_backend_python/examples/test.sh
@@ -48,7 +48,8 @@ fi
 pip3 install validators
 
 # Install JAX
-if [ "$TEST_JETSON" == "0" ]; then
+# Jax has dropped the support for Python 3.8. See https://jax.readthedocs.io/en/latest/changelog.html
+if [ "$TEST_JETSON" == "0" ] && [ ${PYTHON_ENV_VERSION} != "8" ]; then
     pip3 install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 fi
 
@@ -117,7 +118,8 @@ kill_server
 
 # JAX AddSub
 # JAX is not supported on Jetson
-if [ "$TEST_JETSON" == "0" ]; then
+# Jax has dropped the support for Python 3.8. See https://jax.readthedocs.io/en/latest/changelog.html
+if [ "$TEST_JETSON" == "0" ] && [ ${PYTHON_ENV_VERSION} != "8" ]; then
     CLIENT_LOG="./examples_jax_client.log"
     mkdir -p models/jax/1/
     cp examples/jax/model.py models/jax/1/model.py


### PR DESCRIPTION
Jax has dropped the support for Python 3.8. See here for more info: https://jax.readthedocs.io/en/latest/changelog.html