### PR TITLE
build: Add default value for argument 'TRITON_REPO_ORGANIZATION' from sdk Dockerfile

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -33,6 +33,7 @@ ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:24.07-py3-min
 
 ARG TRITON_CLIENT_REPO_SUBDIR=clientrepo
 ARG TRITON_PA_REPO_SUBDIR=perfanalyzerrepo
+ARG TRITON_REPO_ORGANIZATION=http://github.com/triton-inference-server
 ARG TRITON_COMMON_REPO_TAG=main
 ARG TRITON_CORE_REPO_TAG=main
 ARG TRITON_CLIENT_REPO_TAG=main

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -331,13 +331,13 @@ invocation builds all features and backends available on windows.
 python build.py --cmake-dir=<path/to/repo>/build --build-dir=/tmp/citritonbuild --no-container-pull --image=base,win10-py3-min --enable-logging --enable-stats --enable-tracing --enable-gpu --endpoint=grpc --endpoint=http --repo-tag=common:<container tag> --repo-tag=core:<container tag> --repo-tag=backend:<container tag> --repo-tag=thirdparty:<container tag> --backend=ensemble --backend=tensorrt:<container tag> --backend=onnxruntime:<container tag> --backend=openvino:<container tag>
 ```
 
-If you are building on *main* branch then '<container tag>' will
+If you are building on *main* branch then `<container tag>` will
 default to "main". If you are building on a release branch then
-'<container tag>' will default to the branch name. For example, if you
-are building on the r24.07 branch, '<container tag>' will default to
-r24.07. Therefore, you typically do not need to provide '<container
-tag>' at all (nor the preceding colon). You can use a different
-'<container tag>' for a component to instead use the corresponding
+`<container tag>` will default to the branch name. For example, if you
+are building on the r24.07 branch, `<container tag>` will default to
+r24.07. Therefore, you typically do not need to provide `<container
+tag>` at all (nor the preceding colon). You can use a different
+`<container tag>` for a component to instead use the corresponding
 branch/tag in the build. For example, if you have a branch called
 "mybranch" in the
 [onnxruntime_backend](https://github.com/triton-inference-server/onnxruntime_backend)

--- a/docs/customization_guide/test.md
+++ b/docs/customization_guide/test.md
@@ -57,14 +57,17 @@ in the scripts for how to target a specific GPU.
 ## Build SDK Image
 
 Build the *tritonserver_sdk* image that contains the client
-libraries, model analyzer, and examples using the following
+libraries, model analyzer, perf analyzer and examples using the following
 commands. You must first checkout the <client branch> branch of the
-*client* repo into the clientrepo/ subdirectory. Typically you want to
-set <client branch> to be the same as your current server branch.
+*client* repo into the clientrepo/ subdirectory and the <perf analyzer branch>
+branch of the *perf_analyzer* repo into the perfanalyzerrepo/ subdirectory
+respectively. Typically you want to set both <client branch> and <perf analyzer branch>
+to be the same as your current server branch.
 
 ```
 $ cd <server repo root>
 $ git clone --single-branch --depth=1 -b <client branch> https://github.com/triton-inference-server/client.git clientrepo
+$ git clone --single-branch --depth=1 -b <perf analyzer branch> https://github.com/triton-inference-server/perf_analyzer.git perfanalyzerrepo
 $ docker build -t tritonserver_sdk -f Dockerfile.sdk .
 ```
 

--- a/docs/customization_guide/test.md
+++ b/docs/customization_guide/test.md
@@ -48,7 +48,7 @@ $ ./gen_qa_model_repository
 $ ./gen_qa_custom_ops
 ```
 
-This will create multiple model repositories in /tmp/<version>/qa_*
+This will create multiple model repositories in /tmp/\<version\>/qa_*
 (for example /tmp/24.07/qa_model_repository).  The TensorRT models
 will be created for the GPU on the system that CUDA considers device 0
 (zero). If you have multiple GPUs on your system see the documentation
@@ -58,10 +58,10 @@ in the scripts for how to target a specific GPU.
 
 Build the *tritonserver_sdk* image that contains the client
 libraries, model analyzer, perf analyzer and examples using the following
-commands. You must first checkout the <client branch> branch of the
-*client* repo into the clientrepo/ subdirectory and the <perf analyzer branch>
+commands. You must first checkout the `<client branch>` branch of the
+*client* repo into the clientrepo/ subdirectory and the `<perf analyzer branch>`
 branch of the *perf_analyzer* repo into the perfanalyzerrepo/ subdirectory
-respectively. Typically you want to set both <client branch> and <perf analyzer branch>
+respectively. Typically you want to set both `<client branch>` and `<perf analyzer branch>`
 to be the same as your current server branch.
 
 ```


### PR DESCRIPTION
#### What does the PR do?
Add default value for argument `TRITON_REPO_ORGANIZATION` from sdk Dockerfile. Otherwise it breaks manual build described from https://github.com/triton-inference-server/server/blob/main/docs/customization_guide/test.md#build-sdk-image. This issue seems introduced by PR https://github.com/triton-inference-server/server/pull/6934

And add instruction about clone perf analyzer repo for SDK image build. It's new added to sdk Dockerfile by https://github.com/triton-inference-server/server/pull/7449. And escape angle brackets surrounded strings properly.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build

#### Related PRs:
n/a

#### Where should the reviewer start?
n/a

#### Test plan:
Manual build sdk docker image that's described from https://github.com/triton-inference-server/server/blob/main/docs/customization_guide/test.md#build-sdk-image

- CI Pipeline ID:
n/a

#### Caveats:
n/a

#### Background
n/a

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
n/a
