### PR TITLE
test: Add small delay to L0_lifecycle test_load_new_model_version after each model reload

### DIFF
--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -3529,6 +3529,8 @@ class LifeCycleTest(tu.TestResultCollector):
             f.truncate(0)
             f.seek(0)
             f.write(config)
+        # make sure the disk operation is done before reloading
+        time.sleep(0.1)
         # reload the model
         client.load_model(model_name)
 
@@ -3550,6 +3552,8 @@ class LifeCycleTest(tu.TestResultCollector):
 
         # simulate a dependency change to all versions
         Path(os.path.join("models", model_name, "dummy_dependency.py")).touch()
+        # make sure the disk operation is done before reloading
+        time.sleep(0.1)
         # reload the model
         client.load_model(model_name)
 
@@ -3577,6 +3581,8 @@ class LifeCycleTest(tu.TestResultCollector):
             f.truncate(0)
             f.seek(0)
             f.write(config)
+        # make sure the disk operation is done before reloading
+        time.sleep(0.1)
         # reload the model
         client.load_model(model_name)
 
@@ -3604,6 +3610,8 @@ class LifeCycleTest(tu.TestResultCollector):
             f.truncate(0)
             f.seek(0)
             f.write(config)
+        # make sure the disk operation is done before reloading
+        time.sleep(0.1)
         # reload the model
         client.load_model(model_name)
 

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -3531,7 +3531,6 @@ class LifeCycleTest(tu.TestResultCollector):
             f.write(config)
         # reload the model
         client.load_model(model_name)
-        time.sleep(0.2)
 
         # version 1 is unmodified so it should not be reloaded
         # version 2 is modified so it should be reloaded
@@ -3553,7 +3552,6 @@ class LifeCycleTest(tu.TestResultCollector):
         Path(os.path.join("models", model_name, "dummy_dependency.py")).touch()
         # reload the model
         client.load_model(model_name)
-        time.sleep(0.2)
 
         # all 4 versions should be reloaded
         self.assertTrue(client.is_model_ready(model_name, "1"))
@@ -3581,7 +3579,6 @@ class LifeCycleTest(tu.TestResultCollector):
             f.write(config)
         # reload the model
         client.load_model(model_name)
-        time.sleep(0.2)
 
         # only version 4 should be available and no reloads should happen
         self.assertFalse(client.is_model_ready(model_name, "1"))
@@ -3609,7 +3606,6 @@ class LifeCycleTest(tu.TestResultCollector):
             f.write(config)
         # reload the model
         client.load_model(model_name)
-        time.sleep(0.2)
 
         # version 1 should be loaded and version 4 should not be reloaded
         self.assertTrue(client.is_model_ready(model_name, "1"))

--- a/qa/L0_lifecycle/lifecycle_test.py
+++ b/qa/L0_lifecycle/lifecycle_test.py
@@ -3531,6 +3531,7 @@ class LifeCycleTest(tu.TestResultCollector):
             f.write(config)
         # reload the model
         client.load_model(model_name)
+        time.sleep(0.2)
 
         # version 1 is unmodified so it should not be reloaded
         # version 2 is modified so it should be reloaded
@@ -3552,6 +3553,7 @@ class LifeCycleTest(tu.TestResultCollector):
         Path(os.path.join("models", model_name, "dummy_dependency.py")).touch()
         # reload the model
         client.load_model(model_name)
+        time.sleep(0.2)
 
         # all 4 versions should be reloaded
         self.assertTrue(client.is_model_ready(model_name, "1"))
@@ -3579,6 +3581,7 @@ class LifeCycleTest(tu.TestResultCollector):
             f.write(config)
         # reload the model
         client.load_model(model_name)
+        time.sleep(0.2)
 
         # only version 4 should be available and no reloads should happen
         self.assertFalse(client.is_model_ready(model_name, "1"))
@@ -3606,6 +3609,7 @@ class LifeCycleTest(tu.TestResultCollector):
             f.write(config)
         # reload the model
         client.load_model(model_name)
+        time.sleep(0.2)
 
         # version 1 should be loaded and version 4 should not be reloaded
         self.assertTrue(client.is_model_ready(model_name, "1"))


### PR DESCRIPTION
#### What does the PR do?
Add a small delay to L0_lifecycle test_load_new_model_version after each model reload, to prevent flaky results due to model version load/unload is not completed by the time it is checked by the test script.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
N/A

#### Where should the reviewer start?
Start by looking into the L0_lifecycle failure of pipeline 19628457

#### Test plan:
L0_lifecycle pass after the patch.

- CI Pipeline ID: 19662667

#### Caveats:
N/A

#### Background
See https://github.com/triton-inference-server/server/pull/7730 and job 117883843

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A
