### PR TITLE
Commit for Draft Changes

### DIFF
--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -67,6 +67,7 @@ target_link_libraries(
     triton-common-json            # from repo-common
     grpc-health-library           # from repo-common
     grpc-service-library          # from repo-common
+    grpccallback-service-library  # from repo-common
     triton-core-serverapi         # from repo-core
     triton-core-serverstub        # from repo-core
     gRPC::grpc++

--- a/src/grpc/grpc_handler.h
+++ b/src/grpc/grpc_handler.h
@@ -1,4 +1,4 @@
-// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,7 +25,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <grpc++/grpc++.h>
+
 #include <string>
+
+#include "grpc_service.grpc.pb.h"
 
 namespace triton { namespace server { namespace grpc {
 class HandlerBase {
@@ -33,6 +37,11 @@ class HandlerBase {
   virtual ~HandlerBase() = default;
   virtual void Start() = 0;
   virtual void Stop() = 0;
+  virtual inference::GRPCInferenceService::CallbackService*
+  GetUnifiedCallbackService()
+  {
+    return nullptr;
+  }
 };
 
 class ICallData {

--- a/src/grpc/grpc_handler.h
+++ b/src/grpc/grpc_handler.h
@@ -31,6 +31,7 @@
 
 #include "grpc_service.grpc.pb.h"
 #include "grpccallback_service.grpc.pb.h"
+#include "health.grpc.pb.h"
 
 namespace triton { namespace server { namespace grpc {
 class HandlerBase {
@@ -40,6 +41,12 @@ class HandlerBase {
   virtual void Stop() = 0;
   virtual inference::GRPCInferenceServiceCallback::CallbackService*
   GetUnifiedCallbackService()
+  {
+    return nullptr;
+  }
+
+  virtual ::grpc::health::v1::Health::CallbackService*
+  GetHealthCallbackService()
   {
     return nullptr;
   }

--- a/src/grpc/grpc_handler.h
+++ b/src/grpc/grpc_handler.h
@@ -30,6 +30,7 @@
 #include <string>
 
 #include "grpc_service.grpc.pb.h"
+#include "grpccallback_service.grpc.pb.h"
 
 namespace triton { namespace server { namespace grpc {
 class HandlerBase {
@@ -37,7 +38,7 @@ class HandlerBase {
   virtual ~HandlerBase() = default;
   virtual void Start() = 0;
   virtual void Stop() = 0;
-  virtual inference::GRPCInferenceService::CallbackService*
+  virtual inference::GRPCInferenceServiceCallback::CallbackService*
   GetUnifiedCallbackService()
   {
     return nullptr;

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -82,7 +82,7 @@ namespace {
 // Define your unified callback service that implements several non-inference
 // RPCs.
 class UnifiedCallbackService
-    : public inference::GRPCInferenceService::CallbackService {
+    : public inference::GRPCInferenceServiceCallback::CallbackService {
  public:
   UnifiedCallbackService(
       const std::shared_ptr<TRITONSERVER_Server>& server,
@@ -1557,7 +1557,7 @@ class CommonHandler : public HandlerBase {
       TraceManager* trace_manager,
       inference::GRPCInferenceService::AsyncService* service,
       ::grpc::health::v1::Health::AsyncService* health_service,
-      inference::GRPCInferenceService::CallbackService*
+      inference::GRPCInferenceServiceCallback::CallbackService*
           non_inference_callback_service,
       const RestrictedFeatures& restricted_keys, const uint64_t response_delay);
 
@@ -1571,7 +1571,8 @@ class CommonHandler : public HandlerBase {
   void CreateUnifiedCallbackService();
 
   // Add a new public method to return the non_inference_callback_service_
-  inference::GRPCInferenceService::CallbackService* GetUnifiedCallbackService()
+  inference::GRPCInferenceServiceCallback::CallbackService*
+  GetUnifiedCallbackService()
   {
     return non_inference_callback_service_;
   }
@@ -1583,7 +1584,7 @@ class CommonHandler : public HandlerBase {
   TraceManager* trace_manager_;
   inference::GRPCInferenceService::AsyncService* service_;
   ::grpc::health::v1::Health::AsyncService* health_service_;
-  inference::GRPCInferenceService::CallbackService*
+  inference::GRPCInferenceServiceCallback::CallbackService*
       non_inference_callback_service_;
   std::unique_ptr<std::thread> thread_;
   RestrictedFeatures restricted_keys_;
@@ -1597,7 +1598,7 @@ CommonHandler::CommonHandler(
     TraceManager* trace_manager,
     inference::GRPCInferenceService::AsyncService* service,
     ::grpc::health::v1::Health::AsyncService* health_service,
-    inference::GRPCInferenceService::CallbackService*
+    inference::GRPCInferenceServiceCallback::CallbackService*
         non_inference_callback_service,
     const RestrictedFeatures& restricted_keys, const uint64_t response_delay)
     : name_(name), tritonserver_(tritonserver), shm_manager_(shm_manager),
@@ -1657,7 +1658,7 @@ Server::Server(
 
   builder_.AddListeningPort(server_addr_, credentials, &bound_port_);
   builder_.SetMaxMessageSize(MAX_GRPC_MESSAGE_SIZE);
-  // builder_.RegisterService(&service_);
+  builder_.RegisterService(&service_);
   // builder_.RegisterService(&health_service_);
   builder_.AddChannelArgument(
       GRPC_ARG_ALLOW_REUSEPORT, options.socket_.reuse_port_);

--- a/src/grpc/grpc_server.h
+++ b/src/grpc/grpc_server.h
@@ -143,6 +143,7 @@ class Server {
   inference::GRPCInferenceServiceCallback::CallbackService
       non_inference_callback_service_;
 
+  ::grpc::health::v1::Health::CallbackService* health_callback_service_;
   std::unique_ptr<::grpc::Server> server_;
 
   // std::unique_ptr<::grpc::ServerCompletionQueue> common_cq_;

--- a/src/grpc/grpc_server.h
+++ b/src/grpc/grpc_server.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -139,14 +139,16 @@ class Server {
 
   inference::GRPCInferenceService::AsyncService service_;
   ::grpc::health::v1::Health::AsyncService health_service_;
+  inference::GRPCInferenceService::CallbackService
+      non_inference_callback_service_;
 
   std::unique_ptr<::grpc::Server> server_;
 
-  std::unique_ptr<::grpc::ServerCompletionQueue> common_cq_;
+  // std::unique_ptr<::grpc::ServerCompletionQueue> common_cq_;
   std::unique_ptr<::grpc::ServerCompletionQueue> model_infer_cq_;
   std::unique_ptr<::grpc::ServerCompletionQueue> model_stream_infer_cq_;
 
-  std::unique_ptr<HandlerBase> common_handler_;
+  // std::unique_ptr<HandlerBase> common_handler_;
   std::vector<std::unique_ptr<HandlerBase>> model_infer_handlers_;
   std::vector<std::unique_ptr<HandlerBase>> model_stream_infer_handlers_;
 

--- a/src/grpc/grpc_server.h
+++ b/src/grpc/grpc_server.h
@@ -36,6 +36,7 @@
 #include "grpc_handler.h"
 #include "grpc_service.grpc.pb.h"
 #include "grpc_utils.h"
+#include "grpccallback_service.grpc.pb.h"
 #include "health.grpc.pb.h"
 #include "infer_handler.h"
 #include "stream_infer_handler.h"
@@ -139,7 +140,7 @@ class Server {
 
   inference::GRPCInferenceService::AsyncService service_;
   ::grpc::health::v1::Health::AsyncService health_service_;
-  inference::GRPCInferenceService::CallbackService
+  inference::GRPCInferenceServiceCallback::CallbackService
       non_inference_callback_service_;
 
   std::unique_ptr<::grpc::Server> server_;

--- a/src/grpc/grpc_server.h
+++ b/src/grpc/grpc_server.h
@@ -148,7 +148,7 @@ class Server {
   std::unique_ptr<::grpc::ServerCompletionQueue> model_infer_cq_;
   std::unique_ptr<::grpc::ServerCompletionQueue> model_stream_infer_cq_;
 
-  // std::unique_ptr<HandlerBase> common_handler_;
+  std::unique_ptr<HandlerBase> common_handler_;
   std::vector<std::unique_ptr<HandlerBase>> model_infer_handlers_;
   std::vector<std::unique_ptr<HandlerBase>> model_stream_infer_handlers_;
 

--- a/test_grpc_callbacks.sh
+++ b/test_grpc_callbacks.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Note: Before running this script, start Triton server in explicit model control mode:
+# tritonserver --model-repository=/path/to/model/repository --model-control-mode=explicit
+
+# Default server URL
+SERVER_URL=${1:-"localhost:8001"}
+PROTO_PATH="/mnt/builddir/triton-server/_deps/repo-common-src/protobuf"
+PROTO_FILE="${PROTO_PATH}/grpccallback_service.proto"
+HEALTH_PROTO="${PROTO_PATH}/health.proto"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+# Function to print test results
+print_result() {
+    local test_name=$1
+    local result=$2
+    if [ $result -eq 0 ]; then
+        echo -e "${test_name}: ${GREEN}PASSED${NC}"
+    else
+        echo -e "${test_name}: ${RED}FAILED${NC}"
+    fi
+}
+
+echo -e "\n${BOLD}Testing gRPC Callback RPCs against ${SERVER_URL}${NC}\n"
+
+# Test Health Check
+echo -e "\n${BOLD}Testing Health Check:${NC}"
+grpcurl -proto ${HEALTH_PROTO} \
+    --import-path ${PROTO_PATH} \
+    -plaintext ${SERVER_URL} \
+    grpc.health.v1.Health/Check
+print_result "Health Check" $?
+
+# Test Repository Index
+echo -e "\n${BOLD}Testing Repository Index:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/RepositoryIndex
+print_result "Repository Index" $?
+
+# Test Model Load
+echo -e "\n${BOLD}Testing Model Load:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext -d '{"model_name": "simple"}' \
+    ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/RepositoryModelLoad
+print_result "Model Load" $?
+
+# Wait for model to load
+sleep 2
+
+# Test Model Unload
+echo -e "\n${BOLD}Testing Model Unload:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext -d '{"model_name": "simple"}' \
+    ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/RepositoryModelUnload
+print_result "Model Unload" $?
+
+# Test Server Live
+echo -e "\n${BOLD}Testing Server Live:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/ServerLive
+print_result "Server Live" $?
+
+# Test Server Ready
+echo -e "\n${BOLD}Testing Server Ready:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/ServerReady
+print_result "Server Ready" $?
+
+# Load model again before testing Model Ready
+echo -e "\n${BOLD}Loading model for Model Ready test:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext -d '{"model_name": "simple"}' \
+    ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/RepositoryModelLoad
+print_result "Model Load" $?
+
+# Wait for model to load
+sleep 2
+
+# Test Model Ready
+echo -e "\n${BOLD}Testing Model Ready:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext -d '{"name": "simple"}' \
+    ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/ModelReady
+print_result "Model Ready" $?
+
+# Test Server Metadata
+echo -e "\n${BOLD}Testing Server Metadata:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/ServerMetadata
+print_result "Server Metadata" $?
+
+# Test Model Metadata
+echo -e "\n${BOLD}Testing Model Metadata:${NC}"
+grpcurl -proto ${PROTO_FILE} \
+    --import-path ${PROTO_PATH} \
+    -plaintext -d '{"name": "simple"}' \
+    ${SERVER_URL} \
+    inference.GRPCInferenceServiceCallback/ModelMetadata
+print_result "Model Metadata" $?
+
+echo -e "\n${BOLD}Test Summary:${NC}"
+echo "----------------------------------------"


### PR DESCRIPTION
1. Added a New Service `GRPCInferenceServiceCallback::CallbackService` which is responsible for all Non Inference Callback RPCs.
2. On grpc Start-up.
We register this service with the builder here
`builder_.RegisterService(handler->GetUnifiedCallbackService());`
3. Change structure of all RPCs to adhere to callback based reactor pattern