### PR TITLE
Revert "security: Update package version due to CVE-2025-62727"

### DIFF
--- a/python/openai/requirements.txt
+++ b/python/openai/requirements.txt
@@ -33,4 +33,4 @@ openai==1.107.3
 partial-json-parser # used for parsing partial JSON outputs
 # Minimum starlette version needed to address CVE:
 # https://github.com/advisories/GHSA-f96h-pmfr-66vw
-starlette>=0.49.1
+starlette>=0.40.0


### PR DESCRIPTION
Reverts triton-inference-server/server#8482