### PR TITLE
fix: Fix L0_perf_nomodel shared memory

### DIFF
--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -38,6 +38,7 @@ PERF_CLIENT_PERCENTILE=${PERF_CLIENT_PERCENTILE:=95}
 PERF_CLIENT_STABILIZE_WINDOW=${PERF_CLIENT_STABILIZE_WINDOW:=5000}
 PERF_CLIENT_STABILIZE_THRESHOLD=${PERF_CLIENT_STABILIZE_THRESHOLD:=5}
 TENSOR_SIZE=${TENSOR_SIZE:=1}
+TENSOR_ELEMENT_BYTES=${TENSOR_ELEMENT_BYTES:=4}
 SHARED_MEMORY=${SHARED_MEMORY:="none"}
 REPORTER=../common/reporter.py
 
@@ -126,6 +127,16 @@ for BACKEND in $BACKENDS; do
         fi
     fi
 
+    # set shared memory output size
+    OUTPUT_SHARED_MEMORY_SIZE=""
+    if [[ "$SHARED_MEMORY" != "none" ]]; then
+        OUTPUT_SHARED_MEMORY_SIZE=$((TENSOR_ELEMENT_BYTES*TENSOR_SIZE))
+        if [ $MAX_BATCH > 1 ]; then
+            OUTPUT_SHARED_MEMORY_SIZE=$((OUTPUT_SHARED_MEMORY_SIZE*MAX_BATCH))
+        fi
+        OUTPUT_SHARED_MEMORY_SIZE="--output-shared-memory-size $OUTPUT_SHARED_MEMORY_SIZE"
+    fi
+
     if [ $DYNAMIC_BATCH > 1 ]; then
         NAME=${BACKEND}_sbatch${STATIC_BATCH}_dbatch${DYNAMIC_BATCH}_instance${INSTANCE_CNT}
     else
@@ -189,6 +200,7 @@ for BACKEND in $BACKENDS; do
                  -p${PERF_CLIENT_STABILIZE_WINDOW} \
                  -s${PERF_CLIENT_STABILIZE_THRESHOLD} \
                  ${PERF_CLIENT_EXTRA_ARGS} \
+                 ${OUTPUT_SHARED_MEMORY_SIZE} \
                  -m ${MODEL_NAME} \
                  -b${STATIC_BATCH} -t${CONCURRENCY} \
                  --max-trials "${PA_MAX_TRIALS}" \

--- a/qa/L0_perf_nomodel/test.sh
+++ b/qa/L0_perf_nomodel/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_perf_nomodel/test.sh
+++ b/qa/L0_perf_nomodel/test.sh
@@ -72,14 +72,14 @@ RUNTEST=./run_test.sh
 # by 4.
 TENSOR_SIZE_16MB=$((4*1024*1024))
 
-if [ "$BENCHMARK_TEST_SHARED_MEMORY" == "system" ]; then
+if [ "$TEST_SHARED_MEMORY" == "system" ]; then
     UNDERTEST_NAME="$UNDERTEST_NAME System Shared Memory";
     SUFFIX="_shm"
-elif [ "$BENCHMARK_TEST_SHARED_MEMORY" == "cuda" ]; then
+elif [ "$TEST_SHARED_MEMORY" == "cuda" ]; then
     UNDERTEST_NAME="$UNDERTEST_NAME CUDA Shared Memory";
     SUFFIX="_cudashm"
 else
-    BENCHMARK_TEST_SHARED_MEMORY="none"
+    TEST_SHARED_MEMORY="none"
     TEST_NAMES=(
         "${UNDERTEST_NAME} Minimum Latency GRPC"
         "${UNDERTEST_NAME} Minimum Latency HTTP"
@@ -188,7 +188,7 @@ for idx in "${!TEST_NAMES[@]}"; do
     TEST_CONCURRENCY=${TEST_CONCURRENCY[$idx]}
 
     # FIXME: If PA C API adds SHMEM support, remove this.
-    if [[ "${BENCHMARK_TEST_SHARED_MEMORY}" != "none" ]] && \
+    if [[ "${TEST_SHARED_MEMORY}" != "none" ]] && \
        [[ "${TEST_PROTOCOL}" == "triton_c_api" ]]; then
       echo "WARNING: Perf Analyzer does not support shared memory I/O when benchmarking directly with Triton C API, skipping."
       continue
@@ -202,7 +202,7 @@ for idx in "${!TEST_NAMES[@]}"; do
                 PERF_CLIENT_PROTOCOL=${TEST_PROTOCOL} \
                 TENSOR_SIZE=${TEST_TENSOR_SIZE} \
                 BACKENDS=${TEST_BACKENDS} \
-                SHARED_MEMORY=${BENCHMARK_TEST_SHARED_MEMORY} \
+                SHARED_MEMORY=${TEST_SHARED_MEMORY} \
                 STATIC_BATCH_SIZES=1 \
                 DYNAMIC_BATCH_SIZES=1 \
                 INSTANCE_COUNTS=${TEST_INSTANCE_COUNT} \


### PR DESCRIPTION
#### What does the PR do?
Fix L0_perf_nomodel shared memory test - system and cuda.
* Update flag name `BENCHMARK_TEST_SHARED_MEMORY` to `TEST_SHARED_MEMORY`.
* Correctly set the `--output-shared-memory-size` flag for perf analyzer.

Root cause:
* The CI runners were re-configured to set `TEST_SHARED_MEMORY` instead of `BENCHMARK_TEST_SHARED_MEMORY`, causing the system/CUDA shared memory tests to run as non-shared memory test, resulting in no data reported for both shared memory tests since the re-configuration.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
N/A

#### Where should the reviewer start?
N/A

#### Test plan:
N/A

- CI Pipeline ID: 19429907

#### Caveats:
N/A

#### Background
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A
