### PR TITLE
Reverse order of GAP and PA installation to avoid installing outdated PA

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -238,6 +238,8 @@ COPY --from=sdk_build /workspace/client/src/python/library/tests/* qa/python_cli
 # Install an image needed by the quickstart and other documentation.
 COPY qa/images/mug.jpg images/mug.jpg
 
+RUN pip3 install install/python/genai_perf-*.whl
+
 # Install the dependencies needed to run the client examples. These
 # are not needed for building but including them allows this image to
 # be used to run the client examples.
@@ -245,8 +247,6 @@ RUN pip3 install --upgrade "numpy<2" pillow attrdict && \
     find install/python/ -maxdepth 1 -type f -name \
          "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
     xargs pip3 install --upgrade
-
-RUN pip3 install install/python/genai_perf-*.whl
 
 # Install DCGM
 RUN if [ "$TRITON_ENABLE_GPU" = "ON" ]; then \


### PR DESCRIPTION
* SDK container is supposed to contain the version of PA and GAP that was built during its job
* `pip`-installing the GAP wheel built in the SDK job causes [tritonclient](https://pypi.org/project/tritonclient/) from PyPI to be installed
* [tritonclient](https://pypi.org/project/tritonclient/) from PyPI contains its own `perf_analyzer` binary that it installs to `/usr/local/bin`
* [tritonclient](https://pypi.org/project/tritonclient/) from PyPI is going to contain last month's `perf_analyzer` binary (older than the `perf_analyzer` binary built in the SDK job)
* This SDK Dockerfile was inadvertently installing its manually-built `perf_analyzer` binary into `/usr/local/bin` and _then_ `pip`-installing the manually-built GenAI-Perf wheel, causing the previously installed `perf_analyzer` to get overwritten with the last-month's `perf_analyzer` binary packaged with [tritonclient](https://pypi.org/project/tritonclient/) from PyPI
* To fix this, I propose reversing the order of GAP and PA installations
  * Install GAP wheel first, which installs last month's PA into `/usr/local/bin`
  * Install manual/latest PA next into `/usr/local/bin` overwriting outdated last-month's PA