### PR TITLE
fix: mlflow plugin model deletion

### DIFF
--- a/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
+++ b/deploy/mlflow-triton-plugin/mlflow_triton/deployments.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -463,20 +463,31 @@ default_model_filename: "{}"
         triton_deployment_dir = os.path.join(self.triton_model_repo, name)
 
         if "s3" in self.server_config:
-            objs = self.server_config["s3"].list_objects(
-                Bucket=self.server_config["s3_bucket"],
-                Prefix=os.path.join(self.server_config["s3_prefix"], name),
+            # Ensure the prefix ends with a slash to treat it as a folder
+            # This is the key change to prevent deleting "name_1" when "name" is specified.
+            folder_prefix = os.path.join(self.server_config["s3_prefix"], name, "")
+            # use paginator because `list_objects` is limited to list 1000 objects
+            paginator = self.server_config["s3"].get_paginator("list_objects_v2")
+            pages = paginator.paginate(
+                Bucket=self.server_config["s3_bucket"], Prefix=folder_prefix
             )
-
-            for key in objs["Contents"]:
-                key = key["Key"]
-                try:
+            objects_to_delete = []
+            for page in pages:
+                if "Contents" in page:
+                    for item in page["Contents"]:
+                        objects_to_delete.append(item["Key"])
+            if not objects_to_delete:
+                print("Folder is empty. Nothing to delete")
+                return
+            try:
+                for object_key in objects_to_delete:
                     self.server_config["s3"].delete_object(
-                        Bucket=self.server_config["s3_bucket"],
-                        Key=key,
+                        Bucket=self.server_config["s3_bucket"], Key=object_key
                     )
-                except Exception as e:
-                    raise Exception(f"Could not delete {key}: {e}")
+            except Exception as e:
+                raise Exception(
+                    f"Could not delete objects in folder {folder_prefix}: {e}"
+                )
 
         else:
             # Check if the deployment directory exists


### PR DESCRIPTION
#### What does the PR do?
This PR fixes a bug where deleting a deployed model using the mlflow plugin (e.g., `name`) would also delete other models with similar prefixes (e.g., `name_1`).

The fix ensures an exact match by appending a `/` to the folder prefix. It also introduces a paginator to handle folders containing more than 1,000 objects correctly. 

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [X] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the GitHub PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [X] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Where should the reviewer start?
`deploy/mlflow-triton-plugin/mlflow_triton/deployments.py`

#### Test plan:
- Deploy two models with the same prefix (`model` and `model_1`)
- Delete `model` and check whether `model_1` is still present

#### Caveats:
This was tested on Minio S3 storage. I've tried to optimize it to work with other S3-compatible storage, but I don't have the means to test it extensively 

#### Background
I was deleting a model from Triton Inference Server using the MLflow plugin, and that led to all the models with the same prefix as the requested model name being deleted...
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: [#8266](https://github.com/triton-inference-server/server/issues/8266)
