### PR TITLE
fix: System shared memory boundary check

### DIFF
--- a/qa/L0_shared_memory/shared_memory_test.py
+++ b/qa/L0_shared_memory/shared_memory_test.py
@@ -407,7 +407,12 @@ class SharedMemoryTest(SystemSharedMemoryTestBase):
     def test_infer_byte_size_out_of_bound(self):
         # Shared memory byte_size outside output region - Throws error
         error_msg = []
-        self._configure_server()
+        create_byte_size = self.SYS_PAGE_SIZE + self.DEFAULT_SHM_BYTE_SIZE
+        register_offset = self.SYS_PAGE_SIZE
+        self._configure_server(
+            create_byte_size=create_byte_size,
+            register_offset=register_offset,
+        )
         offset = 1
         byte_size = self.DEFAULT_SHM_BYTE_SIZE
 

--- a/qa/L0_shared_memory/shared_memory_test.py
+++ b/qa/L0_shared_memory/shared_memory_test.py
@@ -47,7 +47,7 @@ from tritonclient import utils
 
 class SystemSharedMemoryTestBase(tu.TestResultCollector):
     DEFAULT_SHM_BYTE_SIZE = 64
-    SYS_PAGE_SIZE = 4096
+    SYS_PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
 
     def setUp(self):
         self._setup_client()

--- a/src/shared_memory_manager.cc
+++ b/src/shared_memory_manager.cc
@@ -483,14 +483,11 @@ SharedMemoryManager::GetMemoryInfo(
   }
 
   // validate offset
-  size_t shm_region_end = 0;
-  if (it->second->kind_ == TRITONSERVER_MEMORY_CPU) {
-    shm_region_end = it->second->offset_;
-  }
+  size_t shm_region_size = 0;
   if (it->second->byte_size_ > 0) {
-    shm_region_end += it->second->byte_size_ - 1;
+    shm_region_size += it->second->byte_size_;
   }
-  if (offset > shm_region_end) {
+  if (offset >= shm_region_size) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
         std::string("Invalid offset for shared memory region: '" + name + "'")
@@ -510,8 +507,8 @@ SharedMemoryManager::GetMemoryInfo(
   }
 
   // validate byte_size + offset is within memory bounds
-  size_t total_req_shm = offset + byte_size - 1;
-  if (total_req_shm > shm_region_end) {
+  size_t total_req_shm = offset + byte_size;
+  if (total_req_shm > shm_region_size) {
     return TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
         std::string(


### PR DESCRIPTION
#### What does the PR do?
Followup from the original request. Similar bug in shared memory boundary checks.
Modify test cases to include `register_offset` in boundary checks.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] fix

#### Related PRs:
https://github.com/triton-inference-server/server/pull/8334

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
L0_shared_memory

- CI Pipeline ID:
32964778

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx