### PR TITLE
fix: enable deployment on OpenShift

### DIFF
--- a/deploy/k8s-onprem/README.md
+++ b/deploy/k8s-onprem/README.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright (c) 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/deploy/k8s-onprem/README.md
+++ b/deploy/k8s-onprem/README.md
@@ -234,6 +234,26 @@ EOF
 $ helm install example -f config.yaml .
 ```
 
+## Deploying the Inference Server on OpenShift or OKD
+
+Because of the default security posture of OpenShift and OKD, the configuration
+of which uses OpenShift-specific APIs, the chart needs special consideration
+when targeting those environments. Any of the above discussed customizations and
+prerequisites hold for an OpenShift environment, except that you do not need to
+install Prometheus and Grafana and can instead enable monitoring for
+user-defined projects by following
+[the OpenShift documentation on the topic](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/monitoring/enabling-monitoring-for-user-defined-projects).
+
+To deploy the configurations to enable NFS mounts and the non-root UIDs used in
+the Triton deployment, a tag can be enabled alongside any other configurations
+discussed above. In the simplest case, to use `--set` on the command line, you
+can simply update the tags.openshift parameter.
+
+```
+$ cd <directory containing Chart.yaml>
+$ helm install example --set tags.openshift=true .
+```
+
 ## Probe Configuration
 
 In `templates/deployment.yaml` is configurations for `livenessProbe`, `readinessProbe` and `startupProbe` for the Triton server container.

--- a/deploy/k8s-onprem/templates/deployment.yaml
+++ b/deploy/k8s-onprem/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
         release: {{ .Release.Name }}
 
     spec:
+      serviceAccountName: {{ template "triton-inference-server.fullname" . }}
       volumes:
         - name: models
           nfs:

--- a/deploy/k8s-onprem/templates/deployment.yaml
+++ b/deploy/k8s-onprem/templates/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/deploy/k8s-onprem/templates/rbac.yaml
+++ b/deploy/k8s-onprem/templates/rbac.yaml
@@ -1,0 +1,114 @@
+# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Configures RBAC if required for the platform to support running with
+# NFS volumes and pinned non-root UIDs as required
+
+{{- if .Values.tags.openshift }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ template "triton-inference-server.fullname" . }}
+  annotations:
+    kubernetes.io/description: triton has the same settings as restricted-v2,
+      except it also allows non-root UIDs and NFS mounts.
+  labels:
+    app: {{ template "triton-inference-server.name" . }}
+    chart: {{ template "triton-inference-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- NET_BIND_SERVICE
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- ALL
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+- runtime/default
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- csi
+- downwardAPI
+- emptyDir
+- ephemeral
+- nfs
+- persistentVolumeClaim
+- projected
+- secret
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "triton-inference-server.fullname" . }}-scc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "triton-inference-server.name" . }}
+    chart: {{ template "triton-inference-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: [{{ include "triton-inference-server.fullname" . | quote }}]
+  verbs: ["use"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "triton-inference-server.fullname" . }}-scc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "triton-inference-server.name" . }}
+    chart: {{ template "triton-inference-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "triton-inference-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "triton-inference-server.fullname" . }}-scc
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/deploy/k8s-onprem/templates/rbac.yaml
+++ b/deploy/k8s-onprem/templates/rbac.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/deploy/k8s-onprem/templates/serviceaccount.yaml
+++ b/deploy/k8s-onprem/templates/serviceaccount.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Configures a ServiceAccount for the Triton deployment to enable RBAC
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "triton-inference-server.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "triton-inference-server.name" . }}
+    chart: {{ template "triton-inference-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/deploy/k8s-onprem/templates/serviceaccount.yaml
+++ b/deploy/k8s-onprem/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/deploy/k8s-onprem/values.yaml
+++ b/deploy/k8s-onprem/values.yaml
@@ -27,6 +27,7 @@
 tags:
   autoscaling: true
   loadBalancing: true
+  openshift: false
 
 image:
   imageName: nvcr.io/nvidia/tritonserver:25.01-py3


### PR DESCRIPTION
#### What does the PR do?
Enables deployment, out of the box, on OpenShift by adding the `openshift` toggle to the `tags` top-level values key in the `k8s-onprem` Chart. If this option is enabled, a custom SecurityContextConstraint and bindings to support it are made to a ServiceAccount that is now used for all deployments - instead of using the namespace's `default` account.

With this change:
```
$ helm upgrade --install --namespace triton triton deploy/k8s-onprem --set-json 'tags={"autoscaling":false,"loadBalancing":false,"openshift":true}'
Release "triton" has been upgraded. Happy Helming!
NAME: triton
LAST DEPLOYED: Tue Feb 11 11:44:10 2025
NAMESPACE: triton
STATUS: deployed
REVISION: 2
TEST SUITE: None
$ oc get pod -n triton
NAME                                              READY   STATUS    RESTARTS   AGE
triton-triton-inference-server-56ffdd976d-5wcrf   0/1     Pending   0          8s
```
(I didn't bother using a real NFS mount, so it'll be stuck in pending - but it schedules!)

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [x] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
None

#### Where should the reviewer start?
`deploy/k8s-onprem/templates/rbac.yaml` has the most meaningful changes.

#### Test plan:
- Provision OpenShift
- Deploy the chart, with `tags.openshift` set to `true`

I don't imagine the Triton team will want to extend CI to automatically test OpenShift deployment. If I'm wrong, please let me know.

#### Caveats:
Forcing NFS is limiting. See the discussion in #8004 around additional changes I'd like to see discussion around before implementing.

#### Background
Chart is undeployable on OpenShift and OKD clusters by default.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- fixes: #8004 
