### PR TITLE
build: Adding b64 dependency to relevant targets (fix L0_build_variants) (#7855)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,7 +118,7 @@ if (NOT WIN32)
 endif()
 
 target_compile_features(main PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if(WIN32)
   message("Using MSVC as compiler, default target on Windows 10. "
     "If the target system is not Windows 10, please update _WIN32_WINNT "
     "to corresponding value.")
@@ -130,13 +130,30 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_compile_definitions(main
     PRIVATE
       NOMINMAX)
+
+  # Dependency from common.h
+  find_library(B64_LIBRARY NAMES b64)
+  target_link_libraries(
+    main
+    PRIVATE
+      ${B64_LIBRARY}
+  )
+
 else()
+
   target_compile_options(
     main
     PRIVATE
       -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Werror
   )
-endif()
+
+  # Dependency from common.h
+  target_link_libraries(
+    main
+    PRIVATE
+      b64
+  )
+  endif()
 
 set(LIB_DIR "lib")
 if(LINUX)

--- a/src/python/tritonfrontend/CMakeLists.txt
+++ b/src/python/tritonfrontend/CMakeLists.txt
@@ -59,13 +59,14 @@ set(
   ../../shared_memory_manager.h
   ../../shared_memory_manager.cc
   ../../data_compressor.h
-  ../../common.h
-  ../../common.cc
   ../../restricted_features.h
   ../../classification.cc
+  ../../common.h
+  ../../common.cc
 )
 
-set(PY_BINDING_DEPENDENCY_LIBS)
+set(PY_BINDING_DEPENDENCY_LIBS
+      b64) # Dependency from common.h
 
 # Conditional Linking Based on Flags
 if(${TRITON_ENABLE_HTTP})


### PR DESCRIPTION
Cherry-pick https://github.com/triton-inference-server/server/pull/7855 into r24.12
Pipeline ID: 21450412