### PR TITLE
test: Enhance Python gRPC streaming test to send multiple requests

### DIFF
--- a/qa/L0_python_api/test_kserve.py
+++ b/qa/L0_python_api/test_kserve.py
@@ -296,37 +296,3 @@ class TestKServe:
 
     #     utils.teardown_client(http_client)
     #     utils.teardown_service(http_service)
-
-    @pytest.mark.parametrize("frontend, client_type, url", [GRPC_ARGS])
-    def test_grpc_streaming(self, frontend, client_type, url):
-        num_requests = 100
-        requests = []
-        for i in range(num_requests):
-            input0_np = np.array([[float(i) / 1000]], dtype=np.float32)
-            inputs = [client_type.InferInput("INPUT0", input0_np.shape, "FP32")]
-            inputs[0].set_data_from_numpy(input0_np)
-            requests.append(inputs)
-
-        responses = []
-
-        def callback(responses, result, error):
-            responses.append({"result": result, "error": error})
-
-        server = utils.setup_server()
-        service = utils.setup_service(server, frontend)
-        client = utils.setup_client(client_type, url=url)
-
-        client.start_stream(partial(callback, responses))
-        for inputs in requests:
-            client.async_stream_infer("delayed_identity", inputs)
-        client.stop_stream()
-
-        utils.teardown_client(client)
-        utils.teardown_service(service)
-        utils.teardown_server(server)
-
-        assert len(responses) == num_requests
-        for i in range(len(responses)):
-            assert responses[i]["error"] is None
-            output0_np = responses[i]["result"].as_numpy(name="OUTPUT0")
-            assert np.allclose(output0_np, [[float(i) / 1000]])


### PR DESCRIPTION
#### What does the PR do?
Enhance Python gRPC streaming test to send multiple requests, and asserts the request ordering is preserved.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
N/A

#### Where should the reviewer start?
N/A

#### Test plan:
The updated test needs to pass either locally or on the CI.

- CI Pipeline ID: 19114649

#### Caveats:
N/A

#### Background
The original test only sends one request and expects one response, which leaves the hole open for incorrect request/response ordering when there are multiple requests.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A
