### PR TITLE
fix: Ensure model name cannot be used to escape model repository

### DIFF
--- a/python/openai/openai_frontend/engine/utils/triton.py
+++ b/python/openai/openai_frontend/engine/utils/triton.py
@@ -362,6 +362,11 @@ def _get_vllm_lora_names(
         repo_paths = [repo_paths]
     for repo_path in repo_paths:
         model_path = os.path.join(repo_path, model_name)
+        if os.path.normpath(model_path) != model_path:
+            raise ValueError(
+                f"Invalid model name: '{model_name}'. Model names must be valid file-system-path segment names."
+            )
+        model_path = os.path.normpath(model_path)
         if not os.path.isdir(model_path):
             # Cloud path?
             return None


### PR DESCRIPTION
This change adds a check to ensure that when model name is appended to the model-repository path that the combined path does not escape the model repository.

Linear [TRI-54](https://linear.app/nvidia/issue/TRI-54/os-access-violation-via-path-access)
CI Pipeline #35390548

