### PR TITLE
Update build.py - DEFAULT_TRITON_VERSION_MAP for 25.04 release

### DIFF
--- a/build.py
+++ b/build.py
@@ -71,9 +71,9 @@ import requests
 #
 
 DEFAULT_TRITON_VERSION_MAP = {
-    "release_version": "2.57.0dev",
-    "triton_container_version": "25.04dev",
-    "upstream_container_version": "25.03",
+    "release_version": "2.57.0",
+    "triton_container_version": "25.04",
+    "upstream_container_version": "25.04",
     "ort_version": "1.21.0",
     "ort_openvino_version": "2025.0.0",
     "standalone_openvino_version": "2025.0.0",


### PR DESCRIPTION
Thanks for submitting a PR to Triton!
Please go the the `Preview` tab above this description box and select the appropriate sub-template:

* [PR description template for Triton Engineers](?expand=1&template=pull_request_template_internal_contrib.md)
* [PR description template for External Contributors](?expand=1&template=pull_request_template_external_contrib.md)

If you already created the PR, please replace this message with one of
* [External contribution template](https://raw.githubusercontent.com/triton-inference-server/server/main/.github/PULL_REQUEST_TEMPLATE/pull_request_template_external_contrib.md)
* [Internal contribution template](https://raw.githubusercontent.com/triton-inference-server/server/main/.github/PULL_REQUEST_TEMPLATE/pull_request_template_internal_contrib.md)

and fill it out.


