### PR TITLE
build: Adding b64 dependency to relevant targets (fix L0_build_variants)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,12 +97,10 @@ add_executable(
   main
   classification.cc
   command_line_parser.cc
-  common.cc
   main.cc
   shared_memory_manager.cc
   triton_signal.cc
   classification.h
-  common.h
   shared_memory_manager.h
   triton_signal.h
 )
@@ -590,6 +588,42 @@ if(${TRITON_ENABLE_TRACING})
       tracing-library
   )
 endif() # TRITON_ENABLE_TRACING
+
+# Common Library
+add_library(common_obj OBJECT common.cc)
+
+if(${TRITON_ENABLE_GPU})
+  target_compile_definitions(
+      common_obj
+      PRIVATE TRITON_ENABLE_GPU=1
+  )
+endif()
+
+
+if (WIN32)
+  find_library(B64_LIBRARY NAMES b64)
+  target_link_libraries(
+      common_obj
+      PUBLIC
+        ${B64_LIBRARY}
+        triton-core-serverapi  # from repo-core
+  )
+else()
+  target_link_libraries(
+      common_obj
+      PUBLIC
+        b64
+        triton-core-serverapi  # from repo-core
+    )
+endif()
+
+set_target_properties(
+    common_obj
+    PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+)
+
+target_link_libraries(main PRIVATE common_obj)
 
 if (NOT WIN32)
   #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,10 +97,12 @@ add_executable(
   main
   classification.cc
   command_line_parser.cc
+  common.cc
   main.cc
   shared_memory_manager.cc
   triton_signal.cc
   classification.h
+  common.h
   shared_memory_manager.h
   triton_signal.h
 )
@@ -116,7 +118,7 @@ if (NOT WIN32)
 endif()
 
 target_compile_features(main PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if(WIN32)
   message("Using MSVC as compiler, default target on Windows 10. "
     "If the target system is not Windows 10, please update _WIN32_WINNT "
     "to corresponding value.")
@@ -128,13 +130,30 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_compile_definitions(main
     PRIVATE
       NOMINMAX)
+
+  # Dependency from common.h
+  find_library(B64_LIBRARY NAMES b64)
+  target_link_libraries(
+    main
+    PRIVATE
+      ${B64_LIBRARY}
+  )
+
 else()
+
   target_compile_options(
     main
     PRIVATE
       -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Werror
   )
-endif()
+
+  # Dependency from common.h
+  target_link_libraries(
+    main
+    PRIVATE
+      b64
+  )
+  endif()
 
 set(LIB_DIR "lib")
 if(LINUX)
@@ -588,57 +607,6 @@ if(${TRITON_ENABLE_TRACING})
       tracing-library
   )
 endif() # TRITON_ENABLE_TRACING
-
-# Common Library
-add_library(common_obj OBJECT common.h common.cc)
-
-target_compile_features(common_obj PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(
-    common_obj
-    PRIVATE
-      /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-  )
-else()
-  target_compile_options(
-    common_obj
-    PRIVATE
-      -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=maybe-uninitialized -Werror
-  )
-endif()
-
-if(${TRITON_ENABLE_GPU})
-  target_compile_definitions(
-      common_obj
-      PRIVATE TRITON_ENABLE_GPU=1
-  )
-endif()
-
-
-if (WIN32)
-  find_library(B64_LIBRARY NAMES b64)
-  target_link_libraries(
-      common_obj
-      PUBLIC
-        ${B64_LIBRARY}
-        triton-core-serverapi  # from repo-core
-  )
-else()
-  target_link_libraries(
-      common_obj
-      PUBLIC
-        b64
-        triton-core-serverapi  # from repo-core
-    )
-endif()
-
-set_target_properties(
-    common_obj
-    PROPERTIES
-      POSITION_INDEPENDENT_CODE ON
-)
-
-target_link_libraries(main PRIVATE common_obj)
 
 if (NOT WIN32)
   #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -590,7 +590,22 @@ if(${TRITON_ENABLE_TRACING})
 endif() # TRITON_ENABLE_TRACING
 
 # Common Library
-add_library(common_obj OBJECT common.cc)
+add_library(common_obj OBJECT common.h common.cc)
+
+target_compile_features(common_obj PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  target_compile_options(
+    common_obj
+    PRIVATE
+      /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
+  )
+else()
+  target_compile_options(
+    common_obj
+    PRIVATE
+      -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=maybe-uninitialized -Werror
+  )
+endif()
 
 if(${TRITON_ENABLE_GPU})
   target_compile_definitions(

--- a/src/python/tritonfrontend/CMakeLists.txt
+++ b/src/python/tritonfrontend/CMakeLists.txt
@@ -59,13 +59,12 @@ set(
   ../../shared_memory_manager.h
   ../../shared_memory_manager.cc
   ../../data_compressor.h
-  ../../common.h
-  ../../common.cc
   ../../restricted_features.h
   ../../classification.cc
 )
 
-set(PY_BINDING_DEPENDENCY_LIBS)
+set(PY_BINDING_DEPENDENCY_LIBS
+      common_obj)
 
 # Conditional Linking Based on Flags
 if(${TRITON_ENABLE_HTTP})

--- a/src/python/tritonfrontend/CMakeLists.txt
+++ b/src/python/tritonfrontend/CMakeLists.txt
@@ -61,10 +61,12 @@ set(
   ../../data_compressor.h
   ../../restricted_features.h
   ../../classification.cc
+  ../../common.h
+  ../../common.cc
 )
 
 set(PY_BINDING_DEPENDENCY_LIBS
-      common_obj)
+      b64) # Dependency from common.h
 
 # Conditional Linking Based on Flags
 if(${TRITON_ENABLE_HTTP})


### PR DESCRIPTION
#### What does the PR do?
After #7787, L0_build_variants started failing with the following error message:
```
...
=== Building wheel
=== Output wheel file is in: /workspace/build/tritonserver/build/triton-server/python/generic
[ 98%] Built target frontend-server-wheel
[100%] Linking CXX executable tritonserver
/usr/bin/ld: CMakeFiles/main.dir/common.cc.o: in function `triton::server::DecodeBase64(char const*, unsigned long, std::vector<char, std::allocator<char> >&, unsigned long&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
common.cc:(.text+0x76a): undefined reference to `base64_init_decodestate'
/usr/bin/ld: common.cc:(.text+0x77b): undefined reference to `base64_decode_block'
collect2: error: ld returned 1 exit status
gmake[5]: *** [CMakeFiles/main.dir/build.make:205: tritonserver] Error 1
gmake[4]: *** [CMakeFiles/Makefile2:411: CMakeFiles/main.dir/all] Error 2
gmake[3]: *** [Makefile:136: all] Error 2
gmake[2]: *** [CMakeFiles/triton-server.dir/build.make:86: triton-server/src/triton-server-stamp/triton-server-build] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:192: CMakeFiles/triton-server.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
error: build failed
***
*** No-Endpoint/No-Filesystem FAILED
***  
```
If we comment out the `tritonfrontend` wheel building, we get the following error message:
```
...
[ 89%] Linking CXX executable tritonserver
/usr/bin/ld: CMakeFiles/main.dir/common.cc.o: in function `triton::server::DecodeBase64(char const*, unsigned long, std::vector<char, std::allocator<char> >&, unsigned long&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/server/src/common.cc:125: undefined reference to `base64_init_decodestate'
/usr/bin/ld: /server/src/common.cc:128: undefined reference to `base64_decode_block'
collect2: error: ld returned 1 exit status
make[5]: *** [CMakeFiles/main.dir/build.make:205: tritonserver] Error 1
make[4]: *** [CMakeFiles/Makefile2:359: CMakeFiles/main.dir/all] Error 2
make[3]: *** [Makefile:136: all] Error 2
make[2]: *** [CMakeFiles/triton-server.dir/build.make:86: triton-server/src/triton-server-stamp/triton-server-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:193: CMakeFiles/triton-server.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

With the b64 dependency being introduced to `common.h`, it needs to be linked to whatever executable/library/object that uses `common.cc/common.h`. Hence, this PR links the b64 dependency to the tritonserver and py-bindings targets that both directly add link the b64 dependency.

#### Related PRs:
#7787

- CI Pipeline ID: 21154897