### PR TITLE
chore: Fix argparse typo, cleanup argparse groups, make kserve frontends optional

### DIFF
--- a/python/openai/README.md
+++ b/python/openai/README.md
@@ -29,7 +29,7 @@ docker run -it --net=host --gpus all --rm \
 cd openai/
 
 # NOTE: Adjust the --tokenizer based on the model being used
-python3 openai_frontend/main.py --model-repository tests/vllm_models/ --tokenizer meta-llama/Meta-Llama-3.1-8B-Instruct
+python3 openai_frontend/main.py --model-repository tests/vllm_models --tokenizer meta-llama/Meta-Llama-3.1-8B-Instruct
 ```
 
 3. Send a `/v1/chat/completions` request:
@@ -131,7 +131,7 @@ docker run -it --net=host --gpus all --rm \
 cd openai/
 
 # NOTE: Adjust the --tokenizer based on the model being used
-python3 openai_frontend/main.py --model-repository tests/tensorrtllm_models/ --tokenizer meta-llama/Meta-Llama-3.1-8B-Instruct
+python3 openai_frontend/main.py --model-repository tests/tensorrtllm_models --tokenizer meta-llama/Meta-Llama-3.1-8B-Instruct
 ```
 
 3. Send a `/v1/chat/completions` request:
@@ -146,3 +146,23 @@ curl -s http://localhost:9000/v1/chat/completions -H 'Content-Type: application/
 
 The other examples should be the same as vLLM, except that you should set `MODEL="tensorrt_llm_bls"`,
 everywhere applicable as seen in the example request above.
+
+## KServe Frontends
+
+To support serving requests through both the OpenAI-Compatible and
+KServe Predict v2 frontends to the same running Triton Inference Server,
+the `tritonfrontend` python bindings are included for optional use in this
+application as well.
+
+You can opt-in to including these additional frontends, assuming `tritonfrontend`
+is installed, with `--enable-kserve-frontends` like below:
+
+```
+python3 openai_frontend/main.py \
+  --model-repository tests/vllm_models \
+  --tokenizer meta-llama/Meta-Llama-3.1-8B-Instruct \
+  --enable-kserve-frontends
+```
+
+See `python3 openai_frontend/main.py --help` for more information on the
+available arguments and default values.

--- a/python/openai/tests/conftest.py
+++ b/python/openai/tests/conftest.py
@@ -92,6 +92,10 @@ def server():
         "--backend",
         TEST_BACKEND,
     ]
+    # TODO: Incorporate kserve frontend binding smoke tests to catch any
+    # breakage with default values or slight cli arg variations
+    extra_args = ["--enable-kserve-frontends"]
+    args += extra_args
 
     with OpenAIServer(args) as openai_server:
         yield openai_server

--- a/python/openai/tests/utils.py
+++ b/python/openai/tests/utils.py
@@ -71,8 +71,9 @@ class OpenAIServer:
         *,
         env_dict: Optional[Dict[str, str]] = None,
     ) -> None:
+        # TODO: Incorporate caller's cli_args passed to this instance instead
         self.host = "localhost"
-        self.port = 8000
+        self.port = 9000
 
         env = os.environ.copy()
         if env_dict is not None:


### PR DESCRIPTION
- Fix argparse typo with `args.port` instead of `args.openai_port`
- Cleanup argparse groups and documentation
- Make kserve frontends optional for now via `--enable-kserve-frontends` to allow opt-in since it's currently an "openai_frontend" application, and in case we need to allow users to disable kserve portions for some reason
- Add small section to README (can be fleshed out in other docs follow-up)

Cleanup to `--help` output example:
```
# python3 openai_frontend/main.py --help
usage: main.py [-h] --model-repository MODEL_REPOSITORY [--tokenizer TOKENIZER] [--backend {vllm,tensorrtllm}]
               [--tritonserver-log-verbose-level TRITONSERVER_LOG_VERBOSE_LEVEL] [--host HOST]
               [--openai-port OPENAI_PORT] [--uvicorn-log-level {debug,info,warning,error,critical,trace}]
               [--enable-kserve-frontends] [--kserve-http-port KSERVE_HTTP_PORT]
               [--kserve-grpc-port KSERVE_GRPC_PORT]

Triton Inference Server with OpenAI-Compatible RESTful API server.

options:
  -h, --help            show this help message and exit

Triton Inference Server:
  --model-repository MODEL_REPOSITORY
                        Path to the Triton model repository holding the models to be served
  --tokenizer TOKENIZER
                        HuggingFace ID or local folder path of the Tokenizer to use for chat templates
  --backend {vllm,tensorrtllm}
                        Manual override of Triton backend request format (inputs/output names) to use for inference
  --tritonserver-log-verbose-level TRITONSERVER_LOG_VERBOSE_LEVEL
                        The tritonserver log verbosity level
  --host HOST           Address/host of frontends (default: '0.0.0.0')

Triton OpenAI-Compatible Frontend:
  --openai-port OPENAI_PORT
                        OpenAI HTTP port (default: 9000)
  --uvicorn-log-level {debug,info,warning,error,critical,trace}
                        log level for uvicorn

Triton KServe Frontend:
  --enable-kserve-frontends
                        Enable KServe Predict v2 HTTP/GRPC frontends (disabled by default)
  --kserve-http-port KSERVE_HTTP_PORT
                        KServe Predict v2 HTTP port (default: 8000)
  --kserve-grpc-port KSERVE_GRPC_PORT
                        KServe Predict v2 GRPC port (default: 8001)
```