### PR TITLE
build: Downgrade patchelf version from 0.18.0 to 0.17.2 

### DIFF
--- a/build.py
+++ b/build.py
@@ -1566,8 +1566,7 @@ COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.9 /usr/lib/
 RUN apt-get update \\
       && apt-get install -y --no-install-recommends openmpi-bin 
 RUN pip3 install --upgrade pip \\
-    && pip3 install --upgrade \\
-        patchelf==0.17.2
+    && pip3 install patchelf==0.17.2
 
 ENV LD_LIBRARY_PATH /usr/local/cuda/targets/{cuda_arch}-linux/lib:/usr/local/cuda/lib64/stubs:${{LD_LIBRARY_PATH}}
 """.format(

--- a/build.py
+++ b/build.py
@@ -962,7 +962,6 @@ RUN yum install -y \\
             libcurl-devel \\
             libb64-devel \\
             gperftools-devel \\
-            patchelf \\
             python3-pip \\
             python3-setuptools \\
             rapidjson-devel \\
@@ -990,7 +989,8 @@ RUN pip3 install --upgrade pip \\
           wheel \\
           setuptools \\
           docker \\
-          virtualenv
+          virtualenv \\
+          patchelf==0.17.2
 
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
@@ -1089,7 +1089,6 @@ RUN apt-get update \\
             libcurl4-openssl-dev \\
             libb64-dev \\
             libgoogle-perftools-dev \\
-            patchelf \\
             python3-dev \\
             python3-pip \\
             python3-wheel \\
@@ -1110,7 +1109,8 @@ RUN apt-get update \\
 RUN pip3 install --upgrade \\
           build \\
           docker \\
-          virtualenv
+          virtualenv \\
+          patchelf==0.17.2
 
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
@@ -1354,10 +1354,13 @@ RUN yum install -y \\
         libcurl-devel \\
         libb64-devel \\
         gperftools-devel \\
-        patchelf \\
         wget \\
         python3-pip \\
         numactl-devel
+
+RUN pip3 install --upgrade pip \\
+    && pip3 install --upgrade \\
+        patchelf==0.17.2
 
 """
     else:
@@ -1562,7 +1565,10 @@ COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.9 /usr/lib/
 
 # patchelf is needed to add deps of libcublasLt.so.12 to libtorch_cuda.so
 RUN apt-get update \\
-      && apt-get install -y --no-install-recommends openmpi-bin patchelf
+      && apt-get install -y --no-install-recommends openmpi-bin 
+RUN pip3 install --upgrade pip \\
+    && pip3 install --upgrade \\
+        patchelf==0.17.2
 
 ENV LD_LIBRARY_PATH /usr/local/cuda/targets/{cuda_arch}-linux/lib:/usr/local/cuda/lib64/stubs:${{LD_LIBRARY_PATH}}
 """.format(

--- a/build.py
+++ b/build.py
@@ -1564,7 +1564,7 @@ COPY --from=min_container /usr/lib/{libs_arch}-linux-gnu/libcudnn.so.9 /usr/lib/
 
 # patchelf is needed to add deps of libcublasLt.so.12 to libtorch_cuda.so
 RUN apt-get update \\
-      && apt-get install -y --no-install-recommends openmpi-bin 
+      && apt-get install -y --no-install-recommends openmpi-bin
 RUN pip3 install --upgrade pip \\
     && pip3 install patchelf==0.17.2
 

--- a/build.py
+++ b/build.py
@@ -1359,8 +1359,7 @@ RUN yum install -y \\
         numactl-devel
 
 RUN pip3 install --upgrade pip \\
-    && pip3 install --upgrade \\
-        patchelf==0.17.2
+    && pip3 install patchelf==0.17.2
 
 """
     else:

--- a/docs/user_guide/jetson.md
+++ b/docs/user_guide/jetson.md
@@ -82,7 +82,6 @@ apt-get update && \
             libtool \
             libboost-dev \
             rapidjson-dev \
-            patchelf \
             pkg-config \
             libopenblas-dev \
             libarchive-dev \
@@ -95,7 +94,7 @@ apt-get update && \
 Additional Onnx Runtime dependencies must be installed to build the Onnx Runtime backend:
 
 ```
-pip3 install --upgrade flake8 flatbuffers
+pip3 install --upgrade flake8 flatbuffers patchelf==0.17.2
 ```
 
 Additional PyTorch dependencies must be installed to build (and run) the PyTorch backend:

--- a/docs/user_guide/jetson.md
+++ b/docs/user_guide/jetson.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions


### PR DESCRIPTION

#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Downgrade patchelf version from 0.18.0 to 0.17.2 due to patchelf regression

Patchelf shipped a regression in 0.18.0 and has since yanked the pypi release pointing to
0.17.2 as the most recent version. However, 0.18.0 is still the version shipped in both the apt and yum
repositories, thus we must use pip to install the version we want.
See https://github.com/mayeut/patchelf-pypi/issues/87


#### Checklist
- [X] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [X] Related issues are referenced.
- [X] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [X] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->
- https://github.com/triton-inference-server/pytorch_backend/pull/145
- https://github.com/triton-inference-server/openvino_backend/pull/94
- https://github.com/triton-inference-server/onnxruntime_backend/pull/295
- https://github.com/triton-inference-server/tensorflow_backend/pull/109

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->
Core `L0_*` tests were segfaulting on loading a shared library used by the pytorch backend. Now they are failing due to known issues with the TensorRT backend.

- CI Pipeline ID:
<!-- Only Pipeline ID and no direct link here -->
22812543

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->
No further explanation required.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to https://github.com/mayeut/patchelf-pypi/issues/87