### PR TITLE
[24.07] Revert vllm to 0.5.0.post1

### DIFF
--- a/build.py
+++ b/build.py
@@ -76,7 +76,7 @@ TRITON_VERSION_MAP = {
         "2024.0.0",  # ORT OpenVINO
         "2024.0.0",  # Standalone OpenVINO
         "3.2.6",  # DCGM version
-        "0.5.1",  # vLLM version
+        "0.5.0.post1",  # vLLM version
     )
 }
 


### PR DESCRIPTION
One of CI tests is failing with the latest version of vLLM. We will revert to 0.5.0.post1 which is known to be working until we can investigate further.


