### PR TITLE
PA Migration: Update L0_client_build_variants

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -218,6 +218,7 @@ WORKDIR /workspace
 COPY TRITON_VERSION .
 COPY NVIDIA_Deep_Learning_Container_License.pdf .
 COPY --from=sdk_build /workspace/client/ client/
+COPY --from=sdk_build /workspace/perf_analyzer/ perf_analyzer/
 COPY --from=sdk_build /workspace/install/ install/
 RUN cd install && \
     export VERSION=`cat /workspace/TRITON_VERSION` && \

--- a/qa/L0_client_build_variants/test.sh
+++ b/qa/L0_client_build_variants/test.sh
@@ -131,11 +131,12 @@ fi
 
 # TODO: These tests should be PA CI test cases
 # not Triton test cases
+rm -fr /workspace/build
+mkdir -p /workspace/build
 #
 # Build without C API in Perf Analyzer
 #
 (cd /workspace/build && \
-        rm -fr cc_clients && \
         cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
               -DTRITON_ENABLE_CC_HTTP=ON \
               -DTRITON_ENABLE_CC_GRPC=ON \

--- a/qa/L0_client_build_variants/test.sh
+++ b/qa/L0_client_build_variants/test.sh
@@ -129,8 +129,8 @@ else
     exit 1
 fi
 
-# TODO: These tests should be PA CI test cases
-# not Triton test cases
+# TODO: TPRD-342 These tests should be PA CI test
+# cases not Triton test cases
 rm -fr /workspace/build
 mkdir -p /workspace/build
 #

--- a/qa/L0_client_build_variants/test.sh
+++ b/qa/L0_client_build_variants/test.sh
@@ -58,10 +58,6 @@ TRITON_REPO_ORGANIZATION=${TRITON_REPO_ORGANIZATION:="http://github.com/triton-i
               -DTRITON_ENABLE_PYTHON_HTTP=ON \
               -DTRITON_ENABLE_PYTHON_GRPC=ON \
               -DTRITON_ENABLE_JAVA_HTTP=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER_C_API=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER_TFS=OFF \
-              -DTRITON_ENABLE_PERF_ANALYZER_TS=OFF \
               -DTRITON_ENABLE_EXAMPLES=ON \
               -DTRITON_ENABLE_TESTS=ON \
               -DTRITON_ENABLE_GPU=OFF \
@@ -90,10 +86,6 @@ fi
               -DTRITON_ENABLE_CC_GRPC=ON \
               -DTRITON_ENABLE_PYTHON_HTTP=OFF \
               -DTRITON_ENABLE_PYTHON_GRPC=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER_C_API=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER_TFS=OFF \
-              -DTRITON_ENABLE_PERF_ANALYZER_TS=OFF \
               -DTRITON_ENABLE_EXAMPLES=ON \
               -DTRITON_ENABLE_TESTS=ON \
               -DTRITON_ENABLE_GPU=ON \
@@ -121,10 +113,6 @@ fi
               -DTRITON_ENABLE_CC_GRPC=OFF \
               -DTRITON_ENABLE_PYTHON_HTTP=ON \
               -DTRITON_ENABLE_PYTHON_GRPC=OFF \
-              -DTRITON_ENABLE_PERF_ANALYZER=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER_C_API=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER_TFS=OFF \
-              -DTRITON_ENABLE_PERF_ANALYZER_TS=OFF \
               -DTRITON_ENABLE_EXAMPLES=ON \
               -DTRITON_ENABLE_TESTS=ON \
               -DTRITON_ENABLE_GPU=ON \
@@ -141,59 +129,26 @@ else
     exit 1
 fi
 
-#
-# Build without Perf Analyzer
-#
-(cd /workspace/build && \
-        rm -fr cc-clients python-clients && \
-        cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
-              -DTRITON_ENABLE_CC_HTTP=ON \
-              -DTRITON_ENABLE_CC_GRPC=ON \
-              -DTRITON_ENABLE_PYTHON_HTTP=ON \
-              -DTRITON_ENABLE_PYTHON_GRPC=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER=OFF \
-              -DTRITON_ENABLE_PERF_ANALYZER_C_API=OFF \
-              -DTRITON_ENABLE_PERF_ANALYZER_TFS=OFF \
-              -DTRITON_ENABLE_PERF_ANALYZER_TS=OFF \
-              -DTRITON_ENABLE_EXAMPLES=ON \
-              -DTRITON_ENABLE_TESTS=ON \
-              -DTRITON_ENABLE_GPU=ON \
-              -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
-              -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} \
-              -DTRITON_CORE_REPO_TAG=${TRITON_CORE_REPO_TAG} \
-              -DTRITON_THIRD_PARTY_REPO_TAG=${TRITON_THIRD_PARTY_REPO_TAG} \
-              /workspace/client && \
-        make -j16 cc-clients python-clients)
-if [ $? -eq 0 ]; then
-    echo -e "\n***\n*** No-Perf-Analyzer Passed\n***"
-else
-    echo -e "\n***\n*** No-Perf-Analyzer FAILED\n***"
-    exit 1
-fi
-
+# TODO: These tests should be PA CI test cases
+# not Triton test cases
 #
 # Build without C API in Perf Analyzer
 #
 (cd /workspace/build && \
-        rm -fr cc-clients python-clients && \
+        rm -fr cc_clients && \
         cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
               -DTRITON_ENABLE_CC_HTTP=ON \
               -DTRITON_ENABLE_CC_GRPC=ON \
-              -DTRITON_ENABLE_PYTHON_HTTP=ON \
-              -DTRITON_ENABLE_PYTHON_GRPC=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER=ON \
               -DTRITON_ENABLE_PERF_ANALYZER_C_API=OFF \
               -DTRITON_ENABLE_PERF_ANALYZER_TFS=ON \
               -DTRITON_ENABLE_PERF_ANALYZER_TS=ON \
-              -DTRITON_ENABLE_EXAMPLES=ON \
-              -DTRITON_ENABLE_TESTS=ON \
               -DTRITON_ENABLE_GPU=ON \
               -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
               -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} \
               -DTRITON_CORE_REPO_TAG=${TRITON_CORE_REPO_TAG} \
-              -DTRITON_THIRD_PARTY_REPO_TAG=${TRITON_THIRD_PARTY_REPO_TAG} \
-              /workspace/client && \
-        make -j16 cc-clients python-clients)
+              -DTRITON_CLIENT_REPO_TAG=${TRITON_CLIENT_REPO_TAG} \
+              /workspace/perf_analyzer && \
+        make -j16 perf-analyzer)
 if [ $? -eq 0 ]; then
     echo -e "\n***\n*** No-CAPI Passed\n***"
 else
@@ -205,25 +160,20 @@ fi
 # Build without TensorFlow Serving in Perf Analyzer
 #
 (cd /workspace/build && \
-        rm -fr cc-clients python-clients && \
+        rm -fr cc_clients perf_analyzer && \
         cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
               -DTRITON_ENABLE_CC_HTTP=ON \
               -DTRITON_ENABLE_CC_GRPC=ON \
-              -DTRITON_ENABLE_PYTHON_HTTP=ON \
-              -DTRITON_ENABLE_PYTHON_GRPC=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER=ON \
               -DTRITON_ENABLE_PERF_ANALYZER_C_API=ON \
               -DTRITON_ENABLE_PERF_ANALYZER_TFS=OFF \
               -DTRITON_ENABLE_PERF_ANALYZER_TS=ON \
-              -DTRITON_ENABLE_EXAMPLES=ON \
-              -DTRITON_ENABLE_TESTS=ON \
               -DTRITON_ENABLE_GPU=ON \
               -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
               -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} \
               -DTRITON_CORE_REPO_TAG=${TRITON_CORE_REPO_TAG} \
-              -DTRITON_THIRD_PARTY_REPO_TAG=${TRITON_THIRD_PARTY_REPO_TAG} \
-              /workspace/client && \
-        make -j16 cc-clients python-clients)
+              -DTRITON_CLIENT_REPO_TAG=${TRITON_CLIENT_REPO_TAG} \
+              /workspace/perf_analyzer && \
+        make -j16 perf-analyzer)
 if [ $? -eq 0 ]; then
     echo -e "\n***\n*** No-TF-Serving Passed\n***"
 else
@@ -235,25 +185,20 @@ fi
 # Build without TorchServe in Perf Analyzer
 #
 (cd /workspace/build && \
-        rm -fr cc-clients python-clients && \
+        rm -fr cc_clients perf_analyzer && \
         cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
               -DTRITON_ENABLE_CC_HTTP=ON \
               -DTRITON_ENABLE_CC_GRPC=ON \
-              -DTRITON_ENABLE_PYTHON_HTTP=ON \
-              -DTRITON_ENABLE_PYTHON_GRPC=ON \
-              -DTRITON_ENABLE_PERF_ANALYZER=ON \
               -DTRITON_ENABLE_PERF_ANALYZER_C_API=ON \
               -DTRITON_ENABLE_PERF_ANALYZER_TFS=ON \
               -DTRITON_ENABLE_PERF_ANALYZER_TS=OFF \
-              -DTRITON_ENABLE_EXAMPLES=ON \
-              -DTRITON_ENABLE_TESTS=ON \
               -DTRITON_ENABLE_GPU=ON \
               -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
               -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} \
               -DTRITON_CORE_REPO_TAG=${TRITON_CORE_REPO_TAG} \
-              -DTRITON_THIRD_PARTY_REPO_TAG=${TRITON_THIRD_PARTY_REPO_TAG} \
-              /workspace/client && \
-        make -j16 cc-clients python-clients)
+              -DTRITON_CLIENT_REPO_TAG=${TRITON_CLIENT_REPO_TAG} \
+              /workspace/perf_analyzer && \
+        make -j16 perf-analyzer)
 if [ $? -eq 0 ]; then
     echo -e "\n***\n*** No-TorchServe Passed\n***"
 else


### PR DESCRIPTION
The objective of `L0_client_build_variants` is to build client libraries/binaries by enabling/disabling various optional features and verify that the build succeeds.

One such set of combinations is to enable/disable optional PA features and verify the build succeeds. This test had been passing (false positive) despite running with a client branch that purged PA from the client repo. Examining the logs closer, it was because CMake was simply ignoring PA-related parameters and repeatedly performing the same standard cc-client/python-client build:

```bash
Manually-specified variables were not used by the project:

    TRITON_ENABLE_PERF_ANALYZER
    TRITON_ENABLE_PERF_ANALYZER_C_API
    TRITON_ENABLE_PERF_ANALYZER_TFS
    TRITON_ENABLE_PERF_ANALYZER_TS
```
These changes modify the script to point to PA source code that recognizes these optional parameters, restoring the test's original purpose.

Ideally, these tests will eventually be moved out of Triton CI entirely and into PA CI.