### PR TITLE
fix: Remove .Server subclass to reflect 24.12 tritonfrontend version

### DIFF
--- a/python/openai/openai_frontend/main.py
+++ b/python/openai/openai_frontend/main.py
@@ -65,11 +65,11 @@ def start_kserve_frontends(server, args):
         from tritonfrontend import KServeGrpc, KServeHttp
 
         http_options = KServeHttp.Options(address=args.host, port=args.kserve_http_port)
-        http_service = KServeHttp.Server(server, http_options)
+        http_service = KServeHttp(server, http_options)
         http_service.start()
 
         grpc_options = KServeGrpc.Options(address=args.host, port=args.kserve_grpc_port)
-        grpc_service = KServeGrpc.Server(server, grpc_options)
+        grpc_service = KServeGrpc(server, grpc_options)
         grpc_service.start()
 
     except ModuleNotFoundError:


### PR DESCRIPTION
Following updates to tritonfrontend package here that removed the `.Server` subclass from KServeHTTP and KServeGRPC classes: https://github.com/triton-inference-server/server/pull/7683

This should be observable when running the OpenAI frontend application with the `--enable-kserve-frontends` flag