### PR TITLE
fix: Re-enables copyright hook, updates GitHub Action to only run pre-commi…

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,6 +34,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Get modified files
+      id: modified-files
+      run: echo "modified_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
     - uses: actions/setup-python@v3
     - uses: pre-commit/action@v3.0.0
-
+      with:
+        extra_args: --files ${{ steps.modified-files.outputs.modified_files }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,13 +73,12 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
-# FIXME: Only run on changed files when triggered by GitHub Actions
-#- repo: local
-#  hooks:
-#  - id: add-license
-#    name: Add License
-#    entry: python tools/add_copyright.py
-#    language: python
-#    stages: [pre-commit]
-#    verbose: true
-#    require_serial: true
+- repo: local
+  hooks:
+  - id: add-license
+    name: Add License
+    entry: python tools/add_copyright.py
+    language: python
+    stages: [pre-commit]
+    verbose: true
+    require_serial: true

--- a/tools/add_copyright.py
+++ b/tools/add_copyright.py
@@ -259,6 +259,8 @@ def add_copyrights(paths):
 
     # Don't automatically 'git add' changes for now, make it more clear which
     # files were changed and have ability to see 'git diff' on them.
+    # Note that this means the hook will modify files and then cancel the commit, which you will then
+    # have to manually make again.
     # subprocess.run(["git", "add"] + paths)
 
     print(f"Processed copyright headers for {len(paths)} file(s).")


### PR DESCRIPTION
…t on modified/added files

#### What does the PR do?
Re-enables the copyright hook and updates the pre-commit action to only run on modified/added files.

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Where should the reviewer start?
`pre-commit.yaml` has been updated to only run the pre-commit hook on modified/added files and I have re-enabled the copyright hook in `.pre-commit-config.yaml`. 
