### PR TITLE
fix: Support sampling parameters of type List for vLLM backend (stop words)

### DIFF
--- a/python/openai/openai_frontend/engine/utils/triton.py
+++ b/python/openai/openai_frontend/engine/utils/triton.py
@@ -46,7 +46,7 @@ def _create_vllm_inference_request(
     )
     exclude_input_in_output = True
     echo = getattr(request, "echo", None)
-    if echo:
+    if echo is not None:
         exclude_input_in_output = not echo
 
     inputs["text_input"] = [prompt]
@@ -55,7 +55,7 @@ def _create_vllm_inference_request(
     # Pass sampling_parameters as serialized JSON string input to support List
     # fields like 'stop' that aren't supported by TRITONSERVER_Parameters yet.
     inputs["sampling_parameters"] = [sampling_parameters]
-    return model.create_request(inputs=inputs, parameters={})
+    return model.create_request(inputs=inputs)
 
 
 def _create_trtllm_inference_request(

--- a/python/openai/openai_frontend/schemas/openai.py
+++ b/python/openai/openai_frontend/schemas/openai.py
@@ -806,6 +806,7 @@ class CreateChatCompletionRequest(BaseModel):
         None,
         description="An integer between 0 and 20 specifying the number of most likely tokens to return at each token position, each with an associated log probability. `logprobs` must be set to `true` if this parameter is used.",
     )
+    # TODO: Consider new max_completion_tokens field in the future: https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens
     max_tokens: Optional[conint(ge=0)] = Field(
         16,
         description="The maximum number of [tokens](/tokenizer) that can be generated in the chat completion.\n\nThe total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.\n",

--- a/python/openai/tests/test_chat_completions.py
+++ b/python/openai/tests/test_chat_completions.py
@@ -95,6 +95,11 @@ class TestChatCompletions:
             ("frequency_penalty", 0.5),
             ("presence_penalty", 0.2),
             ("n", 1),
+            # Single stop word as a string
+            ("stop", "."),
+            # List of stop words
+            ("stop", []),
+            ("stop", [".", ","]),
             # logprobs is a boolean for chat completions
             ("logprobs", True),
             ("logit_bias", {"0": 0}),
@@ -156,8 +161,9 @@ class TestChatCompletions:
                 param_key: param_value,
             },
         )
-
         print("Response:", response.json())
+
+        # Assert schema validation error
         assert response.status_code == 422
 
     # Simple tests to verify max_tokens roughly behaves as expected
@@ -568,4 +574,11 @@ class TestChatCompletionsTokenizers:
             )
 
         assert response.status_code == 400
-        assert "cannot use apply_chat_template()" in response.json()["detail"].lower()
+        # Error may vary based on transformers version
+        expected_errors = [
+            "cannot use apply_chat_template()",
+            "cannot use chat template",
+        ]
+        assert any(
+            error in response.json()["detail"].lower() for error in expected_errors
+        )


### PR DESCRIPTION
Adds support and some smoke testing for parameters of type `List` such as `stop: [".", ","]`. This is done by passing sampling_parameters to vLLM backend as serialized JSON string input rather than the previous `TRITONSERVER_Parameter` approach, which didn't support Lists.

Resolves the error:
```
"Unsupported Value. Can\'t convert <class \'list\'> to Request Parameter"
```