### PR TITLE
Lock grpcio version

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -214,7 +214,7 @@ RUN apt-get update && \
             python3-pdfkit \
             maven \
             default-jdk && \
-    pip3 install --upgrade grpcio-tools
+    pip3 install --upgrade "grpcio-tools<1.68"
 
 WORKDIR /workspace
 COPY TRITON_VERSION .


### PR DESCRIPTION
### Intro:
Without this upper version limit model we getting issue where Model Analyzer is unable to reach grpc endpoint.

related to: 
* https://github.com/triton-inference-server/model_analyzer/pull/946
* https://github.com/triton-inference-server/client/pull/811