### PR TITLE
Support tokenizer override per model for multi-model Triton + vLLM serving with OpenAI-Compatible

### DIFF
--- a/python/openai/openai_frontend/engine/triton_engine.py
+++ b/python/openai/openai_frontend/engine/triton_engine.py
@@ -395,10 +395,16 @@ class TritonLLMEngine(LLMEngine):
     def _get_model_metadata(self) -> Dict[str, TritonModelMetadata]:
         # One tokenizer and creation time shared for all loaded models for now.
         model_metadata = {}
+        
+        # Mapping of custom model identifiers to their corresponding Hugging Face model names
+        HF_MODEL_NAME_MAP = {
+            "llama-3.1-8b-instruct": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "mistral-nemo-instruct-2407": "mistralai/Mistral-Nemo-Instruct-2407",
+        }
 
         # Read all triton models and store the necessary metadata for each
         for name, _ in self.server.models().keys():
-            model = self.server.model(name)
+            model = self.server.model(name)           
             backend = model.config()["backend"]
             # Explicitly handle ensembles to avoid any runtime validation errors
             if not backend and model.config()["platform"] == "ensemble":
@@ -410,12 +416,19 @@ class TritonLLMEngine(LLMEngine):
                 lora_names = _get_vllm_lora_names(
                     self.server.options.model_repository, name, model.version
                 )
+            # Map to Hugging Face model name if available
+            hf_model_name = HF_MODEL_NAME_MAP.get(name, name)
+            # Try to get tokenizer for the mapped model name
+            tokenizer_override = get_tokenizer(hf_model_name)
+            # Use the override tokenizer if available; otherwise fall back to default
+            tokenizer = tokenizer_override if tokenizer_override else self.tokenizer            
 
             metadata = TritonModelMetadata(
                 name=name,
                 backend=backend,
                 model=model,
-                tokenizer=self.tokenizer,
+                # tokenizer=self.tokenizer,
+                tokenizer=tokenizer,
                 lora_names=lora_names,
                 create_time=self.create_time,
                 request_converter=self._determine_request_converter(backend),


### PR DESCRIPTION
#### What does the PR do?
Support per-model tokenizer override when using Triton + vLLM in OpenAI-compatible mode.

This PR introduces `HF_MODEL_NAME_MAP` to associate custom model names with their corresponding Hugging Face model identifiers. During model registration, if a mapping is found, the tokenizer is loaded accordingly; otherwise, the system falls back to the default tokenizer.

This enables true multi-model serving in scenarios where each model may require a different tokenizer — something not possible with the previous global `--tokenizer` option.

---

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

---

#### Commit Type:
- [x] feat

---

#### Related PRs:
<!-- None -->

---

#### Where should the reviewer start?
- `python/openai/openai_frontend/engine/triton_engine.py`: Tokenizer override logic introduced here.

---

#### Test plan:
- Ran frontend with:
  ```bash
  python3 openai_frontend/main.py --model-repository tests/vllm_models
