### PR TITLE
fix: Improve validation for system shared memory register

### DIFF
--- a/qa/L0_shared_memory/shared_memory_test.py
+++ b/qa/L0_shared_memory/shared_memory_test.py
@@ -556,16 +556,45 @@ class SharedMemoryTest(SystemSharedMemoryTestBase):
         """
         # This matches kTritonSharedMemoryRegionPrefix in the server code.
         reserved_prefix = "triton_python_backend_shm_region_"
-
-        # The shared memory key cannot start with the reserved prefix.
         shm_name = "my_test_shm_name"
-        shm_key = f"{reserved_prefix}_my_test_shm_key"
 
-        with self.assertRaisesRegex(
-            utils.InferenceServerException,
-            f"cannot register shared memory region '{shm_name}' with key '{shm_key}' as the key contains the reserved prefix '{reserved_prefix}'",
-        ) as e:
-            self.triton_client.register_system_shared_memory(shm_name, shm_key, 10000)
+        # The shared memory key cannot start with the reserved prefix,
+        # regardless of leading slashes.
+        shm_keys_to_test = [
+            f"{reserved_prefix}_my_test_shm_key",
+            f"/{reserved_prefix}_my_test_shm_key",
+            f"///{reserved_prefix}_my_test_shm_key",
+        ]
+
+        for shm_key in shm_keys_to_test:
+            with self.subTest(shm_key=shm_key):
+                expected_msg = f"cannot register shared memory region '{shm_name}' with key '{shm_key}' as the key contains the reserved prefix '{reserved_prefix}'"
+                with self.assertRaisesRegex(
+                    utils.InferenceServerException, expected_msg
+                ):
+                    self.triton_client.register_system_shared_memory(
+                        shm_name, shm_key, 10000
+                    )
+
+    def test_register_invalid_shm_key(self):
+        """
+        Test that registration fails if attempting to use an invalid name for the shm key.
+        """
+        shm_name = "my_test_shm_name"
+        shm_keys_to_test = [
+            "/",
+            "///",
+        ]
+
+        for shm_key in shm_keys_to_test:
+            with self.subTest(shm_key=shm_key):
+                expected_msg = f"cannot register shared memory region '{shm_name}' - invalid shm key '{shm_key}'"
+                with self.assertRaisesRegex(
+                    utils.InferenceServerException, expected_msg
+                ):
+                    self.triton_client.register_system_shared_memory(
+                        shm_name, shm_key, 10000
+                    )
 
 
 def callback(user_data, result, error):

--- a/qa/L0_shared_memory/test.sh
+++ b/qa/L0_shared_memory/test.sh
@@ -70,6 +70,7 @@ for i in \
         test_infer_integer_overflow \
         test_register_out_of_bound \
         test_register_reserved_names \
+        test_register_invalid_shm_key \
         test_python_client_leak; do
     for client_type in http grpc; do
         SERVER_ARGS="--model-repository=`pwd`/models --log-verbose=1 ${SERVER_ARGS_EXTRA}"

--- a/src/common.h
+++ b/src/common.h
@@ -196,6 +196,16 @@ TRITONSERVER_Error* DecodeBase64(
     const char* input, size_t input_len, std::vector<char>& decoded_data,
     size_t& decoded_size, const std::string& name);
 
+
+/// Validate shared memory key
+///
+/// \param name The name of the memory block.
+/// \param shm_key The name of the posix shared memory object
+/// \return The error status.
+TRITONSERVER_Error*
+ValidateSharedMemoryKey(const std::string& name, const std::string& shm_key);
+
+
 /// Joins container of strings into a single string delimited by
 /// 'delim'.
 ///

--- a/src/common.h
+++ b/src/common.h
@@ -202,8 +202,8 @@ TRITONSERVER_Error* DecodeBase64(
 /// \param name The name of the memory block.
 /// \param shm_key The name of the posix shared memory object
 /// \return The error status.
-TRITONSERVER_Error*
-ValidateSharedMemoryKey(const std::string& name, const std::string& shm_key);
+TRITONSERVER_Error* ValidateSharedMemoryKey(
+    const std::string& name, const std::string& shm_key);
 
 
 /// Joins container of strings into a single string delimited by

--- a/src/shared_memory_manager.cc
+++ b/src/shared_memory_manager.cc
@@ -355,15 +355,7 @@ SharedMemoryManager::RegisterSystemSharedMemory(
     const size_t byte_size)
 {
   // Check if the shared memory key starts with the reserved prefix
-  if (shm_key.rfind(kTritonSharedMemoryRegionPrefix, 0) == 0) {
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INVALID_ARG,
-        std::string(
-            "cannot register shared memory region '" + name + "' with key '" +
-            shm_key + "' as the key contains the reserved prefix '" +
-            kTritonSharedMemoryRegionPrefix + "'")
-            .c_str());
-  }
+  RETURN_IF_ERR(ValidateSharedMemoryKey(name, shm_key));
 
   std::lock_guard<std::mutex> lock(mu_);
 


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR is an enhancement for #8273.
Previously, users could bypass validation by using a leading slash in shm_key, such as `"/triton_python_backend_shm_region_my_test_shm_key"`, `"///triton_python_backend_shm_region_my_test_shm_key"`

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID: 33011596
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
