### PR TITLE
fix: Fixing pip installation as a system package

### DIFF
--- a/build.py
+++ b/build.py
@@ -1216,7 +1216,8 @@ COPY --chown=1000:1000 NVIDIA_Deep_Learning_Container_License.pdf .
 RUN find /opt/tritonserver/python -maxdepth 1 -type f -name \\
     "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[all] && \\
     find /opt/tritonserver/python -maxdepth 1 -type f -name \\
-    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all] \\
+    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all]
+
 """
     if not FLAGS.no_core_build:
         # Add feature labels for SageMaker endpoint

--- a/build.py
+++ b/build.py
@@ -1213,10 +1213,13 @@ COPY --chown=1000:1000 build/install tritonserver
 WORKDIR /opt/tritonserver
 COPY --chown=1000:1000 NVIDIA_Deep_Learning_Container_License.pdf .
 
-RUN find /opt/tritonserver/python -maxdepth 1 -type f -name \
-    "tritonserver-*.whl" | xargs -I {} pip3 install --upgrade {}[all] && \
-    find /opt/tritonserver/python -maxdepth 1 -type f -name \
-    "tritonfrontend-*.whl" | xargs -I {} pip3 install --upgrade {}[all]
+RUN apt-get update && \\
+    apt-get install python3-pip -y && \\
+    find /opt/tritonserver/python -maxdepth 1 -type f -name \\
+    "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[all] && \\
+    find /opt/tritonserver/python -maxdepth 1 -type f -name \\
+    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all] && \\
+    apt-get remove python3-pip -y
 """
     if not FLAGS.no_core_build:
         # Add feature labels for SageMaker endpoint
@@ -1357,7 +1360,6 @@ RUN apt-get update \\
               libre2-9 \\
               software-properties-common \\
               wget \\
-              python3-pip \\
               {backend_dependencies} \\
       && rm -rf /var/lib/apt/lists/*
 """.format(

--- a/build.py
+++ b/build.py
@@ -1323,7 +1323,7 @@ RUN userdel tensorrt-server > /dev/null 2>&1 || true \\
 
     if target_platform() == "rhel":
         df += """
-# Common dpeendencies.
+# Common dependencies.
 RUN yum install -y \\
         git \\
         gperf \\
@@ -1335,7 +1335,6 @@ RUN yum install -y \\
         gperftools-devel \\
         patchelf \\
         wget \\
-        python3-pip \\
         numactl-devel
 """
     else:

--- a/build.py
+++ b/build.py
@@ -1213,13 +1213,10 @@ COPY --chown=1000:1000 build/install tritonserver
 WORKDIR /opt/tritonserver
 COPY --chown=1000:1000 NVIDIA_Deep_Learning_Container_License.pdf .
 
-RUN apt-get update && \\
-    apt-get install python3-pip -y && \\
-    find /opt/tritonserver/python -maxdepth 1 -type f -name \\
+RUN find /opt/tritonserver/python -maxdepth 1 -type f -name \\
     "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[all] && \\
     find /opt/tritonserver/python -maxdepth 1 -type f -name \\
-    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all] && \\
-    apt-get remove python3-pip -y
+    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all] \\
 """
     if not FLAGS.no_core_build:
         # Add feature labels for SageMaker endpoint
@@ -1335,7 +1332,8 @@ RUN yum install -y \\
         gperftools-devel \\
         patchelf \\
         wget \\
-        numactl-devel
+        numactl-devel \\
+        python3-pip
 """
     else:
         df += """
@@ -1360,6 +1358,8 @@ RUN apt-get update \\
               software-properties-common \\
               wget \\
               {backend_dependencies} \\
+              python3-pip \\
+      && python3 -m pip install --upgrade pip \\
       && rm -rf /var/lib/apt/lists/*
 """.format(
             backend_dependencies=backend_dependencies
@@ -1405,7 +1405,6 @@ RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \\
 # python3, python3-pip and some pip installs required for the python backend
 RUN yum install -y \\
         libarchive-devel \\
-        python3-pip \\
         openssl-devel \\
         readline-devel
 """
@@ -1428,7 +1427,6 @@ RUN apt-get update \\
       && apt-get install -y --no-install-recommends \\
             python3 \\
             libarchive-dev \\
-            python3-pip \\
             libpython3-dev \\
       && pip3 install --upgrade pip \\
       && pip3 install --upgrade \\

--- a/build.py
+++ b/build.py
@@ -1403,9 +1403,10 @@ RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \\
     if "python" in backends:
         if target_platform() == "rhel":
             df += """
-# python3 and some pip installs required for the python backend
+# python3, python3-pip and some pip installs required for the python backend
 RUN yum install -y \\
         libarchive-devel \\
+        python3-pip \\
         openssl-devel \\
         readline-devel
 """
@@ -1423,11 +1424,12 @@ RUN pip3 install --upgrade pip \\
 """
         else:
             df += """
-# python3 and some pip installs required for the python backend
+# python3, python3-pip and some pip installs required for the python backend
 RUN apt-get update \\
       && apt-get install -y --no-install-recommends \\
             python3 \\
             libarchive-dev \\
+            python3-pip \\
             libpython3-dev \\
       && pip3 install --upgrade pip \\
       && pip3 install --upgrade \\

--- a/build.py
+++ b/build.py
@@ -1333,8 +1333,9 @@ RUN yum install -y \\
         gperftools-devel \\
         patchelf \\
         wget \\
-        numactl-devel \\
-        python3-pip
+        python3-pip \\
+        numactl-devel
+
 """
     else:
         df += """
@@ -1403,7 +1404,7 @@ RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \\
     if "python" in backends:
         if target_platform() == "rhel":
             df += """
-# python3, python3-pip and some pip installs required for the python backend
+# python3 and some pip installs required for the python backend
 RUN yum install -y \\
         libarchive-devel \\
         openssl-devel \\
@@ -1423,7 +1424,7 @@ RUN pip3 install --upgrade pip \\
 """
         else:
             df += """
-# python3, python3-pip and some pip installs required for the python backend
+# python3 and some pip installs required for the python backend
 RUN apt-get update \\
       && apt-get install -y --no-install-recommends \\
             python3 \\


### PR DESCRIPTION
#### What does the PR do?
The PR is to address CI jobs that are failing due to tritonfrontend and tritonserver wheel installation PR [[Link](https://github.com/triton-inference-server/server/pull/7759)] with the following error message:
```
+ python3 -m pip install --upgrade pip
Requirement already satisfied: pip in /usr/lib/python3/dist-packages (24.0)
Collecting pip
  Downloading pip-24.3.1-py3-none-any.whl.metadata (3.7 kB)
Downloading pip-24.3.1-py3-none-any.whl (1.8 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 MB 45.0 MB/s eta 0:00:00
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 24.0
ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian.
```
From my understanding, the CI jobs were previously failing because the only relevant package installed was `apt-get install python3-pip` which is a system level package leading to the following error. This can be resolved by adding `python3 -m pip install --upgrade pip` or `pip3 install --upgrade pip` which upgrades pip to a user-level version that can be upgraded in the future without the same level of protections.

- CI Pipeline ID: 20137857