### PR TITLE
fix: Lock httpx version to fix L0_openai--trtllm test failures (#7870)

### DIFF
--- a/python/openai/openai_frontend/main.py
+++ b/python/openai/openai_frontend/main.py
@@ -65,11 +65,11 @@ def start_kserve_frontends(server, args):
         from tritonfrontend import KServeGrpc, KServeHttp
 
         http_options = KServeHttp.Options(address=args.host, port=args.kserve_http_port)
-        http_service = KServeHttp.Server(server, http_options)
+        http_service = KServeHttp(server, http_options)
         http_service.start()
 
         grpc_options = KServeGrpc.Options(address=args.host, port=args.kserve_grpc_port)
-        grpc_service = KServeGrpc.Server(server, grpc_options)
+        grpc_service = KServeGrpc(server, grpc_options)
         grpc_service.start()
 
     except ModuleNotFoundError:

--- a/python/openai/requirements.txt
+++ b/python/openai/requirements.txt
@@ -26,4 +26,7 @@
 
 # FastAPI Application
 fastapi==0.111.1
+# Fix httpx version to avoid bug in openai library:
+# https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/3
+httpx==0.27.2
 openai==1.40.6


### PR DESCRIPTION
Cherry-pick https://github.com/triton-inference-server/server/pull/7881 into r24.12
Pipeline ID: 21458354