### PR TITLE
fix: Handle TRT-LLM models with max_batch_size of zero in OpenAI frontend

### DIFF
--- a/qa/L0_openai/test.sh
+++ b/qa/L0_openai/test.sh
@@ -53,7 +53,9 @@ function prepare_tensorrtllm() {
     MODEL_REPO="tests/tensorrtllm_models"
     rm -rf ${MODEL_REPO}
 
-    # FIXME: This will require an upgrade each release to match the TRT-LLM version
+    # FIXME: Test a model with max_batch_size == 0 for proper shape conversion.
+    #        This would be easier to test without using Triton CLI for setup.
+    # FIXME: This may require an upgrade each release to match the TRT-LLM version
     # Use Triton CLI to prepare model repository for testing
     pip install git+https://github.com/triton-inference-server/triton_cli.git@0.0.10
     # NOTE: Could use ENGINE_DEST_PATH set to NFS mount for pre-built engines in future


### PR DESCRIPTION
Pass model config read at load time through to check max_batch_size when forming requests.

Currently, the conversion logic creates inputs of shape `[-1, 1]` for most inputs, which assumes a `max_batch_size > 0`. If `max_batch_size == 0`, then the inputs should be of shape `[1]` without the extra batch dimension, based on the current reference model configs of TRT-LLM models.

In the future, this could probably be made more advanced to actually double check the shapes and presence of each input when converting from OpenAI -> Triton request format, but for now it will be kept more lightweight for simplicity until needed.

Before:
```
# Model with max_batch_size == 0
$  curl http://localhost:9000/v1/chat/completions ...
{"detail":"[request id: <id_unknown>] unexpected shape for input 'temperature' for model 'mock'. Expected [1], got [1,1]. "}
```

After:
```
# Model with max_batch_size == 0
$  curl http://localhost:9000/v1/chat/completions ...
{"id":"cmpl-4e98a5c2-b820-11ef-8bf9-04d4c4933ecf","choices":[{"finish_reason":"stop","index":0,"message":{"content":"..."}], ...}
```