### PR TITLE
feat: Minor improvements to build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -692,17 +692,17 @@ def onnxruntime_cmake_args(images, library_paths):
             )
 
     if target_platform() == "windows":
-        if "base" in images:
+        if "buildbase" in images:
             cargs.append(
                 cmake_backend_arg(
-                    "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["base"]
+                    "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["buildbase"]
                 )
             )
     else:
-        if "base" in images:
+        if "buildbase" in images:
             cargs.append(
                 cmake_backend_arg(
-                    "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["base"]
+                    "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["buildbase"]
                 )
             )
         else:
@@ -758,17 +758,17 @@ def openvino_cmake_args():
         )
     ]
     if target_platform() == "windows":
-        if "base" in images:
+        if "buildbase" in images:
             cargs.append(
                 cmake_backend_arg(
-                    "openvino", "TRITON_BUILD_CONTAINER", None, images["base"]
+                    "openvino", "TRITON_BUILD_CONTAINER", None, images["buildbase"]
                 )
             )
     else:
-        if "base" in images:
+        if "buildbase" in images:
             cargs.append(
                 cmake_backend_arg(
-                    "openvino", "TRITON_BUILD_CONTAINER", None, images["base"]
+                    "openvino", "TRITON_BUILD_CONTAINER", None, images["buildbase"]
                 )
             )
         else:
@@ -805,9 +805,9 @@ def dali_cmake_args():
 
 def fil_cmake_args(images):
     cargs = [cmake_backend_enable("fil", "TRITON_FIL_DOCKER_BUILD", True)]
-    if "base" in images:
+    if "buildbase" in images:
         cargs.append(
-            cmake_backend_arg("fil", "TRITON_BUILD_CONTAINER", None, images["base"])
+            cmake_backend_arg("fil", "TRITON_BUILD_CONTAINER", None, images["buildbase"])
         )
     else:
         cargs.append(
@@ -2569,6 +2569,12 @@ if __name__ == "__main__":
         required=False,
         help='Use specified Docker image in build as <image-name>,<full-image-name>. <image-name> can be "base", "gpu-base", or "pytorch".',
     )
+    parser.add_argument(
+        "--use-buildbase",
+        default=False,
+        action="store_true",
+        help='Use local temporary "buildbase" Docker image as "base" image to build backends',
+    )
 
     parser.add_argument(
         "--enable-all",
@@ -2936,6 +2942,11 @@ if __name__ == "__main__":
         )
         log('image "{}": "{}"'.format(parts[0], parts[1]))
         images[parts[0]] = parts[1]
+    if FLAGS.use_buildbase:
+        images["buildbase"] = "tritonserver_buildbase"
+    else:
+        if "base" in images:
+            images["buildbase"] = images["base"]
 
     # Initialize map of library paths for each backend.
     library_paths = {}

--- a/build.py
+++ b/build.py
@@ -32,6 +32,7 @@ import os
 import os.path
 import pathlib
 import platform
+import re
 import stat
 import subprocess
 import sys
@@ -2045,14 +2046,14 @@ def tensorrtllm_postbuild(cmake_script, repo_install_dir, tensorrtllm_be_dir):
 def backend_build(
     be,
     cmake_script,
-    tag,
+    tag_org,
     build_dir,
     install_dir,
-    github_organization,
     images,
     components,
     library_paths,
 ):
+    tag, github_organization = tag_org
     repo_build_dir = os.path.join(build_dir, be, "build")
     repo_install_dir = os.path.join(build_dir, be, "install")
 
@@ -2110,11 +2111,11 @@ def backend_build(
 def backend_clone(
     be,
     clone_script,
-    tag,
+    tag_org,
     build_dir,
     install_dir,
-    github_organization,
 ):
+    tag, github_organization = tag_org
     clone_script.commentln(8)
     clone_script.comment(f"'{be}' backend")
     clone_script.comment("Delete this section to remove backend from build")
@@ -2654,7 +2655,7 @@ if __name__ == "__main__":
         "--backend",
         action="append",
         required=False,
-        help='Include specified backend in build as <backend-name>[:<repo-tag>]. If <repo-tag> starts with "pull/" then it refers to a pull-request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).',
+        help='Include specified backend in build as <backend-name>[:<repo-tag>][:<org>]. If <repo-tag> starts with "pull/" then it refers to a pull-request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main). <org> allows using a forked repository instead of the default --github-organization value.',
     )
     parser.add_argument(
         "--repo-tag",
@@ -2890,11 +2891,14 @@ if __name__ == "__main__":
     # Initialize map of backends to build and repo-tag for each.
     backends = {}
     for be in FLAGS.backend:
-        parts = be.split(":")
+        pattern = r"(https?:\/\/[^\s:]+)|:"
+        parts = list(filter(None,re.split(pattern, be)))
         if len(parts) == 1:
             parts.append(default_repo_tag)
-        log('backend "{}" at tag/branch "{}"'.format(parts[0], parts[1]))
-        backends[parts[0]] = parts[1]
+        if len(parts) == 2:
+            parts.append(FLAGS.github_organization)
+        log('backend "{}" at tag/branch "{}" from org "{}"'.format(parts[0], parts[1], parts[2]))
+        backends[parts[0]] = parts[1:]
 
     if "vllm" in backends:
         if "python" not in backends:
@@ -3105,7 +3109,6 @@ if __name__ == "__main__":
                     backends[be],
                     script_build_dir,
                     script_install_dir,
-                    github_organization,
                 )
             else:
                 backend_build(
@@ -3114,7 +3117,6 @@ if __name__ == "__main__":
                     backends[be],
                     script_build_dir,
                     script_install_dir,
-                    github_organization,
                     images,
                     components,
                     library_paths,

--- a/build.py
+++ b/build.py
@@ -2717,6 +2717,12 @@ if __name__ == "__main__":
         help="This flag sets the upstream container version for Triton Inference Server to be built. Default: the latest released version.",
     )
     parser.add_argument(
+        "--default-repo-tag",
+        required=False,
+        default=None,
+        help="Override the calculated default-repo-tag value",
+    )
+    parser.add_argument(
         "--ort-version",
         required=False,
         default=DEFAULT_TRITON_VERSION_MAP["ort_version"],
@@ -2857,6 +2863,8 @@ if __name__ == "__main__":
         if FLAGS.triton_container_version.endswith("dev")
         else "r" + FLAGS.triton_container_version
     )
+    if FLAGS.default_repo_tag:
+        default_repo_tag = FLAGS.default_repo_tag
     log("default repo-tag: {}".format(default_repo_tag))
 
     # For other versions use the TRITON_VERSION_MAP unless explicitly

--- a/build.py
+++ b/build.py
@@ -1770,6 +1770,11 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
                 "--pull",
             ]
 
+        if FLAGS.no_container_cache:
+            baseargs += [
+                "--no-cache",
+            ]
+
         # Windows docker runs in a VM and memory needs to be specified
         # explicitly (at least for some configurations of docker).
         if target_platform() == "windows":
@@ -2444,6 +2449,12 @@ if __name__ == "__main__":
         action="store_true",
         required=False,
         help="Do not use Docker --pull argument when building container.",
+    )
+    parser.add_argument(
+        "--no-container-cache",
+        action="store_true",
+        required=False,
+        help="Use Docker --no-cache argument when building container.",
     )
     parser.add_argument(
         "--container-memory",

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -111,6 +111,8 @@ building with Docker.
     build Triton. When building without GPU support, the *min* image
     is the standard ubuntu:22.04 image.
 
+    * The flag `--use-buildbase` can be specified to automate the use of the *tritonserver_buildbase* image to build backends that require a base image.
+
   * Run the cmake_build script within the *tritonserver_buildbase*
     image to actually build Triton. The cmake_build script performs
     the following steps.
@@ -157,7 +159,7 @@ If you want to enable only certain Triton features, backends and
 repository agents, do not specify --enable-all. Instead you must
 specify the individual flags as documented by --help.
 
-#### Building With Specific GitHub Branches
+#### Building With Specific GitHub Branches and Organization
 
 As described above, the build is performed in the server repo, but
 source from several other repos is fetched during the build
@@ -180,7 +182,12 @@ instead use the corresponding branch/tag in the build. For example, if
 you have a branch called "mybranch" in the
 [onnxruntime_backend](https://github.com/triton-inference-server/onnxruntime_backend)
 repo that you want to use in the build, you would specify
---backend=onnxruntime:mybranch.
+`--backend=onnxruntime:mybranch`.
+
+If you want to build a backend from an alternative organization or user `<org>`, you can extend this syntax as follows:
+```bash
+$ ./build.py ... --backend=onnxruntime:mybranch:https://github.com/<org>
+```
 
 #### CPU-Only Build
 


### PR DESCRIPTION
#### What does the PR do?

This PR adds three new flags and updates one flag in `build.py`. These changes all go toward increasing build flexibility.
1. Add flag `--no-container-cache`, which propagates to `docker --no-cache`.
2. Add flag `--default-repo-tag <tag>` to override the calculated default value, which is not always appropriate. For example, when trying to build a dev version (currently 25.08), the upstream container version is set to the previous version (25.07), which takes precedence in the calculated default value, but using the corresponding dev versions of component and backend repositories may be intended. Rather than having to override it for each repo, it is useful to be able to override it globally.
3. Add flag `--use-buildbase` to use the temporary "buildbase" image as the "base" image for backends that need it (e.g. onnxruntime).
4. Extend `--backend` syntax to `<backend-name>[:<repo-tag>][:<org>]` to allow specifying a different organization/repository, in addition to a different tag/branch. This is useful for external contributors developing in forks.

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [X] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:

N/A

#### Where should the reviewer start?

Changes only affect build.py and associated documentation.

#### Test plan:

These changes only affect the build script, so there is no impact on server functionality.

An example of using some of these options:

in branch `r25.08` (without these changes):
```
./build.py --target-platform linux -j 24 -v --enable-all --dryrun
```
<details>
<summary>output:</summary>

Building Triton Inference Server
platform linux
machine x86_64
version 2.60.0dev
build dir /storage/local/data2/pedrok/sonic/server/build
install dir None
cmake dir None
default repo-tag: r25.07
container version 25.08dev
upstream container version 25.07
endpoint "http"
endpoint "grpc"
endpoint "sagemaker"
endpoint "vertex-ai"
filesystem "gcs"
filesystem "s3"
filesystem "azure_storage"
backend "ensemble" at tag/branch "r25.07"
backend "identity" at tag/branch "r25.07"
backend "square" at tag/branch "r25.07"
backend "repeat" at tag/branch "r25.07"
backend "onnxruntime" at tag/branch "r25.07"
backend "python" at tag/branch "r25.07"
backend "dali" at tag/branch "r25.07"
backend "pytorch" at tag/branch "r25.07"
backend "openvino" at tag/branch "r25.07"
backend "fil" at tag/branch "r25.07"
backend "tensorrt" at tag/branch "r25.07"
repoagent "checksum" at tag/branch "r25.07"
cache "local" at tag/branch "r25.07"
cache "redis" at tag/branch "r25.07"
component "common" at tag/branch "r25.07"
component "core" at tag/branch "r25.07"
component "backend" at tag/branch "r25.07"
component "thirdparty" at tag/branch "r25.07"
</details>

After merging this branch into `r25.08`, the following is possible:
```
./build.py --target-platform linux -j 24 -v --enable-all --backend onnxruntime:r25.08_kjp:https://github.com/kpedro88 --default-repo-tag r25.08 --use-buildbase --dryrun
```
<details>
<summary>output:</summary>

Building Triton Inference Server
platform linux
machine x86_64
version 2.60.0dev
build dir /storage/local/data2/pedrok/sonic/server/build
install dir None
cmake dir None
default repo-tag: r25.08
container version 25.08dev
upstream container version 25.07
endpoint "http"
endpoint "grpc"
endpoint "sagemaker"
endpoint "vertex-ai"
filesystem "gcs"
filesystem "s3"
filesystem "azure_storage"
backend "onnxruntime" at tag/branch "r25.08_kjp" from org "https://github.com/kpedro88"
backend "ensemble" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "identity" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "square" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "repeat" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "python" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "dali" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "pytorch" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "openvino" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "fil" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
backend "tensorrt" at tag/branch "r25.08" from org "https://github.com/triton-inference-server"
repoagent "checksum" at tag/branch "r25.08"
cache "local" at tag/branch "r25.08"
cache "redis" at tag/branch "r25.08"
component "common" at tag/branch "r25.08"
component "core" at tag/branch "r25.08"
component "backend" at tag/branch "r25.08"
component "thirdparty" at tag/branch "r25.08"
</details>

#### Caveats:

The syntax for changing the backend org could be more elegant, and the feature is not extended to other components besides backends. I am planning a more thorough improvement to `build.py` that will address this in a followup PR, but it will be a more involved change and is still in progress.

#### Background

These changes were useful in building a `25.08dev` server to incorporate #8335, which includes an important bug fix and is not yet in a released version.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A
