### PR TITLE
Fix: Add mutex lock for state completion check in gRPC streaming to prevent race condition

### DIFF
--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -217,15 +217,6 @@ class ResponseQueue {
     return ((alloc_count_ == ready_count_) && (alloc_count_ == current_index_));
   }
 
-  // [FIXME] Remove debug info method below, added for testing
-  void PrintAttributes()
-  {
-    std::cout << "\n response_queue_->alloc_count_" << alloc_count_
-              << "\n response_queue_->ready_count_" << ready_count_
-              << "\n response_queue_->current_index_" << current_index_
-              << std::endl;
-  }
-
   // Returns whether the queue has responses
   // ready to be written.
   bool HasReadyResponse()

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -217,6 +217,15 @@ class ResponseQueue {
     return ((alloc_count_ == ready_count_) && (alloc_count_ == current_index_));
   }
 
+  // [FIXME] Remove debug info method below, added for testing
+  void PrintAttributes()
+  {
+    std::cout << "\n response_queue_->alloc_count_" << alloc_count_
+              << "\n response_queue_->ready_count_" << ready_count_
+              << "\n response_queue_->current_index_" << current_index_
+              << std::endl;
+  }
+
   // Returns whether the queue has responses
   // ready to be written.
   bool HasReadyResponse()

--- a/src/grpc/stream_infer_handler.cc
+++ b/src/grpc/stream_infer_handler.cc
@@ -545,13 +545,6 @@ ModelStreamInferHandler::Process(InferHandler::State* state, bool rpc_ok)
         } else {
           LOG_ERROR << "Should not print this! Decoupled should NOT write via "
                        "WRITEREADY!";
-
-          // [FIXME] Remove debug info below
-          std::cout << "******************\n"
-                    << " state->complete_: " << state->complete_ << std::endl;
-          state->response_queue_->PrintAttributes();
-          std::cout << "*********************";
-
           // Remove the state from the completion queue
           std::lock_guard<std::recursive_mutex> lock(state->step_mtx_);
           state->step_ = Steps::ISSUED;


### PR DESCRIPTION
#### What does the PR do?
This PR aims to fix an occasional error (caused by a race condition) that occurs when making multiple asynchronous requests to the ASR model in decoupled mode:
```
E0829 13:41:44.609857 147 stream_infer_handler.cc:528] "Should not print this! Decoupled should NOT write via WRITEREADY!"
```

#### Checklist
- [X] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [X] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [X] Verified that the PR passes existing CI.
- [X] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [X] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID: 18428769
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
