### PR TITLE
fix: Update L0_openai to adapt TRT-LLM v1.0

### DIFF
--- a/qa/L0_openai/generate_engine.py
+++ b/qa/L0_openai/generate_engine.py
@@ -25,7 +25,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from argparse import ArgumentParser
 
-from tensorrt_llm import LLM, BuildConfig
+from tensorrt_llm import BuildConfig
+from tensorrt_llm._tensorrt_engine import LLM
 from tensorrt_llm.plugin import PluginConfig
 
 


### PR DESCRIPTION
This change moves the import of `LLM` from `tensorrt_llm` to `tensorrt_llm._tensorrt_engine` to adapt the API changes in TRT-LLM v1.0.

[TRI-71](https://linear.app/nvidia/issue/TRI-71/2509-ci-failure-l0-openai-trtllm-base)
