### PR TITLE
refactor: Removing `Server` subclass from `tritonfrontend`

### DIFF
--- a/docs/customization_guide/tritonfrontend.md
+++ b/docs/customization_guide/tritonfrontend.md
@@ -59,11 +59,11 @@ Note: `model_path` may need to be edited depending on your setup.
 ```python
 from tritonfrontend import KServeHttp, KServeGrpc
 http_options = KServeHttp.Options(thread_count=5)
-http_service = KServeHttp.Server(server, http_options)
+http_service = KServeHttp(server, http_options)
 http_service.start()
 
 # Default options (if none provided)
-grpc_service = KServeGrpc.Server(server)
+grpc_service = KServeGrpc(server)
 grpc_service.start()
 ```
 
@@ -110,7 +110,7 @@ from tritonfrontend import KServeHttp
 import tritonclient.http as httpclient
 import numpy as np  # Use version numpy < 2
 
-with KServeHttp.Server(server) as http_service:
+with KServeHttp(server) as http_service:
     # The identity model returns an exact duplicate of the input data as output
     model_name = "identity"
     url = "localhost:8000"

--- a/qa/L0_python_api/test_kserve.py
+++ b/qa/L0_python_api/test_kserve.py
@@ -118,7 +118,7 @@ class TestKServe:
             tritonserver.InvalidArgumentError,
             match="Incorrect type for options. options argument must be of type",
         ):
-            frontend.Server(server, {"port": 8001})
+            frontend(server, {"port": 8001})
 
         utils.teardown_server(server)
 

--- a/qa/L0_python_api/testing_utils.py
+++ b/qa/L0_python_api/testing_utils.py
@@ -63,7 +63,7 @@ def setup_service(
     frontend: Union[KServeHttp, KServeGrpc],
     options=None,
 ) -> Union[KServeHttp, KServeGrpc]:
-    service = frontend.Server(server=server, options=options)
+    service = frontend(server=server, options=options)
     service.start()
     return service
 

--- a/src/python/examples/example.py
+++ b/src/python/examples/example.py
@@ -51,7 +51,7 @@ def main():
     http_options = KServeHttp.Options(port=8005)
 
     # or http_service = KServeHttp.Server(server, http_options) & http_service.stop()
-    with KServeHttp.Server(server, http_options) as http_service:
+    with KServeHttp(server, http_options) as http_service:
         # The identity model returns an exact duplicate of the input data as output
         model_name = "identity"
         url = "localhost:8005"
@@ -74,7 +74,6 @@ def main():
         output_data = results.as_numpy("OUTPUT0")
 
         print("--------------------- INFERENCE RESULTS ---------------------")
-        print("Input data:", input_data)
         print("Output data:", output_data)
         print("-------------------------------------------------------------")
 


### PR DESCRIPTION
#### What does the PR do?
Removes the keyword `Server` from the `tritonfrontend` package to avoid confusion with multiple definitions of `Server` in the core and frontend bindings.

Previously, using `tritonfrontend.KServeHttp` would look like this:
```
import tritonserver
from tritonfrontend import KServeHttp, KServeGrpc

server = tritonserver.Server(...).start(wait_until_ready=True)
http_service = KServeHttp.Server(server)
http_service.start()
```

New workflow replaces `KServeHttp.Server` with just `KServeHttp`:
```
import tritonserver
from tritonfrontend import KServeHttp, KServeGrpc

server = tritonserver.Server(...).start(wait_until_ready=True)
http_service = KServeHttp(server)
http_service.start()
```

- CI Pipeline ID: 19109526