### PR TITLE
test: Fix L0_backend_python for Ubuntu 24.04 base

### DIFF
--- a/qa/L0_backend_python/bls/test.sh
+++ b/qa/L0_backend_python/bls/test.sh
@@ -38,7 +38,7 @@ rm -fr *.log ./models *.txt *.xml
 # FIXME: [DLIS-5970] Until Windows supports GPU tensors, only test CPU
 if [[ ${TEST_WINDOWS} == 0 ]]; then
     pip3 uninstall -y torch
-    pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html
+    pip3 install torch==2.3.1+cu118 -f https://download.pytorch.org/whl/torch_stable.html
 
     mkdir -p models/bls/1/
     cp ../../python_models/bls/model.py models/bls/1/

--- a/qa/L0_backend_python/common.sh
+++ b/qa/L0_backend_python/common.sh
@@ -32,7 +32,7 @@ get_shm_pages() {
 
 install_conda() {
   rm -rf ./miniconda
-  file_name="Miniconda3-py310_23.11.0-2-Linux-x86_64.sh"
+  file_name="Miniconda3-py312_24.9.2-0-Linux-x86_64.sh"
   wget https://repo.anaconda.com/miniconda/$file_name
 
   # install miniconda in silent mode

--- a/qa/L0_backend_python/common.sh
+++ b/qa/L0_backend_python/common.sh
@@ -51,7 +51,7 @@ install_build_deps() {
     && . /etc/os-release \
     && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $UBUNTU_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
     && apt-get update -q=2 \
-    && apt-get install -y --no-install-recommends cmake=3.28.3* cmake-data=3.28.3*
+    && apt-get install -y --no-install-recommends cmake=3.30.2* cmake-data=3.30.2*
 }
 
 create_conda_env() {

--- a/qa/L0_backend_python/common.sh
+++ b/qa/L0_backend_python/common.sh
@@ -51,7 +51,7 @@ install_build_deps() {
     && . /etc/os-release \
     && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $UBUNTU_CODENAME main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
     && apt-get update -q=2 \
-    && apt-get install -y --no-install-recommends cmake=3.30.2* cmake-data=3.30.2*
+    && apt-get install -y --no-install-recommends cmake=3.28.3* cmake-data=3.28.3*
 }
 
 create_conda_env() {

--- a/qa/L0_backend_python/decoupled/test.sh
+++ b/qa/L0_backend_python/decoupled/test.sh
@@ -37,7 +37,7 @@ pip3 uninstall -y torch
 if [[ ${TEST_WINDOWS} == 1 ]]; then
   pip3 install torch==1.13.0 -f https://download.pytorch.org/whl/torch_stable.html
 else
-  pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html
+  pip3 install torch==2.3.1+cu118 -f https://download.pytorch.org/whl/torch_stable.html
 fi
 
 RET=0

--- a/qa/L0_backend_python/env/test.sh
+++ b/qa/L0_backend_python/env/test.sh
@@ -47,7 +47,7 @@ install_conda
 create_conda_env "3.7" "python-3-7"
 conda install numpy=1.20.1 -y
 conda install tensorflow=2.1.0 -y
-conda install -c conda-forge libstdcxx-ng=12 -y
+conda install -c conda-forge libstdcxx-ng=14 -y
 
 PY37_VERSION_STRING="Python version is 3.7, NumPy version is 1.20.1, and Tensorflow version is 2.1.0"
 create_python_backend_stub
@@ -71,7 +71,7 @@ path_to_conda_pack="$PWD/python-3-7-1"
 create_conda_env_with_specified_path "3.7" $path_to_conda_pack
 conda install numpy=1.20.3 -y
 conda install tensorflow=2.1.0 -y
-conda install -c conda-forge libstdcxx-ng=12 -y
+conda install -c conda-forge libstdcxx-ng=14 -y
 
 PY37_1_VERSION_STRING="Python version is 3.7, NumPy version is 1.20.3, and Tensorflow version is 2.1.0"
 create_python_backend_stub
@@ -90,7 +90,7 @@ conda deactivate
 # Tensorflow 2.1.0 only works with Python 3.4 - 3.7. Successful execution of
 # the Python model indicates that the environment has been setup correctly.
 create_conda_env "3.6" "python-3-6"
-conda install -c conda-forge libstdcxx-ng=12 -y
+conda install -c conda-forge libstdcxx-ng=14 -y
 conda install numpy=1.18.1 -y
 conda install tensorflow=2.1.0 -y
 PY36_VERSION_STRING="Python version is 3.6, NumPy version is 1.18.1, and Tensorflow version is 2.1.0"
@@ -114,7 +114,7 @@ conda deactivate
 # it is Python 3.10 and for Ubuntu 20.04 is 3.8
 path_to_conda_pack='$$TRITON_MODEL_DIRECTORY/python_3_10_environment.tar.gz'
 create_conda_env "3.10" "python-3-10"
-conda install -c conda-forge libstdcxx-ng=12 -y
+conda install -c conda-forge libstdcxx-ng=14 -y
 conda install numpy=1.23.4 -y
 conda install tensorflow=2.10.0 -y
 PY310_VERSION_STRING="Python version is 3.10, NumPy version is 1.23.4, and Tensorflow version is 2.10.0"

--- a/qa/L0_backend_python/env/test.sh
+++ b/qa/L0_backend_python/env/test.sh
@@ -116,9 +116,9 @@ conda deactivate
 path_to_conda_pack='$$TRITON_MODEL_DIRECTORY/python_3_12_environment.tar.gz'
 create_conda_env "3.12" "python-3-12"
 conda install -c conda-forge libstdcxx-ng=14 -y
-conda install numpy=1.23.4 -y
-conda install tensorflow=2.10.0 -y
-PY312_VERSION_STRING="Python version is 3.12, NumPy version is 1.23.4, and Tensorflow version is 2.10.0"
+conda install numpy=1.26.4 -y
+conda install tensorflow=2.16.2 -y
+PY312_VERSION_STRING="Python version is 3.12, NumPy version is 1.26.4, and Tensorflow version is 2.16.2"
 conda pack -o python3.12.tar.gz
 mkdir -p models/python_3_12/1/
 cp ../../python_models/python_version/config.pbtxt ./models/python_3_12

--- a/qa/L0_backend_python/io/test.sh
+++ b/qa/L0_backend_python/io/test.sh
@@ -38,7 +38,7 @@ RET=0
 rm -fr *.log ./models
 
 pip3 uninstall -y torch
-pip3 install torch==1.13.0+cu117 -f https://download.pytorch.org/whl/torch_stable.html
+pip3 install torch==2.3.1+cu118 -f https://download.pytorch.org/whl/torch_stable.html
 
 # IOTest.test_ensemble_io
 TRIALS="default decoupled"

--- a/qa/L0_backend_python/setup_python_enviroment.sh
+++ b/qa/L0_backend_python/setup_python_enviroment.sh
@@ -26,7 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 RET=0
 set -e
-if [ ${PYTHON_ENV_VERSION} = "10" ]; then
+if [ ${PYTHON_ENV_VERSION} = "12" ]; then
     echo No need to set up anything for default python3.${PYTHON_ENV_VERSION}
     exit $RET
 fi
@@ -39,7 +39,7 @@ BASE_SERVER_ARGS="--model-repository=${MODELDIR}/models --log-verbose=1 --disabl
 PYTHON_BACKEND_BRANCH=$PYTHON_BACKEND_REPO_TAG
 SERVER_ARGS=$BASE_SERVER_ARGS
 SERVER_LOG="./inference_server.log"
-export PYTHON_ENV_VERSION=${PYTHON_ENV_VERSION:="10"}
+export PYTHON_ENV_VERSION=${PYTHON_ENV_VERSION:="12"}
 RET=0
 EXPECTED_VERSION_STRINGS=""
 

--- a/qa/L0_backend_python/setup_python_enviroment.sh
+++ b/qa/L0_backend_python/setup_python_enviroment.sh
@@ -55,7 +55,7 @@ conda update -n base -c defaults conda -y
 # been setup correctly.
 if [ ${PYTHON_ENV_VERSION} = "8" ]; then
     create_conda_env "3.8" "python-3-8"
-    conda install -c conda-forge libstdcxx-ng=12 -y
+    conda install -c conda-forge libstdcxx-ng=14 -y
     conda install numpy=1.23.4 -y
     conda install tensorflow=2.10.0 -y
     EXPECTED_VERSION_STRING="Python version is 3.8, NumPy version is 1.23.4, and Tensorflow version is 2.10.0"
@@ -78,7 +78,7 @@ fi
 # been setup correctly.
 if [ ${PYTHON_ENV_VERSION} = "9" ]; then
     create_conda_env "3.9" "python-3-9"
-    conda install -c conda-forge libstdcxx-ng=12 -y
+    conda install -c conda-forge libstdcxx-ng=14 -y
     conda install numpy=1.23.4 -y
     conda install tensorflow=2.10.0 -y
     EXPECTED_VERSION_STRING="Python version is 3.9, NumPy version is 1.23.4, and Tensorflow version is 2.10.0"
@@ -102,7 +102,7 @@ fi
 if [ ${PYTHON_ENV_VERSION} = "11" ]; then
     create_conda_env "3.11" "python-3-11"
     conda install tensorflow=2.12.0 -y
-    conda install -c conda-forge libstdcxx-ng=12 -y
+    conda install -c conda-forge libstdcxx-ng=14 -y
     conda install numpy=1.23.5 -y
     EXPECTED_VERSION_STRING="Python version is 3.11, NumPy version is 1.23.5, and Tensorflow version is 2.12.0"
     create_python_backend_stub

--- a/qa/L0_backend_python/setup_python_enviroment.sh
+++ b/qa/L0_backend_python/setup_python_enviroment.sh
@@ -96,6 +96,29 @@ if [ ${PYTHON_ENV_VERSION} = "9" ]; then
     cp python_backend/builddir/triton_python_backend_stub ./models/python_3_9
 fi
 
+# Create a model with python 3.10 version
+# Successful execution of the Python model indicates that the environment has
+# been setup correctly.
+if [ ${PYTHON_ENV_VERSION} = "10" ]; then
+    create_conda_env "3.10" "python-3-10"
+    conda install -c conda-forge libstdcxx-ng=14 -y
+    conda install tensorflow=2.10.0 -y
+    conda install numpy=1.23.4 -y
+    EXPECTED_VERSION_STRING="Python version is 3.10, NumPy version is 1.23.4, and Tensorflow version is 2.10.0"
+    create_python_backend_stub
+    conda-pack -o python3.10.tar.gz
+    path_to_conda_pack="$PWD/python-3-10"
+    mkdir -p $path_to_conda_pack
+    tar -xzf python3.10.tar.gz -C $path_to_conda_pack
+    mkdir -p models/python_3_10/1/
+    cp ../python_models/python_version/config.pbtxt ./models/python_3_10
+    (cd models/python_3_10 && \
+            sed -i "s/^name:.*/name: \"python_3_10\"/" config.pbtxt && \
+            echo "parameters: {key: \"EXECUTION_ENV_PATH\", value: {string_value: \"$path_to_conda_pack\"}}">> config.pbtxt)
+    cp ../python_models/python_version/model.py ./models/python_3_10/1/
+    cp python_backend/builddir/triton_python_backend_stub ./models/python_3_10
+fi
+
 # Create a model with python 3.11 version
 # Successful execution of the Python model indicates that the environment has
 # been setup correctly.

--- a/qa/L0_backend_python/test.sh
+++ b/qa/L0_backend_python/test.sh
@@ -169,7 +169,7 @@ cp ../python_models/dlpack_identity/config.pbtxt ./models/dlpack_identity
 
 
 if [ "$TEST_JETSON" == "0" ] && [[ ${TEST_WINDOWS} == 0 ]]; then
-  pip3 install torch==1.13.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+  pip3 install torch==2.3.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
 else
   # GPU tensor tests are disabled on jetson
   pip3 install torch==1.13.0 -f https://download.pytorch.org/whl/torch_stable.html

--- a/qa/L0_backend_python/test.sh
+++ b/qa/L0_backend_python/test.sh
@@ -80,7 +80,7 @@ rm -fr *.log ./models
 
 python3 --version | grep "3.12" > /dev/null
 if [ $? -ne 0 ]; then
-    echo -e "Expecting Python default version to be: Python 3.10 but actual version is $(python3 --version)"
+    echo -e "Expecting Python default version to be: Python 3.12 but actual version is $(python3 --version)"
     exit 1
 fi
 

--- a/qa/L0_backend_python/test.sh
+++ b/qa/L0_backend_python/test.sh
@@ -444,7 +444,7 @@ if [ "$TEST_JETSON" == "0" ]; then
     done
 
     # [DLIS-5969]: Incorporate env test for windows
-    if [[ ${PYTHON_ENV_VERSION} = "10" ]] && [[ ${TEST_WINDOWS} == 0 ]]; then
+    if [[ ${PYTHON_ENV_VERSION} = "12" ]] && [[ ${TEST_WINDOWS} == 0 ]]; then
         # In 'env' test we use miniconda for dependency management. No need to run
         # the test in a virtual environment.
         set +e


### PR DESCRIPTION
#### What does the PR do?

Fix L0_backend_python for Ubuntu 24.04 base container:
- Upgrade default Python version setting to 3.12
- Upgrade default Python version grep
- Upgrade removed PyTorch version
- ~~Upgrade removed cmake version from Kitware repo~~
- Upgrade outdated Conda version
- Upgrade outdated Conda libstd version
- Upgrade Conda python_3_10_environment to 3.12
- Upgrade outdated numpy and TF version for 3.12
- Add Python 3.10 env test

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
N/A

#### Where should the reviewer start?
N/A

#### Test plan:
Show L0_backend_python can pass on Ubuntu 24.04 base

- CI Pipeline ID: 20372466 & 20380045

#### Caveats:
N/A

#### Background
The base container has been upgraded from Ubuntu 22.04 to 24.04.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A
