### PR TITLE
fix: Clone TRT Repository when Necessary

### DIFF
--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -434,13 +434,8 @@ chmod -R 777 $VOLUME_FORMATDESTDIR
 nvidia-smi --query-gpu=compute_cap | grep -qz 11.0 && echo -e '\033[33m[WARNING]\033[0m Skipping model generation for data dependent shape' || python3 $VOLUME_SRCDIR/gen_qa_trt_data_dependent_shape.py --models_dir=$VOLUME_DATADEPENDENTDIR
 chmod -R 777 $VOLUME_DATADEPENDENTDIR
 # Make shared library for custom Hardmax plugin.
-if [ -d "/usr/src/tensorrt" ]; then
-    if [ ! -d "/usr/src/tensorrt/samples/python" ]; then
-        git clone -b release/${TENSORRT_VERSION} https://github.com/NVIDIA/TensorRT.git
-        cd /workspace/TensorRT/samples/python/onnx_custom_plugin
-    else
-        cd /usr/src/tensorrt/samples/python/onnx_custom_plugin
-    fi
+if [ -d "/usr/src/tensorrt" ] && [ ! -d "/usr/src/tensorrt/samples/python" ]; then
+    cd /usr/src/tensorrt/samples/python/onnx_custom_plugin
 else
     git clone -b release/${TENSORRT_VERSION} https://github.com/NVIDIA/TensorRT.git
     cd /workspace/TensorRT/samples/python/onnx_custom_plugin


### PR DESCRIPTION
This change tests for the full path before changing directory and clones the TensorRT directory when the full path is unavailable.



