### PR TITLE
Update "cuda-cupy" package

### DIFF
--- a/python/openai/README.md
+++ b/python/openai/README.md
@@ -34,13 +34,6 @@
 
 ## Pre-requisites
 
-> [!WARNING]
-> **CuPy CUDA 13 Compatibility Issue**: The Triton Inference Server Image has been upgraded to CUDA 13. You may encounter issues when using CuPy before it officially supports CUDA 13 (see [this issue](https://github.com/cupy/cupy/issues/9286) requesting CUDA 13 support). Some issues may be resolved by linking CUDA 12 shared objects to CUDA 13, for example:
-> ```bash
-> ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13.0.48 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.12
-> export LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib:$LD_LIBRARY_PATH"
-> ```
-
 1. Docker + NVIDIA Container Runtime
 2. A correctly configured `HF_TOKEN` for access to HuggingFace models.
     - The current examples and testing primarily use the

--- a/qa/L0_dlpack_multi_gpu/test.sh
+++ b/qa/L0_dlpack_multi_gpu/test.sh
@@ -44,7 +44,7 @@ pip3 uninstall -y torch
 pip3 install torch==2.3.1+cu118 -f https://download.pytorch.org/whl/torch_stable.html
 
 # Install CuPy for testing non_blocking compute streams
-pip3 install cupy-cuda12x
+pip3 install cupy-cuda13x
 
 if [ ${CUDA_VERSION%%.*} -gt 12 ]; then
     curl -L https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/linux-x86_64/cuda_nvrtc-linux-x86_64-12.9.86-archive.tar.xz \

--- a/qa/L0_python_api/test.sh
+++ b/qa/L0_python_api/test.sh
@@ -27,11 +27,6 @@
 
 pip3 install pytest-asyncio==0.23.8
 
-# Create CUDA compatibility symlink for CuPy
-# TODO: Remove patch once CuPy supports CUDA 13
-ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.13.0.48 /usr/local/cuda/targets/x86_64-linux/lib/libnvrtc.so.12
-export LD_LIBRARY_PATH="/usr/local/cuda/targets/x86_64-linux/lib:$LD_LIBRARY_PATH"
-
 RET=0
 
 set +e

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -71,7 +71,7 @@ platform_package_data = [
     "_c/triton_bindings.pyi",
 ]
 
-gpu_extras = ["cupy-cuda12x"]
+gpu_extras = ["cupy-cuda13x"]
 test_extras = ["pytest"]
 all_extras = gpu_extras + test_extras
 


### PR DESCRIPTION
`cuda-cupy` package has been released with support of CUDA 13. 
Updating configuration in order to confirm that the package can be used.

related to: https://github.com/triton-inference-server/core/pull/450

