### PR TITLE
fix: Adding copyright support for `.pyi` files

### DIFF
--- a/src/python/tritonfrontend/_api/_metrics.pyi
+++ b/src/python/tritonfrontend/_api/_metrics.pyi
@@ -1,3 +1,28 @@
+# Copyright (c) 2024, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import tritonserver
 from _typeshed import Incomplete
 from tritonfrontend._api._error_mapping import (

--- a/src/python/tritonfrontend/_api/_metrics.pyi
+++ b/src/python/tritonfrontend/_api/_metrics.pyi
@@ -23,6 +23,7 @@
 # OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import tritonserver
 from _typeshed import Incomplete
 from tritonfrontend._api._error_mapping import (

--- a/tools/add_copyright.py
+++ b/tools/add_copyright.py
@@ -215,7 +215,7 @@ def register(match: Callable[[str], bool]):
 
 @register(
     any_of(
-        has_ext([".py", ".sh", ".bash", ".yaml", ".pbtxt"]),
+        has_ext([".py", ".pyi", ".sh", ".bash", ".yaml", ".pbtxt"]),
         basename_is("CMakeLists.txt"),
         path_contains("Dockerfile"),
     )


### PR DESCRIPTION
#### What does the PR do?
Added support to `add_copyright.py` for files with extension `*.pyi` (Python stub files). Once this PR is merged, copyright headers will automatically be added to any python stub files that are generated with the standard pre-commit workflow.

#### Test plan:
Ran pipeline with `L0_copyrights--build`.
- CI Pipeline ID: 20148091