### PR TITLE
build: Downgrade ORT to 1.19.2 until OpenVINO NPU EP issue is resolved

### DIFF
--- a/build.py
+++ b/build.py
@@ -74,7 +74,7 @@ DEFAULT_TRITON_VERSION_MAP = {
     "release_version": "2.54.0dev",
     "triton_container_version": "25.01dev",
     "upstream_container_version": "24.12",
-    "ort_version": "1.20.1",
+    "ort_version": "1.19.2",
     "ort_openvino_version": "2024.4.0",
     "standalone_openvino_version": "2024.4.0",
     "dcgm_version": "3.3.6",


### PR DESCRIPTION
Downgrade to working version (1.19.2 used in r24.12) for stable support of ONNX Runtime OpenVino Execution Provider until we address the issues with NPU support.