### PR TITLE
build: Dockerfiles generated by build.py for RHEL require base image specification

### DIFF
--- a/build.py
+++ b/build.py
@@ -1644,7 +1644,9 @@ def create_build_dockerfiles(
     if "base" in images:
         base_image = images["base"]
         if target_platform() == "rhel":
-            print("warning: RHEL is not an officially supported target and you will probably experience errors attempting to build this container.")
+            print(
+                "warning: RHEL is not an officially supported target and you will probably experience errors attempting to build this container."
+            )
     elif target_platform() == "windows":
         base_image = "mcr.microsoft.com/dotnet/framework/sdk:4.8"
     elif target_platform() == "rhel":

--- a/build.py
+++ b/build.py
@@ -1645,6 +1645,10 @@ def create_build_dockerfiles(
         base_image = images["base"]
     elif target_platform() == "windows":
         base_image = "mcr.microsoft.com/dotnet/framework/sdk:4.8"
+    elif target_platform() == "rhel":
+        # Disallow RHEL target unless base image is specified
+        if not "base" in images:
+            raise KeyError("A base image must be specified when targeting RHEL")
     elif FLAGS.enable_gpu:
         base_image = "nvcr.io/nvidia/tritonserver:{}-py3-min".format(
             FLAGS.upstream_container_version

--- a/build.py
+++ b/build.py
@@ -1643,12 +1643,13 @@ def create_build_dockerfiles(
 ):
     if "base" in images:
         base_image = images["base"]
+        if target_platform() == "rhel":
+            print("warning: RHEL is not an officially supported target and you will probably experience errors attempting to build this container.")
     elif target_platform() == "windows":
         base_image = "mcr.microsoft.com/dotnet/framework/sdk:4.8"
     elif target_platform() == "rhel":
         # Disallow RHEL target unless base image is specified
-        if not "base" in images:
-            raise KeyError("A base image must be specified when targeting RHEL")
+        raise KeyError("A base image must be specified when targeting RHEL")
     elif FLAGS.enable_gpu:
         base_image = "nvcr.io/nvidia/tritonserver:{}-py3-min".format(
             FLAGS.upstream_container_version

--- a/build.py
+++ b/build.py
@@ -1650,7 +1650,6 @@ def create_build_dockerfiles(
     elif target_platform() == "windows":
         base_image = "mcr.microsoft.com/dotnet/framework/sdk:4.8"
     elif target_platform() == "rhel":
-        # Disallow RHEL target unless base image is specified
         raise KeyError("A base image must be specified when targeting RHEL")
     elif FLAGS.enable_gpu:
         base_image = "nvcr.io/nvidia/tritonserver:{}-py3-min".format(


### PR DESCRIPTION
#### What does the PR do?
Images built for RHEL which did not specify a base image defaulted to Ubuntu 24.04 which caused error during the docker build stage as the `yum` package manager was unavailable. This change causes `build.py` to error out with a message should the RHEL target be specified without a base image also being specified.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

- CI Pipeline ID:
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->
Specification of a RHEL base image does _not_ guarantee that the container will build as there are internal dependencies that may be missing.
