### PR TITLE
build: Convert vLLM index url ARGS into docker secrets

### DIFF
--- a/build.py
+++ b/build.py
@@ -1516,6 +1516,9 @@ RUN --mount=type=secret,id=req,target=/run/secrets/requirements \\
         # public vLLM needed for vLLM backend
         pip3 install vllm=={DEFAULT_TRITON_VERSION_MAP["vllm_version"]}; \\
     fi
+
+ARG PYVER=3.12
+ENV LD_LIBRARY_PATH /usr/local/lib:/usr/local/lib/python${{PYVER}}/dist-packages/torch/lib:${{LD_LIBRARY_PATH}}
 """
 
     if "dali" in backends:

--- a/build.py
+++ b/build.py
@@ -1907,7 +1907,7 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
                 f"--secret id=vllm_index_url,src={secrets.get('vllm_index_url', '')}",
                 f"--secret id=pytorch_triton_url,src={secrets.get('pytorch_triton_url', '')}",
                 f"--secret id=build_public_vllm,src={secrets.get('build_public_vllm', '')}",
-                f"--secret id=nvpl_slim_url,src={secrets.get('nvpl_slim_url', '')}"
+                f"--secret id=nvpl_slim_url,src={secrets.get('nvpl_slim_url', '')}",
             ]
         finalargs += [
             "-t",

--- a/build.py
+++ b/build.py
@@ -1481,12 +1481,13 @@ RUN apt-get update \\
 
     if "vllm" in backends:
         df += f"""
-ARG BUILD_PUBLIC_VLLM="true"
-ARG VLLM_INDEX_URL
-ARG PYTORCH_TRITON_URL
-ARG NVPL_SLIM_URL
-
+# Install required packages for vLLM models
 RUN --mount=type=secret,id=req,target=/run/secrets/requirements \\
+    --mount=type=secret,id=vllm_index_url,target=/run/secrets/vllm_index_url \\
+    --mount=type=secret,id=pytorch_triton_url,target=/run/secrets/pytorch_triton_url \\
+    --mount=type=secret,id=build_public_vllm,target=/run/secrets/build_public_vllm \\
+    --mount=type=secret,id=nvpl_slim_url,target=/run/secrets/nvpl_slim_url \\
+    BUILD_PUBLIC_VLLM=$(cat /run/secrets/build_public_vllm) && \\
     if [ "$BUILD_PUBLIC_VLLM" = "false" ]; then \\
         if [ "$(uname -m)" = "x86_64" ]; then \\
             pip3 install --no-cache-dir \\
@@ -1494,18 +1495,18 @@ RUN --mount=type=secret,id=req,target=/run/secrets/requirements \\
                 mkl-include==2021.1.1 \\
                 mkl-devel==2021.1.1; \\
         elif [ "$(uname -m)" = "aarch64" ]; then \\
-            echo "Downloading NVPL from: $NVPL_SLIM_URL" && \\
+            echo "Downloading NVPL from: $(cat /run/secrets/nvpl_slim_url)" && \\
             cd /tmp && \\
-            wget -O nvpl_slim_24.04.tar $NVPL_SLIM_URL && \\
+            wget -O nvpl_slim_24.04.tar $(cat /run/secrets/nvpl_slim_url) && \\
             tar -xf nvpl_slim_24.04.tar && \\
             cp -r nvpl_slim_24.04/lib/* /usr/local/lib && \\
             cp -r nvpl_slim_24.04/include/* /usr/local/include && \\
             rm -rf nvpl_slim_24.04.tar nvpl_slim_24.04; \\
         fi \\
-        && pip3 install --no-cache-dir --progress-bar on --index-url $VLLM_INDEX_URL -r /run/secrets/requirements \\
+        && pip3 install --no-cache-dir --progress-bar on --index-url $(cat /run/secrets/vllm_index_url) -r /run/secrets/requirements \\
         # Need to install in-house build of pytorch-triton to support triton_key definition used by torch 2.5.1
         && cd /tmp \\
-        && wget $PYTORCH_TRITON_URL \\
+        && wget $(cat /run/secrets/pytorch_triton_url) \\
         && pip install --no-cache-dir /tmp/pytorch_triton-*.whl \\
         && rm /tmp/pytorch_triton-*.whl; \\
     else \\
@@ -1899,11 +1900,11 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         ]
         if secrets:
             finalargs += [
-                f"--secret id=req,src={requirements}",
-                f"--build-arg VLLM_INDEX_URL={vllm_index_url}",
-                f"--build-arg PYTORCH_TRITON_URL={pytorch_triton_url}",
-                f"--build-arg BUILD_PUBLIC_VLLM={build_public_vllm}",
-                f"--build-arg NVPL_SLIM_URL={nvpl_slim_url}",
+                f"--secret id=req,src={secrets.get('req', '')}",
+                f"--secret id=vllm_index_url,src={secrets.get('vllm_index_url', '')}",
+                f"--secret id=pytorch_triton_url,src={secrets.get('pytorch_triton_url', '')}",
+                f"--secret id=build_public_vllm,src={secrets.get('build_public_vllm', '')}",
+                f"--secret id=nvpl_slim_url,src={secrets.get('nvpl_slim_url', '')}"
             ]
         finalargs += [
             "-t",

--- a/build.py
+++ b/build.py
@@ -1484,10 +1484,9 @@ RUN apt-get update \\
 # Install required packages for vLLM models
 ARG BUILD_PUBLIC_VLLM="true"
 RUN --mount=type=secret,id=req,target=/run/secrets/requirements \\
-    --mount=type=secret,id=vllm_index_url,target=/run/secrets/vllm_index_url \\
-    --mount=type=secret,id=pytorch_triton_url,target=/run/secrets/pytorch_triton_url \\
-    --mount=type=secret,id=build_public_vllm,target=/run/secrets/build_public_vllm \\
-    --mount=type=secret,id=nvpl_slim_url,target=/run/secrets/nvpl_slim_url \\
+    --mount=type=secret,id=VLLM_INDEX_URL,env=VLLM_INDEX_URL \\
+    --mount=type=secret,id=PYTORCH_TRITON_URL,env=PYTORCH_TRITON_URL \\
+    --mount=type=secret,id=NVPL_SLIM_URL,env=NVPL_SLIM_URL \\
     if [ "$BUILD_PUBLIC_VLLM" = "false" ]; then \\
         if [ "$(uname -m)" = "x86_64" ]; then \\
             pip3 install --no-cache-dir \\
@@ -1495,18 +1494,18 @@ RUN --mount=type=secret,id=req,target=/run/secrets/requirements \\
                 mkl-include==2021.1.1 \\
                 mkl-devel==2021.1.1; \\
         elif [ "$(uname -m)" = "aarch64" ]; then \\
-            echo "Downloading NVPL from: $(cat /run/secrets/nvpl_slim_url)" && \\
+            echo "Downloading NVPL from: $NVPL_SLIM_URL" && \\
             cd /tmp && \\
-            wget -O nvpl_slim_24.04.tar $(cat /run/secrets/nvpl_slim_url) && \\
+            wget -O nvpl_slim_24.04.tar $NVPL_SLIM_URL && \\
             tar -xf nvpl_slim_24.04.tar && \\
             cp -r nvpl_slim_24.04/lib/* /usr/local/lib && \\
             cp -r nvpl_slim_24.04/include/* /usr/local/include && \\
             rm -rf nvpl_slim_24.04.tar nvpl_slim_24.04; \\
         fi \\
-        && pip3 install --no-cache-dir --progress-bar on --index-url $(cat /run/secrets/vllm_index_url) -r /run/secrets/requirements \\
+        && pip3 install --no-cache-dir --progress-bar on --index-url $VLLM_INDEX_URL -r /run/secrets/requirements \\
         # Need to install in-house build of pytorch-triton to support triton_key definition used by torch 2.5.1
         && cd /tmp \\
-        && wget $(cat /run/secrets/pytorch_triton_url) \\
+        && wget $PYTORCH_TRITON_URL \\
         && pip install --no-cache-dir /tmp/pytorch_triton-*.whl \\
         && rm /tmp/pytorch_triton-*.whl; \\
     else \\
@@ -1901,9 +1900,9 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         if secrets:
             finalargs += [
                 f"--secret id=req,src={requirements}",
-                f"--secret id=vllm_index_url,src={vllm_index_url}",
-                f"--secret id=pytorch_triton_url,src={pytorch_triton_url}",
-                f"--secret id=nvpl_slim_url,src={nvpl_slim_url}",
+                f"--secret id=VLLM_INDEX_URL",
+                f"--secret id=PYTORCH_TRITON_URL",
+                f"--secret id=NVPL_SLIM_URL",
                 f"--build-arg BUILD_PUBLIC_VLLM={build_public_vllm}",
             ]
         finalargs += [
@@ -2770,8 +2769,6 @@ if __name__ == "__main__":
         metavar=("key", "value"),
         help="Add build secrets in the form of <key> <value>. These secrets are used during the build process for vllm. The secrets are passed to the Docker build step as `--secret id=<key>`. The following keys are expected and their purposes are described below:\n\n"
         "  - 'req': A file containing a list of dependencies for pip (e.g., requirements.txt).\n"
-        "  - 'vllm_index_url': The index URL for the pip install.\n"
-        "  - 'pytorch_triton_url': The location of the PyTorch wheel to download.\n"
         "  - 'build_public_vllm': A flag (default is 'true') indicating whether to build the public VLLM version.\n\n"
         "Ensure that the required environment variables for these secrets are set before running the build.",
     )
@@ -2893,9 +2890,6 @@ if __name__ == "__main__":
     secrets = dict(getattr(FLAGS, "build_secret", []))
     if secrets:
         requirements = secrets.get("req", "")
-        vllm_index_url = secrets.get("vllm_index_url", "")
-        pytorch_triton_url = secrets.get("pytorch_triton_url", "")
-        nvpl_slim_url = secrets.get("nvpl_slim_url", "")
         build_public_vllm = secrets.get("build_public_vllm", "true")
         log('Build Arg for BUILD_PUBLIC_VLLM: "{}"'.format(build_public_vllm))
 


### PR DESCRIPTION
#### What does the PR do?
This PR converts the build arguments used for internal vLLM into secrets.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [ ] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
- build.py

- CI Pipeline ID:
#28811183

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
- Better practice for dealing with repo URL variables.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
