### PR TITLE
test: Fix CuPy CUDA library link

### DIFF
--- a/python/openai/README.md
+++ b/python/openai/README.md
@@ -35,7 +35,7 @@
 ## Pre-requisites
 
 > [!WARNING]
-> **CuPy CUDA 13 Compatibility Issue**: The Triton Inference Server Image has been upgraded to CUDA 13. The latest CuPy wheel released at the time of writing is not fully compatible with CUDA 13. If you encounter issues with CuPy, they may be fixed by running the following commands before starting the Frontend:
+> **CuPy CUDA 13 Compatibility Issue**: The Triton Inference Server Image has been upgraded to CUDA 13. You may encounter issues when using CuPy before it officially supports CUDA 13 (see [this issue](https://github.com/cupy/cupy/issues/9286) requesting CUDA 13 support). Some issues may be resolved by linking CUDA 12 shared objects to CUDA 13, for example:
 > ```bash
 > ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13.0.48 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.12
 > export LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib:$LD_LIBRARY_PATH"

--- a/python/openai/README.md
+++ b/python/openai/README.md
@@ -34,6 +34,13 @@
 
 ## Pre-requisites
 
+> [!WARNING]
+> **CuPy CUDA 13 Compatibility Issue**: The Triton Inference Server Image has been upgraded to CUDA 13. The latest CuPy wheel released at the time of writing is not fully compatible with CUDA 13. If you encounter issues with CuPy, they may be fixed by running the following commands before starting the Frontend:
+> ```bash
+> ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13.0.48 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.12
+> export LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib:$LD_LIBRARY_PATH"
+> ```
+
 1. Docker + NVIDIA Container Runtime
 2. A correctly configured `HF_TOKEN` for access to HuggingFace models.
     - The current examples and testing primarily use the

--- a/qa/L0_python_api/test.sh
+++ b/qa/L0_python_api/test.sh
@@ -27,6 +27,11 @@
 
 pip3 install pytest-asyncio==0.23.8
 
+# Create CUDA compatibility symlink for CuPy
+# TODO: Remove patch once CuPy supports CUDA 13
+ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13.0.48 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.12
+export LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib:$LD_LIBRARY_PATH"
+
 RET=0
 
 set +e


### PR DESCRIPTION
Fix for CuPy CUDA 13 library link.

This PR targets the r25.08 branch directly. Pipeline: 33318849