### PR TITLE
fix: Replace Use of `alloca`

### DIFF
--- a/src/data_compressor.h
+++ b/src/data_compressor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -93,11 +93,12 @@ class DataCompressor {
         &stream, deflateEnd);
 
     // Get the addr and size of each chunk of memory in 'source'
+    std::unique_ptr<struct evbuffer_iovec[]> buffer_array_holder;
     struct evbuffer_iovec* buffer_array = nullptr;
     int buffer_count = evbuffer_peek(source, -1, NULL, NULL, 0);
     if (buffer_count > 0) {
-      buffer_array = static_cast<struct evbuffer_iovec*>(
-          alloca(sizeof(struct evbuffer_iovec) * buffer_count));
+      buffer_array_holder.reset(new struct evbuffer_iovec[buffer_count]);
+      buffer_array = buffer_array_holder.get();
       if (evbuffer_peek(source, -1, NULL, buffer_array, buffer_count) !=
           buffer_count) {
         return TRITONSERVER_ErrorNew(
@@ -201,11 +202,12 @@ class DataCompressor {
               &stream, inflateEnd);
 
           // Get the addr and size of each chunk of memory in 'source'
+          std::unique_ptr<struct evbuffer_iovec[]> buffer_array_holder;
           struct evbuffer_iovec* buffer_array = nullptr;
           int buffer_count = evbuffer_peek(source, -1, NULL, NULL, 0);
           if (buffer_count > 0) {
-            buffer_array = static_cast<struct evbuffer_iovec*>(
-                alloca(sizeof(struct evbuffer_iovec) * buffer_count));
+            buffer_array_holder.reset(new struct evbuffer_iovec[buffer_count]);
+            buffer_array = buffer_array_holder.get();
             if (evbuffer_peek(source, -1, NULL, buffer_array, buffer_count) !=
                 buffer_count) {
               return TRITONSERVER_ErrorNew(

--- a/src/test/data_compressor_test.cc
+++ b/src/test/data_compressor_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -64,11 +64,12 @@ void
 WriteEVBufferToFile(const std::string& file_name, evbuffer* evb)
 {
   std::ofstream fs(file_name);
+  std::unique_ptr<struct evbuffer_iovec[]> buffer_array_holder;
   struct evbuffer_iovec* buffer_array = nullptr;
   int buffer_count = evbuffer_peek(evb, -1, NULL, NULL, 0);
   if (buffer_count > 0) {
-    buffer_array = static_cast<struct evbuffer_iovec*>(
-        alloca(sizeof(struct evbuffer_iovec) * buffer_count));
+    buffer_array_holder.reset(new struct evbuffer_iovec[buffer_count]);
+    buffer_array = buffer_array_holder.get();
     ASSERT_EQ(
         evbuffer_peek(evb, -1, NULL, buffer_array, buffer_count), buffer_count)
         << "unexpected error getting buffers for result";
@@ -85,11 +86,12 @@ EVBufferToContiguousBuffer(evbuffer* evb, std::vector<char>* buffer)
 {
   *buffer = std::vector<char>(evbuffer_get_length(evb));
   {
+    std::unique_ptr<struct evbuffer_iovec[]> buffer_array_holder;
     struct evbuffer_iovec* buffer_array = nullptr;
     int buffer_count = evbuffer_peek(evb, -1, NULL, NULL, 0);
     if (buffer_count > 0) {
-      buffer_array = static_cast<struct evbuffer_iovec*>(
-          alloca(sizeof(struct evbuffer_iovec) * buffer_count));
+      buffer_array_holder.reset(new struct evbuffer_iovec[buffer_count]);
+      buffer_array = buffer_array_holder.get();
       ASSERT_EQ(
           evbuffer_peek(evb, -1, NULL, buffer_array, buffer_count),
           buffer_count)
@@ -276,11 +278,12 @@ TEST_F(DataCompressorTest, DeflateTwoBuffer)
       << "Failed to create compressed evbuffer";
   // Reconstruct the compressed buffer to be two buffers
   if (evbuffer_peek(compressed, -1, NULL, NULL, 0) == 1) {
+    std::unique_ptr<struct evbuffer_iovec[]> buffer_array_holder;
     struct evbuffer_iovec* buffer_array = nullptr;
     int buffer_count = evbuffer_peek(compressed, -1, NULL, NULL, 0);
     if (buffer_count > 0) {
-      buffer_array = static_cast<struct evbuffer_iovec*>(
-          alloca(sizeof(struct evbuffer_iovec) * buffer_count));
+      buffer_array_holder.reset(new struct evbuffer_iovec[buffer_count]);
+      buffer_array = buffer_array_holder.get();
       ASSERT_EQ(
           evbuffer_peek(compressed, -1, NULL, buffer_array, buffer_count),
           buffer_count)
@@ -357,11 +360,12 @@ TEST_F(DataCompressorTest, GzipTwoBuffer)
       << "Failed to create compressed evbuffer";
   // Reconstruct the compressed buffer to be two buffers
   if (evbuffer_peek(compressed, -1, NULL, NULL, 0) == 1) {
+    std::unique_ptr<struct evbuffer_iovec[]> buffer_array_holder;
     struct evbuffer_iovec* buffer_array = nullptr;
     int buffer_count = evbuffer_peek(compressed, -1, NULL, NULL, 0);
     if (buffer_count > 0) {
-      buffer_array = static_cast<struct evbuffer_iovec*>(
-          alloca(sizeof(struct evbuffer_iovec) * buffer_count));
+      buffer_array_holder.reset(new struct evbuffer_iovec[buffer_count]);
+      buffer_array = buffer_array_holder.get();
       ASSERT_EQ(
           evbuffer_peek(compressed, -1, NULL, buffer_array, buffer_count),
           buffer_count)


### PR DESCRIPTION
This change replaces the use of `alloca` which performs stack allocation with `std::unique_ptr<T[]> holder{new T[count]}` because it is safer to perform unknown size allocation in the heap vs stack.

[TRI-69](https://linear.app/nvidia/issue/TRI-69/psirt-buffer-overflow-v2modelsmodel-nameinfer) 
[DLIS-8500](https://jirasw.nvidia.com/browse/DLIS-8500)

CI-Pipeline: [35590031](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/pipelines/35590031)

