### PR TITLE
Remove TensorFlow references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ proposed change so that the Triton team can provide feedback.
     documentation for instructions on running these tests.
 
 - Triton Inference Server's default build assumes recent versions of
-  dependencies (CUDA, TensorFlow, PyTorch, TensorRT,
+  dependencies (CUDA, PyTorch, TensorRT,
   etc.). Contributions that add compatibility with older versions of
   those dependencies will be considered, but NVIDIA cannot guarantee
   that all possible build configurations work, are not broken by

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 Triton Inference Server is an open source inference serving software that
 streamlines AI inferencing. Triton enables teams to deploy any AI model from
 multiple deep learning and machine learning frameworks, including TensorRT,
-TensorFlow, PyTorch, ONNX, OpenVINO, Python, RAPIDS FIL, and more. Triton
+PyTorch, ONNX, OpenVINO, Python, RAPIDS FIL, and more. Triton
 Inference Server supports inference across cloud, data center, edge and embedded
 devices on NVIDIA GPUs, x86 and ARM CPU, or AWS Inferentia. Triton Inference
 Server delivers optimized performance for many query types, including real time,
@@ -166,7 +166,6 @@ configuration](docs/user_guide/model_configuration.md) for the model.
 - Triton supports multiple execution engines, called
   [backends](https://github.com/triton-inference-server/backend#where-can-i-find-all-the-backends-that-are-available-for-triton), including
   [TensorRT](https://github.com/triton-inference-server/tensorrt_backend),
-  [TensorFlow](https://github.com/triton-inference-server/tensorflow_backend),
   [PyTorch](https://github.com/triton-inference-server/pytorch_backend),
   [ONNX](https://github.com/triton-inference-server/onnxruntime_backend),
   [OpenVINO](https://github.com/triton-inference-server/openvino_backend),

--- a/deploy/gke-marketplace-app/server-deployer/data-test/schema.yaml
+++ b/deploy/gke-marketplace-app/server-deployer/data-test/schema.yaml
@@ -88,11 +88,11 @@ properties:
     default: 85
   modelRepositoryPath:
     type: string
-    title: Bucket where models are stored. Please make sure the user/service account to create the GKE app has permission to this GCS bucket. Read Triton documentation on configs and formatting details, supporting TensorRT, TensorFlow, Pytorch, Onnx ... etc.
+    title: Bucket where models are stored. Please make sure the user/service account to create the GKE app has permission to this GCS bucket. Read Triton documentation on configs and formatting details, supporting TensorRT, Pytorch, Onnx ... etc.
     default: gs://triton_sample_models/models
   image.ldPreloadPath:
     type: string
-    title: Leave this empty by default. Triton allows users to create custom layers for backend such as TensorRT plugin or Tensorflow custom ops, the compiled shared library must be provided via LD_PRELOAD environment variable.
+    title: Leave this empty by default. Triton allows users to create custom layers for backend such as TensorRT plugin or custom ops, the compiled shared library must be provided via LD_PRELOAD environment variable.
     default: ''
   image.logVerboseLevel:
     type: integer

--- a/deploy/gke-marketplace-app/server-deployer/schema.yaml
+++ b/deploy/gke-marketplace-app/server-deployer/schema.yaml
@@ -88,11 +88,11 @@ properties:
     default: 85
   modelRepositoryPath:
     type: string
-    title: Bucket where models are stored. Please make sure the user/service account to create the GKE app has permission to this GCS bucket. Read Triton documentation on configs and formatting details, supporting TensorRT, TensorFlow, Pytorch, Onnx ... etc.
+    title: Bucket where models are stored. Please make sure the user/service account to create the GKE app has permission to this GCS bucket. Read Triton documentation on configs and formatting details, supporting TensorRT, Pytorch, Onnx ... etc.
     default: gs://triton_sample_models/25.07
   image.ldPreloadPath:
     type: string
-    title: Leave this empty by default. Triton allows users to create custom layers for backend such as TensorRT plugin or Tensorflow custom ops, the compiled shared library must be provided via LD_PRELOAD environment variable.
+    title: Leave this empty by default. Triton allows users to create custom layers for backend such as TensorRT plugin, the compiled shared library must be provided via LD_PRELOAD environment variable.
     default: ''
   image.logVerboseLevel:
     type: integer

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ A [Model Configuration](user_guide/model_configuration.md) file is where you set
 
 #### Required Model Configuration
 
-Triton Inference Server requires some [Minimum Required parameters](user_guide/model_configuration.md#minimal-model-configuration) to be filled in the Model Configuration. These required parameters essentially pertain to the structure of the model. For TensorFlow, ONNX and TensorRT models, users can rely on Triton to [Auto Generate](user_guide/model_configuration.md#auto-generated-model-configuration) the Minimum Required model configuration.
+Triton Inference Server requires some [Minimum Required parameters](user_guide/model_configuration.md#minimal-model-configuration) to be filled in the Model Configuration. These required parameters essentially pertain to the structure of the model. For ONNX and TensorRT models, users can rely on Triton to [Auto Generate](user_guide/model_configuration.md#auto-generated-model-configuration) the Minimum Required model configuration.
 - [Maximum Batch Size - Batching and Non-Batching Models](user_guide/model_configuration.md#maximum-batch-size)
 - [Input and Output Tensors](user_guide/model_configuration.md#inputs-and-outputs)
     - [Tensor Datatypes](user_guide/model_configuration.md#datatypes)
@@ -107,8 +107,6 @@ The Model Configuration ModelOptimizationPolicy property is used to specify opti
 - [Framework-Specific Optimization](user_guide/optimization.md#framework-specific-optimization)
   - [ONNX-TensorRT](user_guide/optimization.md#onnx-with-tensorrt-optimization-ort-trt)
   - [ONNX-OpenVINO](user_guide/optimization.md#onnx-with-openvino-optimization)
-  - [TensorFlow-TensorRT](user_guide/optimization.md#tensorflow-with-tensorrt-optimization-tf-trt)
-  - [TensorFlow-Mixed-Precision](user_guide/optimization.md#tensorflow-automatic-fp16-optimization)
 - [NUMA Optimization](user_guide/optimization.md#numa-optimization)
 
 #### Scheduling and Batching
@@ -153,7 +151,6 @@ Triton provides Prometheus metrics like GPU Utilization, Memory Usage, Latency a
 ### Framework Custom Operations
 Some frameworks provide the option of building custom layers/operations. These can be added to specific Triton Backends for the those frameworks. [Learn more](user_guide/custom_operations.md)
 - [TensorRT](user_guide/custom_operations.md#tensorrt)
-- [TensorFlow](user_guide/custom_operations.md#tensorflow)
 - [PyTorch](user_guide/custom_operations.md#pytorch)
 - [ONNX](user_guide/custom_operations.md#onnx)
 ### Client Libraries and Examples
@@ -194,7 +191,6 @@ The following resources are recommended to explore the full suite of Triton Infe
 
 - **Backends**: Triton supports a wide variety of frameworks used to run models. Users can extend this functionality by creating custom backends.
   - [PyTorch](https://github.com/triton-inference-server/pytorch_backend): Widely used Open Source DL Framework
-  - [TensorFlow](https://github.com/triton-inference-server/tensorflow_backend): Widely used Open Source DL Framework
   - [TensorRT](https://github.com/triton-inference-server/tensorrt_backend): NVIDIA [TensorRT](https://developer.nvidia.com/tensorrt) is an inference acceleration SDK that provide a with range of graph optimizations, kernel optimization, use of lower precision, and more.
   - [ONNX](https://github.com/triton-inference-server/onnxruntime_backend): ONNX Runtime is a cross-platform inference and training machine-learning accelerator.
   - [OpenVINO](https://github.com/triton-inference-server/openvino_backend): OpenVINO™ is an open-source toolkit for optimizing and deploying AI inference.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/client_guide/python_readme.rst
+++ b/docs/client_guide/python_readme.rst
@@ -87,7 +87,7 @@ tritonserver ``nvcr.io/nvidia/tritonserver:24.01-py3`` container.
 
 ::
 
-   dali  fil  identity  onnxruntime  openvino  python  pytorch  repeat  square  tensorflow  tensorrt
+   dali  fil  identity  onnxruntime  openvino  python  pytorch  repeat  square  tensorrt
 
 Included Models
 ^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ tritonserver ``nvcr.io/nvidia/tritonserver:24.01-py3`` container.
 
 ::
 
-   dali  fil  identity  onnxruntime  openvino  python  pytorch  repeat  square  tensorflow  tensorrt
+   dali  fil  identity  onnxruntime  openvino  python  pytorch  repeat  square  tensorrt
 
 .. _included-models-1:
 

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -101,7 +101,6 @@
    Python <python_backend/README>
    Pytorch <pytorch_backend/README>
    ONNX Runtime <onnxruntime_backend/README>
-   TensorFlow <tensorflow_backend/README>
    TensorRT <tensorrt_backend/README>
    FIL <fil_backend/README>
    DALI <dali_backend/README>

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -72,8 +72,8 @@ on how to perform incremental build.
 For Ubuntu-22.04, build.py supports both a Docker build and a
 non-Docker build.
 
-* [Build using Docker](#building-with-docker) and the TensorFlow and PyTorch
-  Docker images from [NVIDIA GPU Cloud (NGC)](https://ngc.nvidia.com).
+* [Build using Docker](#building-with-docker) and the PyTorch
+  Docker image from [NVIDIA GPU Cloud (NGC)](https://ngc.nvidia.com).
 
 * [Build without Docker](#building-without-docker).
 
@@ -190,14 +190,10 @@ If you want to build without GPU support you must specify individual
 feature flags and not include the `--enable-gpu` and
 `--enable-gpu-metrics` flags. Only the following backends are
 available for a non-GPU / CPU-only build: `identity`, `repeat`, `ensemble`,
-`square`, `tensorflow2`, `pytorch`, `onnxruntime`, `openvino`,
+`square`, `pytorch`, `onnxruntime`, `openvino`,
 `python` and `fil`.
 
-To include the TensorFlow2 backend in your CPU-only build, you must
-provide this additional flag to build.py:
-`--extra-backend-cmake-arg=tensorflow2:TRITON_TENSORFLOW_INSTALL_EXTRA_DEPS=ON`.
-
-CPU-only builds of the TensorFlow and PyTorch backends require some CUDA stubs
+CPU-only builds of the PyTorch backends require some CUDA stubs
 and runtime dependencies that are not present in the CPU-only base container.
 These are retrieved from a GPU base container, which can be changed with the
 `--image=gpu-base,nvcr.io/nvidia/tritonserver:<xx.yy>-py3-min` flag.
@@ -401,17 +397,6 @@ and cmake_build or the equivalent commands to perform a build.
   that package by not specifying --filesystem=s3 when you run
   build.py. In general, you should start by running build.py with the
   minimal required feature set.
-
-* The
-  [TensorFlow](https://github.com/triton-inference-server/tensorflow_backend)
-  backend extracts pre-built shared libraries from the TensorFlow NGC
-  container as part of the build. This container is only available for
-  Ubuntu-22.04 / x86-64, so if you require the TensorFlow backend for
-  your platform you will need download the TensorFlow container and
-  modify its build to produce shared libraries for your platform. You
-  must use the TensorFlow source and build scripts from within the NGC
-  container because they contain Triton-specific patches that are
-  required for the Triton TensorFlow backend.
 
 * By default, the
   [PyTorch](https://github.com/triton-inference-server/pytorch_backend)

--- a/docs/customization_guide/compose.md
+++ b/docs/customization_guide/compose.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright (c) 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/customization_guide/compose.md
+++ b/docs/customization_guide/compose.md
@@ -52,12 +52,11 @@ should be used to create a image based on the NGC 24.12 Triton release.
 `compose.py` provides `--backend`, `--repoagent` options that allow you to
 specify which backends and repository agents to include in the custom image.
 For example, the following creates a new docker image that
-contains only the Pytorch and Tensorflow backends and the checksum
-repository agent.
+contains only the Pytorch backends and the checksum repository agent.
 
 Example:
 ```
-python3 compose.py --backend pytorch --backend tensorflow --repoagent checksum
+python3 compose.py --backend pytorch --repoagent checksum
 ```
 will provide a container `tritonserver` locally. You can access the container
 with
@@ -111,7 +110,7 @@ it would be better to [build it yourself](#build-it-yourself) by using
 
 CPU-only containers are not yet available for customization. Please see
  [build documentation](build.md) for instructions to build a full CPU-only
- container. When including TensorFlow or PyTorch backends in the composed
+ container. When including PyTorch backend in the composed
  container, an additional `gpu-min` container is needed
 since this container provided the CUDA stubs and runtime dependencies which are
 not provided in the CPU only min container.

--- a/docs/getting_started/quick_deployment_by_backend.rst
+++ b/docs/getting_started/quick_deployment_by_backend.rst
@@ -40,5 +40,4 @@ Quick Deployment Guide by backend
    Python with HuggingFace <../tutorials/Quick_Deploy/HuggingFaceTransformers/README.md>
    PyTorch <../tutorials/Quick_Deploy/PyTorch/README.md>
    ONNX <../tutorials/Quick_Deploy/ONNX/README.md>
-   TensorFlow <../tutorials/Quick_Deploy/TensorFlow/README.md>
    Openvino <../tutorials/Quick_Deploy/OpenVINO/README.md>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,8 @@
 
 Triton Inference Server is an open source inference serving software that streamlines
 AI inferencing. Triton Inference Server enables teams to deploy any AI model from multiple deep
-learning and machine learning frameworks, including TensorRT, TensorFlow,
-PyTorch, ONNX, OpenVINO, Python, RAPIDS FIL, and more. Triton supports inference
+learning and machine learning frameworks, including TensorRT, PyTorch,
+ONNX, OpenVINO, Python, RAPIDS FIL, and more. Triton supports inference
 across cloud, data center, edge and embedded devices on NVIDIA GPUs, x86 and ARM
 CPU, or AWS Inferentia. Triton Inference Server delivers optimized performance
 for many query types, including real time, batched, ensembles and audio/video

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -30,7 +30,7 @@
 
 Triton Inference Server is an open source inference serving software that streamlines
 AI inferencing. Triton Inference Server enables teams to deploy any AI model from multiple deep
-learning and machine learning frameworks, including TensorRT, TensorFlow,
+learning and machine learning frameworks, including TensorRT,
 PyTorch, ONNX, OpenVINO, Python, RAPIDS FIL, and more. Triton supports inference
 across cloud, data center, edge and embedded devices on NVIDIA GPUs, x86 and ARM
 CPU, or AWS Inferentia. Triton Inference Server delivers optimized performance

--- a/docs/perf_benchmark/perf-analyzer-README.rst
+++ b/docs/perf_benchmark/perf-analyzer-README.rst
@@ -77,11 +77,6 @@ Other Features
 -  `Input Data <docs/input_data.md>`__ to model inferences can be
    auto-generated or specified as well as verifying output
 
--  `TensorFlow
-   Serving <docs/benchmarking.md#benchmarking-tensorflow-serving>`__ and
-   `TorchServe <docs/benchmarking.md#benchmarking-torchserve>`__ can be
-   used as the inference server in addition to the default Triton server
-
 Quick Start
 ===========
 

--- a/docs/repositories.txt
+++ b/docs/repositories.txt
@@ -8,7 +8,6 @@ onnxruntime_backend
 perf_analyzer
 python_backend
 pytorch_backend
-tensorflow_backend
 tensorrt_backend
 tensorrtllm_backend
 tutorials

--- a/docs/user_guide/custom_operations.md
+++ b/docs/user_guide/custom_operations.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/user_guide/custom_operations.md
+++ b/docs/user_guide/custom_operations.md
@@ -67,65 +67,6 @@ corresponding to the Triton container. For example, if you are using
 the 24.12 version of Triton, use the 24.12 version of the TensorRT
 container.
 
-## TensorFlow
-
-TensorFlow allows users to [add custom
-operations](https://www.tensorflow.org/guide/create_op) which can then
-be used in TensorFlow models. You can load custom TensorFlow operations
-into Triton in two ways:
-* At model load time, by listing them in the model configuration.
-* At server launch time, by using LD_PRELOAD.
-
-To register your custom operations library via the the model configuration,
-you can include it as an additional field. See the below configuration as an example.
-
-```bash
-$ model_operations { op_library_filename: "path/to/libtfcustom.so" }
-```
-
-Note that even though the models are loaded at runtime, multiple models can use the custom
-operators. There is currently no way to deallocate the custom operators, so they will stay
-available until Triton is shut down.
-
-You can also register your custom operations library via LD_PRELOAD. For example,
-assuming your TensorFlow custom operations are compiled into libtfcustom.so,
-starting Triton with the following command makes those operations
-available to all TensorFlow models.
-
-```bash
-$ LD_PRELOAD=libtfcustom.so:${LD_PRELOAD} tritonserver --model-repository=/tmp/models ...
-```
-
-With this approach, all TensorFlow custom operations depend on a TensorFlow shared
-library that must be available to the custom shared library when it is
-loading. In practice, this means that you must make sure that
-/opt/tritonserver/backends/tensorflow1 or
-/opt/tritonserver/backends/tensorflow2 is on the library path before
-issuing the above command. There are several ways to control the
-library path and a common one is to use the LD_LIBRARY_PATH. You can
-set LD_LIBRARY_PATH in the "docker run" command or inside the
-container.
-
-```bash
-$ export LD_LIBRARY_PATH=/opt/tritonserver/backends/tensorflow1:$LD_LIBRARY_PATH
-```
-
-A limitation of this approach is that the custom operations must be
-managed separately from the model repository itself. And more
-seriously, if there are custom layer name conflicts across multiple
-shared libraries there is currently no way to handle it.
-
-When building the custom operations shared library it is important to
-use the same version of TensorFlow as is being used in Triton. You can
-find the TensorFlow version in the [Triton Release
-Notes](https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/index.html). A
-simple way to ensure you are using the correct version of TensorFlow
-is to use the [NGC TensorFlow
-container](https://ngc.nvidia.com/catalog/containers/nvidia:tensorflow)
-corresponding to the Triton container. For example, if you are using
-the 24.12 version of Triton, use the 24.12 version of the TensorFlow
-container.
-
 ## PyTorch
 
 Torchscript allows users to [add custom

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -42,7 +42,7 @@ is that Triton can be deployed as a Docker container, anywhere – on
 premises and on public clouds. Triton Inference Server also [supports
 multiple
 frameworks](https://github.com/triton-inference-server/backend) such
-as TensorRT, TensorFlow, PyTorch, and ONNX on both GPUs and CPUs
+as TensorRT, PyTorch, and ONNX on both GPUs and CPUs
 leading to a streamlined deployment.
 
 ## Can Triton Inference Server run on systems that don't have GPUs?

--- a/docs/user_guide/jetson.md
+++ b/docs/user_guide/jetson.md
@@ -190,13 +190,11 @@ LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/llvm-8/lib"
 ```
 
 **Note**: On Jetson, the backend directory must be explicitly specified using the
-`--backend-directory` flag. Starting from 23.04, Triton no longer supports
-TensorFlow 1.x. If you'd like to use TensorFlow 1.x with Triton prior to 23.04,
-a version string is required to use TensorFlow 1.x.
+`--backend-directory` flag.
 
 ```
 tritonserver --model-repository=/path/to/model_repo --backend-directory=/path/to/tritonserver/backends \
-             --backend-config=tensorflow,version=2
+             --backend-config=onnx,version=2
 ```
 
 **Note**:

--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -283,7 +283,7 @@ fill in missing [`instance_group`](#instance-groups) settings with
 default values.
 
 Triton can derive all the required settings automatically for
-most of the TensorRT, TensorFlow saved-model, ONNX models, and OpenVINO models.
+most of the TensorRT saved-model, ONNX models, and OpenVINO models.
 For Python models, [`auto_complete_config`](https://github.com/triton-inference-server/python_backend/#auto_complete_config)
 function can be implemented in Python backend to provide
 [`max_batch_size`](#maximum-batch-size), [`input`](#inputs-and-outputs)
@@ -296,8 +296,7 @@ All other model types *must* provide a model configuration file.
 When developing a custom backend, you can populate required settings
 in the configuration and call `TRITONBACKEND_ModelSetConfig` API to
 update completed configuration with Triton core. You can take a
-look at [TensorFlow](https://github.com/triton-inference-server/tensorflow_backend)
-and [Onnxruntime](https://github.com/triton-inference-server/onnxruntime_backend)
+look at [Onnxruntime](https://github.com/triton-inference-server/onnxruntime_backend)
 backends as examples of how to achieve this. Currently, only
 [inputs, outputs](#inputs-and-outputs), [max_batch_size](#maximum-batch-size)
 and [dynamic batching](#dynamic-batcher) settings can be populated by
@@ -411,9 +410,8 @@ by obtaining it from the TRITONBACKEND_BackendConfig api. Currently, the
 following backends which utilize these default batch values and turn on
 dynamic batching in their generated model configurations are:
 
-1. [TensorFlow backend](https://github.com/triton-inference-server/tensorflow_backend)
-2. [Onnxruntime backend](https://github.com/triton-inference-server/onnxruntime_backend)
-3. [TensorRT backend](https://github.com/triton-inference-server/tensorrt_backend)
+1. [Onnxruntime backend](https://github.com/triton-inference-server/onnxruntime_backend)
+2. [TensorRT backend](https://github.com/triton-inference-server/tensorrt_backend)
    1. TensorRT models store the maximum batch size explicitly and do not make use
    of the default-max-batch-size parameter. However, if max_batch_size > 1
    and no [scheduler](model_configuration.md#scheduling-and-batching)
@@ -437,29 +435,26 @@ API, TRITONBACKEND C API, HTTP/REST protocol and GRPC protocol. The
 last column shows the corresponding datatype for the Python numpy
 library.
 
-|Model Config  |TensorRT      |TensorFlow    |ONNX Runtime  |PyTorch  |API      |NumPy         |
-|--------------|--------------|--------------|--------------|---------|---------|--------------|
-|TYPE_BOOL     | kBOOL        |DT_BOOL       |BOOL          |kBool    |BOOL     |bool          |
-|TYPE_UINT8    | kUINT8       |DT_UINT8      |UINT8         |kByte    |UINT8    |uint8         |
-|TYPE_UINT16   |              |DT_UINT16     |UINT16        |         |UINT16   |uint16        |
-|TYPE_UINT32   |              |DT_UINT32     |UINT32        |         |UINT32   |uint32        |
-|TYPE_UINT64   |              |DT_UINT64     |UINT64        |         |UINT64   |uint64        |
-|TYPE_INT8     | kINT8        |DT_INT8       |INT8          |kChar    |INT8     |int8          |
-|TYPE_INT16    |              |DT_INT16      |INT16         |kShort   |INT16    |int16         |
-|TYPE_INT32    | kINT32       |DT_INT32      |INT32         |kInt     |INT32    |int32         |
-|TYPE_INT64    | kINT64       |DT_INT64      |INT64         |kLong    |INT64    |int64         |
-|TYPE_FP16     | kHALF        |DT_HALF       |FLOAT16       |         |FP16     |float16       |
-|TYPE_FP32     | kFLOAT       |DT_FLOAT      |FLOAT         |kFloat   |FP32     |float32       |
-|TYPE_FP64     |              |DT_DOUBLE     |DOUBLE        |kDouble  |FP64     |float64       |
-|TYPE_STRING   |              |DT_STRING     |STRING        |         |BYTES    |dtype(object) |
+|Model Config  |TensorRT      |ONNX Runtime  |PyTorch  |API      |NumPy         |
+|--------------|--------------|--------------|---------|---------|--------------|
+|TYPE_BOOL     | kBOOL        |BOOL          |kBool    |BOOL     |bool          |
+|TYPE_UINT8    | kUINT8       |UINT8         |kByte    |UINT8    |uint8         |
+|TYPE_UINT16   |              |UINT16        |         |UINT16   |uint16        |
+|TYPE_UINT32   |              |UINT32        |         |UINT32   |uint32        |
+|TYPE_UINT64   |              |UINT64        |         |UINT64   |uint64        |
+|TYPE_INT8     | kINT8        |INT8          |kChar    |INT8     |int8          |
+|TYPE_INT16    |              |INT16         |kShort   |INT16    |int16         |
+|TYPE_INT32    | kINT32       |INT32         |kInt     |INT32    |int32         |
+|TYPE_INT64    | kINT64       |INT64         |kLong    |INT64    |int64         |
+|TYPE_FP16     | kHALF        |FLOAT16       |         |FP16     |float16       |
+|TYPE_FP32     | kFLOAT       |FLOAT         |kFloat   |FP32     |float32       |
+|TYPE_FP64     |              |DOUBLE        |kDouble  |FP64     |float64       |
+|TYPE_STRING   |              |STRING        |         |BYTES    |dtype(object) |
 |TYPE_BF16     | kBF16        |              |              |         |BF16     |              |
 
 For TensorRT each value is in the nvinfer1::DataType namespace. For
 example, nvinfer1::DataType::kFLOAT is the 32-bit floating-point
 datatype.
-
-For TensorFlow each value is in the tensorflow namespace. For example,
-tensorflow::DT_FLOAT is the 32-bit floating-point value.
 
 For ONNX Runtime each value is prepended with ONNX_TENSOR_ELEMENT_DATA_TYPE_.
 For example, ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT is the 32-bit floating-point
@@ -750,7 +745,7 @@ on the CPU.
 ```
 
 If no `count` is specified for a KIND_CPU instance group, then the default instance
-count will be 2 for selected backends (Tensorflow and Onnxruntime). All
+count will be 2 for selected backends (Onnxruntime). All
 other backends will default to 1.
 
 ### Host Policy

--- a/docs/user_guide/model_configuration.md
+++ b/docs/user_guide/model_configuration.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -100,7 +100,7 @@ specific
 [backend](https://github.com/triton-inference-server/backend/blob/main/README.md).
 Within each version sub-directory there must be the files required by
 that backend. For example, models that use framework backends such as
-TensorRT, PyTorch, ONNX, OpenVINO and TensorFlow must provide the
+TensorRT, PyTorch, ONNX and OpenVINO must provide the
 [framework-specific model files](#model-files).
 
 ## Model Repository Locations
@@ -417,40 +417,6 @@ A minimal model repository for a TorchScript model is:
       config.pbtxt
       1/
         model.pt
-```
-
-### TensorFlow Models
-
-TensorFlow saves models in one of two formats: *GraphDef* or
-*SavedModel*. Triton supports both formats.
-
-A TensorFlow GraphDef is a single file that by default must be named
-model.graphdef. A TensorFlow SavedModel is a directory containing
-multiple files. By default the directory must be named
-model.savedmodel. These default names can be overridden using the
-*default_model_filename* property in the [model
-configuration](model_configuration.md).
-
-A minimal model repository for a TensorFlow
-GraphDef model is:
-
-```
-  <model-repository-path>/
-    <model-name>/
-      config.pbtxt
-      1/
-        model.graphdef
-```
-
-A minimal model repository for a TensorFlow SavedModel model is:
-
-```
-  <model-repository-path>/
-    <model-name>/
-      config.pbtxt
-      1/
-        model.savedmodel/
-           <saved-model files>
 ```
 
 ### OpenVINO Models

--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/user_guide/optimization.md
+++ b/docs/user_guide/optimization.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/docs/user_guide/performance_tuning.md
+++ b/docs/user_guide/performance_tuning.md
@@ -47,7 +47,7 @@ For additional material, see the
     [supported backends](https://github.com/triton-inference-server/backend),
     then we can simply try to deploy the model as described in the
     [Quickstart](../getting_started/quickstart.md) guide.
-    For the ONNXRuntime, TensorFlow SavedModel, and TensorRT backends, the
+    For the ONNXRuntime and TensorRT backends, the
     minimal model configuration can be inferred from the model using Triton's
     [AutoComplete](model_configuration.md#auto-generated-model-configuration)
     feature.

--- a/docs/user_guide/performance_tuning.md
+++ b/docs/user_guide/performance_tuning.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/python_models/identity_bf16/model.py
+++ b/qa/python_models/identity_bf16/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/python_models/identity_bf16/model.py
+++ b/qa/python_models/identity_bf16/model.py
@@ -71,7 +71,7 @@ class TritonPythonModel:
             bf16_dlpack = input_tensor.to_dlpack()
 
             # OPTIONAL: The tensor can be converted to other dlpack-compatible
-            # frameworks like PyTorch and TensorFlow with their dlpack utilities.
+            # frameworks like PyTorch with their dlpack utilities.
             torch_tensor = torch.utils.dlpack.from_dlpack(bf16_dlpack)
 
             # When complete, convert back to a pb_utils.Tensor via DLPack.

--- a/qa/python_models/python_version/model.py
+++ b/qa/python_models/python_version/model.py
@@ -50,8 +50,6 @@ class TritonPythonModel:
         self.model_config = args["model_config"]
         # This is to make sure that /bin/bash is not picking up
         # the wrong shared libraries after installing PyTorch.
-        # Tensorflow uses a shared library which is common with
-        # bash.
         os.system("/bin/bash --help")
         print(
             f"Python version is {sys.version_info.major}.{sys.version_info.minor}, NumPy version is {np.version.version}, and PyTorch version is {torch.__version__}",


### PR DESCRIPTION
This change fix the removal of obsolete documentation left after 25.04


