### PR TITLE
build: Upgrade DCGM from 3.3.6 to 3.3.9

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -1,4 +1,4 @@
-# Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,7 @@ ARG JAVA_BINDINGS_MAVEN_VERSION=3.8.4
 ARG JAVA_BINDINGS_JAVACPP_PRESETS_TAG=1.5.8
 
 # DCGM version to install for Model Analyzer
-ARG DCGM_VERSION=3.3.6
+ARG DCGM_VERSION=3.3.9
 
 ARG NVIDIA_TRITON_SERVER_SDK_VERSION=unknown
 ARG NVIDIA_BUILD_ID=unknown

--- a/build.py
+++ b/build.py
@@ -77,7 +77,7 @@ DEFAULT_TRITON_VERSION_MAP = {
     "ort_version": "1.20.1",
     "ort_openvino_version": "2024.4.0",
     "standalone_openvino_version": "2024.4.0",
-    "dcgm_version": "3.3.6",
+    "dcgm_version": "3.3.9",
     "vllm_version": "0.6.3.post1",
     "rhel_py_version": "3.12.3",
 }


### PR DESCRIPTION
Possible resolution to an intermittent segfault from DCGM in various test scenarios, specifically on machines with an NVSwitch:
```
Signal (11) received.
 0# 0x000055F7D4359B48 in /opt/tritonserver/bin/tritonserver
 1# 0x00007F4E49FEF320 in /usr/lib/x86_64-linux-gnu/libc.so.6
 2# 0x00007F4DCA04FCB3 in /usr/lib/x86_64-linux-gnu/libnvidia-nscq.so.2
 3# 0x00007F4DCA050661 in /usr/lib/x86_64-linux-gnu/libnvidia-nscq.so.2
 4# 0x00007F4DCA04EB50 in /usr/lib/x86_64-linux-gnu/libnvidia-nscq.so.2
 5# nscq_session_path_observe in /usr/lib/x86_64-linux-gnu/libnvidia-nscq.so.2
 6# 0x00007F4E404F10E7 in /usr/lib/x86_64-linux-gnu/libdcgmmodulenvswitch.so.3
 7# 0x00007F4E4048DE53 in /usr/lib/x86_64-linux-gnu/libdcgmmodulenvswitch.so.3
 8# 0x00007F4E40474E54 in /usr/lib/x86_64-linux-gnu/libdcgmmodulenvswitch.so.3
 9# 0x00007F4E40478BCB in /usr/lib/x86_64-linux-gnu/libdcgmmodulenvswitch.so.3
10# 0x00007F4E404FFE5B in /usr/lib/x86_64-linux-gnu/libdcgmmodulenvswitch.so.3
11# 0x00007F4E405003A9 in /usr/lib/x86_64-linux-gnu/libdcgmmodulenvswitch.so.3
12# 0x00007F4E4A046A94 in /usr/lib/x86_64-linux-gnu/libc.so.6
13# __clone in /usr/lib/x86_64-linux-gnu/libc.so.6
```

Other possible workarounds for end-users if the issue is still seen after version upgrade is to disable GPU metrics when running Triton:
```bash
tritonserver --allow-gpu-metrics false ...
```