### PR TITLE
perf: Improve response throughput of a single gRPC stream

### DIFF
--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -1,4 +1,4 @@
-// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -979,6 +979,9 @@ class InferHandlerState {
     // Tracks all the states that have been created on this context.
     std::set<InferHandlerStateType*> all_states_;
 
+    // Ready to write queue for decoupled
+    std::queue<InferHandlerStateType*> ready_to_write_states_;
+
     // The step of the entire context.
     Steps step_;
 

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -367,14 +367,9 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         std::lock_guard<std::recursive_mutex> lk1(state->context_->mu_);
         {
           std::lock_guard<std::recursive_mutex> lk2(state->step_mtx_);
-          bool has_prev_ready_response =
-              state->response_queue_->HasReadyResponse();
           state->response_queue_->MarkNextResponseComplete();
-          if (!has_prev_ready_response) {
-            state->context_->ready_to_write_states_.push(state);
-          }
-          if (!state->context_->ongoing_write_ &&
-              !state->context_->ready_to_write_states_.empty()) {
+          state->context_->ready_to_write_states_.push(state);
+          if (!state->context_->ongoing_write_) {
             state->context_->ongoing_write_ = true;
             writing_state = state->context_->ready_to_write_states_.front();
             state->context_->ready_to_write_states_.pop();

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -554,6 +554,8 @@ ModelStreamInferHandler::StateWriteResponse(InferHandler::State* state)
   {
     std::lock_guard<std::recursive_mutex> lock(state->step_mtx_);
     state->step_ = Steps::WRITTEN;
+    // gRPC doesn't allow to issue another write till the notification from
+    // previous write has been delivered.
     state->context_->DecoupledWriteResponse(state);
     if (state->response_queue_->HasReadyResponse()) {
       state->context_->ready_to_write_states_.push(state);

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -780,6 +780,8 @@ ModelStreamInferHandler::StreamInferResponseComplete(
       }
       if (is_complete && state->response_queue_->IsEmpty() &&
           state->step_ == Steps::ISSUED) {
+        // The response queue is empty and complete final flag is received, so
+        // mark the state as 'WRITEREADY' so it can be cleaned up later.
         state->step_ = Steps::WRITEREADY;
         state->context_->PutTaskBackToQueue(state);
       }

--- a/src/grpc/stream_infer_handler.h
+++ b/src/grpc/stream_infer_handler.h
@@ -1,4 +1,4 @@
-// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/grpc/stream_infer_handler.h
+++ b/src/grpc/stream_infer_handler.h
@@ -112,6 +112,7 @@ class ModelStreamInferHandler
   static void StreamInferResponseComplete(
       TRITONSERVER_InferenceResponse* response, const uint32_t flags,
       void* userp);
+  static void StateWriteResponse(InferHandler::State* state);
   bool Finish(State* state);
 
   TraceManager* trace_manager_;


### PR DESCRIPTION
#### What does the PR do?
Improve the response throughput of a single gRPC stream on the server frontend.

When there is a large number of responses, responses will compete with each others for the single write slot - a restriction imposed by gRPC that no concurrent write is allowed within a stream. A response that do not get a chance to write will be placed to the back of the completion queue and try again when it comes out. Unless the number of responses reduces immediately, the response that do not get a chance to write will likely not get a chance to write when it comes out. The same happens to other responses at the same time, resulting in a busy loop on the completion queue that impact performance.

This change introduces a new queue for holding responses that do not get a chance to write. When a new response arrives, if the stream is writing another response, then the new response will be placed to the back of the new queue. When the ongoing write is completed, the top response from the new queue will be popped and starts writing.

With this change, the response throughput previously handled by 4 gRPC streams in parallel can be handled by only 1 gRPC stream, with a lot of room to spare.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [x] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
N/A

#### Where should the reviewer start?
Start reviewing from the bottom of `stream_infer_handler.cc` and make your way to the top of the file.

#### Test plan:
This PR is only a performance improvement, so existing tests should be covering all issues.

- CI Pipeline ID:
#16352903

#### Caveats:
N/A

#### Background
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A
