### PR TITLE
ci: Pin awscli version due to botocore incompatibility to fix L0_storage_swiftstack

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -1,4 +1,4 @@
-# Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -346,7 +346,7 @@ RUN rm -f /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip3 install --upgrade "numpy<2" pillow attrdict future "grpcio<1.68" requests gsutil \
-                           awscli six "grpcio-channelz<1.68" prettytable virtualenv \
+                           "awscli<=1.36.40" six "grpcio-channelz<1.68" prettytable virtualenv \
                            check-jsonschema
 
 # go needed for example go client test.


### PR DESCRIPTION
Fix `L0_storage_swiftstack` due to [botocore 1.36 incompatibility](https://github.com/boto/boto3/issues/4392). The solution is to pin `awscli<=1.36.40` to make sure we use `botocore<1.36` or else we'd run into the following error when uploading to 3rd party s3 clone:
```
An error occurred (InvalidArgument) when calling the PutObject operation: x-amz-content-sha256 must be UNSIGNED-PAYLOAD, or a valid sha256 value
```