### PR TITLE
fix: Handle Parsing Error

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2366,8 +2366,7 @@ HTTPAPIServer::GetContentLength(
             TRITONSERVER_ERROR_INVALID_ARG,
             (std::string("Unable to parse ") + kContentLengthHeader +
              ", value is out of range [ " +
-             std::to_string(std::numeric_limits<std::int32_t>::min()) +
-             ", " +
+             std::to_string(std::numeric_limits<std::int32_t>::min()) + ", " +
              std::to_string(std::numeric_limits<std::int32_t>::max()) +
              " ], got: " + content_length_c_str)
                 .c_str());


### PR DESCRIPTION
This change adds a handler for `std::atoi` possibly throwing a `std::out_of_range` exception.

Prior to this change, it was possible to send a malformed HTTP request to the server that would result in an unhandled exception causing the server to fault.

[TRI-115](https://linear.app/nvidia/issue/TRI-115/integer-overflow-lead-to-dos)


