### PR TITLE
Feat: revamp build.py CLI to improve usability and maintainability

### DIFF
--- a/build.py
+++ b/build.py
@@ -32,7 +32,6 @@ import os
 import os.path
 import pathlib
 import platform
-import re
 import stat
 import subprocess
 import sys

--- a/build.py
+++ b/build.py
@@ -92,7 +92,7 @@ OVERRIDE_BACKEND_CMAKE_FLAGS = {}
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
 ELEMENTS = {
-    'backend': ['tag', 'org', 'lib'],
+    'backend': ['tag', 'org'],
     'repoagent': ['tag', 'org'],
     'cache': ['tag', 'org'],
     'filesystem': ['strict'],
@@ -2436,16 +2436,6 @@ if __name__ == "__main__":
                 default=[],
                 help=f'Select <org> for specified <{element}>, to use the fork of the corresponding repository from <org> instead of the default --github-organization value.',
             )
-        if 'lib' in properties:
-            group.add_argument(
-                f"--{element}-library-path",
-                action="append",
-                metavar=(f"<{element}>","<library_path>"),
-                nargs=2,
-                required=False,
-                default=[],
-                help=f'Specify library paths for specified <{element}> in build.',
-            )
 
     parser.add_argument(
         "--min-compute-capability",
@@ -2683,18 +2673,15 @@ if __name__ == "__main__":
         map[key]["tag"] = value
     def do_org(element, map, key, value):
         map[key]["org"] = value
-    def do_lib(element, map, key, value):
-        map[key]["lib"] = value
     attr_fns = {
         "enable": do_enable,
         "disable": do_disable,
         "tag": do_tag,
         "org": do_org,
-        "library_path": do_lib,
     }
     for element in ELEMENTS:
         map = getattr(FLAGS, element)
-        attr_names = [f"enable_{element}", f"disable_{element}", f"{element}_tag", f"{element}_org", f"{element}_library_path"]
+        attr_names = [f"enable_{element}", f"disable_{element}", f"{element}_tag", f"{element}_org"]
         for attr_name in attr_names:
             attr = getattr(FLAGS, attr_name, None)
             if not attr: continue
@@ -2730,7 +2717,6 @@ if __name__ == "__main__":
                 f'{element} "{key}"',
                 'at tag/branch "{}"'.format(info["tag"]) if "tag" in info else "",
                 'from org "{}"'.format(info["org"]) if "org" in info else "",
-                'with library path "{}"'.format(info["lib"]) if "lib" in info else "",
             ])))
 
     # Initialize map of docker images.

--- a/build.py
+++ b/build.py
@@ -1621,6 +1621,11 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
                 "--pull",
             ]
 
+        if FLAGS.no_container_cache:
+            baseargs += [
+                "--no-cache",
+            ]
+
         baseargs += ["--cache-from={}".format(k) for k in cachefrommap]
 
         baseargs += ["."]
@@ -2229,6 +2234,12 @@ if __name__ == "__main__":
         action="store_true",
         required=False,
         help="Do not use Docker --pull argument when building container.",
+    )
+    parser.add_argument(
+        "--no-container-cache",
+        action="store_true",
+        required=False,
+        help="Use Docker --no-cache argument when building container.",
     )
     parser.add_argument(
         "--target-platform",

--- a/build.py
+++ b/build.py
@@ -32,6 +32,7 @@ import os
 import os.path
 import pathlib
 import platform
+import re
 import stat
 import subprocess
 import sys
@@ -1861,14 +1862,14 @@ def tensorrtllm_postbuild(cmake_script, repo_install_dir, tensorrtllm_be_dir):
 def backend_build(
     be,
     cmake_script,
-    tag,
+    tag_org,
     build_dir,
     install_dir,
-    github_organization,
     images,
     components,
     library_paths,
 ):
+    tag, github_organization = tag_org
     repo_build_dir = os.path.join(build_dir, be, "build")
     repo_install_dir = os.path.join(build_dir, be, "install")
 
@@ -1926,11 +1927,11 @@ def backend_build(
 def backend_clone(
     be,
     clone_script,
-    tag,
+    tag_org,
     build_dir,
     install_dir,
-    github_organization,
 ):
+    tag, github_organization = tag_org
     clone_script.commentln(8)
     clone_script.comment(f"'{be}' backend")
     clone_script.comment("Delete this section to remove backend from build")
@@ -2433,7 +2434,7 @@ if __name__ == "__main__":
         "--backend",
         action="append",
         required=False,
-        help='Include specified backend in build as <backend-name>[:<repo-tag>]. If <repo-tag> starts with "pull/" then it refers to a pull-request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).',
+        help='Include specified backend in build as <backend-name>[:<repo-tag>][:<org>]. If <repo-tag> starts with "pull/" then it refers to a pull-request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main). <org> allows using a forked repository instead of the default --github-organization value.',
     )
     parser.add_argument(
         "--repo-tag",
@@ -2663,11 +2664,14 @@ if __name__ == "__main__":
     # Initialize map of backends to build and repo-tag for each.
     backends = {}
     for be in FLAGS.backend:
-        parts = be.split(":")
+        pattern = r"(https?:\/\/[^\s:]+)|:"
+        parts = list(filter(None,re.split(pattern, be)))
         if len(parts) == 1:
             parts.append(default_repo_tag)
-        log('backend "{}" at tag/branch "{}"'.format(parts[0], parts[1]))
-        backends[parts[0]] = parts[1]
+        if len(parts) == 2:
+            parts.append(FLAGS.github_organization)
+        log('backend "{}" at tag/branch "{}" from org "{}"'.format(parts[0], parts[1], parts[2]))
+        backends[parts[0]] = parts[1:]
 
     if "vllm" in backends:
         if "python" not in backends:
@@ -2869,7 +2873,6 @@ if __name__ == "__main__":
                     backends[be],
                     script_build_dir,
                     script_install_dir,
-                    github_organization,
                 )
             else:
                 backend_build(
@@ -2878,7 +2881,6 @@ if __name__ == "__main__":
                     backends[be],
                     script_build_dir,
                     script_install_dir,
-                    github_organization,
                     images,
                     components,
                     library_paths,

--- a/build.py
+++ b/build.py
@@ -93,8 +93,8 @@ THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
 ELEMENTS = {
     'backend': ['tag', 'org', 'cmake'],
-    'repoagent': ['tag', 'org'],
-    'cache': ['tag', 'org'],
+    'repoagent': ['tag', 'org', 'cmake'],
+    'cache': ['tag', 'org', 'cmake'],
     'filesystem': ['strict'],
     'endpoint': ['strict'],
     'feature': ['strict'],
@@ -405,40 +405,28 @@ def cmake_backend_extra_args(backend):
     return cmake_element_extra_args('backend', backend)
 
 
-def cmake_repoagent_arg(name, type, value):
-    # For now there is no override for repo-agents
-    type = ":{}".format(type) if type else ""
-    return '"-D{}{}={}"'.format(name, type, value)
+def cmake_repoagent_arg(*args, **kwargs):
+    return cmake_element_arg('repoagent', *args, **kwargs)
 
 
-def cmake_repoagent_enable(name, flag):
-    # For now there is no override for repo-agents
-    value = "ON" if flag else "OFF"
-    return '"-D{}:BOOL={}"'.format(name, value)
+def cmake_repoagent_enable(*args, **kwargs):
+    return cmake_element_enable('repoagent', *args, **kwargs)
 
 
-def cmake_repoagent_extra_args():
-    # For now there is no extra args for repo-agents
-    args = []
-    return args
+def cmake_repoagent_extra_args(repoagent):
+    return cmake_element_extra_args('repoagent', repoagent)
 
 
-def cmake_cache_arg(name, type, value):
-    # For now there is no override for caches
-    type = ":{}".format(type) if type else ""
-    return '"-D{}{}={}"'.format(name, type, value)
+def cmake_cache_arg(*args, **kwargs):
+    return cmake_element_arg('cache', *args, **kwargs)
 
 
-def cmake_cache_enable(name, flag):
-    # For now there is no override for caches
-    value = "ON" if flag else "OFF"
-    return '"-D{}:BOOL={}"'.format(name, value)
+def cmake_cache_enable(*args, **kwargs):
+    return cmake_element_enable('cache', *args, **kwargs)
 
 
-def cmake_cache_extra_args():
-    # For now there is no extra args for caches
-    args = []
-    return args
+def cmake_cache_extra_args(cache):
+    return cmake_element_extra_args('cache', cache)
 
 
 def core_cmake_args(cmake_dir, install_dir):
@@ -509,17 +497,17 @@ def repoagent_cmake_args(images, ra, install_dir):
     args = []
 
     cargs = args + [
-        cmake_repoagent_arg("CMAKE_BUILD_TYPE", None, FLAGS.build_type),
-        cmake_repoagent_arg("CMAKE_INSTALL_PREFIX", "PATH", install_dir),
+        cmake_repoagent_arg(ra, "CMAKE_BUILD_TYPE", None, FLAGS.build_type),
+        cmake_repoagent_arg(ra, "CMAKE_INSTALL_PREFIX", "PATH", install_dir),
         cmake_repoagent_arg(
-            "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
+            ra, "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
         ),
-        cmake_repoagent_arg("TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
-        cmake_repoagent_arg("TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
+        cmake_repoagent_arg(ra, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
+        cmake_repoagent_arg(ra, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
     ]
 
-    cargs.append(cmake_repoagent_enable("TRITON_ENABLE_GPU", "gpu" in FLAGS.feature))
-    cargs += cmake_repoagent_extra_args()
+    cargs.append(cmake_repoagent_enable(ra, "TRITON_ENABLE_GPU", "gpu" in FLAGS.feature))
+    cargs += cmake_repoagent_extra_args(ra)
     cargs.append("..")
     return cargs
 
@@ -533,17 +521,17 @@ def cache_cmake_args(images, cache, install_dir):
     args = []
 
     cargs = args + [
-        cmake_cache_arg("CMAKE_BUILD_TYPE", None, FLAGS.build_type),
-        cmake_cache_arg("CMAKE_INSTALL_PREFIX", "PATH", install_dir),
+        cmake_cache_arg(cache, "CMAKE_BUILD_TYPE", None, FLAGS.build_type),
+        cmake_cache_arg(cache, "CMAKE_INSTALL_PREFIX", "PATH", install_dir),
         cmake_cache_arg(
-            "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
+            cache, "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
         ),
-        cmake_cache_arg("TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
-        cmake_cache_arg("TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
+        cmake_cache_arg(cache, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
+        cmake_cache_arg(cache, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
     ]
 
-    cargs.append(cmake_cache_enable("TRITON_ENABLE_GPU", 'gpu' in FLAGS.feature))
-    cargs += cmake_cache_extra_args()
+    cargs.append(cmake_cache_enable(cache, "TRITON_ENABLE_GPU", 'gpu' in FLAGS.feature))
+    cargs += cmake_cache_extra_args(cache)
     cargs.append("..")
     return cargs
 

--- a/build.py
+++ b/build.py
@@ -2496,6 +2496,12 @@ if __name__ == "__main__":
         help="This flag sets the upstream container version for Triton Inference Server to be built. Default: the latest released version.",
     )
     parser.add_argument(
+        "--default-repo-tag",
+        required=False,
+        default=None,
+        help="Override the calculated default-repo-tag value",
+    )
+    parser.add_argument(
         "--ort-version",
         required=False,
         default=DEFAULT_TRITON_VERSION_MAP["ort_version"],
@@ -2630,6 +2636,8 @@ if __name__ == "__main__":
         if FLAGS.triton_container_version.endswith("dev")
         else "r" + FLAGS.triton_container_version
     )
+    if FLAGS.default_repo_tag:
+        default_repo_tag = FLAGS.default_repo_tag
     log("default repo-tag: {}".format(default_repo_tag))
 
     # For other versions use the TRITON_VERSION_MAP unless explicitly

--- a/build.py
+++ b/build.py
@@ -92,6 +92,66 @@ OVERRIDE_BACKEND_CMAKE_FLAGS = {}
 
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
+ELEMENTS = {
+    'backend': ['tag', 'org'],
+    'repoagent': ['tag', 'org'],
+    'cache': ['tag', 'org'],
+    'filesystem': ['strict'],
+    'endpoint': ['strict'],
+    'feature': ['strict'],
+    'component': ['tag', 'strict', 'required'],
+}
+
+ELEMENTS_LISTS = {
+    "backend": [
+        "ensemble",
+        "identity",
+        "square",
+        "repeat",
+        "onnxruntime",
+        "python",
+        "dali",
+        "pytorch",
+        "openvino",
+        "fil",
+        "tensorrt",
+    ],
+    "repoagent": [
+        "checksum",
+    ],
+    "cache": [
+        "local",
+        "redis",
+    ],
+    "filesystem": [
+        "gcs",
+        "s3",
+        "azure_storage",
+    ],
+    "endpoint": [
+        "http",
+        "grpc",
+        "sagemaker",
+        "vertex-ai",
+    ],
+    "feature": [
+        "logging",
+        "stats",
+        "metrics",
+        "gpu_metrics",
+        "cpu_metrics",
+        "tracing",
+        "nvtx",
+        "gpu",
+        "mali_gpu",
+    ],
+    "component": [
+        "common",
+        "core",
+        "backend",
+        "thirdparty",
+    ],
+}
 
 def log(msg, force=False):
     if force or not FLAGS.quiet:
@@ -391,40 +451,40 @@ def cmake_cache_extra_args():
     return args
 
 
-def core_cmake_args(components, backends, cmake_dir, install_dir):
+def core_cmake_args(cmake_dir, install_dir):
     cargs = [
         cmake_core_arg("CMAKE_BUILD_TYPE", None, FLAGS.build_type),
         cmake_core_arg("CMAKE_INSTALL_PREFIX", "PATH", install_dir),
         cmake_core_arg("TRITON_VERSION", "STRING", FLAGS.version),
         cmake_core_arg("TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization),
-        cmake_core_arg("TRITON_COMMON_REPO_TAG", "STRING", components["common"]),
-        cmake_core_arg("TRITON_CORE_REPO_TAG", "STRING", components["core"]),
-        cmake_core_arg("TRITON_BACKEND_REPO_TAG", "STRING", components["backend"]),
+        cmake_core_arg("TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
+        cmake_core_arg("TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
+        cmake_core_arg("TRITON_BACKEND_REPO_TAG", "STRING", FLAGS.component["backend"]["tag"]),
         cmake_core_arg(
-            "TRITON_THIRD_PARTY_REPO_TAG", "STRING", components["thirdparty"]
+            "TRITON_THIRD_PARTY_REPO_TAG", "STRING", FLAGS.component["thirdparty"]["tag"]
         ),
     ]
 
-    cargs.append(cmake_core_enable("TRITON_ENABLE_LOGGING", FLAGS.enable_logging))
-    cargs.append(cmake_core_enable("TRITON_ENABLE_STATS", FLAGS.enable_stats))
-    cargs.append(cmake_core_enable("TRITON_ENABLE_METRICS", FLAGS.enable_metrics))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_LOGGING", 'logging' in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_STATS", 'stats' in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_METRICS", 'metrics' in FLAGS.feature))
     cargs.append(
-        cmake_core_enable("TRITON_ENABLE_METRICS_GPU", FLAGS.enable_gpu_metrics)
+        cmake_core_enable("TRITON_ENABLE_METRICS_GPU", 'gpu_metrics' in FLAGS.feature)
     )
     cargs.append(
-        cmake_core_enable("TRITON_ENABLE_METRICS_CPU", FLAGS.enable_cpu_metrics)
+        cmake_core_enable("TRITON_ENABLE_METRICS_CPU", 'cpu_metrics' in FLAGS.feature)
     )
-    cargs.append(cmake_core_enable("TRITON_ENABLE_TRACING", FLAGS.enable_tracing))
-    cargs.append(cmake_core_enable("TRITON_ENABLE_NVTX", FLAGS.enable_nvtx))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_TRACING", 'tracing' in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_NVTX", 'nvtx' in FLAGS.feature))
 
-    cargs.append(cmake_core_enable("TRITON_ENABLE_GPU", FLAGS.enable_gpu))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_GPU", 'gpu' in FLAGS.feature))
     cargs.append(
         cmake_core_arg(
             "TRITON_MIN_COMPUTE_CAPABILITY", None, FLAGS.min_compute_capability
         )
     )
 
-    cargs.append(cmake_core_enable("TRITON_ENABLE_MALI_GPU", FLAGS.enable_mali_gpu))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_MALI_GPU", 'mali_gpu' in FLAGS.feature))
 
     cargs.append(cmake_core_enable("TRITON_ENABLE_GRPC", "grpc" in FLAGS.endpoint))
     cargs.append(cmake_core_enable("TRITON_ENABLE_HTTP", "http" in FLAGS.endpoint))
@@ -443,8 +503,8 @@ def core_cmake_args(components, backends, cmake_dir, install_dir):
         )
     )
 
-    cargs.append(cmake_core_enable("TRITON_ENABLE_ENSEMBLE", "ensemble" in backends))
-    cargs.append(cmake_core_enable("TRITON_ENABLE_TENSORRT", "tensorrt" in backends))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_ENSEMBLE", "ensemble" in FLAGS.backend))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_TENSORRT", "tensorrt" in FLAGS.backend))
 
     cargs += cmake_core_extra_args()
     cargs.append(cmake_dir)
@@ -455,7 +515,7 @@ def repoagent_repo(ra):
     return "{}_repository_agent".format(ra)
 
 
-def repoagent_cmake_args(images, components, ra, install_dir):
+def repoagent_cmake_args(images, ra, install_dir):
     args = []
 
     cargs = args + [
@@ -464,11 +524,11 @@ def repoagent_cmake_args(images, components, ra, install_dir):
         cmake_repoagent_arg(
             "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
         ),
-        cmake_repoagent_arg("TRITON_COMMON_REPO_TAG", "STRING", components["common"]),
-        cmake_repoagent_arg("TRITON_CORE_REPO_TAG", "STRING", components["core"]),
+        cmake_repoagent_arg("TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
+        cmake_repoagent_arg("TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
     ]
 
-    cargs.append(cmake_repoagent_enable("TRITON_ENABLE_GPU", FLAGS.enable_gpu))
+    cargs.append(cmake_repoagent_enable("TRITON_ENABLE_GPU", "gpu" in FLAGS.feature))
     cargs += cmake_repoagent_extra_args()
     cargs.append("..")
     return cargs
@@ -479,7 +539,7 @@ def cache_repo(cache):
     return "{}_cache".format(cache)
 
 
-def cache_cmake_args(images, components, cache, install_dir):
+def cache_cmake_args(images, cache, install_dir):
     args = []
 
     cargs = args + [
@@ -488,11 +548,11 @@ def cache_cmake_args(images, components, cache, install_dir):
         cmake_cache_arg(
             "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
         ),
-        cmake_cache_arg("TRITON_COMMON_REPO_TAG", "STRING", components["common"]),
-        cmake_cache_arg("TRITON_CORE_REPO_TAG", "STRING", components["core"]),
+        cmake_cache_arg("TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
+        cmake_cache_arg("TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
     ]
 
-    cargs.append(cmake_cache_enable("TRITON_ENABLE_GPU", FLAGS.enable_gpu))
+    cargs.append(cmake_cache_enable("TRITON_ENABLE_GPU", 'gpu' in FLAGS.feature))
     cargs += cmake_cache_extra_args()
     cargs.append("..")
     return cargs
@@ -502,7 +562,7 @@ def backend_repo(be):
     return "{}_backend".format(be)
 
 
-def backend_cmake_args(images, components, be, install_dir, library_paths):
+def backend_cmake_args(images, be, install_dir, library_paths):
     cmake_build_type = FLAGS.build_type
 
     if be == "onnxruntime":
@@ -536,20 +596,20 @@ def backend_cmake_args(images, components, be, install_dir, library_paths):
         cmake_backend_arg(
             be, "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
         ),
-        cmake_backend_arg(be, "TRITON_COMMON_REPO_TAG", "STRING", components["common"]),
-        cmake_backend_arg(be, "TRITON_CORE_REPO_TAG", "STRING", components["core"]),
+        cmake_backend_arg(be, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
+        cmake_backend_arg(be, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
         cmake_backend_arg(
-            be, "TRITON_BACKEND_REPO_TAG", "STRING", components["backend"]
+            be, "TRITON_BACKEND_REPO_TAG", "STRING", FLAGS.component["backend"]["tag"]
         ),
     ]
 
-    cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_GPU", FLAGS.enable_gpu))
+    cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_GPU", 'gpu' in FLAGS.feature))
     cargs.append(
-        cmake_backend_enable(be, "TRITON_ENABLE_MALI_GPU", FLAGS.enable_mali_gpu)
+        cmake_backend_enable(be, "TRITON_ENABLE_MALI_GPU", 'mali_gpu' in FLAGS.feature)
     )
-    cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_STATS", FLAGS.enable_stats))
+    cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_STATS", 'stats' in FLAGS.feature))
     cargs.append(
-        cmake_backend_enable(be, "TRITON_ENABLE_METRICS", FLAGS.enable_metrics)
+        cmake_backend_enable(be, "TRITON_ENABLE_METRICS", 'metrics' in FLAGS.feature)
     )
 
     if target_platform() == "igpu":
@@ -557,7 +617,7 @@ def backend_cmake_args(images, components, be, install_dir, library_paths):
             "Warning: Detected iGPU build, backend utility 'device memory tracker' will be disabled as iGPU doesn't contain required version of the library."
         )
         cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_MEMORY_TRACKER", False))
-    elif FLAGS.enable_gpu:
+    elif 'gpu' in FLAGS.feature:
         cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_MEMORY_TRACKER", True))
 
     cargs += cmake_backend_extra_args(be)
@@ -593,12 +653,12 @@ def pytorch_cmake_args(images):
     # TODO: TPRD-372 TorchTRT extension is not currently supported by our manylinux build
     # TODO: TPRD-373 NVTX extension is not currently supported by our manylinux build
     if target_platform() != "rhel":
-        if FLAGS.enable_gpu:
+        if 'gpu' in FLAGS.feature:
             cargs.append(
                 cmake_backend_enable("pytorch", "TRITON_PYTORCH_ENABLE_TORCHTRT", True)
             )
         cargs.append(
-            cmake_backend_enable("pytorch", "TRITON_ENABLE_NVTX", FLAGS.enable_nvtx)
+            cmake_backend_enable("pytorch", "TRITON_ENABLE_NVTX", 'nvtx' in FLAGS.feature)
         )
         if target_platform() == "igpu":
             cargs.append(
@@ -620,7 +680,7 @@ def onnxruntime_cmake_args(images, library_paths):
     ]
 
     # TRITON_ENABLE_GPU is already set for all backends in backend_cmake_args()
-    if FLAGS.enable_gpu:
+    if 'gpu' in FLAGS.feature:
         # TODO: TPRD-712 TensorRT is not currently supported by our RHEL build for SBSA.
         if target_platform() != "rhel" or (
             target_platform() == "rhel" and target_machine() == "x86_64"
@@ -709,7 +769,7 @@ def openvino_cmake_args():
 
 def tensorrt_cmake_args():
     cargs = [
-        cmake_backend_enable("tensorrt", "TRITON_ENABLE_NVTX", FLAGS.enable_nvtx),
+        cmake_backend_enable("tensorrt", "TRITON_ENABLE_NVTX", 'nvtx' in FLAGS.feature),
     ]
 
     return cargs
@@ -939,7 +999,7 @@ RUN wget -O /tmp/boost.tar.gz {FLAGS.boost_url} \\
       && mv /tmp/boost_1_80_0/boost /usr/include/boost
 """
 
-    if FLAGS.enable_gpu:
+    if 'gpu' in FLAGS.feature:
         df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine())
     df += """
 ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
@@ -1052,7 +1112,7 @@ RUN wget -O /tmp/boost.tar.gz {FLAGS.boost_url} \\
       && mv /tmp/boost_1_80_0/boost /usr/include/boost
 """
 
-    if FLAGS.enable_gpu:
+    if 'gpu' in FLAGS.feature:
         df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine())
 
     df += """
@@ -1119,7 +1179,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 
 def create_dockerfile_linux(
-    ddir, dockerfile_name, argmap, backends, repoagents, caches, endpoints
+    ddir, dockerfile_name, argmap
 ):
     df = """
 ARG TRITON_VERSION={}
@@ -1128,7 +1188,7 @@ ARG TRITON_CONTAINER_VERSION={}
         argmap["TRITON_VERSION"],
         argmap["TRITON_CONTAINER_VERSION"],
     )
-    if "vllm" in backends and argmap["INFERENCE_IMAGE"] is None:
+    if "vllm" in FLAGS.backend and argmap["INFERENCE_IMAGE"] is None:
         argmap[
             "INFERENCE_IMAGE"
         ] = f"nvcr.io/nvidia/vllm:{FLAGS.upstream_container_version}-py3"
@@ -1142,7 +1202,7 @@ ARG TRITON_CONTAINER_VERSION={}
     # PyTorch backends need extra CUDA and other
     # dependencies during runtime that are missing in the CPU-only base container.
     # These dependencies must be copied from the Triton Min image.
-    if not FLAGS.enable_gpu and ("pytorch" in backends):
+    if not 'gpu' in FLAGS.feature and ("pytorch" in FLAGS.backend):
         df += """
 ############################################################################
 ##  Triton Min image
@@ -1163,7 +1223,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 """
 
     df += dockerfile_prepare_container_linux(
-        argmap, backends, FLAGS.enable_gpu, target_machine()
+        argmap, 'gpu' in FLAGS.feature, target_machine()
     )
 
     df += f"""
@@ -1182,7 +1242,7 @@ RUN pip3 install -r python/openai/requirements.txt
 """
     if not FLAGS.no_core_build:
         # Add feature labels for SageMaker endpoint
-        if "sagemaker" in endpoints:
+        if "sagemaker" in FLAGS.endpoint:
             df += """
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
@@ -1190,11 +1250,11 @@ COPY docker/sagemaker/serve /usr/bin/.
 """
     # This is required since libcublasLt.so is not present during the build
     # stage of the PyTorch backend
-    if not FLAGS.enable_gpu and ("pytorch" in backends):
+    if not 'gpu' in FLAGS.feature and ("pytorch" in FLAGS.backend):
         df += """
 RUN patchelf --add-needed /usr/local/cuda/lib64/stubs/libcublasLt.so.13 backends/pytorch/libtorch_cuda.so
 """
-    if "tensorrtllm" in backends:
+    if "tensorrtllm" in FLAGS.backend:
         df += """
 RUN ldconfig && \\
     find /opt/tritonserver -name lib*so -exec dirname {} \\; > /etc/ld.so.conf.d/tritonserver.conf && \\
@@ -1205,7 +1265,7 @@ RUN ldconfig && \\
         dfile.write(df)
 
 
-def dockerfile_prepare_container_linux(argmap, backends, enable_gpu, target_machine):
+def dockerfile_prepare_container_linux(argmap, enable_gpu, target_machine):
     gpu_enabled = 1 if enable_gpu else 0
     # Common steps to produce docker images shared by build.py and compose.py.
     # Sets environment variables, installs dependencies and adds entrypoint
@@ -1224,21 +1284,21 @@ ENV UCX_MEM_EVENTS no
 """
 
     # Necessary for libtorch.so to find correct HPCX libraries
-    if "pytorch" in backends:
+    if "pytorch" in FLAGS.backend:
         df += """
 ENV LD_LIBRARY_PATH /opt/hpcx/ucc/lib/:/opt/hpcx/ucx/lib/:${LD_LIBRARY_PATH}
 """
 
     backend_dependencies = ""
     # libgomp1 is needed by both onnxruntime and pytorch backends
-    if ("onnxruntime" in backends) or ("pytorch" in backends):
+    if ("onnxruntime" in FLAGS.backend) or ("pytorch" in FLAGS.backend):
         backend_dependencies = "libgomp1"
 
     # libgfortran5 is needed by pytorch backend on ARM
-    if ("pytorch" in backends) and (target_machine == "aarch64"):
+    if ("pytorch" in FLAGS.backend) and (target_machine == "aarch64"):
         backend_dependencies += " libgfortran5"
     # openssh-server is needed for fastertransformer
-    if "fastertransformer" in backends:
+    if "fastertransformer" in FLAGS.backend:
         backend_dependencies += " openssh-server"
 
     df += """
@@ -1315,10 +1375,10 @@ RUN apt-get update \\
 ENV TCMALLOC_RELEASE_RATE 200
 """
 
-    if "fastertransformer" in backends:
+    if "fastertransformer" in FLAGS.backend:
         be = "fastertransformer"
         url = "https://raw.githubusercontent.com/triton-inference-server/fastertransformer_backend/{}/docker/create_dockerfile_and_build.py".format(
-            backends[be]
+            FLAGS.backend[be]["tag"]
         )
         response = requests.get(url)
         spec = importlib.util.spec_from_loader(
@@ -1328,7 +1388,7 @@ ENV TCMALLOC_RELEASE_RATE 200
         exec(response.content, fastertransformer_buildscript.__dict__)
         df += fastertransformer_buildscript.create_postbuild(is_multistage_build=False)
 
-    if enable_gpu:
+    if 'gpu' in FLAGS.feature:
         df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine)
         # This segment will break the RHEL SBSA build. Need to determine whether
         # this is necessary to incorporate.
@@ -1341,10 +1401,10 @@ RUN ln -sf ${_CUDA_COMPAT_PATH}/lib.real ${_CUDA_COMPAT_PATH}/lib \\
     && rm -f ${_CUDA_COMPAT_PATH}/lib
 """
     else:
-        df += add_cpu_libs_to_linux_dockerfile(backends, target_machine)
+        df += add_cpu_libs_to_linux_dockerfile(target_machine)
 
     # Add dependencies needed for python backend
-    if "python" in backends:
+    if "python" in FLAGS.backend:
         if target_platform() == "rhel":
             df += """
 # python3, python3-pip and some pip installs required for the python backend
@@ -1379,7 +1439,7 @@ RUN apt-get update \\
             virtualenv \\
       && rm -rf /var/lib/apt/lists/*
 """
-    if "tensorrtllm" in backends or "vllm" in backends:
+    if "tensorrtllm" in FLAGS.backend or "vllm" in FLAGS.backend:
         df += """
 ENV TRITON_CUDACRT_PATH=/usr/local/cuda/include \\
     TRITON_CUDART_PATH=/usr/local/cuda/include \\
@@ -1389,7 +1449,7 @@ ENV TRITON_CUDACRT_PATH=/usr/local/cuda/include \\
     TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas
 """
 
-    if "dali" in backends:
+    if "dali" in FLAGS.backend:
         df += """
 # Update Python path to include DALI
 ENV PYTHONPATH=/opt/tritonserver/backends/dali/wheel/dali:$PYTHONPATH
@@ -1417,7 +1477,7 @@ COPY docker/entrypoint.d/ /opt/nvidia/entrypoint.d/
     # The CPU-only build uses ubuntu as the base image, and so the
     # entrypoint files are not available in /opt/nvidia in the base
     # image, so we must provide them ourselves.
-    if not enable_gpu:
+    if not 'gpu' in FLAGS.feature:
         df += """
 COPY docker/cpu_only/ /opt/nvidia/
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
@@ -1433,10 +1493,10 @@ LABEL com.nvidia.build.ref={}
     return df
 
 
-def add_cpu_libs_to_linux_dockerfile(backends, target_machine):
+def add_cpu_libs_to_linux_dockerfile(target_machine):
     df = ""
     libs_arch = "aarch64" if target_machine == "aarch64" else "x86_64"
-    if "pytorch" in backends:
+    if "pytorch" in FLAGS.backend:
         # Add extra dependencies for pytorch backend.
         # Note: Even though the build is CPU-only, the version of pytorch
         # we are using depend upon libraries like cuda and cudnn. Since
@@ -1480,7 +1540,7 @@ ENV LD_LIBRARY_PATH /usr/local/cuda/targets/{cuda_arch}-linux/lib:/usr/local/cud
             cuda_arch=cuda_arch, libs_arch=libs_arch
         )
 
-    if "pytorch" in backends:
+    if "pytorch" in FLAGS.backend:
         # Add NCCL dependency for pytorch backend.
         # Note: Even though the build is CPU-only, the version of
         # pytorch we are using depends upon the NCCL library.
@@ -1520,7 +1580,7 @@ ENV PYTHON_BIN_PATH=${{PYBIN}}/python${{PYVER}} PATH=${{PYBIN}}:${{PATH}}
 
 
 def create_build_dockerfiles(
-    container_build_dir, images, backends, repoagents, caches, endpoints
+    container_build_dir, images
 ):
     if "base" in images:
         base_image = images["base"]
@@ -1530,7 +1590,7 @@ def create_build_dockerfiles(
             )
     elif target_platform() == "rhel":
         raise KeyError("A base image must be specified when targeting RHEL")
-    elif FLAGS.enable_gpu:
+    elif 'gpu' in FLAGS.feature:
         base_image = "nvcr.io/nvidia/tritonserver:{}-py3-min".format(
             FLAGS.upstream_container_version
         )
@@ -1554,7 +1614,10 @@ def create_build_dockerfiles(
 
     # For CPU-only image we need to copy some cuda libraries and dependencies
     # since we are using PyTorch containers that are not CPU-only.
-    if not FLAGS.enable_gpu and ("pytorch" in backends):
+    if (
+        not 'gpu' in FLAGS.feature
+        and ("pytorch" in FLAGS.backend)
+    ):
         if "gpu-base" in images:
             gpu_base_image = images["gpu-base"]
         else:
@@ -1576,10 +1639,6 @@ def create_build_dockerfiles(
         FLAGS.build_dir,
         "Dockerfile",
         dockerfileargmap,
-        backends,
-        repoagents,
-        caches,
-        endpoints,
     )
 
     # Dockerfile used for the creating the CI base image.
@@ -1753,7 +1812,7 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
 
 
 def core_build(
-    cmake_script, repo_dir, cmake_dir, build_dir, install_dir, components, backends
+    cmake_script, repo_dir, cmake_dir, build_dir, install_dir
 ):
     repo_build_dir = os.path.join(build_dir, "tritonserver", "build")
     repo_install_dir = os.path.join(build_dir, "tritonserver", "install")
@@ -1764,7 +1823,7 @@ def core_build(
     cmake_script.mkdir(repo_build_dir)
     cmake_script.cwd(repo_build_dir)
     cmake_script.cmake(
-        core_cmake_args(components, backends, cmake_dir, repo_install_dir)
+        core_cmake_args(cmake_dir, repo_install_dir)
     )
     cmake_script.makeinstall()
 
@@ -1862,14 +1921,12 @@ def tensorrtllm_postbuild(cmake_script, repo_install_dir, tensorrtllm_be_dir):
 def backend_build(
     be,
     cmake_script,
-    tag_org,
     build_dir,
     install_dir,
     images,
-    components,
     library_paths,
 ):
-    tag, github_organization = tag_org
+    tag, github_organization = FLAGS.backend[be]["tag"], FLAGS.backend[be]["org"]
     repo_build_dir = os.path.join(build_dir, be, "build")
     repo_install_dir = os.path.join(build_dir, be, "install")
 
@@ -1879,11 +1936,10 @@ def backend_build(
     cmake_script.comment()
     cmake_script.mkdir(build_dir)
     cmake_script.cwd(build_dir)
+    repository_name = backend_repo(be)
     if be == "tensorrtllm":
         repository_name = "TensorRT-LLM"
-        cmake_script.gitclone(repository_name, tag, be, github_organization)
-    else:
-        cmake_script.gitclone(backend_repo(be), tag, be, github_organization)
+    cmake_script.gitclone(repository_name, tag, be, github_organization)
 
     if be == "tensorrtllm":
         tensorrtllm_prebuild(cmake_script)
@@ -1891,7 +1947,7 @@ def backend_build(
     cmake_script.mkdir(repo_build_dir)
     cmake_script.cwd(repo_build_dir)
     cmake_script.cmake(
-        backend_cmake_args(images, components, be, repo_install_dir, library_paths)
+        backend_cmake_args(images, be, repo_install_dir, library_paths)
     )
     cmake_script.makeinstall()
 
@@ -1927,11 +1983,10 @@ def backend_build(
 def backend_clone(
     be,
     clone_script,
-    tag_org,
     build_dir,
     install_dir,
 ):
-    tag, github_organization = tag_org
+    tag, github_organization = FLAGS.backend[be]["tag"], FLAGS.backend[be]["org"]
     clone_script.commentln(8)
     clone_script.comment(f"'{be}' backend")
     clone_script.comment("Delete this section to remove backend from build")
@@ -1962,7 +2017,7 @@ def backend_clone(
 
 
 def repo_agent_build(
-    ra, cmake_script, build_dir, install_dir, repoagent_repo, repoagents
+    ra, cmake_script, build_dir, install_dir
 ):
     repo_build_dir = os.path.join(build_dir, ra, "build")
     repo_install_dir = os.path.join(build_dir, ra, "install")
@@ -1974,12 +2029,12 @@ def repo_agent_build(
     cmake_script.mkdir(build_dir)
     cmake_script.cwd(build_dir)
     cmake_script.gitclone(
-        repoagent_repo(ra), repoagents[ra], ra, FLAGS.github_organization
+        repoagent_repo(ra), FLAGS.repoagent[ra]["tag"], ra, FLAGS.repoagent[ra]["org"]
     )
 
     cmake_script.mkdir(repo_build_dir)
     cmake_script.cwd(repo_build_dir)
-    cmake_script.cmake(repoagent_cmake_args(images, components, ra, repo_install_dir))
+    cmake_script.cmake(repoagent_cmake_args(images, ra, repo_install_dir))
     cmake_script.makeinstall()
 
     cmake_script.mkdir(os.path.join(install_dir, "repoagents"))
@@ -1994,7 +2049,7 @@ def repo_agent_build(
     cmake_script.blankln()
 
 
-def cache_build(cache, cmake_script, build_dir, install_dir, cache_repo, caches):
+def cache_build(cache, cmake_script, build_dir, install_dir):
     repo_build_dir = os.path.join(build_dir, cache, "build")
     repo_install_dir = os.path.join(build_dir, cache, "install")
 
@@ -2005,12 +2060,12 @@ def cache_build(cache, cmake_script, build_dir, install_dir, cache_repo, caches)
     cmake_script.mkdir(build_dir)
     cmake_script.cwd(build_dir)
     cmake_script.gitclone(
-        cache_repo(cache), caches[cache], cache, FLAGS.github_organization
+        cache_repo(cache), FLAGS.cache[cache]["tag"], cache, FLAGS.cache[cache]["org"]
     )
 
     cmake_script.mkdir(repo_build_dir)
     cmake_script.cwd(repo_build_dir)
-    cmake_script.cmake(cache_cmake_args(images, components, cache, repo_install_dir))
+    cmake_script.cmake(cache_cmake_args(images, cache, repo_install_dir))
     cmake_script.makeinstall()
 
     cmake_script.mkdir(os.path.join(install_dir, "caches"))
@@ -2026,7 +2081,7 @@ def cache_build(cache, cmake_script, build_dir, install_dir, cache_repo, caches)
 
 
 def cibase_build(
-    cmake_script, repo_dir, cmake_dir, build_dir, install_dir, ci_dir, backends
+    cmake_script, repo_dir, cmake_dir, build_dir, install_dir, ci_dir
 ):
     repo_install_dir = os.path.join(build_dir, "tritonserver", "install")
 
@@ -2088,7 +2143,7 @@ def cibase_build(
 
     # The onnxruntime_backend build produces some artifacts that
     # are needed for CI testing.
-    if "onnxruntime" in backends:
+    if "onnxruntime" in FLAGS.backend:
         ort_install_dir = os.path.join(build_dir, "onnxruntime", "install")
         cmake_script.mkdir(os.path.join(ci_dir, "qa", "L0_custom_ops"))
         if target_platform() != "igpu":
@@ -2108,7 +2163,7 @@ def cibase_build(
     # rebuilt with specific options.
     cmake_script.mkdir(os.path.join(ci_dir, "tritonbuild"))
     for be in ("identity", "python"):
-        if be in backends:
+        if be in FLAGS.backend:
             cmake_script.rmdir(os.path.join(build_dir, be, "build"))
             cmake_script.rmdir(os.path.join(build_dir, be, "install"))
             cmake_script.cpdir(
@@ -2126,8 +2181,8 @@ def finalize_build(cmake_script, install_dir, ci_dir):
     cmake_script.cmd(f"chmod -R u+rwX,go+rX,go-w {ci_dir}")
 
 
-def enable_all():
-    all_backends = [
+def enable_all(default):
+    FLAGS.backend = [
         "ensemble",
         "identity",
         "square",
@@ -2140,55 +2195,23 @@ def enable_all():
         "fil",
         "tensorrt",
     ]
-    all_repoagents = ["checksum"]
-    all_caches = ["local", "redis"]
-    all_filesystems = ["gcs", "s3", "azure_storage"]
-    all_endpoints = ["http", "grpc", "sagemaker", "vertex-ai"]
+    FLAGS.repoagent = ["checksum"]
+    FLAGS.cache = ["local", "redis"]
+    FLAGS.filesystem = ["gcs", "s3", "azure_storage"]
+    FLAGS.endpoint = ["http", "grpc", "sagemaker", "vertex-ai"]
+    FLAGS.feature = ["logging", "stats", "metrics", "gpu_metrics", "cpu_metrics", "tracing", "nvtx", "gpu"]
 
-    FLAGS.enable_logging = True
-    FLAGS.enable_stats = True
-    FLAGS.enable_metrics = True
-    FLAGS.enable_gpu_metrics = True
-    FLAGS.enable_cpu_metrics = True
-    FLAGS.enable_tracing = True
-    FLAGS.enable_nvtx = True
-    FLAGS.enable_gpu = True
+    FLAGS.component = ["common", "core", "backend", "thirdparty"]
 
-    requested_backends = []
-    for be in FLAGS.backend:
-        parts = be.split(":")
-        requested_backends += [parts[0]]
-    for be in all_backends:
-        if be not in requested_backends:
-            FLAGS.backend += [be]
-
-    requested_repoagents = []
-    for ra in FLAGS.repoagent:
-        parts = ra.split(":")
-        requested_repoagents += [parts[0]]
-    for ra in all_repoagents:
-        if ra not in requested_repoagents:
-            FLAGS.repoagent += [ra]
-
-    requested_caches = []
-    for cache in FLAGS.cache:
-        parts = cache.split(":")
-        requested_caches += [parts[0]]
-    for cache in all_caches:
-        if cache not in requested_caches:
-            FLAGS.cache += [cache]
-
-    for fs in all_filesystems:
-        if fs not in FLAGS.filesystem:
-            FLAGS.filesystem += [fs]
-
-    for ep in all_endpoints:
-        if ep not in FLAGS.endpoint:
-            FLAGS.endpoint += [ep]
-
+    # populate default values as independent objects
+    for element in ELEMENTS:
+        attr = getattr(FLAGS, element)
+        setattr(FLAGS, element, {key: default(element) for key in attr})
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
 
     group_qv = parser.add_mutually_exclusive_group()
     group_qv.add_argument(
@@ -2246,7 +2269,8 @@ if __name__ == "__main__":
         "--target-platform",
         required=False,
         default=None,
-        help='Target platform for build, can be "linux", "rhel" or "igpu". If not specified, build targets the current platform.',
+        choices=["linux","rhel","igpu"],
+        help='Target platform for build. If not specified, build targets the current platform.',
     )
     parser.add_argument(
         "--target-machine",
@@ -2288,20 +2312,23 @@ if __name__ == "__main__":
         type=str,
         required=False,
         default="/tmp",
-        help="Temporary directory used for building inside docker. Default is /tmp.",
+        help="Temporary directory used for building inside docker.",
     )
     parser.add_argument(
         "--library-paths",
         action="append",
+        metavar=("<backend>","<library_path>"),
+        nargs=2,
         required=False,
-        default=None,
-        help="Specify library paths for respective backends in build as <backend-name>[:<library_path>].",
+        default=[],
+        help="Specify library paths for given backend in build.",
     )
     parser.add_argument(
         "--build-type",
         required=False,
         default="Release",
-        help='Build type, one of "Release", "Debug", "RelWithDebInfo" or "MinSizeRel". Default is "Release".',
+        choices=["Release","Debug","RelWithDebInfo","MinSizeRel"],
+        help='Build type.',
     )
     parser.add_argument(
         "-j",
@@ -2317,7 +2344,7 @@ if __name__ == "__main__":
         type=str,
         required=False,
         default="https://github.com/triton-inference-server",
-        help='The GitHub organization containing the repos used for the build. Defaults to "https://github.com/triton-inference-server".',
+        help='The GitHub organization containing the repos used for the build.',
     )
     parser.add_argument(
         "--version",
@@ -2346,8 +2373,11 @@ if __name__ == "__main__":
     parser.add_argument(
         "--image",
         action="append",
+        metavar=("<image-name>","<full-image-name>"),
+        nargs=2,
         required=False,
-        help='Use specified Docker image in build as <image-name>,<full-image-name>. <image-name> can be "base", "gpu-base", or "pytorch".',
+        default=[],
+        help='Use specified Docker image in build. <image-name> can be "base", "gpu-base", or "pytorch".',
     )
     parser.add_argument(
         "--use-buildbase",
@@ -2360,50 +2390,64 @@ if __name__ == "__main__":
         "--enable-all",
         action="store_true",
         required=False,
-        help="Enable all standard released Triton features, backends, repository agents, caches, endpoints and file systems.",
+        help="Enable all standard released Triton features, backends, repository agents, caches, endpoints, and file systems.",
     )
-    parser.add_argument(
-        "--enable-logging", action="store_true", required=False, help="Enable logging."
-    )
-    parser.add_argument(
-        "--enable-stats",
-        action="store_true",
-        required=False,
-        help="Enable statistics collection.",
-    )
-    parser.add_argument(
-        "--enable-metrics",
-        action="store_true",
-        required=False,
-        help="Enable metrics reporting.",
-    )
-    parser.add_argument(
-        "--enable-gpu-metrics",
-        action="store_true",
-        required=False,
-        help="Include GPU metrics in reported metrics.",
-    )
-    parser.add_argument(
-        "--enable-cpu-metrics",
-        action="store_true",
-        required=False,
-        help="Include CPU metrics in reported metrics.",
-    )
-    parser.add_argument(
-        "--enable-tracing", action="store_true", required=False, help="Enable tracing."
-    )
-    parser.add_argument(
-        "--enable-nvtx", action="store_true", required=False, help="Enable NVTX."
-    )
-    parser.add_argument(
-        "--enable-gpu", action="store_true", required=False, help="Enable GPU support."
-    )
-    parser.add_argument(
-        "--enable-mali-gpu",
-        action="store_true",
-        required=False,
-        help="Enable ARM MALI GPU support.",
-    )
+
+    element_groups = {}
+    for element, properties in ELEMENTS.items():
+        if 'strict' in properties:
+            kwargs = {'choices': ELEMENTS_LISTS[element]}
+            help_list = ', '.join(ELEMENTS_LISTS[element])
+        else:
+            kwargs = {}
+            help_list = ', '.join(ELEMENTS_LISTS[element]+['...'])
+
+        group = parser.add_argument_group(
+            element,
+            f"Options to configure {element}s, including: {help_list}",
+        )
+        element_groups[element] = group
+
+        if not 'required' in properties:
+            group.add_argument(
+                f"--enable-{element}",
+                metavar=f"<{element}>",
+                action="append",
+                required=False,
+                default=[],
+                help=f"Enable requested {element}",
+                **kwargs
+            )
+            group.add_argument(
+                f"--disable-{element}",
+                metavar=f"<{element}>",
+                action="append",
+                required=False,
+                default=[],
+                help=f"Disable requested {element} (remove from --enable-all standard list)",
+                **kwargs
+            )
+        if 'tag' in properties:
+            group.add_argument(
+                f"--{element}-tag",
+                action="append",
+                metavar=(f"<{element}>","<tag>"),
+                nargs=2,
+                required=False,
+                default=[],
+                help=f'Select <tag> for specified <{element}>. If <tag> starts with "pull/" then it refers to a pull-request reference, otherwise <tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <tag> is "main" (e.g. version YY.MMdev -> branch main).',
+            )
+        if 'org' in properties:
+            group.add_argument(
+                f"--{element}-org",
+                action="append",
+                metavar=(f"<{element}>","<org>"),
+                nargs=2,
+                required=False,
+                default=[],
+                help=f'Select <org> for specified <{element}>, to use the fork of the corresponding repository from <org> instead of the default --github-organization value.',
+            )
+
     parser.add_argument(
         "--min-compute-capability",
         type=str,
@@ -2413,46 +2457,10 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--endpoint",
-        action="append",
-        required=False,
-        help='Include specified endpoint in build. Allowed values are "grpc", "http", "vertex-ai" and "sagemaker".',
-    )
-    parser.add_argument(
-        "--filesystem",
-        action="append",
-        required=False,
-        help='Include specified filesystem in build. Allowed values are "gcs", "azure_storage" and "s3".',
-    )
-    parser.add_argument(
         "--no-core-build",
         action="store_true",
         required=False,
         help="Do not build Triton core shared library or executable.",
-    )
-    parser.add_argument(
-        "--backend",
-        action="append",
-        required=False,
-        help='Include specified backend in build as <backend-name>[:<repo-tag>][:<org>]. If <repo-tag> starts with "pull/" then it refers to a pull-request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main). <org> allows using a forked repository instead of the default --github-organization value.',
-    )
-    parser.add_argument(
-        "--repo-tag",
-        action="append",
-        required=False,
-        help='The version of a component to use in the build as <component-name>:<repo-tag>. <component-name> can be "common", "core", "backend" or "thirdparty". <repo-tag> indicates the git tag/branch to use for the build. Currently <repo-tag> does not support pull-request reference. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).',
-    )
-    parser.add_argument(
-        "--repoagent",
-        action="append",
-        required=False,
-        help='Include specified repo agent in build as <repoagent-name>[:<repo-tag>]. If <repo-tag> starts with "pull/" then it refers to a pull-request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).',
-    )
-    parser.add_argument(
-        "--cache",
-        action="append",
-        required=False,
-        help='Include specified cache in build as <cache-name>[:<repo-tag>]. If <repo-tag> starts with "pull/" then it refers to a pull-request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).',
     )
     parser.add_argument(
         "--no-force-clone",
@@ -2463,26 +2471,38 @@ if __name__ == "__main__":
     parser.add_argument(
         "--extra-core-cmake-arg",
         action="append",
+        metavar=("<name>","<value>"),
+        nargs=2,
         required=False,
-        help="Extra CMake argument as <name>=<value>. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments added by build.py for the core builds.",
+        default=[],
+        help="Extra CMake argument. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments added by build.py for the core builds.",
     )
     parser.add_argument(
         "--override-core-cmake-arg",
         action="append",
+        metavar=("<name>","<value>"),
+        nargs=2,
         required=False,
-        help="Override specified CMake argument in the build as <name>=<value>. The argument is passed to CMake as -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the core build use --extra-core-cmake-arg.",
+        default=[],
+        help="Override specified CMake argument in the build. The argument is passed to CMake as -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the core build use --extra-core-cmake-arg.",
     )
     parser.add_argument(
         "--extra-backend-cmake-arg",
         action="append",
+        metavar=("<backend>","<name>","<value>"),
+        nargs=3,
         required=False,
-        help="Extra CMake argument for a backend build as <backend>:<name>=<value>. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments added by build.py for the backend.",
+        default=[],
+        help="Extra CMake argument for a backend build. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments added by build.py for the backend.",
     )
     parser.add_argument(
         "--override-backend-cmake-arg",
         action="append",
+        metavar=("<backend>","<name>","<value>"),
+        nargs=3,
         required=False,
-        help="Override specified backend CMake argument in the build as <backend>:<name>=<value>. The argument is passed to CMake as -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the backend build use --extra-backend-cmake-arg.",
+        default=[],
+        help="Override specified backend CMake argument in the build. The argument is passed to CMake as -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the backend build use --extra-backend-cmake-arg.",
     )
     parser.add_argument(
         "--release-version",
@@ -2544,6 +2564,7 @@ if __name__ == "__main__":
         required=False,
         nargs=2,
         metavar=("key", "value"),
+        default=[],
         help="Add build secrets in the form of <key> <value>. These secrets are used during the build process for vllm. The secrets are passed to the Docker build step as `--secret id=<key>`. The following keys are expected and their purposes are described below:\n\n"
         "  - 'req': A file containing a list of dependencies for pip (e.g., requirements.txt).\n"
         "  - 'build_public_vllm': A flag (default is 'true') indicating whether to build the public VLLM version.\n\n"
@@ -2558,33 +2579,6 @@ if __name__ == "__main__":
     )
     FLAGS = parser.parse_args()
 
-    if FLAGS.image is None:
-        FLAGS.image = []
-    if FLAGS.repo_tag is None:
-        FLAGS.repo_tag = []
-    if FLAGS.backend is None:
-        FLAGS.backend = []
-    if FLAGS.endpoint is None:
-        FLAGS.endpoint = []
-    if FLAGS.filesystem is None:
-        FLAGS.filesystem = []
-    if FLAGS.repoagent is None:
-        FLAGS.repoagent = []
-    if FLAGS.cache is None:
-        FLAGS.cache = []
-    if FLAGS.library_paths is None:
-        FLAGS.library_paths = []
-    if FLAGS.extra_core_cmake_arg is None:
-        FLAGS.extra_core_cmake_arg = []
-    if FLAGS.override_core_cmake_arg is None:
-        FLAGS.override_core_cmake_arg = []
-    if FLAGS.override_backend_cmake_arg is None:
-        FLAGS.override_backend_cmake_arg = []
-    if FLAGS.extra_backend_cmake_arg is None:
-        FLAGS.extra_backend_cmake_arg = []
-    if FLAGS.build_secret is None:
-        FLAGS.build_secret = []
-
     FLAGS.boost_url = os.getenv(
         "TRITON_BOOST_URL",
         "https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz",
@@ -2592,10 +2586,6 @@ if __name__ == "__main__":
     FLAGS.boost_sha256 = (
         "4b2136f98bdd1f5857f1c3dea9ac2018effe65286cf251534b6ae20cc45e1847"
     )
-    # if --enable-all is specified, then update FLAGS to enable all
-    # settings, backends, repo-agents, caches, file systems, endpoints, etc.
-    if FLAGS.enable_all:
-        enable_all()
 
     # When doing a docker build, --build-dir, --install-dir and
     # --cmake-dir must not be set. We will use the build/ subdir
@@ -2656,69 +2646,99 @@ if __name__ == "__main__":
     log("container version {}".format(FLAGS.container_version))
     log("upstream container version {}".format(FLAGS.upstream_container_version))
 
-    for ep in FLAGS.endpoint:
-        log(f'endpoint "{ep}"')
-    for fs in FLAGS.filesystem:
-        log(f'filesystem "{fs}"')
-
-    # Initialize map of backends to build and repo-tag for each.
-    backends = {}
-    for be in FLAGS.backend:
-        pattern = r"(https?:\/\/[^\s:]+)|:"
-        parts = list(filter(None,re.split(pattern, be)))
-        if len(parts) == 1:
-            parts.append(default_repo_tag)
-        if len(parts) == 2:
-            parts.append(FLAGS.github_organization)
-        log('backend "{}" at tag/branch "{}" from org "{}"'.format(parts[0], parts[1], parts[2]))
-        backends[parts[0]] = parts[1:]
-
-    if "vllm" in backends:
-        if "python" not in backends:
-            log(
-                "vLLM backend requires Python backend, adding Python backend with tag {}".format(
-                    backends["vllm"]
-                )
-            )
-            backends["python"] = backends["vllm"]
-
     secrets = dict(getattr(FLAGS, "build_secret", []))
     if secrets:
         requirements = secrets.get("req", "")
         build_public_vllm = secrets.get("build_public_vllm", "true")
         log('Build Arg for BUILD_PUBLIC_VLLM: "{}"'.format(build_public_vllm))
 
-    # Initialize map of repo agents to build and repo-tag for each.
-    repoagents = {}
-    for be in FLAGS.repoagent:
-        parts = be.split(":")
-        if len(parts) == 1:
-            parts.append(default_repo_tag)
-        log('repoagent "{}" at tag/branch "{}"'.format(parts[0], parts[1]))
-        repoagents[parts[0]] = parts[1]
+    # initialize element maps
+    def default_element_dict(element):
+        default = {}
+        if "tag" in ELEMENTS[element]:
+            default["tag"] = default_repo_tag
+        if "org" in ELEMENTS[element]:
+            default["org"] = FLAGS.github_organization
+        return default
+    for element, properties in ELEMENTS.items():
+        setattr(FLAGS, f"{element}", {})
+        attr = getattr(FLAGS, f"{element}")
+        # populate the required ones
+        if 'required' in properties:
+            for value in ELEMENTS_LISTS[element]:
+                attr[value] = default_element_dict(element)
 
-    # Initialize map of caches to build and repo-tag for each.
-    caches = {}
-    for be in FLAGS.cache:
-        parts = be.split(":")
-        if len(parts) == 1:
-            parts.append(default_repo_tag)
-        log('cache "{}" at tag/branch "{}"'.format(parts[0], parts[1]))
-        caches[parts[0]] = parts[1]
+    # if --enable-all is specified, then update FLAGS to enable all
+    # settings, backends, repo-agents, caches, file systems, endpoints, etc.
+    if FLAGS.enable_all:
+        enable_all(default_element_dict)
+
+    # Process per-element information
+    def do_enable(element, map, key):
+        if key not in map:
+            map[key] = default_element_dict(element)
+    def do_disable(element, map, key):
+        if key in map:
+            map.pop(key)
+    def do_tag(element, map, key, value):
+        map[key]["tag"] = value
+    def do_org(element, map, key, value):
+        map[key]["org"] = value
+    attr_fns = {
+        "enable": do_enable,
+        "disable": do_disable,
+        "tag": do_tag,
+        "org": do_org,
+    }
+    for element in ELEMENTS:
+        map = getattr(FLAGS, element)
+        attr_names = [f"enable_{element}", f"disable_{element}", f"{element}_tag", f"{element}_org"]
+        for attr_name in attr_names:
+            attr = getattr(FLAGS, attr_name, None)
+            if not attr: continue
+            attr_fn = attr_fns[attr_name.replace(element,"").replace("_","")]
+            for item in attr:
+                if not isinstance(item, list): item = [item]
+                attr_fn(element, map, *item)
+
+    # Handle special cases
+    if "vllm" in FLAGS.backend:
+        if "python" not in FLAGS.backend:
+            log(
+                "vLLM backend requires Python backend, adding Python backend with tag {}, org {}".format(
+                    FLAGS.backend["vllm"]["tag"], FLAGS.backend["vllm"]["org"]
+                )
+            )
+            FLAGS.backend["python"] = FLAGS.backend["vllm"]
+
+    # If armnn_tflite backend, source from external repo for git clone
+    if "armnn_tflite" in FLAGS.backend:
+        if FLAGS.backend["armnn_tflite"]["org"] == FLAGS.github_organization:
+            FLAGS.backend["armnn_tflite"]["org"] = "https://gitlab.com/arm-research/smarter/"
+
+    if "tensorrtllm" in FLAGS.backend:
+        if FLAGS.backend["tensorrtllm"]["org"] == FLAGS.github_organization:
+            FLAGS.backend["tensorrtllm"]["org"] = "https://github.com/NVIDIA"
+
+    # Print final element info
+    for element in ELEMENTS:
+        map = getattr(FLAGS, element)
+        for key, info in map.items():
+            log(' '.join(filter(None, [
+                f'{element} "{key}"',
+                'at tag/branch "{}"'.format(info["tag"]) if "tag" in info else "",
+                'from org "{}"'.format(info["org"]) if "org" in info else "",
+            ])))
 
     # Initialize map of docker images.
     images = {}
-    for img in FLAGS.image:
-        parts = img.split(",")
+    for key,val in FLAGS.image:
         fail_if(
-            len(parts) != 2, "--image must specify <image-name>,<full-image-registry>"
-        )
-        fail_if(
-            parts[0] not in ["base", "gpu-base", "pytorch", "inference"],
+            key not in ["base", "gpu-base", "pytorch", "inference"],
             "unsupported value for --image",
         )
-        log('image "{}": "{}"'.format(parts[0], parts[1]))
-        images[parts[0]] = parts[1]
+        log('image "{}": "{}"'.format(key, val))
+        images[key] = val
     if FLAGS.use_buildbase:
         images["buildbase"] = "tritonserver_buildbase"
     else:
@@ -2727,90 +2747,38 @@ if __name__ == "__main__":
 
     # Initialize map of library paths for each backend.
     library_paths = {}
-    for lpath in FLAGS.library_paths:
-        parts = lpath.split(":")
-        if len(parts) == 2:
-            log('backend "{}" library path "{}"'.format(parts[0], parts[1]))
-            library_paths[parts[0]] = parts[1]
+    for key,val in FLAGS.library_paths:
+        log('backend "{}" library path "{}"'.format(parts[0], parts[1]))
+        library_paths[key] = val
 
     # Parse any explicitly specified cmake arguments
-    for cf in FLAGS.extra_core_cmake_arg:
-        parts = cf.split("=")
-        fail_if(len(parts) != 2, "--extra-core-cmake-arg must specify <name>=<value>")
-        log('CMake core extra "-D{}={}"'.format(parts[0], parts[1]))
-        EXTRA_CORE_CMAKE_FLAGS[parts[0]] = parts[1]
+    for key,val in FLAGS.extra_core_cmake_arg:
+        log('CMake core extra "-D{}={}"'.format(key, val))
+        EXTRA_CORE_CMAKE_FLAGS[key] = val
 
-    for cf in FLAGS.override_core_cmake_arg:
-        parts = cf.split("=")
-        fail_if(
-            len(parts) != 2, "--override-core-cmake-arg must specify <name>=<value>"
-        )
-        log('CMake core override "-D{}={}"'.format(parts[0], parts[1]))
-        OVERRIDE_CORE_CMAKE_FLAGS[parts[0]] = parts[1]
+    for key,val in FLAGS.override_core_cmake_arg:
+        log('CMake core override "-D{}={}"'.format(key, val))
+        OVERRIDE_CORE_CMAKE_FLAGS[key] = val
 
-    for cf in FLAGS.extra_backend_cmake_arg:
-        parts = cf.split(":", 1)
+    for be,key,val in FLAGS.extra_backend_cmake_arg:
         fail_if(
-            len(parts) != 2,
-            "--extra-backend-cmake-arg must specify <backend>:<name>=<value>",
+            be not in FLAGS.backend,
+            f'--extra-backend-cmake-arg specifies backend "{be}" which is not included in build',
         )
-        be = parts[0]
-        parts = parts[1].split("=", 1)
-        fail_if(
-            len(parts) != 2,
-            "--extra-backend-cmake-arg must specify <backend>:<name>=<value>",
-        )
-        fail_if(
-            be not in backends,
-            '--extra-backend-cmake-arg specifies backend "{}" which is not included in build'.format(
-                be
-            ),
-        )
-        log('backend "{}" CMake extra "-D{}={}"'.format(be, parts[0], parts[1]))
+        log('backend "{}" CMake extra "-D{}={}"'.format(be, key, val))
         if be not in EXTRA_BACKEND_CMAKE_FLAGS:
             EXTRA_BACKEND_CMAKE_FLAGS[be] = {}
-        EXTRA_BACKEND_CMAKE_FLAGS[be][parts[0]] = parts[1]
+        EXTRA_BACKEND_CMAKE_FLAGS[be][key] = val
 
-    for cf in FLAGS.override_backend_cmake_arg:
-        parts = cf.split(":", 1)
+    for be,key,val in FLAGS.override_backend_cmake_arg:
         fail_if(
-            len(parts) != 2,
-            "--override-backend-cmake-arg must specify <backend>:<name>=<value>",
+            be not in FLAGS.backend,
+            f'--override-backend-cmake-arg specifies backend "{be}" which is not included in build',
         )
-        be = parts[0]
-        parts = parts[1].split("=", 1)
-        fail_if(
-            len(parts) != 2,
-            "--override-backend-cmake-arg must specify <backend>:<name>=<value>",
-        )
-        fail_if(
-            be not in backends,
-            '--override-backend-cmake-arg specifies backend "{}" which is not included in build'.format(
-                be
-            ),
-        )
-        log('backend "{}" CMake override "-D{}={}"'.format(be, parts[0], parts[1]))
+        log('backend "{}" CMake override "-D{}={}"'.format(be, key, val))
         if be not in OVERRIDE_BACKEND_CMAKE_FLAGS:
             OVERRIDE_BACKEND_CMAKE_FLAGS[be] = {}
-        OVERRIDE_BACKEND_CMAKE_FLAGS[be][parts[0]] = parts[1]
-
-    # Initialize map of common components and repo-tag for each.
-    components = {
-        "common": default_repo_tag,
-        "core": default_repo_tag,
-        "backend": default_repo_tag,
-        "thirdparty": default_repo_tag,
-    }
-    for be in FLAGS.repo_tag:
-        parts = be.split(":")
-        fail_if(len(parts) != 2, "--repo-tag must specify <component-name>:<repo-tag>")
-        fail_if(
-            parts[0] not in components,
-            '--repo-tag <component-name> must be "common", "core", "backend", or "thirdparty"',
-        )
-        components[parts[0]] = parts[1]
-    for c in components:
-        log('component "{}" at tag/branch "{}"'.format(c, components[c]))
+        OVERRIDE_BACKEND_CMAKE_FLAGS[be][key] = [val]
 
     # Set the build, install, and cmake directories to use for the
     # generated build scripts and Dockerfiles. If building without
@@ -2850,27 +2818,18 @@ if __name__ == "__main__":
                 script_cmake_dir,
                 script_build_dir,
                 script_install_dir,
-                components,
-                backends,
             )
 
         # Commands to build each backend...
-        for be in backends:
+        for be in FLAGS.backend:
             # Core backends are not built separately from core so skip...
             if be in CORE_BACKENDS:
                 continue
-
-            # If armnn_tflite backend, source from external repo for git clone
-            if be == "armnn_tflite":
-                github_organization = "https://gitlab.com/arm-research/smarter/"
-            else:
-                github_organization = FLAGS.github_organization
 
             if be == "vllm":
                 backend_clone(
                     be,
                     cmake_script,
-                    backends[be],
                     script_build_dir,
                     script_install_dir,
                 )
@@ -2878,34 +2837,28 @@ if __name__ == "__main__":
                 backend_build(
                     be,
                     cmake_script,
-                    backends[be],
                     script_build_dir,
                     script_install_dir,
                     images,
-                    components,
                     library_paths,
                 )
 
         # Commands to build each repo agent...
-        for ra in repoagents:
+        for ra in FLAGS.repoagent:
             repo_agent_build(
                 ra,
                 cmake_script,
                 script_build_dir,
                 script_install_dir,
-                repoagent_repo,
-                repoagents,
             )
 
         # Commands to build each cache...
-        for cache in caches:
+        for cache in FLAGS.cache:
             cache_build(
                 cache,
                 cmake_script,
                 script_build_dir,
                 script_install_dir,
-                cache_repo,
-                caches,
             )
 
         # Commands needed only when building with Docker...
@@ -2919,7 +2872,6 @@ if __name__ == "__main__":
                 script_build_dir,
                 script_install_dir,
                 script_ci_dir,
-                backends,
             )
 
             # When building with Docker the install and ci artifacts
@@ -2936,9 +2888,7 @@ if __name__ == "__main__":
     if not FLAGS.no_container_build:
         script_name = "docker_build"
 
-        create_build_dockerfiles(
-            script_build_dir, images, backends, repoagents, caches, FLAGS.endpoint
-        )
+        create_build_dockerfiles(script_build_dir, images)
         create_docker_build_script(script_name, script_install_dir, script_ci_dir)
 
     # In not dry-run, execute the script to perform the build...  If a

--- a/build.py
+++ b/build.py
@@ -92,7 +92,7 @@ OVERRIDE_BACKEND_CMAKE_FLAGS = {}
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
 ELEMENTS = {
-    'backend': ['tag', 'org'],
+    'backend': ['tag', 'org', 'lib'],
     'repoagent': ['tag', 'org'],
     'cache': ['tag', 'org'],
     'filesystem': ['strict'],
@@ -561,11 +561,11 @@ def backend_repo(be):
     return "{}_backend".format(be)
 
 
-def backend_cmake_args(images, be, install_dir, library_paths):
+def backend_cmake_args(images, be, install_dir):
     cmake_build_type = FLAGS.build_type
 
     if be == "onnxruntime":
-        args = onnxruntime_cmake_args(images, library_paths)
+        args = onnxruntime_cmake_args(images)
     elif be == "openvino":
         args = openvino_cmake_args()
     elif be == "python":
@@ -666,7 +666,7 @@ def pytorch_cmake_args(images):
     return cargs
 
 
-def onnxruntime_cmake_args(images, library_paths):
+def onnxruntime_cmake_args(images):
     cargs = [
         cmake_backend_arg(
             "onnxruntime",
@@ -1923,7 +1923,6 @@ def backend_build(
     build_dir,
     install_dir,
     images,
-    library_paths,
 ):
     tag, github_organization = FLAGS.backend[be]["tag"], FLAGS.backend[be]["org"]
     repo_build_dir = os.path.join(build_dir, be, "build")
@@ -1946,7 +1945,7 @@ def backend_build(
     cmake_script.mkdir(repo_build_dir)
     cmake_script.cwd(repo_build_dir)
     cmake_script.cmake(
-        backend_cmake_args(images, be, repo_install_dir, library_paths)
+        backend_cmake_args(images, be, repo_install_dir)
     )
     cmake_script.makeinstall()
 
@@ -2314,15 +2313,6 @@ if __name__ == "__main__":
         help="Temporary directory used for building inside docker.",
     )
     parser.add_argument(
-        "--library-paths",
-        action="append",
-        metavar=("<backend>","<library_path>"),
-        nargs=2,
-        required=False,
-        default=[],
-        help="Specify library paths for given backend in build.",
-    )
-    parser.add_argument(
         "--build-type",
         required=False,
         default="Release",
@@ -2445,6 +2435,16 @@ if __name__ == "__main__":
                 required=False,
                 default=[],
                 help=f'Select <org> for specified <{element}>, to use the fork of the corresponding repository from <org> instead of the default --github-organization value.',
+            )
+        if 'lib' in properties:
+            group.add_argument(
+                f"--{element}-library-path",
+                action="append",
+                metavar=(f"<{element}>","<library_path>"),
+                nargs=2,
+                required=False,
+                default=[],
+                help=f'Specify library paths for specified <{element}> in build.',
             )
 
     parser.add_argument(
@@ -2683,15 +2683,18 @@ if __name__ == "__main__":
         map[key]["tag"] = value
     def do_org(element, map, key, value):
         map[key]["org"] = value
+    def do_lib(element, map, key, value):
+        map[key]["lib"] = value
     attr_fns = {
         "enable": do_enable,
         "disable": do_disable,
         "tag": do_tag,
         "org": do_org,
+        "library_path": do_lib,
     }
     for element in ELEMENTS:
         map = getattr(FLAGS, element)
-        attr_names = [f"enable_{element}", f"disable_{element}", f"{element}_tag", f"{element}_org"]
+        attr_names = [f"enable_{element}", f"disable_{element}", f"{element}_tag", f"{element}_org", f"{element}_library_path"]
         for attr_name in attr_names:
             attr = getattr(FLAGS, attr_name, None)
             if not attr: continue
@@ -2727,6 +2730,7 @@ if __name__ == "__main__":
                 f'{element} "{key}"',
                 'at tag/branch "{}"'.format(info["tag"]) if "tag" in info else "",
                 'from org "{}"'.format(info["org"]) if "org" in info else "",
+                'with library path "{}"'.format(info["lib"]) if "lib" in info else "",
             ])))
 
     # Initialize map of docker images.
@@ -2743,12 +2747,6 @@ if __name__ == "__main__":
     else:
         if "base" in images:
             images["buildbase"] = images["base"]
-
-    # Initialize map of library paths for each backend.
-    library_paths = {}
-    for key,val in FLAGS.library_paths:
-        log('backend "{}" library path "{}"'.format(parts[0], parts[1]))
-        library_paths[key] = val
 
     # Parse any explicitly specified cmake arguments
     for key,val in FLAGS.extra_core_cmake_arg:
@@ -2839,7 +2837,6 @@ if __name__ == "__main__":
                     script_build_dir,
                     script_install_dir,
                     images,
-                    library_paths,
                 )
 
         # Commands to build each repo agent...

--- a/build.py
+++ b/build.py
@@ -92,7 +92,7 @@ OVERRIDE_BACKEND_CMAKE_FLAGS = {}
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
 ELEMENTS = {
-    'backend': ['tag', 'org'],
+    'backend': ['tag', 'org', 'cmake'],
     'repoagent': ['tag', 'org'],
     'cache': ['tag', 'org'],
     'filesystem': ['strict'],
@@ -349,10 +349,7 @@ def cmake_core_arg(name, type, value):
     # command-line specified value if one is given.
     if name in OVERRIDE_CORE_CMAKE_FLAGS:
         value = OVERRIDE_CORE_CMAKE_FLAGS[name]
-    if type is None:
-        type = ""
-    else:
-        type = ":{}".format(type)
+    type = ":{}".format(type) if type else ""
     return '"-D{}{}={}"'.format(name, type, value)
 
 
@@ -360,11 +357,7 @@ def cmake_core_enable(name, flag):
     # Return cmake -D setting to set name=flag?ON:OFF for core
     # build. Use command-line specified value for 'flag' if one is
     # given.
-    if name in OVERRIDE_CORE_CMAKE_FLAGS:
-        value = OVERRIDE_CORE_CMAKE_FLAGS[name]
-    else:
-        value = "ON" if flag else "OFF"
-    return '"-D{}:BOOL={}"'.format(name, value)
+    return cmake_core_arg(name, "BOOL", "ON" if flag else "OFF")
 
 
 def cmake_core_extra_args():
@@ -374,46 +367,47 @@ def cmake_core_extra_args():
     return args
 
 
-def cmake_backend_arg(backend, name, type, value):
-    # Return cmake -D setting to set name=value for backend build. Use
+def cmake_element_arg(element, element_val, name, type, value):
+    # Return cmake -D setting to set name=value for <element> build. Use
     # command-line specified value if one is given.
-    if backend in OVERRIDE_BACKEND_CMAKE_FLAGS:
-        if name in OVERRIDE_BACKEND_CMAKE_FLAGS[backend]:
-            value = OVERRIDE_BACKEND_CMAKE_FLAGS[backend][name]
-    if type is None:
-        type = ""
-    else:
-        type = ":{}".format(type)
+    element_flags = getattr(FLAGS, element)
+    if "cmake_override" in element_flags[element_val]:
+        value = element_flags[element_val]["cmake_override"].get(name, value)
+    type = ":{}".format(type) if type else ""
     return '"-D{}{}={}"'.format(name, type, value)
 
 
-def cmake_backend_enable(backend, name, flag):
-    # Return cmake -D setting to set name=flag?ON:OFF for backend
+def cmake_backend_arg(*args, **kwargs):
+    return cmake_element_arg('backend', *args, **kwargs)
+
+
+def cmake_element_enable(element, element_val, name, flag):
+    # Return cmake -D setting to set name=flag?ON:OFF for <element>
     # build. Use command-line specified value for 'flag' if one is
     # given.
-    value = None
-    if backend in OVERRIDE_BACKEND_CMAKE_FLAGS:
-        if name in OVERRIDE_BACKEND_CMAKE_FLAGS[backend]:
-            value = OVERRIDE_BACKEND_CMAKE_FLAGS[backend][name]
-    if value is None:
-        value = "ON" if flag else "OFF"
-    return '"-D{}:BOOL={}"'.format(name, value)
+    return cmake_element_arg(element, element_val, name, "BOOL", "ON" if flag else "OFF")
 
 
-def cmake_backend_extra_args(backend):
+def cmake_backend_enable(*args, **kwargs):
+    return cmake_element_enable('backend', *args, **kwargs)
+
+
+def cmake_element_extra_args(element, element_val):
     args = []
-    if backend in EXTRA_BACKEND_CMAKE_FLAGS:
-        for k, v in EXTRA_BACKEND_CMAKE_FLAGS[backend].items():
+    element_flags = getattr(FLAGS, element)
+    if "cmake_extra" in element_flags[element_val]:
+        for k, v in element_flags[element_val]["cmake_extra"].items():
             args.append('"-D{}={}"'.format(k, v))
     return args
 
 
+def cmake_backend_extra_args(backend):
+    return cmake_element_extra_args('backend', backend)
+
+
 def cmake_repoagent_arg(name, type, value):
     # For now there is no override for repo-agents
-    if type is None:
-        type = ""
-    else:
-        type = ":{}".format(type)
+    type = ":{}".format(type) if type else ""
     return '"-D{}{}={}"'.format(name, type, value)
 
 
@@ -431,10 +425,7 @@ def cmake_repoagent_extra_args():
 
 def cmake_cache_arg(name, type, value):
     # For now there is no override for caches
-    if type is None:
-        type = ""
-    else:
-        type = ":{}".format(type)
+    type = ":{}".format(type) if type else ""
     return '"-D{}{}={}"'.format(name, type, value)
 
 
@@ -2382,6 +2373,34 @@ if __name__ == "__main__":
         help="Enable all standard released Triton features, backends, repository agents, caches, endpoints, and file systems.",
     )
 
+    def add_cmake_args(element, parser):
+        dependent_kwargs = dict(
+            nargs=3,
+            metavar=(f"<{element}>","<name>","<value>"),
+        )
+        if element=="core":
+            # "core" is a special case: it is already a specific component, so no need to select a specific instance of its element type
+            dependent_kwargs = dict(
+                nargs=2,
+                metavar=("<name>","<value>"),
+            )
+        parser.add_argument(
+            f"--extra-{element}-cmake-arg",
+            action="append",
+            required=False,
+            default=[],
+            help=f"Extra CMake argument for {element} build. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments added by build.py.",
+            **dependent_kwargs
+        )
+        parser.add_argument(
+            f"--override-{element}-cmake-arg",
+            action="append",
+            required=False,
+            default=[],
+            help=f"Override specified backend CMake argument in the {element} build. The argument is passed to CMake as -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the {element} build use --extra-{element}-cmake-arg.",
+            **dependent_kwargs
+        )
+
     element_groups = {}
     for element, properties in ELEMENTS.items():
         if 'strict' in properties:
@@ -2436,6 +2455,11 @@ if __name__ == "__main__":
                 default=[],
                 help=f'Select <org> for specified <{element}>, to use the fork of the corresponding repository from <org> instead of the default --github-organization value.',
             )
+        if 'cmake' in properties:
+            add_cmake_args(element, group)
+
+    # special case
+    add_cmake_args("core", element_groups["component"])
 
     parser.add_argument(
         "--min-compute-capability",
@@ -2456,42 +2480,6 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Do not create fresh clones of repos that have already been cloned.",
-    )
-    parser.add_argument(
-        "--extra-core-cmake-arg",
-        action="append",
-        metavar=("<name>","<value>"),
-        nargs=2,
-        required=False,
-        default=[],
-        help="Extra CMake argument. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments added by build.py for the core builds.",
-    )
-    parser.add_argument(
-        "--override-core-cmake-arg",
-        action="append",
-        metavar=("<name>","<value>"),
-        nargs=2,
-        required=False,
-        default=[],
-        help="Override specified CMake argument in the build. The argument is passed to CMake as -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the core build use --extra-core-cmake-arg.",
-    )
-    parser.add_argument(
-        "--extra-backend-cmake-arg",
-        action="append",
-        metavar=("<backend>","<name>","<value>"),
-        nargs=3,
-        required=False,
-        default=[],
-        help="Extra CMake argument for a backend build. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments added by build.py for the backend.",
-    )
-    parser.add_argument(
-        "--override-backend-cmake-arg",
-        action="append",
-        metavar=("<backend>","<name>","<value>"),
-        nargs=3,
-        required=False,
-        default=[],
-        help="Override specified backend CMake argument in the build. The argument is passed to CMake as -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the backend build use --extra-backend-cmake-arg.",
     )
     parser.add_argument(
         "--release-version",
@@ -2648,6 +2636,9 @@ if __name__ == "__main__":
             default["tag"] = default_repo_tag
         if "org" in ELEMENTS[element]:
             default["org"] = FLAGS.github_organization
+        if "cmake" in ELEMENTS[element]:
+            default["cmake_extra"] = {}
+            default["cmake_override"] = {}
         return default
     for element, properties in ELEMENTS.items():
         setattr(FLAGS, f"{element}", {})
@@ -2673,15 +2664,24 @@ if __name__ == "__main__":
         map[key]["tag"] = value
     def do_org(element, map, key, value):
         map[key]["org"] = value
+    def do_cmake_extra(element, map, key, name, value):
+        map[key]["cmake_extra"][name] = value
+    def do_cmake_override(element, map, key, name, value):
+        map[key]["cmake_override"][name] = value
     attr_fns = {
         "enable": do_enable,
         "disable": do_disable,
         "tag": do_tag,
         "org": do_org,
+        "extracmakearg": do_cmake_extra,
+        "overridecmakearg": do_cmake_override,
     }
     for element in ELEMENTS:
         map = getattr(FLAGS, element)
-        attr_names = [f"enable_{element}", f"disable_{element}", f"{element}_tag", f"{element}_org"]
+        attr_names = [
+            f"enable_{element}", f"disable_{element}", f"{element}_tag", f"{element}_org",
+            f"extra_{element}_cmake_arg", f"override_{element}_cmake_arg",
+        ]
         for attr_name in attr_names:
             attr = getattr(FLAGS, attr_name, None)
             if not attr: continue
@@ -2710,6 +2710,8 @@ if __name__ == "__main__":
             FLAGS.backend["tensorrtllm"]["org"] = "https://github.com/NVIDIA"
 
     # Print final element info
+    def format_cmake_args(args):
+        return ', '.join(['"-D{}={}"'.format(n,v) for n,v in args.items()])
     for element in ELEMENTS:
         map = getattr(FLAGS, element)
         for key, info in map.items():
@@ -2718,6 +2720,20 @@ if __name__ == "__main__":
                 'at tag/branch "{}"'.format(info["tag"]) if "tag" in info else "",
                 'from org "{}"'.format(info["org"]) if "org" in info else "",
             ])))
+            if any(["cmake" in prop for prop in info]):
+                cmake_extra_str = format_cmake_args(info["cmake_extra"]) if "cmake_extra" in info else ""
+                if cmake_extra_str: log('  CMake extra: '+cmake_extra_str)
+                cmake_override_str = format_cmake_args(info["cmake_override"]) if "cmake_override" in info else ""
+                if cmake_override_str: log('  CMake override: '+cmake_override_str)
+
+    # Parse any explicitly specified cmake arguments
+    for key,val in FLAGS.extra_core_cmake_arg:
+        log('core: CMake extra "-D{}={}"'.format(key, val))
+        EXTRA_CORE_CMAKE_FLAGS[key] = val
+
+    for key,val in FLAGS.override_core_cmake_arg:
+        log('core: CMake override "-D{}={}"'.format(key, val))
+        OVERRIDE_CORE_CMAKE_FLAGS[key] = val
 
     # Initialize map of docker images.
     images = {}
@@ -2733,35 +2749,6 @@ if __name__ == "__main__":
     else:
         if "base" in images:
             images["buildbase"] = images["base"]
-
-    # Parse any explicitly specified cmake arguments
-    for key,val in FLAGS.extra_core_cmake_arg:
-        log('CMake core extra "-D{}={}"'.format(key, val))
-        EXTRA_CORE_CMAKE_FLAGS[key] = val
-
-    for key,val in FLAGS.override_core_cmake_arg:
-        log('CMake core override "-D{}={}"'.format(key, val))
-        OVERRIDE_CORE_CMAKE_FLAGS[key] = val
-
-    for be,key,val in FLAGS.extra_backend_cmake_arg:
-        fail_if(
-            be not in FLAGS.backend,
-            f'--extra-backend-cmake-arg specifies backend "{be}" which is not included in build',
-        )
-        log('backend "{}" CMake extra "-D{}={}"'.format(be, key, val))
-        if be not in EXTRA_BACKEND_CMAKE_FLAGS:
-            EXTRA_BACKEND_CMAKE_FLAGS[be] = {}
-        EXTRA_BACKEND_CMAKE_FLAGS[be][key] = val
-
-    for be,key,val in FLAGS.override_backend_cmake_arg:
-        fail_if(
-            be not in FLAGS.backend,
-            f'--override-backend-cmake-arg specifies backend "{be}" which is not included in build',
-        )
-        log('backend "{}" CMake override "-D{}={}"'.format(be, key, val))
-        if be not in OVERRIDE_BACKEND_CMAKE_FLAGS:
-            OVERRIDE_BACKEND_CMAKE_FLAGS[be] = {}
-        OVERRIDE_BACKEND_CMAKE_FLAGS[be][key] = [val]
 
     # Set the build, install, and cmake directories to use for the
     # generated build scripts and Dockerfiles. If building without

--- a/build.py
+++ b/build.py
@@ -630,10 +630,10 @@ def onnxruntime_cmake_args(images, library_paths):
                 )
             )
 
-    if "base" in images:
+    if "buildbase" in images:
         cargs.append(
             cmake_backend_arg(
-                "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["base"]
+                "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["buildbase"]
             )
         )
     else:
@@ -688,10 +688,10 @@ def openvino_cmake_args():
             FLAGS.standalone_openvino_version,
         )
     ]
-    if "base" in images:
+    if "buildbase" in images:
         cargs.append(
             cmake_backend_arg(
-                "openvino", "TRITON_BUILD_CONTAINER", None, images["base"]
+                "openvino", "TRITON_BUILD_CONTAINER", None, images["buildbase"]
             )
         )
     else:
@@ -722,9 +722,9 @@ def dali_cmake_args():
 
 def fil_cmake_args(images):
     cargs = [cmake_backend_enable("fil", "TRITON_FIL_DOCKER_BUILD", True)]
-    if "base" in images:
+    if "buildbase" in images:
         cargs.append(
-            cmake_backend_arg("fil", "TRITON_BUILD_CONTAINER", None, images["base"])
+            cmake_backend_arg("fil", "TRITON_BUILD_CONTAINER", None, images["buildbase"])
         )
     else:
         cargs.append(
@@ -2348,6 +2348,12 @@ if __name__ == "__main__":
         required=False,
         help='Use specified Docker image in build as <image-name>,<full-image-name>. <image-name> can be "base", "gpu-base", or "pytorch".',
     )
+    parser.add_argument(
+        "--use-buildbase",
+        default=False,
+        action="store_true",
+        help='Use local temporary "buildbase" Docker image as "base" image to build backends',
+    )
 
     parser.add_argument(
         "--enable-all",
@@ -2709,6 +2715,11 @@ if __name__ == "__main__":
         )
         log('image "{}": "{}"'.format(parts[0], parts[1]))
         images[parts[0]] = parts[1]
+    if FLAGS.use_buildbase:
+        images["buildbase"] = "tritonserver_buildbase"
+    else:
+        if "base" in images:
+            images["buildbase"] = images["base"]
 
     # Initialize map of library paths for each backend.
     library_paths = {}

--- a/build.py
+++ b/build.py
@@ -92,13 +92,13 @@ OVERRIDE_BACKEND_CMAKE_FLAGS = {}
 THIS_SCRIPT_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
 
 ELEMENTS = {
-    'backend': ['tag', 'org', 'cmake'],
-    'repoagent': ['tag', 'org', 'cmake'],
-    'cache': ['tag', 'org', 'cmake'],
-    'filesystem': ['strict'],
-    'endpoint': ['strict'],
-    'feature': ['strict'],
-    'component': ['tag', 'strict', 'required'],
+    "backend": ["tag", "org", "cmake"],
+    "repoagent": ["tag", "org", "cmake"],
+    "cache": ["tag", "org", "cmake"],
+    "filesystem": ["strict"],
+    "endpoint": ["strict"],
+    "feature": ["strict"],
+    "component": ["tag", "strict", "required"],
 }
 
 ELEMENTS_LISTS = {
@@ -151,6 +151,7 @@ ELEMENTS_LISTS = {
         "thirdparty",
     ],
 }
+
 
 def log(msg, force=False):
     if force or not FLAGS.quiet:
@@ -378,18 +379,20 @@ def cmake_element_arg(element, element_val, name, type, value):
 
 
 def cmake_backend_arg(*args, **kwargs):
-    return cmake_element_arg('backend', *args, **kwargs)
+    return cmake_element_arg("backend", *args, **kwargs)
 
 
 def cmake_element_enable(element, element_val, name, flag):
     # Return cmake -D setting to set name=flag?ON:OFF for <element>
     # build. Use command-line specified value for 'flag' if one is
     # given.
-    return cmake_element_arg(element, element_val, name, "BOOL", "ON" if flag else "OFF")
+    return cmake_element_arg(
+        element, element_val, name, "BOOL", "ON" if flag else "OFF"
+    )
 
 
 def cmake_backend_enable(*args, **kwargs):
-    return cmake_element_enable('backend', *args, **kwargs)
+    return cmake_element_enable("backend", *args, **kwargs)
 
 
 def cmake_element_extra_args(element, element_val):
@@ -402,31 +405,31 @@ def cmake_element_extra_args(element, element_val):
 
 
 def cmake_backend_extra_args(backend):
-    return cmake_element_extra_args('backend', backend)
+    return cmake_element_extra_args("backend", backend)
 
 
 def cmake_repoagent_arg(*args, **kwargs):
-    return cmake_element_arg('repoagent', *args, **kwargs)
+    return cmake_element_arg("repoagent", *args, **kwargs)
 
 
 def cmake_repoagent_enable(*args, **kwargs):
-    return cmake_element_enable('repoagent', *args, **kwargs)
+    return cmake_element_enable("repoagent", *args, **kwargs)
 
 
 def cmake_repoagent_extra_args(repoagent):
-    return cmake_element_extra_args('repoagent', repoagent)
+    return cmake_element_extra_args("repoagent", repoagent)
 
 
 def cmake_cache_arg(*args, **kwargs):
-    return cmake_element_arg('cache', *args, **kwargs)
+    return cmake_element_arg("cache", *args, **kwargs)
 
 
 def cmake_cache_enable(*args, **kwargs):
-    return cmake_element_enable('cache', *args, **kwargs)
+    return cmake_element_enable("cache", *args, **kwargs)
 
 
 def cmake_cache_extra_args(cache):
-    return cmake_element_extra_args('cache', cache)
+    return cmake_element_extra_args("cache", cache)
 
 
 def core_cmake_args(cmake_dir, install_dir):
@@ -435,34 +438,44 @@ def core_cmake_args(cmake_dir, install_dir):
         cmake_core_arg("CMAKE_INSTALL_PREFIX", "PATH", install_dir),
         cmake_core_arg("TRITON_VERSION", "STRING", FLAGS.version),
         cmake_core_arg("TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization),
-        cmake_core_arg("TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
-        cmake_core_arg("TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
-        cmake_core_arg("TRITON_BACKEND_REPO_TAG", "STRING", FLAGS.component["backend"]["tag"]),
         cmake_core_arg(
-            "TRITON_THIRD_PARTY_REPO_TAG", "STRING", FLAGS.component["thirdparty"]["tag"]
+            "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]
+        ),
+        cmake_core_arg(
+            "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]
+        ),
+        cmake_core_arg(
+            "TRITON_BACKEND_REPO_TAG", "STRING", FLAGS.component["backend"]["tag"]
+        ),
+        cmake_core_arg(
+            "TRITON_THIRD_PARTY_REPO_TAG",
+            "STRING",
+            FLAGS.component["thirdparty"]["tag"],
         ),
     ]
 
-    cargs.append(cmake_core_enable("TRITON_ENABLE_LOGGING", 'logging' in FLAGS.feature))
-    cargs.append(cmake_core_enable("TRITON_ENABLE_STATS", 'stats' in FLAGS.feature))
-    cargs.append(cmake_core_enable("TRITON_ENABLE_METRICS", 'metrics' in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_LOGGING", "logging" in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_STATS", "stats" in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_METRICS", "metrics" in FLAGS.feature))
     cargs.append(
-        cmake_core_enable("TRITON_ENABLE_METRICS_GPU", 'gpu_metrics' in FLAGS.feature)
+        cmake_core_enable("TRITON_ENABLE_METRICS_GPU", "gpu_metrics" in FLAGS.feature)
     )
     cargs.append(
-        cmake_core_enable("TRITON_ENABLE_METRICS_CPU", 'cpu_metrics' in FLAGS.feature)
+        cmake_core_enable("TRITON_ENABLE_METRICS_CPU", "cpu_metrics" in FLAGS.feature)
     )
-    cargs.append(cmake_core_enable("TRITON_ENABLE_TRACING", 'tracing' in FLAGS.feature))
-    cargs.append(cmake_core_enable("TRITON_ENABLE_NVTX", 'nvtx' in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_TRACING", "tracing" in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_NVTX", "nvtx" in FLAGS.feature))
 
-    cargs.append(cmake_core_enable("TRITON_ENABLE_GPU", 'gpu' in FLAGS.feature))
+    cargs.append(cmake_core_enable("TRITON_ENABLE_GPU", "gpu" in FLAGS.feature))
     cargs.append(
         cmake_core_arg(
             "TRITON_MIN_COMPUTE_CAPABILITY", None, FLAGS.min_compute_capability
         )
     )
 
-    cargs.append(cmake_core_enable("TRITON_ENABLE_MALI_GPU", 'mali_gpu' in FLAGS.feature))
+    cargs.append(
+        cmake_core_enable("TRITON_ENABLE_MALI_GPU", "mali_gpu" in FLAGS.feature)
+    )
 
     cargs.append(cmake_core_enable("TRITON_ENABLE_GRPC", "grpc" in FLAGS.endpoint))
     cargs.append(cmake_core_enable("TRITON_ENABLE_HTTP", "http" in FLAGS.endpoint))
@@ -481,8 +494,12 @@ def core_cmake_args(cmake_dir, install_dir):
         )
     )
 
-    cargs.append(cmake_core_enable("TRITON_ENABLE_ENSEMBLE", "ensemble" in FLAGS.backend))
-    cargs.append(cmake_core_enable("TRITON_ENABLE_TENSORRT", "tensorrt" in FLAGS.backend))
+    cargs.append(
+        cmake_core_enable("TRITON_ENABLE_ENSEMBLE", "ensemble" in FLAGS.backend)
+    )
+    cargs.append(
+        cmake_core_enable("TRITON_ENABLE_TENSORRT", "tensorrt" in FLAGS.backend)
+    )
 
     cargs += cmake_core_extra_args()
     cargs.append(cmake_dir)
@@ -502,11 +519,17 @@ def repoagent_cmake_args(images, ra, install_dir):
         cmake_repoagent_arg(
             ra, "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
         ),
-        cmake_repoagent_arg(ra, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
-        cmake_repoagent_arg(ra, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
+        cmake_repoagent_arg(
+            ra, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]
+        ),
+        cmake_repoagent_arg(
+            ra, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]
+        ),
     ]
 
-    cargs.append(cmake_repoagent_enable(ra, "TRITON_ENABLE_GPU", "gpu" in FLAGS.feature))
+    cargs.append(
+        cmake_repoagent_enable(ra, "TRITON_ENABLE_GPU", "gpu" in FLAGS.feature)
+    )
     cargs += cmake_repoagent_extra_args(ra)
     cargs.append("..")
     return cargs
@@ -526,11 +549,15 @@ def cache_cmake_args(images, cache, install_dir):
         cmake_cache_arg(
             cache, "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
         ),
-        cmake_cache_arg(cache, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
-        cmake_cache_arg(cache, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
+        cmake_cache_arg(
+            cache, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]
+        ),
+        cmake_cache_arg(
+            cache, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]
+        ),
     ]
 
-    cargs.append(cmake_cache_enable(cache, "TRITON_ENABLE_GPU", 'gpu' in FLAGS.feature))
+    cargs.append(cmake_cache_enable(cache, "TRITON_ENABLE_GPU", "gpu" in FLAGS.feature))
     cargs += cmake_cache_extra_args(cache)
     cargs.append("..")
     return cargs
@@ -574,20 +601,26 @@ def backend_cmake_args(images, be, install_dir):
         cmake_backend_arg(
             be, "TRITON_REPO_ORGANIZATION", "STRING", FLAGS.github_organization
         ),
-        cmake_backend_arg(be, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]),
-        cmake_backend_arg(be, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]),
+        cmake_backend_arg(
+            be, "TRITON_COMMON_REPO_TAG", "STRING", FLAGS.component["common"]["tag"]
+        ),
+        cmake_backend_arg(
+            be, "TRITON_CORE_REPO_TAG", "STRING", FLAGS.component["core"]["tag"]
+        ),
         cmake_backend_arg(
             be, "TRITON_BACKEND_REPO_TAG", "STRING", FLAGS.component["backend"]["tag"]
         ),
     ]
 
-    cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_GPU", 'gpu' in FLAGS.feature))
+    cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_GPU", "gpu" in FLAGS.feature))
     cargs.append(
-        cmake_backend_enable(be, "TRITON_ENABLE_MALI_GPU", 'mali_gpu' in FLAGS.feature)
+        cmake_backend_enable(be, "TRITON_ENABLE_MALI_GPU", "mali_gpu" in FLAGS.feature)
     )
-    cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_STATS", 'stats' in FLAGS.feature))
     cargs.append(
-        cmake_backend_enable(be, "TRITON_ENABLE_METRICS", 'metrics' in FLAGS.feature)
+        cmake_backend_enable(be, "TRITON_ENABLE_STATS", "stats" in FLAGS.feature)
+    )
+    cargs.append(
+        cmake_backend_enable(be, "TRITON_ENABLE_METRICS", "metrics" in FLAGS.feature)
     )
 
     if target_platform() == "igpu":
@@ -595,7 +628,7 @@ def backend_cmake_args(images, be, install_dir):
             "Warning: Detected iGPU build, backend utility 'device memory tracker' will be disabled as iGPU doesn't contain required version of the library."
         )
         cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_MEMORY_TRACKER", False))
-    elif 'gpu' in FLAGS.feature:
+    elif "gpu" in FLAGS.feature:
         cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_MEMORY_TRACKER", True))
 
     cargs += cmake_backend_extra_args(be)
@@ -631,12 +664,14 @@ def pytorch_cmake_args(images):
     # TODO: TPRD-372 TorchTRT extension is not currently supported by our manylinux build
     # TODO: TPRD-373 NVTX extension is not currently supported by our manylinux build
     if target_platform() != "rhel":
-        if 'gpu' in FLAGS.feature:
+        if "gpu" in FLAGS.feature:
             cargs.append(
                 cmake_backend_enable("pytorch", "TRITON_PYTORCH_ENABLE_TORCHTRT", True)
             )
         cargs.append(
-            cmake_backend_enable("pytorch", "TRITON_ENABLE_NVTX", 'nvtx' in FLAGS.feature)
+            cmake_backend_enable(
+                "pytorch", "TRITON_ENABLE_NVTX", "nvtx" in FLAGS.feature
+            )
         )
         if target_platform() == "igpu":
             cargs.append(
@@ -658,7 +693,7 @@ def onnxruntime_cmake_args(images):
     ]
 
     # TRITON_ENABLE_GPU is already set for all backends in backend_cmake_args()
-    if 'gpu' in FLAGS.feature:
+    if "gpu" in FLAGS.feature:
         # TODO: TPRD-712 TensorRT is not currently supported by our RHEL build for SBSA.
         if target_platform() != "rhel" or (
             target_platform() == "rhel" and target_machine() == "x86_64"
@@ -747,7 +782,7 @@ def openvino_cmake_args():
 
 def tensorrt_cmake_args():
     cargs = [
-        cmake_backend_enable("tensorrt", "TRITON_ENABLE_NVTX", 'nvtx' in FLAGS.feature),
+        cmake_backend_enable("tensorrt", "TRITON_ENABLE_NVTX", "nvtx" in FLAGS.feature),
     ]
 
     return cargs
@@ -763,7 +798,9 @@ def fil_cmake_args(images):
     cargs = [cmake_backend_enable("fil", "TRITON_FIL_DOCKER_BUILD", True)]
     if "buildbase" in images:
         cargs.append(
-            cmake_backend_arg("fil", "TRITON_BUILD_CONTAINER", None, images["buildbase"])
+            cmake_backend_arg(
+                "fil", "TRITON_BUILD_CONTAINER", None, images["buildbase"]
+            )
         )
     else:
         cargs.append(
@@ -977,7 +1014,7 @@ RUN wget -O /tmp/boost.tar.gz {FLAGS.boost_url} \\
       && mv /tmp/boost_1_80_0/boost /usr/include/boost
 """
 
-    if 'gpu' in FLAGS.feature:
+    if "gpu" in FLAGS.feature:
         df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine())
     df += """
 ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
@@ -1090,7 +1127,7 @@ RUN wget -O /tmp/boost.tar.gz {FLAGS.boost_url} \\
       && mv /tmp/boost_1_80_0/boost /usr/include/boost
 """
 
-    if 'gpu' in FLAGS.feature:
+    if "gpu" in FLAGS.feature:
         df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine())
 
     df += """
@@ -1156,9 +1193,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
         dfile.write(df)
 
 
-def create_dockerfile_linux(
-    ddir, dockerfile_name, argmap
-):
+def create_dockerfile_linux(ddir, dockerfile_name, argmap):
     df = """
 ARG TRITON_VERSION={}
 ARG TRITON_CONTAINER_VERSION={}
@@ -1180,7 +1215,7 @@ ARG TRITON_CONTAINER_VERSION={}
     # PyTorch backends need extra CUDA and other
     # dependencies during runtime that are missing in the CPU-only base container.
     # These dependencies must be copied from the Triton Min image.
-    if not 'gpu' in FLAGS.feature and ("pytorch" in FLAGS.backend):
+    if not "gpu" in FLAGS.feature and ("pytorch" in FLAGS.backend):
         df += """
 ############################################################################
 ##  Triton Min image
@@ -1201,7 +1236,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
 """
 
     df += dockerfile_prepare_container_linux(
-        argmap, 'gpu' in FLAGS.feature, target_machine()
+        argmap, "gpu" in FLAGS.feature, target_machine()
     )
 
     df += f"""
@@ -1228,7 +1263,7 @@ COPY docker/sagemaker/serve /usr/bin/.
 """
     # This is required since libcublasLt.so is not present during the build
     # stage of the PyTorch backend
-    if not 'gpu' in FLAGS.feature and ("pytorch" in FLAGS.backend):
+    if not "gpu" in FLAGS.feature and ("pytorch" in FLAGS.backend):
         df += """
 RUN patchelf --add-needed /usr/local/cuda/lib64/stubs/libcublasLt.so.13 backends/pytorch/libtorch_cuda.so
 """
@@ -1366,7 +1401,7 @@ ENV TCMALLOC_RELEASE_RATE 200
         exec(response.content, fastertransformer_buildscript.__dict__)
         df += fastertransformer_buildscript.create_postbuild(is_multistage_build=False)
 
-    if 'gpu' in FLAGS.feature:
+    if "gpu" in FLAGS.feature:
         df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine)
         # This segment will break the RHEL SBSA build. Need to determine whether
         # this is necessary to incorporate.
@@ -1455,7 +1490,7 @@ COPY docker/entrypoint.d/ /opt/nvidia/entrypoint.d/
     # The CPU-only build uses ubuntu as the base image, and so the
     # entrypoint files are not available in /opt/nvidia in the base
     # image, so we must provide them ourselves.
-    if not 'gpu' in FLAGS.feature:
+    if not "gpu" in FLAGS.feature:
         df += """
 COPY docker/cpu_only/ /opt/nvidia/
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
@@ -1568,7 +1603,7 @@ def create_build_dockerfiles(
             )
     elif target_platform() == "rhel":
         raise KeyError("A base image must be specified when targeting RHEL")
-    elif 'gpu' in FLAGS.feature:
+    elif "gpu" in FLAGS.feature:
         base_image = "nvcr.io/nvidia/tritonserver:{}-py3-min".format(
             FLAGS.upstream_container_version
         )
@@ -1593,7 +1628,7 @@ def create_build_dockerfiles(
     # For CPU-only image we need to copy some cuda libraries and dependencies
     # since we are using PyTorch containers that are not CPU-only.
     if (
-        not 'gpu' in FLAGS.feature
+        not "gpu" in FLAGS.feature
         and ("pytorch" in FLAGS.backend)
     ):
         if "gpu-base" in images:
@@ -1789,9 +1824,7 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         docker_script.cmd(cibaseargs, check_exitcode=True)
 
 
-def core_build(
-    cmake_script, repo_dir, cmake_dir, build_dir, install_dir
-):
+def core_build(cmake_script, repo_dir, cmake_dir, build_dir, install_dir):
     repo_build_dir = os.path.join(build_dir, "tritonserver", "build")
     repo_install_dir = os.path.join(build_dir, "tritonserver", "install")
 
@@ -1800,9 +1833,7 @@ def core_build(
     cmake_script.comment()
     cmake_script.mkdir(repo_build_dir)
     cmake_script.cwd(repo_build_dir)
-    cmake_script.cmake(
-        core_cmake_args(cmake_dir, repo_install_dir)
-    )
+    cmake_script.cmake(core_cmake_args(cmake_dir, repo_install_dir))
     cmake_script.makeinstall()
 
     if target_platform() == "rhel":
@@ -1923,9 +1954,7 @@ def backend_build(
 
     cmake_script.mkdir(repo_build_dir)
     cmake_script.cwd(repo_build_dir)
-    cmake_script.cmake(
-        backend_cmake_args(images, be, repo_install_dir)
-    )
+    cmake_script.cmake(backend_cmake_args(images, be, repo_install_dir))
     cmake_script.makeinstall()
 
     if be == "tensorrtllm":
@@ -1993,9 +2022,7 @@ def backend_clone(
     clone_script.blankln()
 
 
-def repo_agent_build(
-    ra, cmake_script, build_dir, install_dir
-):
+def repo_agent_build(ra, cmake_script, build_dir, install_dir):
     repo_build_dir = os.path.join(build_dir, ra, "build")
     repo_install_dir = os.path.join(build_dir, ra, "install")
 
@@ -2057,9 +2084,7 @@ def cache_build(cache, cmake_script, build_dir, install_dir):
     cmake_script.blankln()
 
 
-def cibase_build(
-    cmake_script, repo_dir, cmake_dir, build_dir, install_dir, ci_dir
-):
+def cibase_build(cmake_script, repo_dir, cmake_dir, build_dir, install_dir, ci_dir):
     repo_install_dir = os.path.join(build_dir, "tritonserver", "install")
 
     cmake_script.commentln(8)
@@ -2176,7 +2201,16 @@ def enable_all(default):
     FLAGS.cache = ["local", "redis"]
     FLAGS.filesystem = ["gcs", "s3", "azure_storage"]
     FLAGS.endpoint = ["http", "grpc", "sagemaker", "vertex-ai"]
-    FLAGS.feature = ["logging", "stats", "metrics", "gpu_metrics", "cpu_metrics", "tracing", "nvtx", "gpu"]
+    FLAGS.feature = [
+        "logging",
+        "stats",
+        "metrics",
+        "gpu_metrics",
+        "cpu_metrics",
+        "tracing",
+        "nvtx",
+        "gpu",
+    ]
 
     FLAGS.component = ["common", "core", "backend", "thirdparty"]
 
@@ -2184,6 +2218,7 @@ def enable_all(default):
     for element in ELEMENTS:
         attr = getattr(FLAGS, element)
         setattr(FLAGS, element, {key: default(element) for key in attr})
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -2246,8 +2281,8 @@ if __name__ == "__main__":
         "--target-platform",
         required=False,
         default=None,
-        choices=["linux","rhel","igpu"],
-        help='Target platform for build. If not specified, build targets the current platform.',
+        choices=["linux", "rhel", "igpu"],
+        help="Target platform for build. If not specified, build targets the current platform.",
     )
     parser.add_argument(
         "--target-machine",
@@ -2295,8 +2330,8 @@ if __name__ == "__main__":
         "--build-type",
         required=False,
         default="Release",
-        choices=["Release","Debug","RelWithDebInfo","MinSizeRel"],
-        help='Build type.',
+        choices=["Release", "Debug", "RelWithDebInfo", "MinSizeRel"],
+        help="Build type.",
     )
     parser.add_argument(
         "-j",
@@ -2312,7 +2347,7 @@ if __name__ == "__main__":
         type=str,
         required=False,
         default="https://github.com/triton-inference-server",
-        help='The GitHub organization containing the repos used for the build.',
+        help="The GitHub organization containing the repos used for the build.",
     )
     parser.add_argument(
         "--version",
@@ -2341,7 +2376,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--image",
         action="append",
-        metavar=("<image-name>","<full-image-name>"),
+        metavar=("<image-name>", "<full-image-name>"),
         nargs=2,
         required=False,
         default=[],
@@ -2364,13 +2399,13 @@ if __name__ == "__main__":
     def add_cmake_args(element, parser):
         dependent_kwargs = dict(
             nargs=3,
-            metavar=(f"<{element}>","<name>","<value>"),
+            metavar=(f"<{element}>", "<name>", "<value>"),
         )
-        if element=="core":
+        if element == "core":
             # "core" is a special case: it is already a specific component, so no need to select a specific instance of its element type
             dependent_kwargs = dict(
                 nargs=2,
-                metavar=("<name>","<value>"),
+                metavar=("<name>", "<value>"),
             )
         parser.add_argument(
             f"--extra-{element}-cmake-arg",
@@ -2378,7 +2413,7 @@ if __name__ == "__main__":
             required=False,
             default=[],
             help=f"Extra CMake argument for {element} build. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments added by build.py.",
-            **dependent_kwargs
+            **dependent_kwargs,
         )
         parser.add_argument(
             f"--override-{element}-cmake-arg",
@@ -2386,17 +2421,17 @@ if __name__ == "__main__":
             required=False,
             default=[],
             help=f"Override specified backend CMake argument in the {element} build. The argument is passed to CMake as -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the {element} build use --extra-{element}-cmake-arg.",
-            **dependent_kwargs
+            **dependent_kwargs,
         )
 
     element_groups = {}
     for element, properties in ELEMENTS.items():
-        if 'strict' in properties:
-            kwargs = {'choices': ELEMENTS_LISTS[element]}
-            help_list = ', '.join(ELEMENTS_LISTS[element])
+        if "strict" in properties:
+            kwargs = {"choices": ELEMENTS_LISTS[element]}
+            help_list = ", ".join(ELEMENTS_LISTS[element])
         else:
             kwargs = {}
-            help_list = ', '.join(ELEMENTS_LISTS[element]+['...'])
+            help_list = ", ".join(ELEMENTS_LISTS[element] + ["..."])
 
         group = parser.add_argument_group(
             element,
@@ -2404,48 +2439,48 @@ if __name__ == "__main__":
         )
         element_groups[element] = group
 
-        if not 'required' in properties:
+        if not "required" in properties:
             group.add_argument(
                 f"--enable-{element}",
                 metavar=f"<{element}> [<{element}> ...]",
-                nargs='*',
+                nargs="*",
                 action="extend",
                 required=False,
                 default=[],
                 help=f"Enable requested {element}(s)",
-                **kwargs
+                **kwargs,
             )
             group.add_argument(
                 f"--disable-{element}",
                 metavar=f"<{element}> [<{element}> ...]",
-                nargs='*',
+                nargs="*",
                 action="extend",
                 required=False,
                 default=[],
                 help=f"Disable requested {element}(s) (remove from --enable-all standard list)",
-                **kwargs
+                **kwargs,
             )
-        if 'tag' in properties:
+        if "tag" in properties:
             group.add_argument(
                 f"--{element}-tag",
                 action="append",
-                metavar=(f"<{element}>","<tag>"),
+                metavar=(f"<{element}>", "<tag>"),
                 nargs=2,
                 required=False,
                 default=[],
                 help=f'Select <tag> for specified <{element}>. If <tag> starts with "pull/" then it refers to a pull-request reference, otherwise <tag> indicates the git tag/branch to use for the build. If the version is non-development then the default <tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <tag> is "main" (e.g. version YY.MMdev -> branch main).',
             )
-        if 'org' in properties:
+        if "org" in properties:
             group.add_argument(
                 f"--{element}-org",
                 action="append",
-                metavar=(f"<{element}>","<org>"),
+                metavar=(f"<{element}>", "<org>"),
                 nargs=2,
                 required=False,
                 default=[],
-                help=f'Select <org> for specified <{element}>, to use the fork of the corresponding repository from <org> instead of the default --github-organization value.',
+                help=f"Select <org> for specified <{element}>, to use the fork of the corresponding repository from <org> instead of the default --github-organization value.",
             )
-        if 'cmake' in properties:
+        if "cmake" in properties:
             add_cmake_args(element, group)
 
     # special case
@@ -2630,11 +2665,12 @@ if __name__ == "__main__":
             default["cmake_extra"] = {}
             default["cmake_override"] = {}
         return default
+
     for element, properties in ELEMENTS.items():
         setattr(FLAGS, f"{element}", {})
         attr = getattr(FLAGS, f"{element}")
         # populate the required ones
-        if 'required' in properties:
+        if "required" in properties:
             for value in ELEMENTS_LISTS[element]:
                 attr[value] = default_element_dict(element)
 
@@ -2647,17 +2683,23 @@ if __name__ == "__main__":
     def do_enable(element, map, key):
         if key not in map:
             map[key] = default_element_dict(element)
+
     def do_disable(element, map, key):
         if key in map:
             map.pop(key)
+
     def do_tag(element, map, key, value):
         map[key]["tag"] = value
+
     def do_org(element, map, key, value):
         map[key]["org"] = value
+
     def do_cmake_extra(element, map, key, name, value):
         map[key]["cmake_extra"][name] = value
+
     def do_cmake_override(element, map, key, name, value):
         map[key]["cmake_override"][name] = value
+
     attr_fns = {
         "enable": do_enable,
         "disable": do_disable,
@@ -2669,15 +2711,21 @@ if __name__ == "__main__":
     for element in ELEMENTS:
         map = getattr(FLAGS, element)
         attr_names = [
-            f"enable_{element}", f"disable_{element}", f"{element}_tag", f"{element}_org",
-            f"extra_{element}_cmake_arg", f"override_{element}_cmake_arg",
+            f"enable_{element}",
+            f"disable_{element}",
+            f"{element}_tag",
+            f"{element}_org",
+            f"extra_{element}_cmake_arg",
+            f"override_{element}_cmake_arg",
         ]
         for attr_name in attr_names:
             attr = getattr(FLAGS, attr_name, None)
-            if not attr: continue
-            attr_fn = attr_fns[attr_name.replace(element,"").replace("_","")]
+            if not attr:
+                continue
+            attr_fn = attr_fns[attr_name.replace(element, "").replace("_", "")]
             for item in attr:
-                if not isinstance(item, list): item = [item]
+                if not isinstance(item, list):
+                    item = [item]
                 attr_fn(element, map, *item)
 
     # Handle special cases
@@ -2693,7 +2741,9 @@ if __name__ == "__main__":
     # If armnn_tflite backend, source from external repo for git clone
     if "armnn_tflite" in FLAGS.backend:
         if FLAGS.backend["armnn_tflite"]["org"] == FLAGS.github_organization:
-            FLAGS.backend["armnn_tflite"]["org"] = "https://gitlab.com/arm-research/smarter/"
+            FLAGS.backend["armnn_tflite"][
+                "org"
+            ] = "https://gitlab.com/arm-research/smarter/"
 
     if "tensorrtllm" in FLAGS.backend:
         if FLAGS.backend["tensorrtllm"]["org"] == FLAGS.github_organization:
@@ -2701,33 +2751,55 @@ if __name__ == "__main__":
 
     # Print final element info
     def format_cmake_args(args):
-        return ', '.join(['"-D{}={}"'.format(n,v) for n,v in args.items()])
+        return ", ".join(['"-D{}={}"'.format(n, v) for n, v in args.items()])
+
     for element in ELEMENTS:
         map = getattr(FLAGS, element)
         for key, info in map.items():
-            log(' '.join(filter(None, [
-                f'{element} "{key}"',
-                'at tag/branch "{}"'.format(info["tag"]) if "tag" in info else "",
-                'from org "{}"'.format(info["org"]) if "org" in info else "",
-            ])))
+            log(
+                " ".join(
+                    filter(
+                        None,
+                        [
+                            f'{element} "{key}"',
+                            'at tag/branch "{}"'.format(info["tag"])
+                            if "tag" in info
+                            else "",
+                            'from org "{}"'.format(info["org"])
+                            if "org" in info
+                            else "",
+                        ],
+                    )
+                )
+            )
             if any(["cmake" in prop for prop in info]):
-                cmake_extra_str = format_cmake_args(info["cmake_extra"]) if "cmake_extra" in info else ""
-                if cmake_extra_str: log('  CMake extra: '+cmake_extra_str)
-                cmake_override_str = format_cmake_args(info["cmake_override"]) if "cmake_override" in info else ""
-                if cmake_override_str: log('  CMake override: '+cmake_override_str)
+                cmake_extra_str = (
+                    format_cmake_args(info["cmake_extra"])
+                    if "cmake_extra" in info
+                    else ""
+                )
+                if cmake_extra_str:
+                    log("  CMake extra: " + cmake_extra_str)
+                cmake_override_str = (
+                    format_cmake_args(info["cmake_override"])
+                    if "cmake_override" in info
+                    else ""
+                )
+                if cmake_override_str:
+                    log("  CMake override: " + cmake_override_str)
 
     # Parse any explicitly specified cmake arguments
-    for key,val in FLAGS.extra_core_cmake_arg:
+    for key, val in FLAGS.extra_core_cmake_arg:
         log('core: CMake extra "-D{}={}"'.format(key, val))
         EXTRA_CORE_CMAKE_FLAGS[key] = val
 
-    for key,val in FLAGS.override_core_cmake_arg:
+    for key, val in FLAGS.override_core_cmake_arg:
         log('core: CMake override "-D{}={}"'.format(key, val))
         OVERRIDE_CORE_CMAKE_FLAGS[key] = val
 
     # Initialize map of docker images.
     images = {}
-    for key,val in FLAGS.image:
+    for key, val in FLAGS.image:
         fail_if(
             key not in ["base", "gpu-base", "pytorch", "inference"],
             "unsupported value for --image",

--- a/build.py
+++ b/build.py
@@ -2407,20 +2407,22 @@ if __name__ == "__main__":
         if not 'required' in properties:
             group.add_argument(
                 f"--enable-{element}",
-                metavar=f"<{element}>",
-                action="append",
+                metavar=f"<{element}> [<{element}> ...]",
+                nargs='*',
+                action="extend",
                 required=False,
                 default=[],
-                help=f"Enable requested {element}",
+                help=f"Enable requested {element}(s)",
                 **kwargs
             )
             group.add_argument(
                 f"--disable-{element}",
-                metavar=f"<{element}>",
-                action="append",
+                metavar=f"<{element}> [<{element}> ...]",
+                nargs='*',
+                action="extend",
                 required=False,
                 default=[],
-                help=f"Disable requested {element} (remove from --enable-all standard list)",
+                help=f"Disable requested {element}(s) (remove from --enable-all standard list)",
                 **kwargs
             )
         if 'tag' in properties:

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -109,6 +109,8 @@ building with Docker.
     build Triton. When building without GPU support, the *min* image
     is the standard ubuntu:22.04 image.
 
+    * The flag `--use-buildbase` can be specified to automate the use of the *tritonserver_buildbase* image to build backends that require a base image.
+
   * Run the cmake_build script within the *tritonserver_buildbase*
     image to actually build Triton. The cmake_build script performs
     the following steps.
@@ -155,7 +157,7 @@ If you want to enable only certain Triton features, backends and
 repository agents, do not specify --enable-all. Instead you must
 specify the individual flags as documented by --help.
 
-#### Building With Specific GitHub Branches
+#### Building With Specific GitHub Branches and Organization
 
 As described above, the build is performed in the server repo, but
 source from several other repos is fetched during the build
@@ -178,7 +180,12 @@ instead use the corresponding branch/tag in the build. For example, if
 you have a branch called "mybranch" in the
 [onnxruntime_backend](https://github.com/triton-inference-server/onnxruntime_backend)
 repo that you want to use in the build, you would specify
---backend=onnxruntime:mybranch.
+`--backend=onnxruntime:mybranch`.
+
+If you want to build a backend from an alternative organization or user `<org>`, you can extend this syntax as follows:
+```bash
+$ ./build.py ... --backend=onnxruntime:mybranch:https://github.com/<org>
+```
 
 #### CPU-Only Build
 

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -154,8 +154,8 @@ $ ./build.py -v --enable-all
 ```
 
 If you want to enable only certain Triton features, backends, and
-repository agents, there are two options:  
-a. do not specify `--enable-all`, and instead specify the individual flags as documented by `--help`.  
+repository agents, there are two options:
+a. do not specify `--enable-all`, and instead specify the individual flags as documented by `--help`.
 b. specify `--enable-all` and then disable selected features that you wish to omit using the `--disable-...` arguments, also documented by `--help`.
 
 #### Building With Specific GitHub Branches and Organization

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -92,7 +92,7 @@ building with Docker.
 
 * In the *build* subdirectory of the server repo, generate the
   docker_build script, the cmake_build script and the Dockerfiles
-  needed to build Triton. If you use the --dryrun flag, build.py will
+  needed to build Triton. If you use the `--dryrun` flag, build.py will
   stop here so that you can examine these files.
 
 * Run the docker_build script to perform the Docker-based build. The
@@ -101,7 +101,7 @@ building with Docker.
   * Build the *tritonserver_buildbase* Docker image that collects all
     the build dependencies needed to build Triton. The
     *tritonserver_buildbase* image is based on a minimal/base
-    image. When building with GPU support (--enable-gpu), the *min*
+    image. When building with GPU support (`--enable-feature gpu`), the *min*
     image is the
     [\<xx.yy\>-py3-min](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver)
     image pulled from [NGC](https://ngc.nvidia.com) that contains the
@@ -147,15 +147,16 @@ building with Docker.
 
 By default, build.py does not enable any of Triton's optional features
 but you can enable all features, backends, and repository agents with
-the --enable-all flag. The -v flag turns on verbose output.
+the `--enable-all` flag. The `-v` flag turns on verbose output.
 
 ```bash
 $ ./build.py -v --enable-all
 ```
 
-If you want to enable only certain Triton features, backends and
-repository agents, do not specify --enable-all. Instead you must
-specify the individual flags as documented by --help.
+If you want to enable only certain Triton features, backends, and
+repository agents, there are two options:  
+a. do not specify `--enable-all`, and instead specify the individual flags as documented by `--help`.  
+b. specify `--enable-all` and then disable selected features that you wish to omit using the `--disable-...` arguments, also documented by `--help`.
 
 #### Building With Specific GitHub Branches and Organization
 
@@ -166,7 +167,7 @@ other repos, but if you want to control which branch is used in these
 other repos you can as shown in the following example.
 
 ```bash
-$ ./build.py ... --repo-tag=common:<container tag> --repo-tag=core:<container tag> --repo-tag=backend:<container tag> --repo-tag=thirdparty:<container tag> ... --backend=tensorrt:<container tag> ... --repoagent=checksum:<container tag> ...
+$ ./build.py ... --component-tag common <container tag> --component-tag core <container tag> --component-tag backend <container tag> --component-tag thirdparty <container tag> ... --backend-tag tensorrt <container tag> ... --repoagent-tag checksum <container tag> ...
 ```
 
 If you are building on a release branch then `<container tag>` will
@@ -180,18 +181,18 @@ instead use the corresponding branch/tag in the build. For example, if
 you have a branch called "mybranch" in the
 [onnxruntime_backend](https://github.com/triton-inference-server/onnxruntime_backend)
 repo that you want to use in the build, you would specify
-`--backend=onnxruntime:mybranch`.
+`--backend-tag onnxruntime mybranch`.
 
-If you want to build a backend from an alternative organization or user `<org>`, you can extend this syntax as follows:
+If you want to build a backend from an alternative organization or user `<org>`, you can include a similar argument:
 ```bash
-$ ./build.py ... --backend=onnxruntime:mybranch:https://github.com/<org>
+$ ./build.py ... --backend-org onnxruntime https://github.com/<org>
 ```
 
 #### CPU-Only Build
 
 If you want to build without GPU support you must specify individual
-feature flags and not include the `--enable-gpu` and
-`--enable-gpu-metrics` flags. Only the following backends are
+feature flags and not include the `--enable-feature gpu` and
+`--enable-feature gpu-metrics` flags. Only the following backends are
 available for a non-GPU / CPU-only build: `identity`, `repeat`, `ensemble`,
 `square`, `pytorch`, `onnxruntime`, `openvino`,
 `python` and `fil`.
@@ -199,7 +200,7 @@ available for a non-GPU / CPU-only build: `identity`, `repeat`, `ensemble`,
 CPU-only builds of the PyTorch backends require some CUDA stubs
 and runtime dependencies that are not present in the CPU-only base container.
 These are retrieved from a GPU base container, which can be changed with the
-`--image=gpu-base,nvcr.io/nvidia/tritonserver:<xx.yy>-py3-min` flag.
+`--image gpu-base nvcr.io/nvidia/tritonserver:<xx.yy>-py3-min` flag.
 
 ### Building Without Docker
 
@@ -212,7 +213,7 @@ repo branch for the release you are interested in building (or the
 *main* branch to build from the development branch).
 
 To determine what dependencies are required by the build, run build.py
-with the --dryrun flag, and then looking in the build subdirectory at
+with the `--dryrun` flag, and then looking in the build subdirectory at
 Dockerfile.buildbase.
 
 ```bash
@@ -220,8 +221,8 @@ $ ./build.py -v --enable-all
 ```
 
 From Dockerfile.buildbase you can see what dependencies you need to
-install on your host system. Note that when building with --enable-gpu
-(or --enable-all), Dockerfile.buildbase depends on the
+install on your host system. Note that when building with `--enable-feature gpu`
+(or `--enable-all`), Dockerfile.buildbase depends on the
 [\<xx.yy\>-py3-min](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tritonserver)
 image pulled from [NGC](https://ngc.nvidia.com). Unfortunately, a
 Dockerfile is not currently available for the
@@ -231,7 +232,7 @@ cuDNN](#cuda-cublas-cudnn) and [TensorRT](#tensorrt) dependencies as
 described below.
 
 Once you have installed these dependencies on your build system you
-can then use build.py with the --no-container-build flag to build
+can then use build.py with the `--no-container-build` flag to build
 Triton.
 
 ```bash
@@ -313,7 +314,7 @@ and cmake_build or the equivalent commands to perform a build.
   depends on that package. For example, Triton supports the S3
   filesystem by building the aws-sdk-cpp package. If aws-sdk-cpp
   doesn't build for your platform then you can remove the need for
-  that package by not specifying --filesystem=s3 when you run
+  that package by not specifying `--enable-filesystem s3` when you run
   build.py. In general, you should start by running build.py with the
   minimal required feature set.
 
@@ -410,7 +411,7 @@ perform incremental builds by re-running `make`.
 
 ### Building with Debug Symbols
 
-To build with Debug symbols, use the --build-type=Debug argument while
+To build with Debug symbols, use the `--build-type Debug` argument while
 launching build.py. If building directly with CMake use
--DCMAKE_BUILD_TYPE=Debug. You can then launch the built server with
+`-DCMAKE_BUILD_TYPE=Debug`. You can then launch the built server with
 gdb and see the debug symbols/information in the gdb trace.

--- a/docs/user_guide/debugging_guide.md
+++ b/docs/user_guide/debugging_guide.md
@@ -129,7 +129,7 @@ The easiest step to start with is running perf_analyzer to get a breakdown of th
 
 The next step would be to use a performance profiler. One profiler we recommend is [Nsight Systems](https://developer.nvidia.com/nsight-systems) (nsys), optionally including NVIDIA Tools Extension (NVTX) markers to profile Triton.
 
-The Triton server container already has nsys installed. However, Triton does not build with the NVTX markers by default. If you want to use NVTX markers, you should build Triton with build.py, using the “--enable-nvtx” flag. This will provide details around some phases of processing a request, such as queueing, running inference, and handling outputs.
+The Triton server container already has nsys installed. However, Triton does not build with the NVTX markers by default. If you want to use NVTX markers, you should build Triton with build.py, using the “--enable-feature nvtx” flag. This will provide details around some phases of processing a request, such as queueing, running inference, and handling outputs.
 
 You can profile Triton by running `nsys profile tritonserver --model-repository …`. The [nsys documentation](https://docs.nvidia.com/nsight-systems/UserGuide/index.html) provides more options and details for getting a thorough overview of what is going on.
 


### PR DESCRIPTION
#### What does the PR do?

This pull request updates the command-line interface for build.py with two main ideas in mind.

A. Use native features of `argparse` rather than (potentially brittle) manual parsing of multi-valued inputs:
* automatically show default values in help message via built-in formatter
* use `choices` to enforce limited sets of values:
  * `--target-platform {linux,rhel,windows,igpu}`
  * `--build-type {Release,Debug,RelWithDebInfo,MinSizeRel}`
* use `nargs` instead of separate postprocessing to split by separating characters:
  * `--image IMAGE    Use specified Docker image in build as <image-name>,<full-image-name>. <image-name> can be "base", "gpu-base", or "pytorch".`
    ->
    `--image <image-name> <full-image-name>    Use specified Docker image in build. <image-name> can be "base", "gpu-base", or "pytorch". (default: [])`
  * other flags modified similarly, listed below (along with further reorganization)
* use argument groups to provide more structure in help message (grouping available flags for different types of build elements together, providing introductory descriptions of each type)

B. Unify the handling of different elements of the build to reduce code duplication and make it easier to add new features to control the build more precisely and flexibly.  
The different elements are: components, backends, repoagents, caches, filesystems, endpoints, features.
Each type of element can be (internally) assigned different properties, which determine the available command-line arguments for that element type.
The properties include:
* `required`: elements without this property get `--enable` and `--disable` flags.
* `strict`: elements with this property are limited to a predefined set of choices (e.g. `local`, `redis` for caches).
* `tag`: elements with this property get `--<element>-tag <element> <tag>` flags to specify a tag from the central repository.
* `org`: elements with this property get `--<element>-org <element> <org>` flags to specify a different repository. (new feature)
* `cmake`: elements with this property get `--extra-<element>-cmake-arg <element> <name> <value>` and `--override-<element>-cmake-arg <element> <name> <value>` flags to modify their build.

The resulting arguments become:
* features:
  `--enable-logging`, `--enable-stats`, `--enable-metrics`, `--enable-gpu-metrics`, `--enable-cpu-metrics`, `--enable-tracing`, `--enable-nvtx`, `--enable-gpu`, `--enable-mali-gpu`
  ->
  `--enable-feature [<feature> [<feature> ...] ...]`
  * add `--disable-feature [<feature> [<feature> ...] ...]` (in case starting from `--enable-all`)
* endpoints:
  `--endpoint ENDPOINT`
  ->
  `--enable-endpoint [<endpoint> [<endpoint> ...] ...]`
  * add `--disable-endpoint [<endpoint> [<endpoint> ...] ...]`
* filesystems:
  `--filesystem FILESYSTEM`
  ->
  `--enable-filesystem [<filesystem> [<filesystem> ...] ...]`
  * add `--disable-filesystem [<filesystem> [<filesystem> ...] ...]`
* backends:
  `--backend BACKEND    Include specified backend in build as <backend-name>[:<repo-tag>]...`
  `--extra-backend-cmake-arg EXTRA_BACKEND_CMAKE_ARG    Extra CMake argument for a backend build as <backend>:<name>=<value>.`
  `--override-backend-cmake-arg OVERRIDE_BACKEND_CMAKE_ARG    Override specified backend CMake argument in the build as <backend>:<name>=<value>.`
  ->
  `--enable-backend [<backend> [<backend> ...] ...]`
  `--disable-backend [<backend> [<backend> ...] ...]`
  `--backend-tag <backend> <tag>`
  `--backend-org <backend> <org>`
  `--extra-backend-cmake-arg <backend> <name> <value>`
  `--override-backend-cmake-arg <backend> <name> <value>`
* components:
  `--repo-tag REPO_TAG    The version of a component to use in the build as <component-name>:<repo-tag>.`
  `--extra-core-cmake-arg EXTRA_CORE_CMAKE_ARG    Extra CMake argument as <name>=<value>.`
  `--override-core-cmake-arg OVERRIDE_CORE_CMAKE_ARG    Override specified CMake argument in the build as <name>=<value>.`
  ->
  `--component-tag <component> <tag>`
  `--extra-core-cmake-arg <name> <value>`
  `--override-core-cmake-arg <name> <value>`
* repoagents:
  `  --repoagent REPOAGENT    Include specified repo agent in build as <repoagent-name>[:<repo-tag>]`
  ->
  `--enable-repoagent [<repoagent> [<repoagent> ...] ...]`
  `--disable-repoagent [<repoagent> [<repoagent> ...] ...]`
  `--repoagent-tag <repoagent> <tag>`
  `--repoagent-org <repoagent> <org>`
  `--extra-repoagent-cmake-arg <repoagent> <name> <value>`
  `--override-repoagent-cmake-arg <repoagent> <name> <value>`
* caches:
  `--cache CACHE    Include specified cache in build as <cache-name>[:<repo-tag>].`
  ->
  `--enable-cache [<cache> [<cache> ...] ...]`
  `--disable-cache [<cache> [<cache> ...] ...]`
  `--cache-tag <cache> <tag>`
  `--cache-org <cache> <org>`
  `--extra-cache-cmake-arg <cache> <name> <value>`
  `--override-cache-cmake-arg <cache> <name> <value>`

Several minor features are also added:
1. Add flag `--no-container-cache`, which propagates to `docker --no-cache`.
2. Add flag `--default-repo-tag <tag>` to override the calculated default value, which is not always appropriate. For example, when trying to build a dev version (currently 25.08), the upstream container version is set to the previous version (25.07), which takes precedence in the calculated default value, but using the corresponding dev versions of component and backend repositories may be intended. Rather than having to override it for each repo, it is useful to be able to override it globally.
3. Add flag `--use-buildbase` to use the temporary "buildbase" image as the "base" image for backends that need it (e.g. onnxruntime).
4. The feature `--library-paths` is found not to be used anywhere in the script, and is therefore removed (after demonstrating how it could be incorporated in the new scheme).

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:

This PR includes the changes from #8362.

#### Where should the reviewer start?

Changes only affect build.py and associated documentation.

Here is the help message before any of these changes:
<details>

```
usage: build.py [-h] [-q | -v] [--dryrun] [--no-container-build] [--use-user-docker-config USE_USER_DOCKER_CONFIG] [--no-container-interactive]
                [--no-container-pull] [--container-memory CONTAINER_MEMORY] [--target-platform TARGET_PLATFORM] [--target-machine TARGET_MACHINE]
                [--build-id BUILD_ID] [--build-sha BUILD_SHA] [--build-dir BUILD_DIR] [--install-dir INSTALL_DIR] [--cmake-dir CMAKE_DIR]
                [--tmp-dir TMP_DIR] [--library-paths LIBRARY_PATHS] [--build-type BUILD_TYPE] [-j BUILD_PARALLEL]
                [--github-organization GITHUB_ORGANIZATION] [--version VERSION] [--container-version CONTAINER_VERSION]
                [--container-prebuild-command CONTAINER_PREBUILD_COMMAND] [--no-container-source] [--image IMAGE] [--enable-all] [--enable-logging]
                [--enable-stats] [--enable-metrics] [--enable-gpu-metrics] [--enable-cpu-metrics] [--enable-tracing] [--enable-nvtx] [--enable-gpu]
                [--enable-mali-gpu] [--min-compute-capability MIN_COMPUTE_CAPABILITY] [--endpoint ENDPOINT] [--filesystem FILESYSTEM] [--no-core-build]
                [--backend BACKEND] [--repo-tag REPO_TAG] [--repoagent REPOAGENT] [--cache CACHE] [--no-force-clone]
                [--extra-core-cmake-arg EXTRA_CORE_CMAKE_ARG] [--override-core-cmake-arg OVERRIDE_CORE_CMAKE_ARG]
                [--extra-backend-cmake-arg EXTRA_BACKEND_CMAKE_ARG] [--override-backend-cmake-arg OVERRIDE_BACKEND_CMAKE_ARG]
                [--release-version RELEASE_VERSION] [--triton-container-version TRITON_CONTAINER_VERSION]
                [--upstream-container-version UPSTREAM_CONTAINER_VERSION] [--ort-version ORT_VERSION] [--ort-openvino-version ORT_OPENVINO_VERSION]
                [--standalone-openvino-version STANDALONE_OPENVINO_VERSION] [--dcgm-version DCGM_VERSION] [--vllm-version VLLM_VERSION]
                [--rhel-py-version RHEL_PY_VERSION] [--build-secret key value]

optional arguments:
  -h, --help            show this help message and exit
  -q, --quiet           Disable console output.
  -v, --verbose         Enable verbose output.
  --dryrun              Output the build scripts, but do not perform build.
  --no-container-build  Do not use Docker container for build.
  --use-user-docker-config USE_USER_DOCKER_CONFIG
                        Path to the Docker configuration file to be used when performing container build.
  --no-container-interactive
                        Do not use -it argument to "docker run" when performing container build.
  --no-container-pull   Do not use Docker --pull argument when building container.
  --container-memory CONTAINER_MEMORY
                        Value for Docker --memory argument. Used only for windows builds.
  --target-platform TARGET_PLATFORM
                        Target platform for build, can be "linux", "rhel", "windows" or "igpu". If not specified, build targets the current platform.
  --target-machine TARGET_MACHINE
                        Target machine/architecture for build. If not specified, build targets the current machine/architecture.
  --build-id BUILD_ID   Build ID associated with the build.
  --build-sha BUILD_SHA
                        SHA associated with the build.
  --build-dir BUILD_DIR
                        Build directory. All repo clones and builds will be performed in this directory.
  --install-dir INSTALL_DIR
                        Install directory, default is <builddir>/opt/tritonserver.
  --cmake-dir CMAKE_DIR
                        Directory containing the CMakeLists.txt file for Triton server.
  --tmp-dir TMP_DIR     Temporary directory used for building inside docker. Default is /tmp.
  --library-paths LIBRARY_PATHS
                        Specify library paths for respective backends in build as <backend-name>[:<library_path>].
  --build-type BUILD_TYPE
                        Build type, one of "Release", "Debug", "RelWithDebInfo" or "MinSizeRel". Default is "Release".
  -j BUILD_PARALLEL, --build-parallel BUILD_PARALLEL
                        Build parallelism. Defaults to 2 * number-of-cores.
  --github-organization GITHUB_ORGANIZATION
                        The GitHub organization containing the repos used for the build. Defaults to "https://github.com/triton-inference-server".
  --version VERSION     The Triton version. If not specified defaults to the value in the TRITON_VERSION file.
  --container-version CONTAINER_VERSION
                        The Triton container version to build. If not specified the container version will be chosen automatically based on --version value.
  --container-prebuild-command CONTAINER_PREBUILD_COMMAND
                        When performing a container build, this command will be executed within the container just before the build it performed.
  --no-container-source
                        Do not include OSS source code in Docker container.
  --image IMAGE         Use specified Docker image in build as <image-name>,<full-image-name>. <image-name> can be "base", "gpu-base", or "pytorch".
  --enable-all          Enable all standard released Triton features, backends, repository agents, caches, endpoints and file systems.
  --enable-logging      Enable logging.
  --enable-stats        Enable statistics collection.
  --enable-metrics      Enable metrics reporting.
  --enable-gpu-metrics  Include GPU metrics in reported metrics.
  --enable-cpu-metrics  Include CPU metrics in reported metrics.
  --enable-tracing      Enable tracing.
  --enable-nvtx         Enable NVTX.
  --enable-gpu          Enable GPU support.
  --enable-mali-gpu     Enable ARM MALI GPU support.
  --min-compute-capability MIN_COMPUTE_CAPABILITY
                        Minimum CUDA compute capability supported by server.
  --endpoint ENDPOINT   Include specified endpoint in build. Allowed values are "grpc", "http", "vertex-ai" and "sagemaker".
  --filesystem FILESYSTEM
                        Include specified filesystem in build. Allowed values are "gcs", "azure_storage" and "s3".
  --no-core-build       Do not build Triton core shared library or executable.
  --backend BACKEND     Include specified backend in build as <backend-name>[:<repo-tag>]. If <repo-tag> starts with "pull/" then it refers to a pull-
                        request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then
                        the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the
                        default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).
  --repo-tag REPO_TAG   The version of a component to use in the build as <component-name>:<repo-tag>. <component-name> can be "common", "core", "backend"
                        or "thirdparty". <repo-tag> indicates the git tag/branch to use for the build. Currently <repo-tag> does not support pull-request
                        reference. If the version is non-development then the default <repo-tag> is the release branch matching the container version (e.g.
                        version YY.MM -> branch rYY.MM); otherwise the default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).
  --repoagent REPOAGENT
                        Include specified repo agent in build as <repoagent-name>[:<repo-tag>]. If <repo-tag> starts with "pull/" then it refers to a pull-
                        request reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then
                        the default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the
                        default <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).
  --cache CACHE         Include specified cache in build as <cache-name>[:<repo-tag>]. If <repo-tag> starts with "pull/" then it refers to a pull-request
                        reference, otherwise <repo-tag> indicates the git tag/branch to use for the build. If the version is non-development then the
                        default <repo-tag> is the release branch matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default
                        <repo-tag> is "main" (e.g. version YY.MMdev -> branch main).
  --no-force-clone      Do not create fresh clones of repos that have already been cloned.
  --extra-core-cmake-arg EXTRA_CORE_CMAKE_ARG
                        Extra CMake argument as <name>=<value>. The argument is passed to CMake as -D<name>=<value> and is included after all CMake
                        arguments added by build.py for the core builds.
  --override-core-cmake-arg OVERRIDE_CORE_CMAKE_ARG
                        Override specified CMake argument in the build as <name>=<value>. The argument is passed to CMake as -D<name>=<value>. This flag
                        only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the core build use --extra-core-
                        cmake-arg.
  --extra-backend-cmake-arg EXTRA_BACKEND_CMAKE_ARG
                        Extra CMake argument for a backend build as <backend>:<name>=<value>. The argument is passed to CMake as -D<name>=<value> and is
                        included after all CMake arguments added by build.py for the backend.
  --override-backend-cmake-arg OVERRIDE_BACKEND_CMAKE_ARG
                        Override specified backend CMake argument in the build as <backend>:<name>=<value>. The argument is passed to CMake as
                        -D<name>=<value>. This flag only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the
                        backend build use --extra-backend-cmake-arg.
  --release-version RELEASE_VERSION
                        This flag sets the release version for Triton Inference Server to be built. Default: the latest released version.
  --triton-container-version TRITON_CONTAINER_VERSION
                        This flag sets the container version for Triton Inference Server to be built. Default: the latest released version.
  --upstream-container-version UPSTREAM_CONTAINER_VERSION
                        This flag sets the upstream container version for Triton Inference Server to be built. Default: the latest released version.
  --ort-version ORT_VERSION
                        This flag sets the ORT version for Triton Inference Server to be built. Default: the latest supported version.
  --ort-openvino-version ORT_OPENVINO_VERSION
                        This flag sets the OpenVino version for Triton Inference Server to be built. Default: the latest supported version.
  --standalone-openvino-version STANDALONE_OPENVINO_VERSION
                        This flag sets the standalon OpenVino version for Triton Inference Server to be built. Default: the latest supported version.
  --dcgm-version DCGM_VERSION
                        This flag sets the DCGM version for Triton Inference Server to be built. Default: the latest supported version.
  --vllm-version VLLM_VERSION
                        This flag sets the vLLM version for Triton Inference Server to be built. Default: the latest supported version.
  --rhel-py-version RHEL_PY_VERSION
                        This flag sets the Python version for RHEL platform of Triton Inference Server to be built. Default: the latest supported version.
  --build-secret key value
                        Add build secrets in the form of <key> <value>. These secrets are used during the build process for vllm. The secrets are passed to
                        the Docker build step as `--secret id=<key>`. The following keys are expected and their purposes are described below: - 'req': A
                        file containing a list of dependencies for pip (e.g., requirements.txt). - 'build_public_vllm': A flag (default is 'true')
                        indicating whether to build the public VLLM version. Ensure that the required environment variables for these secrets are set before
                        running the build.
```
</details>

Here is the help message after all of the changes:
<details>

```
usage: build.py [-h] [-q | -v] [--dryrun] [--no-container-build] [--use-user-docker-config USE_USER_DOCKER_CONFIG] [--no-container-interactive]
                [--no-container-pull] [--no-container-cache] [--container-memory CONTAINER_MEMORY] [--target-platform {linux,rhel,windows,igpu}]
                [--target-machine TARGET_MACHINE] [--build-id BUILD_ID] [--build-sha BUILD_SHA] [--build-dir BUILD_DIR] [--install-dir INSTALL_DIR]
                [--cmake-dir CMAKE_DIR] [--tmp-dir TMP_DIR] [--build-type {Release,Debug,RelWithDebInfo,MinSizeRel}] [-j BUILD_PARALLEL]
                [--github-organization GITHUB_ORGANIZATION] [--version VERSION] [--container-version CONTAINER_VERSION]
                [--container-prebuild-command CONTAINER_PREBUILD_COMMAND] [--no-container-source] [--image <image-name> <full-image-name>] [--use-buildbase]
                [--enable-all] [--enable-backend [<backend> [<backend> ...] ...]] [--disable-backend [<backend> [<backend> ...] ...]]
                [--backend-tag <backend> <tag>] [--backend-org <backend> <org>] [--extra-backend-cmake-arg <backend> <name> <value>]
                [--override-backend-cmake-arg <backend> <name> <value>] [--enable-repoagent [<repoagent> [<repoagent> ...] ...]]
                [--disable-repoagent [<repoagent> [<repoagent> ...] ...]] [--repoagent-tag <repoagent> <tag>] [--repoagent-org <repoagent> <org>]
                [--extra-repoagent-cmake-arg <repoagent> <name> <value>] [--override-repoagent-cmake-arg <repoagent> <name> <value>]
                [--enable-cache [<cache> [<cache> ...] ...]] [--disable-cache [<cache> [<cache> ...] ...]] [--cache-tag <cache> <tag>]
                [--cache-org <cache> <org>] [--extra-cache-cmake-arg <cache> <name> <value>] [--override-cache-cmake-arg <cache> <name> <value>]
                [--enable-filesystem [<filesystem> [<filesystem> ...] ...]] [--disable-filesystem [<filesystem> [<filesystem> ...] ...]]
                [--enable-endpoint [<endpoint> [<endpoint> ...] ...]] [--disable-endpoint [<endpoint> [<endpoint> ...] ...]]
                [--enable-feature [<feature> [<feature> ...] ...]] [--disable-feature [<feature> [<feature> ...] ...]] [--component-tag <component> <tag>]
                [--extra-core-cmake-arg <name> <value>] [--override-core-cmake-arg <name> <value>] [--min-compute-capability MIN_COMPUTE_CAPABILITY]
                [--no-core-build] [--no-force-clone] [--release-version RELEASE_VERSION] [--triton-container-version TRITON_CONTAINER_VERSION]
                [--upstream-container-version UPSTREAM_CONTAINER_VERSION] [--default-repo-tag DEFAULT_REPO_TAG] [--ort-version ORT_VERSION]
                [--ort-openvino-version ORT_OPENVINO_VERSION] [--standalone-openvino-version STANDALONE_OPENVINO_VERSION] [--dcgm-version DCGM_VERSION]
                [--vllm-version VLLM_VERSION] [--rhel-py-version RHEL_PY_VERSION] [--build-secret key value]

optional arguments:
  -h, --help            show this help message and exit
  -q, --quiet           Disable console output. (default: False)
  -v, --verbose         Enable verbose output. (default: False)
  --dryrun              Output the build scripts, but do not perform build. (default: False)
  --no-container-build  Do not use Docker container for build. (default: False)
  --use-user-docker-config USE_USER_DOCKER_CONFIG
                        Path to the Docker configuration file to be used when performing container build. (default: None)
  --no-container-interactive
                        Do not use -it argument to "docker run" when performing container build. (default: False)
  --no-container-pull   Do not use Docker --pull argument when building container. (default: False)
  --no-container-cache  Use Docker --no-cache argument when building container. (default: False)
  --container-memory CONTAINER_MEMORY
                        Value for Docker --memory argument. Used only for windows builds. (default: None)
  --target-platform {linux,rhel,windows,igpu}
                        Target platform for build. If not specified, build targets the current platform. (default: None)
  --target-machine TARGET_MACHINE
                        Target machine/architecture for build. If not specified, build targets the current machine/architecture. (default: None)
  --build-id BUILD_ID   Build ID associated with the build. (default: None)
  --build-sha BUILD_SHA
                        SHA associated with the build. (default: None)
  --build-dir BUILD_DIR
                        Build directory. All repo clones and builds will be performed in this directory. (default: None)
  --install-dir INSTALL_DIR
                        Install directory, default is <builddir>/opt/tritonserver. (default: None)
  --cmake-dir CMAKE_DIR
                        Directory containing the CMakeLists.txt file for Triton server. (default: None)
  --tmp-dir TMP_DIR     Temporary directory used for building inside docker. (default: /tmp)
  --build-type {Release,Debug,RelWithDebInfo,MinSizeRel}
                        Build type. (default: Release)
  -j BUILD_PARALLEL, --build-parallel BUILD_PARALLEL
                        Build parallelism. Defaults to 2 * number-of-cores. (default: None)
  --github-organization GITHUB_ORGANIZATION
                        The GitHub organization containing the repos used for the build. (default: https://github.com/triton-inference-server)
  --version VERSION     The Triton version. If not specified defaults to the value in the TRITON_VERSION file. (default: None)
  --container-version CONTAINER_VERSION
                        The Triton container version to build. If not specified the container version will be chosen automatically based on --version value.
                        (default: None)
  --container-prebuild-command CONTAINER_PREBUILD_COMMAND
                        When performing a container build, this command will be executed within the container just before the build it performed. (default:
                        None)
  --no-container-source
                        Do not include OSS source code in Docker container. (default: False)
  --image <image-name> <full-image-name>
                        Use specified Docker image in build. <image-name> can be "base", "gpu-base", or "pytorch". (default: [])
  --use-buildbase       Use local temporary "buildbase" Docker image as "base" image to build backends (default: False)
  --enable-all          Enable all standard released Triton features, backends, repository agents, caches, endpoints, and file systems. (default: False)
  --min-compute-capability MIN_COMPUTE_CAPABILITY
                        Minimum CUDA compute capability supported by server. (default: 6.0)
  --no-core-build       Do not build Triton core shared library or executable. (default: False)
  --no-force-clone      Do not create fresh clones of repos that have already been cloned. (default: False)
  --release-version RELEASE_VERSION
                        This flag sets the release version for Triton Inference Server to be built. Default: the latest released version. (default:
                        2.62.0dev)
  --triton-container-version TRITON_CONTAINER_VERSION
                        This flag sets the container version for Triton Inference Server to be built. Default: the latest released version. (default:
                        25.10dev)
  --upstream-container-version UPSTREAM_CONTAINER_VERSION
                        This flag sets the upstream container version for Triton Inference Server to be built. Default: the latest released version.
                        (default: 25.08)
  --default-repo-tag DEFAULT_REPO_TAG
                        Override the calculated default-repo-tag value (default: None)
  --ort-version ORT_VERSION
                        This flag sets the ORT version for Triton Inference Server to be built. Default: the latest supported version. (default: 1.23.0)
  --ort-openvino-version ORT_OPENVINO_VERSION
                        This flag sets the OpenVino version for Triton Inference Server to be built. Default: the latest supported version. (default:
                        2025.3.0)
  --standalone-openvino-version STANDALONE_OPENVINO_VERSION
                        This flag sets the standalon OpenVino version for Triton Inference Server to be built. Default: the latest supported version.
                        (default: 2025.3.0)
  --dcgm-version DCGM_VERSION
                        This flag sets the DCGM version for Triton Inference Server to be built. Default: the latest supported version. (default: 4.4.0-1)
  --vllm-version VLLM_VERSION
                        This flag sets the vLLM version for Triton Inference Server to be built. Default: the latest supported version. (default: 0.9.2)
  --rhel-py-version RHEL_PY_VERSION
                        This flag sets the Python version for RHEL platform of Triton Inference Server to be built. Default: the latest supported version.
                        (default: 3.12.3)
  --build-secret key value
                        Add build secrets in the form of <key> <value>. These secrets are used during the build process for vllm. The secrets are passed to
                        the Docker build step as `--secret id=<key>`. The following keys are expected and their purposes are described below: - 'req': A
                        file containing a list of dependencies for pip (e.g., requirements.txt). - 'build_public_vllm': A flag (default is 'true')
                        indicating whether to build the public VLLM version. Ensure that the required environment variables for these secrets are set before
                        running the build. (default: [])

backend:
  Options to configure backends, including: ensemble, identity, square, repeat, onnxruntime, python, dali, pytorch, openvino, fil, tensorrt, ...

  --enable-backend [<backend> [<backend> ...] ...]
                        Enable requested backend(s) (default: [])
  --disable-backend [<backend> [<backend> ...] ...]
                        Disable requested backend(s) (remove from --enable-all standard list) (default: [])
  --backend-tag <backend> <tag>
                        Select <tag> for specified <backend>. If <tag> starts with "pull/" then it refers to a pull-request reference, otherwise <tag>
                        indicates the git tag/branch to use for the build. If the version is non-development then the default <tag> is the release branch
                        matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <tag> is "main" (e.g. version YY.MMdev
                        -> branch main). (default: [])
  --backend-org <backend> <org>
                        Select <org> for specified <backend>, to use the fork of the corresponding repository from <org> instead of the default --github-
                        organization value. (default: [])
  --extra-backend-cmake-arg <backend> <name> <value>
                        Extra CMake argument for backend build. The argument is passed to CMake as -D<name>=<value> and is included after all CMake
                        arguments added by build.py. (default: [])
  --override-backend-cmake-arg <backend> <name> <value>
                        Override specified backend CMake argument in the backend build. The argument is passed to CMake as -D<name>=<value>. This flag only
                        impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the backend build use --extra-backend-
                        cmake-arg. (default: [])

repoagent:
  Options to configure repoagents, including: checksum, ...

  --enable-repoagent [<repoagent> [<repoagent> ...] ...]
                        Enable requested repoagent(s) (default: [])
  --disable-repoagent [<repoagent> [<repoagent> ...] ...]
                        Disable requested repoagent(s) (remove from --enable-all standard list) (default: [])
  --repoagent-tag <repoagent> <tag>
                        Select <tag> for specified <repoagent>. If <tag> starts with "pull/" then it refers to a pull-request reference, otherwise <tag>
                        indicates the git tag/branch to use for the build. If the version is non-development then the default <tag> is the release branch
                        matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <tag> is "main" (e.g. version YY.MMdev
                        -> branch main). (default: [])
  --repoagent-org <repoagent> <org>
                        Select <org> for specified <repoagent>, to use the fork of the corresponding repository from <org> instead of the default --github-
                        organization value. (default: [])
  --extra-repoagent-cmake-arg <repoagent> <name> <value>
                        Extra CMake argument for repoagent build. The argument is passed to CMake as -D<name>=<value> and is included after all CMake
                        arguments added by build.py. (default: [])
  --override-repoagent-cmake-arg <repoagent> <name> <value>
                        Override specified backend CMake argument in the repoagent build. The argument is passed to CMake as -D<name>=<value>. This flag
                        only impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the repoagent build use --extra-
                        repoagent-cmake-arg. (default: [])

cache:
  Options to configure caches, including: local, redis, ...

  --enable-cache [<cache> [<cache> ...] ...]
                        Enable requested cache(s) (default: [])
  --disable-cache [<cache> [<cache> ...] ...]
                        Disable requested cache(s) (remove from --enable-all standard list) (default: [])
  --cache-tag <cache> <tag>
                        Select <tag> for specified <cache>. If <tag> starts with "pull/" then it refers to a pull-request reference, otherwise <tag>
                        indicates the git tag/branch to use for the build. If the version is non-development then the default <tag> is the release branch
                        matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <tag> is "main" (e.g. version YY.MMdev
                        -> branch main). (default: [])
  --cache-org <cache> <org>
                        Select <org> for specified <cache>, to use the fork of the corresponding repository from <org> instead of the default --github-
                        organization value. (default: [])
  --extra-cache-cmake-arg <cache> <name> <value>
                        Extra CMake argument for cache build. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments
                        added by build.py. (default: [])
  --override-cache-cmake-arg <cache> <name> <value>
                        Override specified backend CMake argument in the cache build. The argument is passed to CMake as -D<name>=<value>. This flag only
                        impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the cache build use --extra-cache-
                        cmake-arg. (default: [])

filesystem:
  Options to configure filesystems, including: gcs, s3, azure_storage

  --enable-filesystem [<filesystem> [<filesystem> ...] ...]
                        Enable requested filesystem(s) (default: [])
  --disable-filesystem [<filesystem> [<filesystem> ...] ...]
                        Disable requested filesystem(s) (remove from --enable-all standard list) (default: [])

endpoint:
  Options to configure endpoints, including: http, grpc, sagemaker, vertex-ai

  --enable-endpoint [<endpoint> [<endpoint> ...] ...]
                        Enable requested endpoint(s) (default: [])
  --disable-endpoint [<endpoint> [<endpoint> ...] ...]
                        Disable requested endpoint(s) (remove from --enable-all standard list) (default: [])

feature:
  Options to configure features, including: logging, stats, metrics, gpu_metrics, cpu_metrics, tracing, nvtx, gpu, mali_gpu

  --enable-feature [<feature> [<feature> ...] ...]
                        Enable requested feature(s) (default: [])
  --disable-feature [<feature> [<feature> ...] ...]
                        Disable requested feature(s) (remove from --enable-all standard list) (default: [])

component:
  Options to configure components, including: common, core, backend, thirdparty

  --component-tag <component> <tag>
                        Select <tag> for specified <component>. If <tag> starts with "pull/" then it refers to a pull-request reference, otherwise <tag>
                        indicates the git tag/branch to use for the build. If the version is non-development then the default <tag> is the release branch
                        matching the container version (e.g. version YY.MM -> branch rYY.MM); otherwise the default <tag> is "main" (e.g. version YY.MMdev
                        -> branch main). (default: [])
  --extra-core-cmake-arg <name> <value>
                        Extra CMake argument for core build. The argument is passed to CMake as -D<name>=<value> and is included after all CMake arguments
                        added by build.py. (default: [])
  --override-core-cmake-arg <name> <value>
                        Override specified backend CMake argument in the core build. The argument is passed to CMake as -D<name>=<value>. This flag only
                        impacts CMake arguments that are used by build.py. To unconditionally add a CMake argument to the core build use --extra-core-cmake-
                        arg. (default: [])
```
</details>

#### Test plan:

I have used the script to build containers in several configurations and found that everything works as desired.

There are changes to some of the CLI flags, listed above.

My understanding from the discussion in #8362 is that there are internal `build.py` commands that need to be checked. I am happy to convert and check these if they can be provided, but I currently have no insight into the exact internal commands that need to be maintained.

#### Caveats:

More features could be added for the "component" elements: using forked repositories, modifying CMake arguments (beyond `core`). However, these changes would require modifying the `CMakeLists.txt` files in the various component repositories, and therefore are left for future PRs (so that this PR only involves modifications to `build.py`).

#### Background

In the process of adding minor features in #8362, I noticed some friction: duplication of code, multiple parsing steps, etc. The partial refactor, implemented here, allowed new options for different elements of the build process to be added much more easily (see https://github.com/triton-inference-server/server/commit/304b1a7e9473791d33631436f9fec0d13b5a01d9 for an example, which resolves an existing todo item noted in the code).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A
