### PR TITLE
test: Tests for Metrics API enhancement to include error counters

### DIFF
--- a/build.py
+++ b/build.py
@@ -76,7 +76,7 @@ TRITON_VERSION_MAP = {
         "2024.0.0",  # ORT OpenVINO
         "2024.0.0",  # Standalone OpenVINO
         "3.2.6",  # DCGM version
-        "0.4.3",  # vLLM version
+        "0.5.0.post1",  # vLLM version
     )
 }
 

--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -100,19 +100,25 @@ Count*. The count metrics are illustrated by the following examples:
 |              |Execution Count |`nv_inference_exec_count` |Number of inference batch executions (see [Inference Request Metrics](#inference-request-metrics), does not include cached requests)|Per model|Per request|
 |              |Pending Request Count |`nv_inference_pending_request_count` |Number of inference requests awaiting execution by a backend. This number is incremented when a request is enqueued to the server (`TRITONSERVER_ServerInferAsync`) and is decremented when a backend is about to start executing the request. More details can be found below. |Per model|Per request|
 
-#### Failure Count is further classified into four distinct types:
+#### Failure Count Categories
 
-|Sub-Category      |Sub-Metric | Sub-Metric Name |Description |
-|--------------|----------------|------------|------------|
-|Failure Reason         |Rejected |REJECTED  | Number of inference failures due to request timeout in the schedular. |
-|              |Canceled |CANCELED  |  Number of inference failures due to request cancellation in the core. |
-|              |Backend  |BACKEND |  Number of inference failures due to errors from backend. |
-|              |Other | OTHER  | Number of inference failures due to unspecified reasons in the core. |
-
+| Failed Request Reason |Description |
+|------------|------------|
+| REJECTED  | Number of inference failures due to request timeout in the schedular. |
+| CANCELED  |  Number of inference failures due to request cancellation in the core. |
+| BACKEND |  Number of inference failures during execution of requests in the backend/model. |
+| OTHER  | Number of inference failures due to other uncategorized reasons in the core. |
 
 > **Note**
 >
 > Ensemble failure metrics will reflect the failure counts of their composing models as well as the parent model, but currently do not capture the same granularity for the "reason" label and will default to the "OTHER" reason.
+>
+> For example, if EnsembleA contains ModelA, and ModelA experiences a failed request due to a queue/backlog timeout in the scheduler, ModelA will have a failed request metric reflecting `reason=REJECTED` and `count=1`.
+> Additionally, EnsembleA will have a failed request metric reflecting `reason=OTHER` and `count=2`. 
+> The `count=2` reflects 1 from the internally failed request captured by ModelA, as well as 1 from the failed top-level request sent to EnsembleA by the user/client.
+> The `reason=OTHER` reflects that fact that the ensemble doesn't currently capture the specific reason why 
+> ModelA's request failed at this time.
+
 #### Pending Request Count (Queue Size) Per-Model
 
 The *Pending Request Count* reflects the number of requests that have been

--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -100,6 +100,19 @@ Count*. The count metrics are illustrated by the following examples:
 |              |Execution Count |`nv_inference_exec_count` |Number of inference batch executions (see [Inference Request Metrics](#inference-request-metrics), does not include cached requests)|Per model|Per request|
 |              |Pending Request Count |`nv_inference_pending_request_count` |Number of inference requests awaiting execution by a backend. This number is incremented when a request is enqueued to the server (`TRITONSERVER_ServerInferAsync`) and is decremented when a backend is about to start executing the request. More details can be found below. |Per model|Per request|
 
+#### Failure Count is further classified into four distinct types:
+
+|Sub-Category      |Sub-Metric | Sub-Metric Name |Description |
+|--------------|----------------|------------|------------|
+|Failure Reason         |Rejected |REJECTED  | Number of inference failures due to request timeout in the schedular. |
+|              |Canceled |CANCELED  |  Number of inference failures due to request cancellation in the core. |
+|              |Backend  |BACKEND |  Number of inference failures due to errors from backend. |
+|              |Other | OTHER  | Number of inference failures due to unspecified reasons in the core. |
+
+
+> **Note**
+>
+> Ensemble failure metrics will reflect the failure counts of their composing models as well as the parent model, but currently do not capture the same granularity for the "reason" label and will default to the "OTHER" reason.
 #### Pending Request Count (Queue Size) Per-Model
 
 The *Pending Request Count* reflects the number of requests that have been

--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -114,9 +114,9 @@ Count*. The count metrics are illustrated by the following examples:
 > Ensemble failure metrics will reflect the failure counts of their composing models as well as the parent model, but currently do not capture the same granularity for the "reason" label and will default to the "OTHER" reason.
 >
 > For example, if EnsembleA contains ModelA, and ModelA experiences a failed request due to a queue/backlog timeout in the scheduler, ModelA will have a failed request metric reflecting `reason=REJECTED` and `count=1`.
-> Additionally, EnsembleA will have a failed request metric reflecting `reason=OTHER` and `count=2`. 
+> Additionally, EnsembleA will have a failed request metric reflecting `reason=OTHER` and `count=2`.
 > The `count=2` reflects 1 from the internally failed request captured by ModelA, as well as 1 from the failed top-level request sent to EnsembleA by the user/client.
-> The `reason=OTHER` reflects that fact that the ensemble doesn't currently capture the specific reason why 
+> The `reason=OTHER` reflects that fact that the ensemble doesn't currently capture the specific reason why
 > ModelA's request failed at this time.
 
 #### Pending Request Count (Queue Size) Per-Model

--- a/qa/L0_backend_python/lifecycle/lifecycle_test.py
+++ b/qa/L0_backend_python/lifecycle/lifecycle_test.py
@@ -79,7 +79,7 @@ class LifecycleTest(unittest.TestCase):
         if match:
             return int(match.group(1))
         else:
-            return int(0)
+            raise Exception(f"Failure metrics for model='{model}' not found")
 
     def _assert_metrics(
         self, model_name, reason, expected_count_increase, initial_count

--- a/qa/L0_model_queue/model_queue_test.py
+++ b/qa/L0_model_queue/model_queue_test.py
@@ -314,7 +314,10 @@ class ModelQueueTest(tu.TestResultCollector):
                 self.check_deferred_exception()
             except InferenceServerException as ex:
                 self.assertTrue(False, "unexpected error {}".format(ex))
-        expected_count_increase = 2
+        expected_count_increase = 4
+        # NOTE: Ensemble failure metrics will reflect the failure counts
+        # of their composing models as well as the parent model, but currently do not capture the same granularity
+        # for the "reason" label and will default to the "OTHER" reason.
         self._assert_metrics(
             "ensemble_zero_1_float32",
             "OTHER",

--- a/qa/L0_model_queue/model_queue_test.py
+++ b/qa/L0_model_queue/model_queue_test.py
@@ -94,10 +94,6 @@ class ModelQueueTest(tu.TestResultCollector):
         expected_metric = f'nv_inference_request_failure{{model="{model_name}",reason="{reason}",version="1"}} {expected_count_increase + initial_count}'
         self.assertIn(expected_metric, metrics)
 
-    def verify_metric_text(self, metrics, model_name, reason, count):
-        expected_metric = f'nv_inference_request_failure{{model="{model_name}",reason="{reason}",version="1"}} {count}'
-        self.assertIn(expected_metric, metrics)
-
     def check_response(
         self,
         bs,

--- a/qa/L0_model_queue/model_queue_test.py
+++ b/qa/L0_model_queue/model_queue_test.py
@@ -30,6 +30,7 @@ import sys
 
 sys.path.append("../common")
 
+import re
 import threading
 import time
 import unittest
@@ -76,16 +77,26 @@ class ModelQueueTest(tu.TestResultCollector):
         r.raise_for_status()
         return r.text
 
+    def _metrics_before_test(self, model, reason):
+        pattern = rf'nv_inference_request_failure\{{model="{model}",reason="{reason}",version="1"\}} (\d+)'
+        metrics = self._get_metrics()
+        match = re.search(pattern, metrics)
+        if match:
+            return int(match.group(1))
+        else:
+            return int(0)
+
+    def _assert_metrics(
+        self, model_name, reason, expected_count_increase, initial_count
+    ):
+        metrics = self._get_metrics()
+        # Add initial count + expected count for the the test
+        expected_metric = f'nv_inference_request_failure{{model="{model_name}",reason="{reason}",version="1"}} {expected_count_increase + initial_count}'
+        self.assertIn(expected_metric, metrics)
+
     def verify_metric_text(self, metrics, model_name, reason, count):
         expected_metric = f'nv_inference_request_failure{{model="{model_name}",reason="{reason}",version="1"}} {count}'
         self.assertIn(expected_metric, metrics)
-
-    def check_metrics(self):
-        metrics = self._get_metrics()
-        # Expect 2 reason="OTHER" for ensemble_zero_1_float32
-        self.verify_metric_text(metrics, "ensemble_zero_1_float32", "OTHER", 2)
-        # Expect 4 reason="REJECTED" for custom_zero_1_float32
-        self.verify_metric_text(metrics, "custom_zero_1_float32", "REJECTED", 4)
 
     def check_response(
         self,
@@ -253,6 +264,12 @@ class ModelQueueTest(tu.TestResultCollector):
         # requests are sent after 'default_timeout_microseconds'.
         # Expect the first request is timed-out and rejected, which makes the
         # second and third request be batched together and executed.
+        initial_metrics_value_ensemble = self._metrics_before_test(
+            "ensemble_zero_1_float32", "OTHER"
+        )
+        initial_metrics_value_custom = self._metrics_before_test(
+            "custom_zero_1_float32", "REJECTED"
+        )
         dtype = np.float32
         shapes = ([16],)
         for trial in self.trials_:
@@ -301,7 +318,20 @@ class ModelQueueTest(tu.TestResultCollector):
                 self.check_deferred_exception()
             except InferenceServerException as ex:
                 self.assertTrue(False, "unexpected error {}".format(ex))
-        self.check_metrics()
+        expected_count_increase = 2
+        self._assert_metrics(
+            "ensemble_zero_1_float32",
+            "OTHER",
+            expected_count_increase,
+            initial_metrics_value_ensemble,
+        )
+        expected_count_increase = 4
+        self._assert_metrics(
+            "custom_zero_1_float32",
+            "REJECTED",
+            expected_count_increase,
+            initial_metrics_value_custom,
+        )
 
     def test_timeout_override(self):
         # Send requests with batch sizes 1, 1, 3 where the first request

--- a/qa/L0_model_queue/model_queue_test.py
+++ b/qa/L0_model_queue/model_queue_test.py
@@ -84,7 +84,7 @@ class ModelQueueTest(tu.TestResultCollector):
         if match:
             return int(match.group(1))
         else:
-            return int(0)
+            raise Exception(f"Failure metrics for model='{model}' not found")
 
     def _assert_metrics(
         self, model_name, reason, expected_count_increase, initial_count

--- a/qa/L0_request_cancellation/scheduler_test.py
+++ b/qa/L0_request_cancellation/scheduler_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,8 +30,8 @@ import concurrent.futures
 import time
 import unittest
 
-import requests
 import numpy as np
+import requests
 import tritonclient.grpc as grpcclient
 from tritonclient.utils import InferenceServerException
 
@@ -90,7 +90,7 @@ class TestScheduler(unittest.TestCase):
         r = requests.get(metrics_url)
         r.raise_for_status()
         return r.text
-    
+
     def _assert_cancel_metrics_sequence_oldest(self, model_name, count, metrics):
         expected_metric = f'nv_inference_request_failure{{model="{model_name}",reason="CANCELED",version="1"}} {count}'
         self.assertIn(expected_metric, metrics)
@@ -242,7 +242,7 @@ class TestScheduler(unittest.TestCase):
         time.sleep(2)  # ensure the cancellation is delivered
         time.sleep(2)  # ensure reaper thread has responded
         self._assert_streaming_response_is_cancelled(response)
-    
+
     def test_zerror_metrics(self):
         metrics = self._get_metrics()
         # Check if we have counted correctly all cancellation for sequence_oldest model

--- a/qa/L0_request_cancellation/scheduler_test.py
+++ b/qa/L0_request_cancellation/scheduler_test.py
@@ -99,7 +99,7 @@ class TestScheduler(unittest.TestCase):
         if match:
             return int(match.group(1))
         else:
-            return int(0)
+            raise Exception(f"Failure metrics for model='{model}' not found")
 
     def _assert_metrics(
         self, model_name, reason, expected_count_increase, initial_count

--- a/qa/L0_request_cancellation/scheduler_test.py
+++ b/qa/L0_request_cancellation/scheduler_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -91,11 +91,7 @@ class TestScheduler(unittest.TestCase):
         r.raise_for_status()
         return r.text
 
-    def _assert_cancel_metrics_sequence_oldest(self, model_name, count, metrics):
-        expected_metric = f'nv_inference_request_failure{{model="{model_name}",reason="CANCELED",version="1"}} {count}'
-        self.assertIn(expected_metric, metrics)
-
-    def _assert_cancel_metrics_sequence_direct(self, model_name, count, metrics):
+    def _assert_metrics(self, model_name, count, metrics):
         expected_metric = f'nv_inference_request_failure{{model="{model_name}",reason="CANCELED",version="1"}} {count}'
         self.assertIn(expected_metric, metrics)
 
@@ -247,10 +243,10 @@ class TestScheduler(unittest.TestCase):
         metrics = self._get_metrics()
         # Check if we have counted correctly all cancellation for sequence_oldest model
         # total expected 2 * 16 + 1
-        self._assert_cancel_metrics_sequence_oldest("sequence_oldest", 33, metrics)
+        self._assert_metrics("sequence_oldest", 33, metrics)
         # Check if we have counted correctly all cancellation for sequence_direct model
         # total expected 2 * 2
-        self._assert_cancel_metrics_sequence_direct("sequence_direct", 4, metrics)
+        self._assert_metrics("sequence_direct", 4, metrics)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### What does the PR do?
Currently We don't have any mechanism to count any failures that happen in triton core before the request gets to the backend.
Enhances existing metrics API to incorporate failure and failure counts in inference requests.
This PR adds new test

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
https://github.com/triton-inference-server/core/pull/377

#### Where should the reviewer start?
RespondIfError function call in core

#### Test plan:
Test for **REJECTED**
Modified qa/L0_model_queue/model_queue_test.py to capture rejections in Ensemble Model and Non Ensemble Model in dynamic batcher.
custom_zero_1_float32 model expected to have 4 request rejects

Test for **OTHER**
Modified qa/L0_model_queue/model_queue_test.py to capture OTHER errors in Ensemble Model.
ensemble_zero_1_float32 expects to have 2 request rejected reported as OTHER.

Test for **CANCELED**
Modified qa/L0_request_cancellation/scheduler_test.py to capture various cancellations.
_test_sequence_batch_scheduler_queued_request_cancellation test cancel 2 requests, expected to be reported as 2 in test_direct_sequence_batch_scheduler_request_cancellation() and test_sequence_batch_scheduler_backlog_request_cancellation()

Test for **BACKEND**
Modified qa/L0_backend_python/lifecycle/lifecycle_test.py which generates errors from backend inside test_infer_pymodel_error by using wrong model name.
Expect the error count to be 1.

**Untested** :
- REJECTED request which gets triggered from SequenceBatchScheduler()
- OTHER uncategorized failures for individual (non-ensemble) models
- Follow-up ticket for further testing: `TODO` @indrajit96 


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes Jira issue: DLIS-5530
