### PR TITLE
Fix L0_response_cache test

### DIFF
--- a/qa/L0_response_cache/ensemble_cache_test.py
+++ b/qa/L0_response_cache/ensemble_cache_test.py
@@ -78,7 +78,7 @@ class EnsembleCacheTest(tu.TestResultCollector):
                 with open(config_file, "w") as f:
                     config_data += config_to_add
                     f.write(config_data)
-    
+
     def _add_instance_group_cpu(self, config_file):
         # Utility function to add instance group of kind CPU to the config file
         with open(config_file, "r") as f:

--- a/qa/L0_response_cache/ensemble_cache_test.py
+++ b/qa/L0_response_cache/ensemble_cache_test.py
@@ -78,6 +78,15 @@ class EnsembleCacheTest(tu.TestResultCollector):
                 with open(config_file, "w") as f:
                     config_data += config_to_add
                     f.write(config_data)
+    
+    def _add_instance_group_cpu(self, config_file):
+        # Utility function to add instance group of kind CPU to the config file
+        with open(config_file, "r") as f:
+            config_data = f.read()
+            if "instance_group" not in config_data:
+                with open(config_file, "w") as f:
+                    config_data += "instance_group {\n  kind: KIND_CPU\n}\n"
+                    f.write(config_data)
 
     def _remove_config(self, config_file, config_to_remove):
         # Utility function to remove extra added config from the config files
@@ -252,6 +261,8 @@ class EnsembleCacheTest(tu.TestResultCollector):
         self._update_config(
             self.composing_config_file, RESPONSE_CACHE_PATTERN, RESPONSE_CACHE_CONFIG
         )
+        # Currently, response cache is supported only for tensors on CPU.
+        self._add_instance_group_cpu(self.composing_config_file)
         self._run_inference_and_validate(self.composing_model)
         ensemble_model_stats = self._get_model_statistics(self.ensemble_model)
         composing_model_stats = self._get_model_statistics(self.composing_model)


### PR DESCRIPTION
TF model would dump its response data on the CPU even if the model was GPU. However, ORT dumps data in GPU memory for the next step to consume it. It only copies the data to CPU if the response data is required. As response cache only supports data from CPU memory we were not populating the cache. Hence seeing no cache hit.