### PR TITLE
test: Fix the test to expect updated error messages

### DIFF
--- a/qa/L0_model_config/noautofill_platform/missing_datatype/config.pbtxt
+++ b/qa/L0_model_config/noautofill_platform/missing_datatype/config.pbtxt
@@ -1,0 +1,15 @@
+name: "missing_datatype"
+max_batch_size: 4
+input [
+  {
+    name: "input"
+    dims: [ 2, -1 ]
+  }
+]
+output [
+  {
+    name: "output"
+    data_type: TYPE_FP32
+    dims: [ 1 ]
+  }
+]

--- a/qa/L0_model_config/noautofill_platform/missing_datatype/expected
+++ b/qa/L0_model_config/noautofill_platform/missing_datatype/expected
@@ -1,0 +1,1 @@
+model input 'input' must specify 'data_type'

--- a/qa/L0_model_config/noautofill_platform/missing_datatype/expected_ensemble
+++ b/qa/L0_model_config/noautofill_platform/missing_datatype/expected_ensemble
@@ -1,0 +1,1 @@
+ensemble scheduling must be set for ensemble missing_datatype whose platform is ensemble

--- a/qa/L0_model_config/noautofill_platform/reshape_elementcount0/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_elementcount0/expected
@@ -1,1 +1,1 @@
-model input has different size for dims and reshape for reshape_elementcount0
+model input 'input' has different size for dims and reshape for reshape_elementcount0

--- a/qa/L0_model_config/noautofill_platform/reshape_elementcount1/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_elementcount1/expected
@@ -1,1 +1,1 @@
-model input has different size for dims and reshape for reshape_elementcount1
+model input 'input' has different size for dims and reshape for reshape_elementcount1

--- a/qa/L0_model_config/noautofill_platform/reshape_elementcount2/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_elementcount2/expected
@@ -1,1 +1,1 @@
-model output has different size for dims and reshape for reshape_elementcount2
+model output 'output' has different size for dims and reshape for reshape_elementcount2

--- a/qa/L0_model_config/noautofill_platform/reshape_elementcount3/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_elementcount3/expected
@@ -1,1 +1,1 @@
-model output has different size for dims and reshape for reshape_elementcount3
+model output 'output' has different size for dims and reshape for reshape_elementcount3

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_empty0/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_empty0/expected
@@ -1,1 +1,1 @@
-model input cannot have empty reshape for non-batching model as scalar tensors are not supported for reshape_nobatch_empty0
+model input 'input' cannot have empty reshape for non-batching model as scalar tensors are not supported for reshape_nobatch_empty0

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_empty1/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_empty1/expected
@@ -1,1 +1,1 @@
-model output cannot have empty reshape for non-batching model as scalar tensors are not supported for reshape_nobatch_empty1
+model output 'output' cannot have empty reshape for non-batching model as scalar tensors are not supported for reshape_nobatch_empty1

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable0/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable0/expected
@@ -1,1 +1,1 @@
-model input has different size for dims and reshape for reshape_nobatch_variable0
+model input 'input' has different size for dims and reshape for reshape_nobatch_variable0

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable1/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable1/expected
@@ -1,1 +1,1 @@
-model output has different size for dims and reshape for reshape_nobatch_variable1
+model output 'output' has different size for dims and reshape for reshape_nobatch_variable1

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable2/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable2/expected
@@ -1,1 +1,1 @@
-model input has different size for dims and reshape for reshape_nobatch_variable2
+model input 'input' has different size for dims and reshape for reshape_nobatch_variable2

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable3/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable3/expected
@@ -1,1 +1,1 @@
-model output has different size for dims and reshape for reshape_nobatch_variable3
+model output 'output' has different size for dims and reshape for reshape_nobatch_variable3

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable4/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable4/expected
@@ -1,1 +1,1 @@
-model input has different number of variable-size dimensions for dims and reshape for reshape_nobatch_variable4
+model input 'input' has different number of variable-size dimensions for dims and reshape for reshape_nobatch_variable4

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable5/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_variable5/expected
@@ -1,1 +1,1 @@
-model output has different number of variable-size dimensions for dims and reshape for reshape_nobatch_variable5
+model output 'output' has different number of variable-size dimensions for dims and reshape for reshape_nobatch_variable5

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_zerodims0/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_zerodims0/expected
@@ -1,1 +1,1 @@
-model input reshape dimensions must be integer >= 1, or -1 to indicate a variable-size dimension for reshape_nobatch_zerodims0
+model input 'input' reshape dimensions must be integer >= 1, or -1 to indicate a variable-size dimension for reshape_nobatch_zerodims0

--- a/qa/L0_model_config/noautofill_platform/reshape_nobatch_zerodims1/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_nobatch_zerodims1/expected
@@ -1,1 +1,1 @@
-model output reshape dimensions must be integer >= 1, or -1 to indicate a variable-size dimension for reshape_nobatch_zerodims1
+model output 'output' reshape dimensions must be integer >= 1, or -1 to indicate a variable-size dimension for reshape_nobatch_zerodims1

--- a/qa/L0_model_config/noautofill_platform/reshape_variable0/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_variable0/expected
@@ -1,1 +1,1 @@
-model input has different size for dims and reshape for reshape_variable0
+model input 'input' has different size for dims and reshape for reshape_variable0

--- a/qa/L0_model_config/noautofill_platform/reshape_variable1/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_variable1/expected
@@ -1,1 +1,1 @@
-model output has different size for dims and reshape for reshape_variable1
+model output 'output' has different size for dims and reshape for reshape_variable1

--- a/qa/L0_model_config/noautofill_platform/reshape_variable2/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_variable2/expected
@@ -1,1 +1,1 @@
-model input has different size for dims and reshape for reshape_variable2
+model input 'input' has different size for dims and reshape for reshape_variable2

--- a/qa/L0_model_config/noautofill_platform/reshape_variable3/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_variable3/expected
@@ -1,1 +1,1 @@
-model output has different size for dims and reshape for reshape_variable3
+model output 'output' has different size for dims and reshape for reshape_variable3

--- a/qa/L0_model_config/noautofill_platform/reshape_variable4/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_variable4/expected
@@ -1,1 +1,1 @@
-model input has different number of variable-size dimensions for dims and reshape for reshape_variable4
+model input 'input' has different number of variable-size dimensions for dims and reshape for reshape_variable4

--- a/qa/L0_model_config/noautofill_platform/reshape_variable5/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_variable5/expected
@@ -1,1 +1,1 @@
-model output has different number of variable-size dimensions for dims and reshape for reshape_variable5
+model output 'output' has different number of variable-size dimensions for dims and reshape for reshape_variable5

--- a/qa/L0_model_config/noautofill_platform/reshape_zerodims0/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_zerodims0/expected
@@ -1,1 +1,1 @@
-model input reshape dimensions must be integer >= 1, or -1 to indicate a variable-size dimension for reshape_zerodims0
+model input 'input' reshape dimensions must be integer >= 1, or -1 to indicate a variable-size dimension for reshape_zerodims0

--- a/qa/L0_model_config/noautofill_platform/reshape_zerodims1/expected
+++ b/qa/L0_model_config/noautofill_platform/reshape_zerodims1/expected
@@ -1,1 +1,1 @@
-model output reshape dimensions must be integer >= 1, or -1 to indicate a variable-size dimension for reshape_zerodims1
+model output 'output' reshape dimensions must be integer >= 1, or -1 to indicate a variable-size dimension for reshape_zerodims1

--- a/qa/L0_model_config/noautofill_platform/zerodims_input0/expected
+++ b/qa/L0_model_config/noautofill_platform/zerodims_input0/expected
@@ -1,1 +1,1 @@
-model input dimension must be integer >= 1, or -1 to indicate a variable-size dimension for zerodims_input0
+model input 'input' dimension must be integer >= 1, or -1 to indicate a variable-size dimension for zerodims_input0

--- a/qa/L0_model_config/noautofill_platform/zerodims_input1/expected
+++ b/qa/L0_model_config/noautofill_platform/zerodims_input1/expected
@@ -1,1 +1,1 @@
-model input dimension must be integer >= 1, or -1 to indicate a variable-size dimension for zerodims_input1
+model input 'input' dimension must be integer >= 1, or -1 to indicate a variable-size dimension for zerodims_input1

--- a/qa/L0_model_config/noautofill_platform/zerodims_output0/expected
+++ b/qa/L0_model_config/noautofill_platform/zerodims_output0/expected
@@ -1,1 +1,1 @@
-model output dimension must be integer >= 1, or -1 to indicate a variable-size dimension for zerodims_output0
+model output 'output' dimension must be integer >= 1, or -1 to indicate a variable-size dimension for zerodims_output0

--- a/qa/L0_model_config/noautofill_platform/zerodims_output1/expected
+++ b/qa/L0_model_config/noautofill_platform/zerodims_output1/expected
@@ -1,1 +1,1 @@
-model output dimension must be integer >= 1, or -1 to indicate a variable-size dimension for zerodims_output1
+model output 'output' dimension must be integer >= 1, or -1 to indicate a variable-size dimension for zerodims_output1

--- a/qa/L0_model_config/test.sh
+++ b/qa/L0_model_config/test.sh
@@ -220,14 +220,14 @@ for modelpath in \
         autofill_noplatform/python/model_transaction_policy_mismatch \
         autofill_noplatform/python/output_wrong_property ; do
     mkdir -p $modelpath/1
-    mv $modelpath/model.py $modelpath/1/.
+    cp $modelpath/model.py $modelpath/1/.
 done
 for modelpath in \
         autofill_noplatform_success/python/conflicting_scheduler_ensemble/conflicting_scheduler_ensemble \
         autofill_noplatform_success/python/conflicting_scheduler_ensemble/ensemble_first_step \
         autofill_noplatform_success/python/conflicting_scheduler_ensemble/ensemble_second_step ; do
     mkdir -p $modelpath/1
-    mv $modelpath/model.py $modelpath/1/.
+    cp $modelpath/model.py $modelpath/1/.
 done
 
 # Make version folders for custom test model repositories.


### PR DESCRIPTION
#### What does the PR do?
Theses updates are added to test the new behavior of Triton core to include tensor names in the error message.
Changing mv to cp so that the test can be re-run multiple number of times in the devel container.

The related core PR: https://github.com/triton-inference-server/core/pull/353.
Passing L0_model_config run: JOB ID 96906455

For the following model configuration:

```
name: "missing_datatype"
max_batch_size: 4
platform: "tensorflow_savedmodel"
input [
  {
    name: "input"
    dims: [ 2, -1 ]
  }
]
output [
  {
    name: "output"
    data_type: TYPE_FP32
    dims: [ 1 ]
  }
]

```

### Before

`E0611 19:35:52.422993 138 model_repository_manager.cc:1371] "Poll failed for model directory 'missing_datatype': model output must specify 'data_type' for missing_datatype"`

### After
`
E0611 19:31:47.991606 9486 model_repository_manager.cc:1371] "Poll failed for model directory 'missing_datatype': model input 'input' must specify 'data_type' for missing_datatype"`

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
Core: https://github.com/triton-inference-server/core/pull/353

#### Where should the reviewer start?
Start reviewing from core PR.

#### Test plan:
Added missing_datatype test case in L0_model_config.


- CI Pipeline ID:
15746435

#### Caveats:
These changes resolves only a subset of error messages to include tensor name. A larger investigation might be needed to identify all the test cases.

#### Background
Some of the user models can have large number of model inputs/ouptuts. Without this change the model tensor name is not a part of the error message. This change improves the error logging of the server offering better debugging ability to the user.

