### PR TITLE
Add Model Analyzer to SDK container

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -219,6 +219,11 @@ RUN if [ "$TRITON_ENABLE_GPU" = "ON" ]; then \
 RUN rm -f /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
+# Install Model Analyzer
+ARG TRITON_MODEL_ANALYZER_REPO_TAG
+ARG TRITON_MODEL_ANALYZER_REPO="${TRITON_REPO_ORGANIZATION}/model_analyzer@${TRITON_MODEL_ANALYZER_REPO_TAG}"
+RUN pip3 install "git+${TRITON_MODEL_ANALYZER_REPO}"
+
 # Entrypoint Banner
 ENV NVIDIA_PRODUCT_NAME="Triton Server SDK"
 COPY docker/entrypoint.d/ /opt/nvidia/entrypoint.d/


### PR DESCRIPTION
Restoring Model Analyzer installation in Triton SDK container.

[TRI-325](https://linear.app/nvidia/issue/TRI-325)
