### PR TITLE
Don't Build `tritonfrontend` for Windows.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -782,8 +782,10 @@ if (NOT WIN32)
   endif() # TRITON_ENABLE_GPU
 endif() # NOT WIN32
 
-# tritonfrontend python package
-add_subdirectory(python)
+if (NOT WIN32)
+  # tritonfrontend python package
+  add_subdirectory(python)
+endif (NOT WIN32)
 
 # Currently unit tests do not build for windows...
 if ( NOT WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -782,6 +782,7 @@ if (NOT WIN32)
   endif() # TRITON_ENABLE_GPU
 endif() # NOT WIN32
 
+# DLIS-7292: Extend tritonfrontend to build for Windows
 if (NOT WIN32)
   # tritonfrontend python package
   add_subdirectory(python)


### PR DESCRIPTION
**Goal:** Don't build `tritonfrontend` for Windows.


