### PR TITLE
ci: Reducing flakiness of `L0_python_api` 

### DIFF
--- a/qa/L0_python_api/test_kserve.py
+++ b/qa/L0_python_api/test_kserve.py
@@ -242,17 +242,18 @@ class TestKServe:
             time.sleep(1)
 
         # Depending on when gRPC frontend shut down StatusCode can vary
-        acceptable_failure_msgs = set(
-            [
-                "[StatusCode.CANCELLED] CANCELLED",
-                "[StatusCode.UNAVAILABLE] failed to connect to all addresses",
-            ]
-        )
+        acceptable_failure_msgs = [
+            "[StatusCode.CANCELLED] CANCELLED",
+            "[StatusCode.UNAVAILABLE] failed to connect to all addresses",
+        ]
 
         assert (
             len(user_data) == 1
             and isinstance(user_data[0], InferenceServerException)
-            and str(user_data[0]) in acceptable_failure_msgs
+            and any(
+                failure_msg in str(user_data[0])
+                for failure_msg in acceptable_failure_msgs
+            )
         )
 
         teardown_client(grpc_client)

--- a/qa/L0_python_api/test_kserve.py
+++ b/qa/L0_python_api/test_kserve.py
@@ -241,11 +241,18 @@ class TestKServe:
             time_out = time_out - 1
             time.sleep(1)
 
+        # Depending on when gRPC frontend shut down StatusCode can vary
+        acceptable_failure_msgs = set(
+            [
+                "[StatusCode.CANCELLED] CANCELLED",
+                "[StatusCode.UNAVAILABLE] failed to connect to all addresses",
+            ]
+        )
+
         assert (
             len(user_data) == 1
             and isinstance(user_data[0], InferenceServerException)
-            and "[StatusCode.UNAVAILABLE] failed to connect to all addresses"
-            in str(user_data[0])
+            and str(user_data[0]) in acceptable_failure_msgs
         )
 
         teardown_client(grpc_client)


### PR DESCRIPTION
#### What does the PR do?
Currently, if an inference request is sent with the `tritonclient` and the `gRPC` frontend is shutdown, the `StatusCode` and message returned varies depending on the timing of the operations. Modified `test_grpc_req_during_shutdown` to accept multiple possible `StatusCode` values.


- CI Pipeline ID:
18939299