### PR TITLE
Removing maven installation as it causes side package installation

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -328,7 +328,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
                               libarchive-dev \
                               libopencv-core-dev \
                               libzmq3-dev \
-                              maven \
                               openjdk-11-jdk \
                               nginx \
                               npm \


### PR DESCRIPTION
Preinstalled maven package in ubuntu 24.04 includes JRE 1.21 which no longer compatible with compiler options 1.7 which we rely on in: 
https://github.com/search?q=repo%3Abytedeco%2Fjavacpp-presets+1.7+language%3A%22Maven+POM%22+&type=code

Related to: https://github.com/triton-inference-server/client/pull/808


