### PR TITLE
fix: openai chat message dump logic

### DIFF
--- a/python/openai/openai_frontend/engine/triton_engine.py
+++ b/python/openai/openai_frontend/engine/triton_engine.py
@@ -118,7 +118,7 @@ class TritonLLMEngine(LLMEngine):
         self._validate_chat_request(request, metadata)
 
         conversation = [
-            {"role": str(message.role), "content": str(message.content)}
+            message.model_dump(exclude_none=True)
             for message in request.messages
         ]
         add_generation_prompt = True

--- a/python/openai/openai_frontend/engine/triton_engine.py
+++ b/python/openai/openai_frontend/engine/triton_engine.py
@@ -118,8 +118,7 @@ class TritonLLMEngine(LLMEngine):
         self._validate_chat_request(request, metadata)
 
         conversation = [
-            message.model_dump(exclude_none=True)
-            for message in request.messages
+            message.model_dump(exclude_none=True) for message in request.messages
         ]
         add_generation_prompt = True
 

--- a/python/openai/openai_frontend/schemas/openai.py
+++ b/python/openai/openai_frontend/schemas/openai.py
@@ -193,6 +193,8 @@ class Detail(Enum):
 
 
 class ImageUrl(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     url: AnyUrl = Field(
         ..., description="Either a URL of the image or the base64 encoded image data."
     )
@@ -203,6 +205,8 @@ class ImageUrl(BaseModel):
 
 
 class ChatCompletionRequestMessageContentPartImage(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     type: Type = Field(..., description="The type of the content part.")
     image_url: ImageUrl
 
@@ -212,6 +216,8 @@ class Type1(Enum):
 
 
 class ChatCompletionRequestMessageContentPartText(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     type: Type1 = Field(..., description="The type of the content part.")
     text: str = Field(..., description="The text content.")
 
@@ -224,6 +230,8 @@ class Role(Enum):
 
 
 class ChatCompletionRequestSystemMessage(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     content: str = Field(..., description="The contents of the system message.")
     role: Role = Field(
         ..., description="The role of the messages author, in this case `system`."
@@ -264,6 +272,8 @@ class Role3(Enum):
 
 
 class ChatCompletionRequestToolMessage(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     role: Role3 = Field(
         ..., description="The role of the messages author, in this case `tool`."
     )
@@ -281,6 +291,8 @@ class Role4(Enum):
 
 
 class ChatCompletionRequestFunctionMessage(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     role: Role4 = Field(
         ..., description="The role of the messages author, in this case `function`."
     )
@@ -656,6 +668,8 @@ class ChatCompletionRequestMessageContentPart(RootModel):
 
 
 class ChatCompletionRequestUserMessage(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     content: Union[str, List[ChatCompletionRequestMessageContentPart]] = Field(
         ..., description="The contents of the user message.\n"
     )
@@ -768,6 +782,8 @@ class CreateChatCompletionFunctionResponse(BaseModel):
 
 
 class ChatCompletionRequestAssistantMessage(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
     content: Optional[str] = Field(
         None,
         description="The contents of the assistant message. Required unless `tool_calls` or `function_call` is specified.\n",

--- a/python/openai/tests/test_chat_completions.py
+++ b/python/openai/tests/test_chat_completions.py
@@ -86,6 +86,37 @@ class TestChatCompletions:
         assert message["content"].strip()
         assert message["role"] == "assistant"
 
+    def test_chat_completions_user_prompt_str(self, client, model: str):
+        # No system prompt provided
+        messages = [{"role": "user", "content": "What is machine learning?"}]
+
+        response = client.post(
+            "/v1/chat/completions", json={"model": model, "messages": messages}
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["content"].strip()
+        assert message["role"] == "assistant"
+
+    def test_chat_completions_user_prompt_dict(self, client, model: str):
+        # No system prompt provided
+        messages = [
+            {
+                "role": "user",
+                "content": {"type": "text", "text": "What is machine learning?"},
+            }
+        ]
+
+        response = client.post(
+            "/v1/chat/completions", json={"model": model, "messages": messages}
+        )
+
+        assert response.status_code == 200
+        message = response.json()["choices"][0]["message"]
+        assert message["content"].strip()
+        assert message["role"] == "assistant"
+
     @pytest.mark.parametrize(
         "param_key, param_value",
         [

--- a/python/openai/tests/test_chat_completions.py
+++ b/python/openai/tests/test_chat_completions.py
@@ -104,7 +104,7 @@ class TestChatCompletions:
         messages = [
             {
                 "role": "user",
-                "content": {"type": "text", "text": "What is machine learning?"},
+                "content": [{"type": "text", "text": "What is machine learning?"}],
             }
         ]
 


### PR DESCRIPTION
#### What does the PR do?
I found an issue with the OpenAI message format where user messages that are not strings are automatically converted to strings by the code, resulting in a `[ChatCompletionResponseMessageContentPart(text="~~~")]` string conversion problem. I have fixed this issue.

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [x] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
#7561

#### Where should the reviewer start?

@rmccorm4 

#### Test plan:
<!-- list steps to verify feature works -->
<!-- were e2e tests added?-->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
To fix the issue of ChatCompletionResponseMessageContentPart being mixed with the output

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
