### PR TITLE
fix: Remove onnxruntime libraries from system path

### DIFF
--- a/build.py
+++ b/build.py
@@ -1143,12 +1143,6 @@ ENV PATH /opt/tritonserver/bin:${PATH}
 ENV UCX_MEM_EVENTS no
 """
 
-    # TODO Remove once the ORT-OpenVINO "Exception while Reading network" is fixed
-    if "onnxruntime" in backends:
-        df += """
-ENV LD_LIBRARY_PATH /opt/tritonserver/backends/onnxruntime:${LD_LIBRARY_PATH}
-"""
-
     # Necessary for libtorch.so to find correct HPCX libraries
     if "pytorch" in backends:
         df += """


### PR DESCRIPTION
#### What does the PR do?
Removes the onnxruntime library from the system path which seemed to have been added as a workaround for openVINO EP running behind onnxruntime backend. 
It has been verified with a glab pipeline with TRITON_NIGHTLY=1 that we no longer need this workaround to use the OV EP.

This might help resolve #7200. 

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
No additional tests were added. The current tests i.e. L0_onnx_optimization and l_onnx_execution_provider should provide sufficient coverage for whether the changes introduced any regressions.

- CI Pipeline ID:
#15568694

#### Caveats:
We can explore if we can now use different versions of openVINO between ORT and OpenVINO backend.

#### Background
By including the onnxruntime libraries in the system path, there is a conflict between the openvino library between ORT backends installation and the OV installed with the OV backend.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Fixes to GitHub issue: #7200
