### PR TITLE
Lock httpx version to fix L0_openai--trtllm test failures

### DIFF
--- a/python/openai/requirements.txt
+++ b/python/openai/requirements.txt
@@ -26,4 +26,7 @@
 
 # FastAPI Application
 fastapi==0.111.1
+# Fix httpx version to avoid bug in openai library:
+# https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/3
+httpx==0.27.2
 openai==1.40.6


### PR DESCRIPTION
Fix failures in L0_openai_trtllm related to OpenAI python package incompatibility: https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/3