### PR TITLE
build: Fix '--no-container-build' option for 'build.py'

### DIFF
--- a/src/python/tritonfrontend/CMakeLists.txt
+++ b/src/python/tritonfrontend/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/python/tritonfrontend/CMakeLists.txt
+++ b/src/python/tritonfrontend/CMakeLists.txt
@@ -163,6 +163,13 @@ endif()
 
 set_property(TARGET py-bindings PROPERTY OUTPUT_NAME tritonfrontend_bindings)
 
+target_include_directories(
+  py-bindings
+  PRIVATE
+  ${repo-core_SOURCE_DIR}/include
+  ${repo-common_SOURCE_DIR}/include
+)
+
 set_target_properties(
     py-bindings
     PROPERTIES


### PR DESCRIPTION
This change is subject to provide resolution for the issue: https://github.com/triton-inference-server/server/issues/7939

It was verified locally and I need to wait on CI.
