### PR TITLE
feat: KServe Bindings to start tritonfrontend

### DIFF
--- a/python/openai/README.md
+++ b/python/openai/README.md
@@ -36,7 +36,7 @@ python3 openai_frontend/main.py --model-repository tests/vllm_models/ --tokenize
   - Note the use of `jq` is optional, but provides a nicely formatted output for JSON responses.
 ```bash
 MODEL="llama-3.1-8b-instruct"
-curl -s http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
+curl -s http://localhost:9000/v1/chat/completions -H 'Content-Type: application/json' -d '{
   "model": "'${MODEL}'",
   "messages": [{"role": "user", "content": "Say this is a test!"}]
 }' | jq
@@ -46,7 +46,7 @@ curl -s http://localhost:8000/v1/chat/completions -H 'Content-Type: application/
   - Note the use of `jq` is optional, but provides a nicely formatted output for JSON responses.
 ```bash
 MODEL="llama-3.1-8b-instruct"
-curl -s http://localhost:8000/v1/completions -H 'Content-Type: application/json' -d '{
+curl -s http://localhost:9000/v1/completions -H 'Content-Type: application/json' -d '{
   "model": "'${MODEL}'",
   "prompt": "Machine learning is"
 }' | jq
@@ -73,7 +73,7 @@ genai-perf \
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="http://localhost:8000/v1",
+    base_url="http://localhost:9000/v1",
     api_key="EMPTY",
 )
 
@@ -138,7 +138,7 @@ python3 openai_frontend/main.py --model-repository tests/tensorrtllm_models/ --t
   - Note the use of `jq` is optional, but provides a nicely formatted output for JSON responses.
 ```bash
 MODEL="tensorrt_llm_bls"
-curl -s http://localhost:8000/v1/chat/completions -H 'Content-Type: application/json' -d '{
+curl -s http://localhost:9000/v1/chat/completions -H 'Content-Type: application/json' -d '{
   "model": "'${MODEL}'",
   "messages": [{"role": "user", "content": "Say this is a test!"}]
 }' | jq

--- a/python/openai/openai_frontend/main.py
+++ b/python/openai/openai_frontend/main.py
@@ -94,7 +94,7 @@ def parse_args():
         "--kserve-http-port",
         type=int,
         default=8000,
-        help="Triton KServeHTTP port number",
+        help="KServe Predict v2 HTTP port (default: 8000)",
     )
     triton_group.add_argument(
         "--kserve-grpc-port",

--- a/python/openai/openai_frontend/main.py
+++ b/python/openai/openai_frontend/main.py
@@ -100,7 +100,7 @@ def parse_args():
         "--kserve-grpc-port",
         type=int,
         default=8001,
-        help="Triton KServeGrpc port number",
+        help="KServe Predict v2 GRPC port (default: 8001)",
     )
 
     return parser.parse_args()

--- a/python/openai/openai_frontend/main.py
+++ b/python/openai/openai_frontend/main.py
@@ -74,7 +74,7 @@ def parse_args():
     # Uvicorn
     uvicorn_group = parser.add_argument_group("Uvicorn")
     uvicorn_group.add_argument("--host", type=str, default=None, help="host name")
-    uvicorn_group.add_argument("--port", type=int, default=9000, help="OpenAI port")
+    uvicorn_group.add_argument("--openai-port", type=int, default=9000, help="OpenAI HTTP port (default: 9000)")
     uvicorn_group.add_argument(
         "--uvicorn-log-level",
         type=str,

--- a/python/openai/openai_frontend/main.py
+++ b/python/openai/openai_frontend/main.py
@@ -53,7 +53,7 @@ def parse_args():
     # Uvicorn
     uvicorn_group = parser.add_argument_group("Uvicorn")
     uvicorn_group.add_argument("--host", type=str, default=None, help="host name")
-    uvicorn_group.add_argument("--port", type=int, default=9000, help="port number")
+    uvicorn_group.add_argument("--port", type=int, default=9000, help="OpenAI port")
     uvicorn_group.add_argument(
         "--uvicorn-log-level",
         type=str,

--- a/python/openai/openai_frontend/main.py
+++ b/python/openai/openai_frontend/main.py
@@ -37,7 +37,7 @@ from frontend.fastapi_frontend import FastApiFrontend
 
 try:
     from tritonfrontend import KServeGrpc, KServeHttp
-except:
+except ModuleNotFoundError:
     print(
         """
           tritonfrontend is not present in this environment.

--- a/python/openai/openai_frontend/main.py
+++ b/python/openai/openai_frontend/main.py
@@ -74,7 +74,9 @@ def parse_args():
     # Uvicorn
     uvicorn_group = parser.add_argument_group("Uvicorn")
     uvicorn_group.add_argument("--host", type=str, default=None, help="host name")
-    uvicorn_group.add_argument("--openai-port", type=int, default=9000, help="OpenAI HTTP port (default: 9000)")
+    uvicorn_group.add_argument(
+        "--openai-port", type=int, default=9000, help="OpenAI HTTP port (default: 9000)"
+    )
     uvicorn_group.add_argument(
         "--uvicorn-log-level",
         type=str,


### PR DESCRIPTION
Adding support to start the `KServeHttp` and `KServeGrpc` frontends from the `server/python/openai/openai_frontend/main.py`