### PR TITLE
fix: Resolve integer overflow in Load API file decoding

### DIFF
--- a/qa/L0_cuda_shared_memory/cuda_shared_memory_test.py
+++ b/qa/L0_cuda_shared_memory/cuda_shared_memory_test.py
@@ -580,8 +580,8 @@ class CudaSharedMemoryTestRawHttpRequest(unittest.TestCase):
 
     def _generate_mock_base64_raw_handle(self, data_length):
         original_data_length = data_length * 3 // 4
-        large_data = b"A" * original_data_length
-        encoded_data = base64.b64encode(large_data)
+        random_data = b"A" * original_data_length
+        encoded_data = base64.b64encode(random_data)
 
         assert (
             len(encoded_data) == data_length
@@ -607,7 +607,8 @@ class CudaSharedMemoryTestRawHttpRequest(unittest.TestCase):
         return response
 
     def test_exceeds_cshm_handle_size_limit(self):
-        byte_size = 2147483648
+        # byte_size greater than INT_MAX
+        byte_size = 1 << 31
         device_id = 0
         shm_name = "invalid_shm"
 

--- a/qa/L0_cuda_shared_memory/cuda_shared_memory_test.py
+++ b/qa/L0_cuda_shared_memory/cuda_shared_memory_test.py
@@ -30,6 +30,7 @@ import sys
 
 sys.path.append("../common")
 
+import base64
 import os
 import time
 import unittest
@@ -37,6 +38,7 @@ from functools import partial
 
 import infer_util as iu
 import numpy as np
+import requests
 import test_util as tu
 import tritonclient.grpc as grpcclient
 import tritonclient.http as httpclient
@@ -562,6 +564,108 @@ class TestCudaSharedMemoryUnregister(CudaSharedMemoryTestBase):
 
         finally:
             self._cleanup_server(shm_handles)
+
+
+class CudaSharedMemoryTestRawHttpRequest(unittest.TestCase):
+    def setUp(self):
+        self.url = "localhost:8000"
+        self.client = httpclient.InferenceServerClient(url=self.url, verbose=True)
+        self.valid_shm_handle = None
+
+    def tearDown(self):
+        self.client.unregister_cuda_shared_memory()
+        if self.valid_shm_handle:
+            cshm.destroy_shared_memory_region(self.valid_shm_handle)
+        self.client.close()
+
+    def _generate_mock_base64_raw_handle(self, data_length):
+        original_data_length = data_length * 3 // 4
+        large_data = b"A" * original_data_length
+        encoded_data = base64.b64encode(large_data)
+
+        assert (
+            len(encoded_data) == data_length
+        ), "Encoded data length does not match the required length."
+        return encoded_data
+
+    def _send_register_cshm_request(self, raw_handle, device_id, byte_size, shm_name):
+        cuda_shared_memory_register_request = {
+            "raw_handle": {"b64": raw_handle.decode("utf-8")},
+            "device_id": device_id,
+            "byte_size": byte_size,
+        }
+
+        url = "http://{}/v2/cudasharedmemory/region/{}/register".format(
+            self.url, shm_name
+        )
+        headers = {"Content-Type": "application/json"}
+
+        # Send POST request
+        response = requests.post(
+            url, headers=headers, json=cuda_shared_memory_register_request
+        )
+        return response
+
+    def test_exceeds_cshm_handle_size_limit(self):
+        byte_size = 2147483648
+        device_id = 0
+        shm_name = "invalid_shm"
+
+        raw_handle = self._generate_mock_base64_raw_handle(byte_size)
+        response = self._send_register_cshm_request(
+            raw_handle, device_id, byte_size, shm_name
+        )
+        self.assertNotEqual(response.status_code, 200)
+
+        try:
+            error_message = response.json().get("error", "")
+            self.assertIn(
+                "The length of 'raw_handle' exceeds the maximum allowed limit INT_MAX",
+                error_message,
+            )
+        except ValueError:
+            self.fail("Response is not valid JSON")
+
+    def test_invalid_small_cshm_handle(self):
+        byte_size = 64
+        device_id = 0
+        shm_name = "invalid_shm"
+
+        raw_handle = self._generate_mock_base64_raw_handle(byte_size)
+        response = self._send_register_cshm_request(
+            raw_handle, device_id, byte_size, shm_name
+        )
+        self.assertNotEqual(response.status_code, 200)
+
+        try:
+            error_message = response.json().get("error", "")
+            self.assertIn(
+                "'raw_handle' must be a valid base64 encoded cudaIpcMemHandle_t",
+                error_message,
+            )
+        except ValueError:
+            self.fail("Response is not valid JSON")
+
+    def test_valid_cshm_handle(self):
+        byte_size = 64
+        device_id = 0
+        shm_name = "test_shm"
+
+        # Create valid shared memory
+        self.valid_shm_handle = cshm.create_shared_memory_region(
+            shm_name, byte_size, device_id
+        )
+        raw_handle = cshm.get_raw_handle(self.valid_shm_handle)
+
+        response = self._send_register_cshm_request(
+            raw_handle, device_id, byte_size, shm_name
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Verify shared memory status
+        status = self.client.get_cuda_shared_memory_status()
+        self.assertEqual(len(status), 1)
+        self.assertEqual(status[0]["name"], shm_name)
 
 
 if __name__ == "__main__":

--- a/qa/L0_cuda_shared_memory/cuda_shared_memory_test.py
+++ b/qa/L0_cuda_shared_memory/cuda_shared_memory_test.py
@@ -621,7 +621,7 @@ class CudaSharedMemoryTestRawHttpRequest(unittest.TestCase):
         try:
             error_message = response.json().get("error", "")
             self.assertIn(
-                "The length of 'raw_handle' exceeds the maximum allowed limit INT_MAX",
+                "'raw_handle' exceeds the maximum allowed data size limit INT_MAX",
                 error_message,
             )
         except ValueError:

--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -29,6 +29,8 @@ import sys
 
 sys.path.append("../common")
 
+import base64
+import json
 import threading
 import time
 import unittest
@@ -43,6 +45,9 @@ from tritonclient.utils import InferenceServerException, np_to_triton_dtype
 class HttpTest(tu.TestResultCollector):
     def _get_infer_url(self, model_name):
         return "http://localhost:8000/v2/models/{}/infer".format(model_name)
+
+    def _get_load_model_url(self, model_name):
+        return "http://localhost:8000/v2/repository/models/{}/load".format(model_name)
 
     def _raw_binary_helper(
         self, model, input_bytes, expected_output_bytes, extra_headers={}
@@ -230,6 +235,43 @@ class HttpTest(tu.TestResultCollector):
             ),
         )
         t.join()
+
+    def test_loading_large_invalid_model(self):
+        # Generate large base64 encoded data
+        data_length = 2147483648
+        original_data_length = data_length * 3 // 4
+        random_data = b"A" * original_data_length
+        encoded_data = base64.b64encode(random_data)
+
+        assert (
+            len(encoded_data) == data_length
+        ), "Encoded data length does not match the required length."
+
+        # Prepare payload with large base64 encoded data
+        payload = {
+            "parameters": {
+                "config": json.dumps({"backend": "onnxruntime"}),
+                "file:1/model.onnx": encoded_data.decode("utf-8"),
+            }
+        }
+        headers = {"Content-Type": "application/json"}
+
+        # Send POST request
+        response = requests.post(
+            self._get_load_model_url("invalid_onnx"), headers=headers, json=payload
+        )
+
+        # Assert the response is not successful
+        self.assertNotEqual(response.status_code, 200)
+        try:
+            error_message = response.json().get("error", "")
+            self.assertIn(
+                "'file:1/model.onnx' exceeds the maximum allowed data size limit "
+                "INT_MAX",
+                error_message,
+            )
+        except ValueError:
+            self.fail("Response is not valid JSON")
 
 
 if __name__ == "__main__":

--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -238,8 +238,8 @@ class HttpTest(tu.TestResultCollector):
 
     def test_loading_large_invalid_model(self):
         # Generate large base64 encoded data
-        data_length = 1 << 32 # 32 is sizeof(int)
-        int_max = (1 << 31) -1
+        data_length = 1 << 31
+        int_max = (1 << 31) - 1
         random_data = b"A" * data_length
         encoded_data = base64.b64encode(random_data)
 

--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -238,13 +238,13 @@ class HttpTest(tu.TestResultCollector):
 
     def test_loading_large_invalid_model(self):
         # Generate large base64 encoded data
-        data_length = 2147483648
-        original_data_length = data_length * 3 // 4
-        random_data = b"A" * original_data_length
+        data_length = 1 << 32 # 32 is sizeof(int)
+        int_max = (1 << 31) -1
+        random_data = b"A" * data_length
         encoded_data = base64.b64encode(random_data)
 
         assert (
-            len(encoded_data) == data_length
+            len(encoded_data) > int_max
         ), "Encoded data length does not match the required length."
 
         # Prepare payload with large base64 encoded data

--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -624,7 +624,7 @@ fi
 
 TEST_RESULT_FILE='test_results.txt'
 PYTHON_TEST=http_test.py
-EXPECTED_NUM_TESTS=9
+EXPECTED_NUM_TESTS=10
 set +e
 python $PYTHON_TEST >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then

--- a/src/common.h
+++ b/src/common.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -166,6 +166,18 @@ int64_t GetElementCount(const std::vector<int64_t>& dims);
 /// \param str The string to lookup.
 /// \return True if the str is found, false otherwise.
 bool Contains(const std::vector<std::string>& vec, const std::string& str);
+
+/// Decodes a Base64 encoded string and stores the result in a vector.
+///
+/// \param input The Base64 encoded input string to decode.
+/// \param input_len The length of the input string.
+/// \param decoded_data A vector to store the decoded data.
+/// \param decoded_size The size of the decoded data.
+/// \param name The name associated with the decoding process.
+/// \return The error status.
+TRITONSERVER_Error* DecodeBase64(
+    const char* input, size_t input_len, std::vector<char>& decoded_data,
+    size_t& decoded_size, const std::string& name);
 
 /// Joins container of strings into a single string delimited by
 /// 'delim'.

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1546,6 +1546,16 @@ HTTPAPIServer::HandleRepositoryControl(
               param = TRITONSERVER_ParameterNew(
                   m.c_str(), TRITONSERVER_PARAMETER_STRING, param_str);
             } else if (m.rfind("file:", 0) == 0) {
+              if (param_len > INT_MAX) {
+                RETURN_AND_RESPOND_IF_ERR(
+                    req, TRITONSERVER_ErrorNew(
+                             TRITONSERVER_ERROR_INVALID_ARG,
+                             ("'" + m +
+                              "' exceeds the maximum allowed data size limit "
+                              "INT_MAX")
+                                 .c_str()));
+              }
+
               // Decode base64
               base64_decodestate s;
               base64_init_decodestate(&s);
@@ -2443,6 +2453,14 @@ HTTPAPIServer::HandleCudaSharedMemory(
           }
 
           if (err == nullptr) {
+            if (b64_handle_len > INT_MAX) {
+              RETURN_AND_RESPOND_IF_ERR(
+                  req, TRITONSERVER_ErrorNew(
+                           TRITONSERVER_ERROR_INVALID_ARG,
+                           "The length of 'raw_handle' exceeds the maximum "
+                           "allowed limit INT_MAX"));
+            }
+
             base64_decodestate s;
             base64_init_decodestate(&s);
 

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -46,10 +46,6 @@
 #define TRITONJSON_STATUSSUCCESS nullptr
 #include "triton/common/triton_json.h"
 
-extern "C" {
-#include <b64/cdecode.h>
-}
-
 namespace triton { namespace server {
 
 #define RETURN_AND_CALLBACK_IF_ERR(X, CALLBACK) \
@@ -1546,24 +1542,12 @@ HTTPAPIServer::HandleRepositoryControl(
               param = TRITONSERVER_ParameterNew(
                   m.c_str(), TRITONSERVER_PARAMETER_STRING, param_str);
             } else if (m.rfind("file:", 0) == 0) {
-              if (param_len > INT_MAX) {
-                RETURN_AND_RESPOND_IF_ERR(
-                    req, TRITONSERVER_ErrorNew(
-                             TRITONSERVER_ERROR_INVALID_ARG,
-                             ("'" + m +
-                              "' exceeds the maximum allowed data size limit "
-                              "INT_MAX")
-                                 .c_str()));
-              }
-
-              // Decode base64
-              base64_decodestate s;
-              base64_init_decodestate(&s);
-
-              // The decoded can not be larger than the input...
-              binary_files.emplace_back(std::vector<char>(param_len + 1));
-              size_t decoded_size = base64_decode_block(
-                  param_str, param_len, binary_files.back().data(), &s);
+              size_t decoded_size;
+              binary_files.emplace_back(std::vector<char>());
+              RETURN_AND_RESPOND_IF_ERR(
+                  req, DecodeBase64(
+                           param_str, param_len, binary_files.back(),
+                           decoded_size, m));
               param = TRITONSERVER_ParameterBytesNew(
                   m.c_str(), binary_files.back().data(), decoded_size);
             }
@@ -2453,21 +2437,13 @@ HTTPAPIServer::HandleCudaSharedMemory(
           }
 
           if (err == nullptr) {
-            if (b64_handle_len > INT_MAX) {
-              RETURN_AND_RESPOND_IF_ERR(
-                  req, TRITONSERVER_ErrorNew(
-                           TRITONSERVER_ERROR_INVALID_ARG,
-                           "The length of 'raw_handle' exceeds the maximum "
-                           "allowed limit INT_MAX"));
-            }
+            size_t decoded_size;
+            std::vector<char> raw_handle;
+            RETURN_AND_RESPOND_IF_ERR(
+                req, DecodeBase64(
+                         b64_handle, b64_handle_len, raw_handle, decoded_size,
+                         "raw_handle"));
 
-            base64_decodestate s;
-            base64_init_decodestate(&s);
-
-            // The decoded can not be larger than the input...
-            std::vector<char> raw_handle(b64_handle_len + 1);
-            size_t decoded_size = base64_decode_block(
-                b64_handle, b64_handle_len, raw_handle.data(), &s);
             if (decoded_size != sizeof(cudaIpcMemHandle_t)) {
               err = TRITONSERVER_ErrorNew(
                   TRITONSERVER_ERROR_INVALID_ARG,


### PR DESCRIPTION
#### What does the PR do?
This PR addresses the following issue:

- When large data is sent to `/v2/repository/models/<model_name>/load`, the server converts the `param_len` variable from `size_t` to `const int` to pass it to `base64_decode_block`. This conversion can cause an integer overflow in `base64_decode_block`, leading to a server crash with a segmentation fault.
- A similar issue occurs with `/v2/cudasharedmemory/region/{}/register` when large data is sent for the `raw_handle` parameter.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID: 20358255
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
