### PR TITLE
build: Add python build package for building core python bindings

### DIFF
--- a/build.py
+++ b/build.py
@@ -986,6 +986,7 @@ RUN yum install -y \\
 
 RUN pip3 install --upgrade pip \\
       && pip3 install --upgrade \\
+          build \\
           wheel \\
           setuptools \\
           docker \\
@@ -1105,6 +1106,7 @@ RUN apt-get update \\
       && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --upgrade \\
+          build \\
           docker \\
           virtualenv
 


### PR DESCRIPTION
https://github.com/triton-inference-server/core/pull/414 proposes some improvements and automation to our core python binding wheel build, but requires the python `build` package to be installed. 

This PR adds this package to the build image.

Pipeline: 21672308