### PR TITLE
[test]: Fix L0_batch_custom - missing CMake variables that could result in defaulting to the wrong main branch

### DIFF
--- a/qa/L0_batch_custom/test.sh
+++ b/qa/L0_batch_custom/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/L0_batch_custom/test.sh
+++ b/qa/L0_batch_custom/test.sh
@@ -87,8 +87,10 @@ git clone --single-branch --depth=1 -b $TRITON_BACKEND_REPO_TAG \
  mkdir build &&
  cd build &&
  cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install \
-      -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
-      -DTRITON_CORE_REPO_TAG=$TRITON_CORE_REPO_TAG .. &&
+       -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
+       -DTRITON_BACKEND_REPO_TAG=${TRITON_BACKEND_REPO_TAG} \
+       -DTRITON_CORE_REPO_TAG=${TRITON_CORE_REPO_TAG} \
+       -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} .. &&
  make -j4 install)
 
  (cd backend/examples/batching_strategies/single_batching &&
@@ -96,7 +98,9 @@ git clone --single-branch --depth=1 -b $TRITON_BACKEND_REPO_TAG \
  cd build &&
  cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install \
        -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
-       -DTRITON_CORE_REPO_TAG=$TRITON_CORE_REPO_TAG .. &&
+       -DTRITON_BACKEND_REPO_TAG=${TRITON_BACKEND_REPO_TAG} \
+       -DTRITON_CORE_REPO_TAG=${TRITON_CORE_REPO_TAG} \
+       -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} .. &&
  make -j4 install)
 
 cp -r backend/examples/batching_strategies/volume_batching/build/libtriton_volumebatching.so models
@@ -164,8 +168,10 @@ sed -i "s/${OLD_STRING}/${NEW_STRING}/g" ${FILE_PATH}
 (cd backend/examples/batching_strategies/volume_batching &&
  cd build &&
  cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install \
-      -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
-      -DTRITON_CORE_REPO_TAG=$TRITON_CORE_REPO_TAG .. &&
+       -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
+       -DTRITON_BACKEND_REPO_TAG=${TRITON_BACKEND_REPO_TAG} \
+       -DTRITON_CORE_REPO_TAG=${TRITON_CORE_REPO_TAG} \
+       -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} .. &&
  make -j4 install)
 
 cp -r backend/examples/batching_strategies/volume_batching/build/libtriton_volumebatching.so models/${MODEL_NAME}/libtriton_volumebatching.so


### PR DESCRIPTION
#### What does the PR do?

Fix L0_batch_custom - missing [CMake variables](https://github.com/triton-inference-server/backend/blob/main/examples/batching_strategies/volume_batching/CMakeLists.txt#L34) that could result in defaulting to the wrong main branch instead of the branch picked by $TRITON_BACKEND_REPO_TAG


#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test


#### Where should the reviewer start?
qa/L0_batch_custom/test.sh


- CI Pipeline ID:
25186266


#### Background
This args require to be passed in to avoid using the default main branch for cases where previous release branches are used. 

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
