### PR TITLE
build: RHEL 8 Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,19 +126,12 @@ FetchContent_Declare(
 # Some libs are installed to ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/{LIB}/lib64 instead
 # of ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/{LIB}/lib on Centos
 set(LIB_DIR "lib")
-# /etc/os-release does not exist on Windows
-if(EXISTS "/etc/os-release")
-  file(STRINGS /etc/os-release DISTRO REGEX "^NAME=")
-  file(STRINGS /etc/os-release DISTRO_LIKE REGEX "^ID_LIKE=")
-  string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" DISTRO "${DISTRO}")
-  string(REGEX REPLACE "ID_LIKE=\"(.*)\"" "\\1" DISTRO_LIKE "${DISTRO_LIKE}")
-  message(STATUS "Distro Name: ${DISTRO}")
-  message(STATUS "Distro Like: ${DISTRO_LIKE}")
-  if(DISTRO_LIKE MATCHES ".*rhel.*" OR DISTRO_LIKE MATCHES ".*centos.*")
+if(LINUX)
+  file(STRINGS "/etc/os-release" DISTRO_ID_LIKE REGEX "ID_LIKE")
+  if(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
     set (LIB_DIR "lib64")
-  endif()
-endif()
-
+  endif(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
+endif(LINUX)
 set(TRITON_CORE_HEADERS_ONLY OFF)
 
 FetchContent_MakeAvailable(repo-third-party repo-core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,13 +125,16 @@ FetchContent_Declare(
 
 # Some libs are installed to ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/{LIB}/lib64 instead
 # of ${TRITON_THIRD_PARTY_INSTALL_PREFIX}/{LIB}/lib on Centos
-set (LIB_DIR "lib")
+set(LIB_DIR "lib")
 # /etc/os-release does not exist on Windows
 if(EXISTS "/etc/os-release")
   file(STRINGS /etc/os-release DISTRO REGEX "^NAME=")
+  file(STRINGS /etc/os-release DISTRO_LIKE REGEX "^ID_LIKE=")
   string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" DISTRO "${DISTRO}")
+  string(REGEX REPLACE "ID_LIKE=\"(.*)\"" "\\1" DISTRO_LIKE "${DISTRO_LIKE}")
   message(STATUS "Distro Name: ${DISTRO}")
-  if(DISTRO MATCHES "CentOS.*")
+  message(STATUS "Distro Like: ${DISTRO_LIKE}")
+  if(DISTRO_LIKE MATCHES ".*rhel.*" OR DISTRO_LIKE MATCHES ".*centos.*")
     set (LIB_DIR "lib64")
   endif()
 endif()

--- a/build.py
+++ b/build.py
@@ -1808,7 +1808,7 @@ def core_build(
             os.path.join(repo_install_dir, "bin", "tritonserver.dll"),
             os.path.join(install_dir, "bin"),
         )
-         cmake_script.cp(
+        cmake_script.cp(
             os.path.join(repo_install_dir, "lib", "tritonserver.lib"),
             os.path.join(install_dir, "bin"),
         )

--- a/build.py
+++ b/build.py
@@ -121,7 +121,7 @@ def target_platform():
     if platform_string == "linux":
         # Need to inspect the /etc/os-release file to get
         # the distribution of linux
-        id_like_list = platform.freedesktop_os_release()["ID_LIKE"].split()
+        id_like_list = distro.like().split()
         if "debian" in id_like_list:
             return "linux"
         else:

--- a/build.py
+++ b/build.py
@@ -117,8 +117,8 @@ def fail_if(p, msg):
 def target_platform():
     if FLAGS.target_platform is not None:
         return FLAGS.target_platform
-    platform = platform.system().lower()
-    if platform == "linux":
+    platform_string = platform.system().lower()
+    if platform_string == "linux":
         # Need to inspect the /etc/os-release file to get
         # the distribution of linux
         id_like_list = platform.freedesktop_os_release()["ID_LIKE"].split()
@@ -127,7 +127,7 @@ def target_platform():
         else:
             return "rhel"
     else:
-        return platform
+        return platform_string
 
 
 def target_machine():

--- a/build.py
+++ b/build.py
@@ -35,6 +35,7 @@ import platform
 import stat
 import subprocess
 import sys
+import distro
 from inspect import getsourcefile
 
 import requests

--- a/build.py
+++ b/build.py
@@ -1152,6 +1152,7 @@ ENV NVIDIA_TRITON_SERVER_VERSION ${TRITON_CONTAINER_VERSION}
     with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
         dfile.write(df)
 
+
 def create_dockerfile_linux(
     ddir, dockerfile_name, argmap, backends, repoagents, caches, endpoints
 ):

--- a/build.py
+++ b/build.py
@@ -35,9 +35,9 @@ import platform
 import stat
 import subprocess
 import sys
-import distro
 from inspect import getsourcefile
 
+import distro
 import requests
 
 #

--- a/build.py
+++ b/build.py
@@ -1316,8 +1316,7 @@ RUN yum install -y \\
         gperftools-devel \\
         patchelf \\
         wget \\
-        numactl-devel \\
-        wget
+        numactl-devel
 """
     else:
         df += """

--- a/build.py
+++ b/build.py
@@ -119,9 +119,9 @@ def target_platform():
         return FLAGS.target_platform
     platform = platform.system().lower()
     if platform == "linux":
-        # Need to inspect the /etc/os-release file to get 
+        # Need to inspect the /etc/os-release file to get
         # the distribution of linux
-        id_like_list = platform.freedesktop_os_release()['ID_LIKE'].split()
+        id_like_list = platform.freedesktop_os_release()["ID_LIKE"].split()
         if "debian" in id_like_list:
             return "linux"
         else:

--- a/build.py
+++ b/build.py
@@ -833,8 +833,27 @@ def install_dcgm_libraries(dcgm_version, target_machine):
         )
         return ""
     else:
-        if target_machine == "aarch64":
-            return """
+                # RHEL has the same install instructions for both aarch64 and x86
+        if target_platform() == "rhel":
+            if target_machine == "aarch64":
+                return """
+ENV DCGM_VERSION {}
+# Install DCGM. Steps from https://developer.nvidia.com/dcgm#Downloads
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-rhel8.repo \\
+    && dnf clean expire-cache \\
+    && dnf install -y datacenter-gpu-manager-{}
+""".format(dcgm_version, dcgm_version)
+            else:
+                return """
+ENV DCGM_VERSION {}
+# Install DCGM. Steps from https://developer.nvidia.com/dcgm#Downloads
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo \\
+    && dnf clean expire-cache \\
+    && dnf install -y datacenter-gpu-manager-{}
+""".format(dcgm_version, dcgm_version)
+        else:
+            if target_machine == "aarch64":
+                return """
 ENV DCGM_VERSION {}
 # Install DCGM. Steps from https://developer.nvidia.com/dcgm#Downloads
 RUN curl -o /tmp/cuda-keyring.deb \\
@@ -846,8 +865,8 @@ RUN curl -o /tmp/cuda-keyring.deb \\
 """.format(
                 dcgm_version, dcgm_version
             )
-        else:
-            return """
+            else:
+                return """
 ENV DCGM_VERSION {}
 # Install DCGM. Steps from https://developer.nvidia.com/dcgm#Downloads
 RUN curl -o /tmp/cuda-keyring.deb \\
@@ -860,6 +879,102 @@ RUN curl -o /tmp/cuda-keyring.deb \\
                 dcgm_version, dcgm_version
             )
 
+def create_dockerfile_buildbase_rhel(ddir, dockerfile_name, argmap):
+    df = """
+ARG TRITON_VERSION={}
+ARG TRITON_CONTAINER_VERSION={}
+ARG BASE_IMAGE={}
+""".format(
+        argmap["TRITON_VERSION"],
+        argmap["TRITON_CONTAINER_VERSION"],
+        argmap["BASE_IMAGE"],
+    )
+
+    df += """
+FROM ${BASE_IMAGE}
+
+ARG TRITON_VERSION
+ARG TRITON_CONTAINER_VERSION
+"""
+    df += """
+# Install docker docker buildx
+RUN yum install -y ca-certificates curl gnupg yum-utils \\
+      && yum-config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo \\
+      && yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+#   && yum install -y docker.io docker-buildx-plugin
+
+# libcurl4-openSSL-dev is needed for GCS
+# python3-dev is needed by Torchvision
+# python3-pip and libarchive-dev is needed by python backend
+# libxml2-dev is needed for Azure Storage
+# scons is needed for armnn_tflite backend build dep
+RUN yum install -y \\
+            ca-certificates \\
+            autoconf \\
+            automake \\
+            git \\
+            gperf \\
+            re2-devel \\
+            openssl-devel \\
+            libtool \\
+            libcurl-devel \\
+            libb64-devel \\
+            gperftools-devel \\
+            patchelf \\
+            python3.11-devel \\
+            python3-pip \\
+            python3-setuptools \\
+            rapidjson-devel \\
+            python3-scons \\
+            pkg-config \\
+            unzip \\
+            wget \\
+            zlib-devel \\
+            libarchive-devel \\
+            libxml2-devel \\
+            numactl-devel \\
+            wget 
+
+RUN pip3 install --upgrade pip \\
+      && pip3 install --upgrade \\
+          wheel \\
+          setuptools \\
+          docker \\
+          virtualenv
+
+# Install boost version >= 1.78 for boost::span
+# Current libboost-dev apt packages are < 1.78, so install from tar.gz
+RUN wget -O /tmp/boost.tar.gz \\
+          https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz \\
+      && (cd /tmp && tar xzf boost.tar.gz) \\
+      && mv /tmp/boost_1_80_0/boost /usr/include/boost
+
+# Server build requires recent version of CMake (FetchContent required)
+# Might not need this if the installed version of cmake is high enough for our build.
+# RUN apt update -q=2 \\
+#       && apt install -y gpg wget \\
+#       && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - |  tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \\
+#       && . /etc/os-release \\
+#       && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $UBUNTU_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null \\
+#       && apt-get update -q=2 \\
+#       && apt-get install -y --no-install-recommends cmake=3.27.7* cmake-data=3.27.7*
+"""
+    if FLAGS.enable_gpu:
+        df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine())
+    df += """
+ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
+ENV NVIDIA_TRITON_SERVER_VERSION ${TRITON_CONTAINER_VERSION}
+"""
+
+    df += """
+WORKDIR /workspace
+RUN rm -fr *
+COPY . .
+ENTRYPOINT []
+"""
+
+    with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
+        dfile.write(df)
 
 def create_dockerfile_buildbase(ddir, dockerfile_name, argmap):
     df = """
@@ -1017,6 +1132,10 @@ ENV NVIDIA_TRITON_SERVER_VERSION ${TRITON_CONTAINER_VERSION}
     with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
         dfile.write(df)
 
+def create_dockerfile_rhel(    
+    ddir, dockerfile_name, argmap, backends, repoagents, caches, endpoints
+):
+    pass 
 
 def create_dockerfile_linux(
     ddir, dockerfile_name, argmap, backends, repoagents, caches, endpoints
@@ -1161,7 +1280,28 @@ RUN userdel tensorrt-server > /dev/null 2>&1 || true \\
         fi \\
       && [ `id -u $TRITON_SERVER_USER` -eq 1000 ] \\
       && [ `id -g $TRITON_SERVER_USER` -eq 1000 ]
+""".format(gpu_enabled=gpu_enabled)
 
+    # This 
+    if target_platform() == "rhel":
+        df += """
+# Common dpeendencies. 
+RUN yum install -y \\
+        git \\
+        gperf \\
+        re2-devel \\
+        openssl-devel \\
+        libtool \\
+        libcurl-devel \\
+        libb64-devel \\
+        gperftools-devel \\
+        patchelf \\
+        wget \\
+        numactl-devel \\
+        wget 
+"""
+    else:
+        df += """
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -1184,12 +1324,12 @@ RUN apt-get update \\
               wget \\
               {backend_dependencies} \\
       && rm -rf /var/lib/apt/lists/*
-
+""".format(backend_dependencies=backend_dependencies)
+   
+    df += """
 # Set TCMALLOC_RELEASE_RATE for users setting LD_PRELOAD with tcmalloc
 ENV TCMALLOC_RELEASE_RATE 200
-""".format(
-        gpu_enabled=gpu_enabled, backend_dependencies=backend_dependencies
-    )
+"""
 
     if "fastertransformer" in backends:
         be = "fastertransformer"
@@ -1433,9 +1573,14 @@ def create_build_dockerfiles(
             )
         dockerfileargmap["GPU_BASE_IMAGE"] = gpu_base_image
 
-    create_dockerfile_buildbase(
-        FLAGS.build_dir, "Dockerfile.buildbase", dockerfileargmap
-    )
+    if target_platform() == "rhel":
+        create_dockerfile_buildbase_rhel(
+            FLAGS.build_dir, "Dockerfile.buildbase", dockerfileargmap
+        )
+    else:
+        create_dockerfile_buildbase(
+            FLAGS.build_dir, "Dockerfile.buildbase", dockerfileargmap
+        )
 
     if target_platform() == "windows":
         create_dockerfile_windows(
@@ -1446,6 +1591,16 @@ def create_build_dockerfiles(
             repoagents,
             caches,
         )
+    # elif target_platform() == "rhel":
+    #     create_dockerfile_rhel(
+    #         FLAGS.build_dir,
+    #         "Dockerfile",
+    #         dockerfileargmap,
+    #         backends,
+    #         repoagents,
+    #         caches,
+    #         endpoints,
+    #     )
     else:
         create_dockerfile_linux(
             FLAGS.build_dir,
@@ -1647,9 +1802,16 @@ def core_build(
             os.path.join(repo_install_dir, "bin", "tritonserver.dll"),
             os.path.join(install_dir, "bin"),
         )
+    elif target_platform() == "rhel":
+        cmake_script.mkdir(os.path.join(install_dir, "bin"))
         cmake_script.cp(
-            os.path.join(repo_install_dir, "lib", "tritonserver.lib"),
+            os.path.join(repo_install_dir, "bin", "tritonserver"),
             os.path.join(install_dir, "bin"),
+        )
+        cmake_script.mkdir(os.path.join(install_dir, "lib64"))
+        cmake_script.cp(
+            os.path.join(repo_install_dir, "lib64", "libtritonserver.so"),
+            os.path.join(install_dir, "lib64"),
         )
     else:
         cmake_script.mkdir(os.path.join(install_dir, "bin"))
@@ -2124,7 +2286,7 @@ if __name__ == "__main__":
         "--target-platform",
         required=False,
         default=None,
-        help='Target platform for build, can be "linux", "windows" or "igpu". If not specified, build targets the current platform.',
+        help='Target platform for build, can be "linux", "rhel", "windows" or "igpu". If not specified, build targets the current platform.',
     )
     parser.add_argument(
         "--target-machine",

--- a/build.py
+++ b/build.py
@@ -1607,16 +1607,6 @@ def create_build_dockerfiles(
             repoagents,
             caches,
         )
-    # elif target_platform() == "rhel":
-    #     create_dockerfile_rhel(
-    #         FLAGS.build_dir,
-    #         "Dockerfile",
-    #         dockerfileargmap,
-    #         backends,
-    #         repoagents,
-    #         caches,
-    #         endpoints,
-    #     )
     else:
         create_dockerfile_linux(
             FLAGS.build_dir,

--- a/build.py
+++ b/build.py
@@ -117,7 +117,17 @@ def fail_if(p, msg):
 def target_platform():
     if FLAGS.target_platform is not None:
         return FLAGS.target_platform
-    return platform.system().lower()
+    platform = platform.system().lower()
+    if platform == "linux":
+        # Need to inspect the /etc/os-release file to get 
+        # the distribution of linux
+        id_like_list = platform.freedesktop_os_release()['ID_LIKE'].split()
+        if "debian" in id_like_list:
+            return "linux"
+        else:
+            return "rhel"
+    else:
+        return platform
 
 
 def target_machine():

--- a/build.py
+++ b/build.py
@@ -1818,6 +1818,10 @@ def core_build(
             os.path.join(repo_install_dir, "bin", "tritonserver.dll"),
             os.path.join(install_dir, "bin"),
         )
+         cmake_script.cp(
+            os.path.join(repo_install_dir, "lib", "tritonserver.lib"),
+            os.path.join(install_dir, "bin"),
+        )
     elif target_platform() == "rhel":
         cmake_script.mkdir(os.path.join(install_dir, "bin"))
         cmake_script.cp(

--- a/build.py
+++ b/build.py
@@ -1152,13 +1152,6 @@ ENV NVIDIA_TRITON_SERVER_VERSION ${TRITON_CONTAINER_VERSION}
     with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
         dfile.write(df)
 
-
-def create_dockerfile_rhel(
-    ddir, dockerfile_name, argmap, backends, repoagents, caches, endpoints
-):
-    pass
-
-
 def create_dockerfile_linux(
     ddir, dockerfile_name, argmap, backends, repoagents, caches, endpoints
 ):

--- a/qa/L0_infer/install_and_test.sh
+++ b/qa/L0_infer/install_and_test.sh
@@ -25,12 +25,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
 # Determine the operating system to call the correct package manager.
-ID_LIKE=$(grep -Po '(?<=ID_LIKE=).*' /etc/os-release | awk -F= '{print $1}' | grep -o 'debian')
+ID_LIKE=$(grep -Po '(?<=ID_LIKE=).*' /etc/os-release | awk -F= '{print $1}' |  tr -d '"' | awk '{print $1}')
+
 # Note: This script is to be used with customized triton containers that need
 # dependencies to run L0_infer tests
-if [[ "$ID_LIKE" == "debian" ]]; then
+if [[ "$ID_LIKE" =~ "debian" ]]; then
     apt-get update && \
         apt-get install -y --no-install-recommends \
             curl \

--- a/qa/L0_infer/install_and_test.sh
+++ b/qa/L0_infer/install_and_test.sh
@@ -25,14 +25,24 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+# Determine the operating system to call the correct package manager.
+ID_LIKE=$(grep -Po '(?<=ID_LIKE=).*' /etc/os-release | awk -F= '{print $1}' | grep -o 'debian')
 # Note: This script is to be used with customized triton containers that need
 # dependencies to run L0_infer tests
-apt-get update && \
-    apt-get install -y --no-install-recommends \
-         curl \
-         jq \
-         python3 \
-         python3-pip
+if [[ "$ID_LIKE" == "debian" ]]; then
+    apt-get update && \
+        apt-get install -y --no-install-recommends \
+            curl \
+            jq \
+            python3 \
+            python3-pip
+else
+    yum install -y \
+        jq \
+        curl
+fi
+
 pip3 install --upgrade pip
 # install client libraries
 pip3 install tritonclient[all]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,18 +139,13 @@ else()
 endif()
 
 set(LIB_DIR "lib")
-# /etc/os-release does not exist on Windows
-if(EXISTS "/etc/os-release")
-  file(STRINGS /etc/os-release DISTRO REGEX "^NAME=")
-  file(STRINGS /etc/os-release DISTRO_LIKE REGEX "^ID_LIKE=")
-  string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" DISTRO "${DISTRO}")
-  string(REGEX REPLACE "ID_LIKE=\"(.*)\"" "\\1" DISTRO_LIKE "${DISTRO_LIKE}")
-  message(STATUS "Distro Name: ${DISTRO}")
-  message(STATUS "Distro Like: ${DISTRO_LIKE}")
-  if(DISTRO_LIKE MATCHES ".*rhel.*" OR DISTRO_LIKE MATCHES ".*centos.*")
+if(LINUX)
+  file(STRINGS "/etc/os-release" DISTRO_ID_LIKE REGEX "ID_LIKE")
+  if(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
     set (LIB_DIR "lib64")
-  endif()
-endif()
+  endif(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
+endif(LINUX)
+set(TRITON_CORE_HEADERS_ONLY OFF)
 
 set_target_properties(
   main

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,6 +138,20 @@ else()
   )
 endif()
 
+set(LIB_DIR "lib")
+# /etc/os-release does not exist on Windows
+if(EXISTS "/etc/os-release")
+  file(STRINGS /etc/os-release DISTRO REGEX "^NAME=")
+  file(STRINGS /etc/os-release DISTRO_LIKE REGEX "^ID_LIKE=")
+  string(REGEX REPLACE "NAME=\"(.*)\"" "\\1" DISTRO "${DISTRO}")
+  string(REGEX REPLACE "ID_LIKE=\"(.*)\"" "\\1" DISTRO_LIKE "${DISTRO_LIKE}")
+  message(STATUS "Distro Name: ${DISTRO}")
+  message(STATUS "Distro Like: ${DISTRO_LIKE}")
+  if(DISTRO_LIKE MATCHES ".*rhel.*" OR DISTRO_LIKE MATCHES ".*centos.*")
+    set (LIB_DIR "lib64")
+  endif()
+endif()
+
 set_target_properties(
   main
   PROPERTIES
@@ -145,7 +159,7 @@ set_target_properties(
     SKIP_BUILD_RPATH TRUE
     BUILD_WITH_INSTALL_RPATH TRUE
     INSTALL_RPATH_USE_LINK_PATH FALSE
-    INSTALL_RPATH "$\{ORIGIN\}/../lib"
+    INSTALL_RPATH "$\{ORIGIN\}/../${LIB_DIR}"
 )
 
 target_link_libraries(


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR adds the following:
- Support for RHEL 8 compatible builds. 
  - Public users will need to setup their RHEL-like systems and then use the `--no-container-build` since Triton Inference Server doesn't publish a base container with which to use
  - NVIDIA users may build using a private base container to build
- Updated the `target_platform()` method in `build.py` to distinguish between debian and rhel-like systems. 
  - A follow on PR to change the target platform from "linux" to "debian" will be generated after this. 
- Update to L0_infer to be able to execute on either debian-like or rhel-like systems. 
- Update to `CMakeLists.txt` files to correctly point at the `lib64` directories on rhel-like systems.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
https://github.com/triton-inference-server/core/pull/387
https://github.com/triton-inference-server/third_party/pull/59

#### Where should the reviewer start?
build.py is the meat of this PR. The CMakeLists.txt files are the same changes which are needed in the Related PRs section.

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->
No new e2e tests were added to this repository

- CI Pipeline ID:17365005
<!-- Only Pipeline ID and no direct link here -->

#### Caveats: N/A
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->
This is a requested feature from users of Triton, check with Product team for specifics. 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- N/A
