### PR TITLE
ci: Raise Documentation Generation Errors

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -126,6 +126,7 @@ def run_command(command):
         log_message(f"Error executing command: {e.cmd}")
         log_message(e.output)
         log_message(e.stderr)
+        raise (e)
 
 
 def clone_from_github(repo, tag, org):
@@ -156,6 +157,7 @@ def clone_from_github(repo, tag, org):
         log_message(f"Successfully cloned {repo}")
     except subprocess.CalledProcessError as e:
         log_message(f"Failed to clone {repo}. Error: {e}")
+        raise (e)
 
 
 def parse_repo_tag(repo_tags):

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -135,7 +135,6 @@ def clone_from_github(repo, tag, org):
     """
     # Construct the full GitHub repository URL
     repo_url = f"https://github.com/{org}/{repo}.git"
-    print(repo_url)
     # Construct the git clone command
     if tag:
         clone_command = [
@@ -187,8 +186,8 @@ def get_git_repo_name(file_path):
             .decode()
             .strip()
         )
-    except subprocess.CalledProcessError:
-        return None
+    except subprocess.CalledProcessError as e:
+        raise (e)
 
     # Extract repository name from the remote URL.
     if remote_url.endswith(".git"):

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -123,9 +123,6 @@ def run_command(command):
             stderr=subprocess.PIPE,
         )
     except subprocess.CalledProcessError as e:
-        log_message(f"Error executing command: {e.cmd}")
-        log_message(e.output)
-        log_message(e.stderr)
         raise (e)
 
 
@@ -156,7 +153,6 @@ def clone_from_github(repo, tag, org):
         subprocess.run(clone_command, check=True)
         log_message(f"Successfully cloned {repo}")
     except subprocess.CalledProcessError as e:
-        log_message(f"Failed to clone {repo}. Error: {e}")
         raise (e)
 
 


### PR DESCRIPTION
#### What does the PR do?
Raise errors in the documentation generation script so that CI doesn't falsely report that the job succeeded

#### Checklist
- [X] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [X] Related issues are referenced.
- [X] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [X] Verified that the PR passes existing CI.
- [X] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [X] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test
