### PR TITLE
Cherry-pick: Don't Build tritonfrontend for Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -782,8 +782,11 @@ if (NOT WIN32)
   endif() # TRITON_ENABLE_GPU
 endif() # NOT WIN32
 
-# tritonfrontend python package
-add_subdirectory(python)
+# DLIS-7292: Extend tritonfrontend to build for Windows
+if (NOT WIN32)
+  # tritonfrontend python package
+  add_subdirectory(python)
+endif (NOT WIN32)
 
 # Currently unit tests do not build for windows...
 if ( NOT WIN32)


### PR DESCRIPTION
Cherry pick based on: https://github.com/triton-inference-server/server/pull/7599


