### PR TITLE
[build]: Add rt_base_image parameter to differentiate triton build base image and runtime base image

### DIFF
--- a/build.py
+++ b/build.py
@@ -1227,12 +1227,12 @@ def create_dockerfile_linux(
     repoagents,
     caches,
     endpoints,
-    rt_base_image=None,
+    runtime_image=None,
 ):
     base_image = argmap["BASE_IMAGE"]
     # If runtime base image is provided, use it as the base image
-    if rt_base_image:
-        base_image = rt_base_image
+    if runtime_image:
+        base_image = runtime_image
 
     df = """
 ARG TRITON_VERSION={}
@@ -1654,12 +1654,12 @@ ENV PYTHON_BIN_PATH=${{PYBIN}}/python${{PYVER}} PATH=${{PYBIN}}:${{PATH}}
 
 
 def create_dockerfile_windows(
-    ddir, dockerfile_name, argmap, backends, repoagents, caches, rt_base_image=None
+    ddir, dockerfile_name, argmap, backends, repoagents, caches, runtime_image=None
 ):
     base_image = argmap["BASE_IMAGE"]
     # If runtime base image is provided, use it as the base image
-    if rt_base_image:
-        base_image = rt_base_image
+    if runtime_image:
+        base_image = runtime_image
     df = """
 ARG TRITON_VERSION={}
 ARG TRITON_CONTAINER_VERSION={}
@@ -1768,7 +1768,7 @@ def create_build_dockerfiles(
             backends,
             repoagents,
             caches,
-            images.get("rt_base"),
+            images.get("runtime"),
         )
     else:
         create_dockerfile_linux(
@@ -1779,7 +1779,7 @@ def create_build_dockerfiles(
             repoagents,
             caches,
             endpoints,
-            images.get("rt_base"),
+            images.get("runtime"),
         )
 
     # Dockerfile used for the creating the CI base image.
@@ -2964,7 +2964,7 @@ if __name__ == "__main__":
                 "pytorch",
                 "tensorflow",
                 "tensorflow2",
-                "rt_base",
+                "runtime",
             ],
             "unsupported value for --image",
         )


### PR DESCRIPTION
#### What does the PR do?
Add new image argument (--rt_base) which if passed in, is used as the final base image for the triton executable. This allows users to pass in their own final base image to host the triton server executable. 

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Where should the reviewer start?
build.py

#### Test plan:
- Validated existing CI tests pass with change

- CI Pipeline ID:
25249521

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
Container Image Size reduction

