### PR TITLE
ci: Set stability factor to a higher value

### DIFF
--- a/qa/L0_perf_analyzer_capi/test.sh
+++ b/qa/L0_perf_analyzer_capi/test.sh
@@ -56,7 +56,7 @@ SHAPETENSORADTAFILE=`pwd`/../common/perf_analyzer_input_data_json/shape_tensor_d
 
 ERROR_STRING="error | Request count: 0 | : 0 infer/sec"
 
-STABILITY_THRESHOLD="15"
+STABILITY_THRESHOLD="9999"
 
 source ../common/util.sh
 


### PR DESCRIPTION
#### What does the PR do?
Set stability threshold to a higher number (9999) to ensure PA gets stable measurement.s

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [x] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Where should the reviewer start?
qa/L0_perf_analyzer_capi/test.sh

- CI Pipeline ID:
<!-- Only Pipeline ID and no direct link here -->


#### Background
PA sometimes cannot get stable measurements due to low stability threshold.

