### PR TITLE
test: Tests new histogram metric

### DIFF
--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -204,6 +204,42 @@ metrics are used for latencies:
 
 To disable these metrics specifically, you can set `--metrics-config counter_latencies=false`
 
+#### Histograms
+
+> **Note**
+>
+> The following Histogram feature is experimental for the time being and may be
+> subject to change based on user feedback.
+
+By default, the following
+[Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram)
+metrics are used for latencies:
+
+|Category      |Metric          |Metric Name |Description                |Granularity|Frequency    |Model Type
+|--------------|----------------|------------|---------------------------|-----------|-------------|-------------|
+|Latency       |Response Time    |`nv_inference_first_response_histogram_ms` |Histogram of end-to-end inference request to response time |Per model  |Per request  | Decoupled |
+
+To disable these metrics specifically, you can set `--metrics-config histogram_latencies=false`
+
+Each histogram above may composed of several sub-metrics. For each
+metric, there is a set of `le` metrics tracking the counter for each
+bucket. Additionally, there are `_count` and `_sum` metrics that aggregate
+the count and observed values for each. For example, see the following
+information exposed by the Inference First Response Histogram metrics:
+```
+# HELP nv_first_response_histogram_ms Histogram of end-to-end inference request to response time in milliseconds.
+# TYPE nv_first_response_histogram_ms histogram
+nv_inference_first_response_histogram_ms_count{model="my_model",version="1"} 101
+nv_inference_first_response_histogram_ms_sum{model="my_model",version="1"} 3685
+nv_inference_first_response_histogram_ms{model="my_model",version="1", le="10"} 55
+nv_inference_first_response_histogram_ms{model="my_model",version="1", le="100"} 97
+nv_inference_first_response_histogram_ms{model="my_model",version="1", le="500"} 98
+nv_inference_first_response_histogram_ms{model="my_model",version="1", le="1000"} 101
+nv_inference_first_response_histogram_ms{model="my_model",version="1", le="+Inf"} 101
+```
+
+Triton has a set of default buckets per metric to track, as shown above. Customization of buckets per metric is  currently not supported.
+
 #### Summaries
 
 > **Note**

--- a/qa/L0_metrics/metrics_config_test.py
+++ b/qa/L0_metrics/metrics_config_test.py
@@ -44,6 +44,7 @@ INF_COUNTER_PATTERNS = [
     "nv_inference_compute_infer_duration",
     "nv_inference_compute_output_duration",
 ]
+INF_HISTOGRAM_DECOUPLED_PATTERNS = ["nv_inference_first_response_histogram"]
 INF_SUMMARY_PATTERNS = [
     "nv_inference_request_summary",
     "nv_inference_queue_summary",
@@ -95,6 +96,17 @@ class MetricsConfigTest(tu.TestResultCollector):
     def test_cache_counters_missing(self):
         metrics = self._get_metrics()
         for metric in CACHE_COUNTER_PATTERNS:
+            self.assertNotIn(metric, metrics)
+
+    # Histograms
+    def test_inf_histograms_decoupled_exist(self):
+        metrics = self._get_metrics()
+        for metric in INF_HISTOGRAM_DECOUPLED_PATTERNS:
+            self.assertIn(metric, metrics)
+
+    def test_inf_histograms_decoupled_missing(self):
+        metrics = self._get_metrics()
+        for metric in INF_HISTOGRAM_DECOUPLED_PATTERNS:
             self.assertNotIn(metric, metrics)
 
     # Summaries

--- a/qa/L0_metrics/test.sh
+++ b/qa/L0_metrics/test.sh
@@ -283,6 +283,41 @@ python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_summaries_missing 2>&1 | tee
 check_unit_test
 kill_server
 
+# Enable histograms (decoupled)
+decoupled_model_name="dlpack_io_identity_decoupled"
+mkdir -p "${MODELDIR}/${decoupled_model_name}/1/"
+cp ../python_models/${decoupled_model_name}/model.py ${MODELDIR}/${decoupled_model_name}/1/
+cp ../python_models/${decoupled_model_name}/config.pbtxt ${MODELDIR}/${decoupled_model_name}/
+
+SERVER_ARGS="${BASE_SERVER_ARGS} --load-model=${decoupled_model_name}"
+run_and_check_server
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_counters_exist 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_decoupled_exist 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_summaries_missing 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_counters_missing 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_summaries_missing 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+kill_server
+
+# Disable histograms (decoupled)
+SERVER_ARGS="${BASE_SERVER_ARGS} --load-model=${decoupled_model_name} --metrics-config histogram_latencies=false"
+run_and_check_server
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_counters_exist 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_decoupled_missing 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_summaries_missing 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_counters_missing 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_summaries_missing 2>&1 | tee ${CLIENT_LOG}
+check_unit_test
+kill_server
+
 # Enable summaries, counters still enabled by default
 SERVER_ARGS="${BASE_SERVER_ARGS} --load-model=identity_cache_off --metrics-config summary_latencies=true"
 run_and_check_server


### PR DESCRIPTION
#### What does the PR do?
The PR adds tests to histogram metrics and new `nv_inference_first_response_histogram`.
1. Verify this metric is only created in decoupled models.
2. Tests `--metrics-config histogram_latencies=<bool>`.

#### Checklist
- [ ] PR title reflects the change and is of format `<commit_type>: <Title>`
- [ ] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [ ] test

#### Related PRs:
https://github.com/triton-inference-server/core/pull/396

#### Where should the reviewer start?
Check the implementation PR first.

#### Test plan:
L0_metrics--base

- CI Pipeline ID:
19270121

#### Background
Standardizing Large Model Server Metrics in Kubernetes