### PR TITLE
ci: modifying stat count for `L0_server_status` 

### DIFF
--- a/qa/L0_server_status/server_status_test.py
+++ b/qa/L0_server_status/server_status_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2018-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -723,8 +723,8 @@ class ModelMetadataTest(tu.TestResultCollector):
                     stats = infer_stats.model_stats
                 self.assertEqual(
                     len(stats),
-                    219,
-                    "expected 219 infer stats for all ready versions of all model",
+                    221,
+                    "expected 221 infer stats for all ready versions of all model",
                 )
 
         except InferenceServerException as ex:

--- a/qa/L0_server_status/server_status_test.py
+++ b/qa/L0_server_status/server_status_test.py
@@ -721,10 +721,6 @@ class ModelMetadataTest(tu.TestResultCollector):
                     stats = infer_stats["model_stats"]
                 else:
                     stats = infer_stats.model_stats
-                print("=" * 100)
-                print(f"[DEBUG] stats: {len(stats)}")
-                print(stats)
-                print("=" * 100)
                 self.assertEqual(
                     len(stats),
                     221,

--- a/qa/L0_server_status/server_status_test.py
+++ b/qa/L0_server_status/server_status_test.py
@@ -721,6 +721,10 @@ class ModelMetadataTest(tu.TestResultCollector):
                     stats = infer_stats["model_stats"]
                 else:
                     stats = infer_stats.model_stats
+                print("=" * 100)
+                print(f"[DEBUG] stats: {len(stats)}")
+                print(stats)
+                print("=" * 100)
                 self.assertEqual(
                     len(stats),
                     221,

--- a/qa/L0_server_status/test.sh
+++ b/qa/L0_server_status/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2020, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -88,6 +88,12 @@ rm -fr models/graphdef_int32_int32_int32/2 models/graphdef_int32_int32_int32/3
 rm -fr models/onnx_int32_int32_int32/2 models/onnx_int32_int32_int32/3
 cp -r models/graphdef_float16_float32_float32/1 models/graphdef_float16_float32_float32/7
 sleep 3
+
+# Dumping the contents of the models that are currently loaded for debugging purposes
+# Primarily meant to assist in debugging ModelMetadataTest::test_infer_stats_no_model
+# Diff the output with a previous L0_server_status job to catch any changes to
+# /data/inferenceserver/${REPO_VERSION}/qa_model_repository that were not accounted for.
+curl -X POST http://localhost:8000/v2/repository/index | jq
 
 set +e
 

--- a/qa/L0_server_status/test.sh
+++ b/qa/L0_server_status/test.sh
@@ -93,7 +93,7 @@ sleep 3
 # Primarily meant to assist in debugging ModelMetadataTest::test_infer_stats_no_model
 # Diff the output with a previous L0_server_status job to catch any changes to
 # /data/inferenceserver/${REPO_VERSION}/qa_model_repository that were not accounted for.
-curl -X POST http://localhost:8000/v2/repository/index | jq
+curl -X POST http://localhost:8000/v2/repository/index
 
 set +e
 


### PR DESCRIPTION
#### What does the PR do?
This PR modifies the stat count in `ModelMetadataTest::test_infer_stats_no_model()` to account for potential changes made to qa_model_repository. Additionally, to assist in future debugging, a request is sent to the model repository index API to be able to catch any changes made to qa_model_repository by comparing job logs.

- CI Pipeline ID:  20575134