### PR TITLE
Minor fix for L0_backend_python

### DIFF
--- a/qa/L0_backend_python/examples/test.sh
+++ b/qa/L0_backend_python/examples/test.sh
@@ -57,7 +57,7 @@ git clone ${TRITON_REPO_ORGANIZATION}/python_backend -b $PYTHON_BACKEND_REPO_TAG
 cd python_backend
 
 # Example 1
-CLIENT_LOG="./examples_add_sub_client.log"
+CLIENT_LOG="../examples_add_sub_client.log"
 mkdir -p models/add_sub/1/
 cp examples/add_sub/model.py models/add_sub/1/model.py
 cp examples/add_sub/config.pbtxt models/add_sub/config.pbtxt
@@ -86,7 +86,7 @@ set -e
 kill_server
 
 # Example 2
-CLIENT_LOG="./examples_pytorch_client.log"
+CLIENT_LOG="../examples_pytorch_client.log"
 mkdir -p models/pytorch/1/
 cp examples/pytorch/model.py models/pytorch/1/model.py
 cp examples/pytorch/config.pbtxt models/pytorch/config.pbtxt
@@ -120,7 +120,7 @@ kill_server
 # JAX is not supported on Jetson
 # Jax has dropped the support for Python 3.8. See https://jax.readthedocs.io/en/latest/changelog.html
 if [ "$TEST_JETSON" == "0" ] && [ ${PYTHON_ENV_VERSION} != "8" ]; then
-    CLIENT_LOG="./examples_jax_client.log"
+    CLIENT_LOG="../examples_jax_client.log"
     mkdir -p models/jax/1/
     cp examples/jax/model.py models/jax/1/model.py
     cp examples/jax/config.pbtxt models/jax/config.pbtxt
@@ -152,7 +152,7 @@ fi
 # Example 4
 
 # BLS Sync
-CLIENT_LOG="./examples_sync_client.log"
+CLIENT_LOG="../examples_sync_client.log"
 mkdir -p models/bls_sync/1
 cp examples/bls/sync_model.py models/bls_sync/1/model.py
 cp examples/bls/sync_config.pbtxt models/bls_sync/config.pbtxt
@@ -183,7 +183,7 @@ kill_server
 # Example 5
 
 # Decoupled Repeat
-CLIENT_LOG="./examples_repeat_client.log"
+CLIENT_LOG="../examples_repeat_client.log"
 mkdir -p models/repeat_int32/1/
 cp examples/decoupled/repeat_model.py models/repeat_int32/1/model.py
 cp examples/decoupled/repeat_config.pbtxt models/repeat_int32/config.pbtxt
@@ -214,7 +214,7 @@ kill_server
 # Example 6
 
 # Decoupled Square
-CLIENT_LOG="./examples_square_client.log"
+CLIENT_LOG="../examples_square_client.log"
 mkdir -p models/square_int32/1/
 cp examples/decoupled/square_model.py models/square_int32/1/model.py
 cp examples/decoupled/square_config.pbtxt models/square_int32/config.pbtxt
@@ -249,7 +249,7 @@ kill_server
 # Having multiple python versions lead to build issues.
 # Anaconda is not officially supported on Jetson.
 if [ "$TEST_JETSON" == "0" ]; then
-    CLIENT_LOG="./examples_async_client.log"
+    CLIENT_LOG="../examples_async_client.log"
     mkdir -p models/bls_async/1
     cp examples/bls/async_model.py models/bls_async/1/model.py
     cp examples/bls/async_config.pbtxt models/bls_async/config.pbtxt
@@ -280,7 +280,7 @@ if [ "$TEST_JETSON" == "0" ]; then
 fi
 
 # Auto Complete Model Configuration Example
-CLIENT_LOG="./examples_auto_complete_client.log"
+CLIENT_LOG="../examples_auto_complete_client.log"
 mkdir -p models/nobatch_auto_complete/1/
 mkdir -p models/batch_auto_complete/1/
 cp examples/auto_complete/nobatch_model.py models/nobatch_auto_complete/1/model.py
@@ -313,7 +313,7 @@ set -e
 kill_server
 
 # BLS Decoupled Sync
-CLIENT_LOG="./examples_bls_decoupled_sync_client.log"
+CLIENT_LOG="../examples_bls_decoupled_sync_client.log"
 mkdir -p models/bls_decoupled_sync/1
 cp examples/bls_decoupled/sync_model.py models/bls_decoupled_sync/1/model.py
 cp examples/bls_decoupled/sync_config.pbtxt models/bls_decoupled_sync/config.pbtxt
@@ -343,7 +343,7 @@ kill_server
 
 # BLS Decoupled Async
 if [ "$TEST_JETSON" == "0" ]; then
-    CLIENT_LOG="./examples_bls_decoupled_async_client.log"
+    CLIENT_LOG="../examples_bls_decoupled_async_client.log"
     mkdir -p models/bls_decoupled_async/1
     cp examples/bls_decoupled/async_model.py models/bls_decoupled_async/1/model.py
     cp examples/bls_decoupled/async_config.pbtxt models/bls_decoupled_async/config.pbtxt
@@ -376,7 +376,7 @@ fi
 # Example 7
 
 # Model Instance Kind
-CLIENT_LOG="./examples_model_instance_kind.log"
+CLIENT_LOG="../examples_model_instance_kind.log"
 mkdir -p models/resnet50/1
 cp examples/instance_kind/model.py models/resnet50/1/
 cp examples/instance_kind/config.pbtxt models/resnet50/
@@ -405,7 +405,7 @@ set -e
 kill_server
 
 # Custom Metrics
-CLIENT_LOG="./examples_custom_metrics_client.log"
+CLIENT_LOG="../examples_custom_metrics_client.log"
 mkdir -p models/custom_metrics/1
 cp examples/custom_metrics/model.py models/custom_metrics/1/model.py
 cp examples/custom_metrics/config.pbtxt models/custom_metrics/config.pbtxt

--- a/qa/L0_backend_python/setup_python_enviroment.sh
+++ b/qa/L0_backend_python/setup_python_enviroment.sh
@@ -101,9 +101,7 @@ fi
 # been setup correctly.
 if [ ${PYTHON_ENV_VERSION} = "11" ]; then
     create_conda_env "3.11" "python-3-11"
-    # tensorflow needs to be installed before numpy so pip does not mess up conda
-    # environment
-    pip install tensorflow==2.12.0
+    conda install tensorflow=2.12.0 -y
     conda install -c conda-forge libstdcxx-ng=12 -y
     conda install numpy=1.23.5 -y
     EXPECTED_VERSION_STRING="Python version is 3.11, NumPy version is 1.23.5, and Tensorflow version is 2.12.0"


### PR DESCRIPTION
- Fix the conda issue for Python 3.11
  - There are some dependency problems: `UNAVAILABLE: Internal: ModuleNotFoundError: No module named 'six'` even though `six` is installed already. Seems like using conda install for TF for Python 3.11 doesn't not mess up with conda env anymore.
- Place the client log of L0_backend_python/example to the outer directory for CI to capture artifacts