### PR TITLE
feat: Add guided decoding support to OpenAI frontend

### DIFF
--- a/python/openai/openai_frontend/schemas/openai.py
+++ b/python/openai/openai_frontend/schemas/openai.py
@@ -153,6 +153,14 @@ class CreateCompletionRequest(BaseModel):
         description="A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).\n",
         examples=["user-1234"],
     )
+    guided_decoding_guide_type: Optional[str] = Field(
+        None,
+        description="The type of guided decoding to use.\n",
+    )
+    guided_decoding_guide: Optional[str] = Field(
+        None,
+        description="The guide to use for guided decoding.\n",
+    )
 
 
 class FinishReason(Enum):
@@ -916,6 +924,14 @@ class CreateChatCompletionRequest(BaseModel):
         description="Deprecated in favor of `tools`.\n\nA list of functions the model may generate JSON inputs for.\n",
         max_length=128,
         min_length=1,
+    )
+    guided_decoding_guide_type: Optional[str] = Field(
+        None,
+        description="The type of guided decoding to use.\n",
+    )
+    guided_decoding_guide: Optional[Union[str, List[str], Dict[str, Any]]] = Field(
+        None,
+        description="The guide to use for guided decoding.\n",
     )
 
 


### PR DESCRIPTION
#### What does the PR do?
This PR adds comprehensive guided decoding support to the OpenAI frontend, enabling users to constrain model outputs to specific formats through the OpenAI-compatible API. 
The implementation supports both vLLM and TensorRT-LLM backends with multiple guide types including JSON schema, regex patterns, choice-based selection, and EBNF grammar.

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->
N/A
#### Where should the reviewer start?
Please focus on these key files:
1. **`python/openai/openai_frontend/schemas/openai.py`** - Review the new schema fields `guided_decoding_guide_type` and `guided_decoding_guide` added to both completion request models
2. **`python/openai/openai_frontend/engine/utils/triton.py`** - Check the implementation of guided decoding integration for both vLLM and TensorRT-LLM backends
3. **`python/openai/README.md`** - Verify the comprehensive documentation and examples for different guide types

#### Test plan:
<!-- list steps to verify feature works -->
<!-- were e2e tests added?-->
please follow the codes in `README.md`

#### Caveats:
1. Different usage patterns per backend:
2. Guided decoding may not function properly when used in conjunction with tool calling
3. Currently relies on backend validation; frontend doesn't validate guide format compatibility

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

