### PR TITLE
Update build.py to allow customer set the dependency group for wheel …

### DIFF
--- a/build.py
+++ b/build.py
@@ -1240,16 +1240,16 @@ ENV PIP_BREAK_SYSTEM_PACKAGES=1
         argmap, backends, FLAGS.enable_gpu, target_machine()
     )
 
-    df += """
+    df += f"""
 WORKDIR /opt
 COPY --chown=1000:1000 build/install tritonserver
 
 WORKDIR /opt/tritonserver
 COPY --chown=1000:1000 NVIDIA_Deep_Learning_Container_License.pdf .
 RUN find /opt/tritonserver/python -maxdepth 1 -type f -name \\
-    "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[all] && \\
+    "tritonserver-*.whl" | xargs -I {{}} pip install --upgrade {{}}[{FLAGS.triton_wheels_dependencies_group}] && \\
     find /opt/tritonserver/python -maxdepth 1 -type f -name \\
-    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all]
+    "tritonfrontend-*.whl" | xargs -I {{}} pip install --upgrade {{}}[{FLAGS.triton_wheels_dependencies_group}]
 
 RUN pip3 install -r python/openai/requirements.txt
 
@@ -2783,6 +2783,13 @@ if __name__ == "__main__":
         "  - 'req': A file containing a list of dependencies for pip (e.g., requirements.txt).\n"
         "  - 'build_public_vllm': A flag (default is 'true') indicating whether to build the public VLLM version.\n\n"
         "Ensure that the required environment variables for these secrets are set before running the build.",
+    )
+    parser.add_argument(
+        "--triton-wheels-dependencies-group",
+        required=False,
+        type=str,
+        default="all",
+        help="The group of dependencies for Triton wheels to be installed. Default value is 'all'.",
     )
     FLAGS = parser.parse_args()
 


### PR DESCRIPTION
This PR provide a change in response on https://github.com/triton-inference-server/server/pull/8329 
This change motivated to align with  https://peps.python.org/pep-0735/ dependency options.

#### CPU only build configuration evidences:
```bash 
# CPU ONLY Scenario
# Dry run on default branch
$ git switch main
$ ./build.py -v --enable-logging --enable-stats --enable-tracing --enable-metrics --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --repo-tag=common:main  --repo-tag=core:main --repo-tag=backend:main --repo-tag=thirdparty:main --backend=ensemble --backend=identity:main --backend=repeat:main --backend=square:main --repoagent=checksum:main --cache=local:main --dryrun ;  grep -e "triton.*whl" build/*
...output omitted...
build/cmake_build:cp /tmp/tritonbuild/tritonserver/install/python/triton*.whl /tmp/tritonbuild/install/python
build/Dockerfile:    "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[all] && \
build/Dockerfile:    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all]
# Dry run on PR branch without options
$ git switch mchornyi/PR8329/option
$ ./build.py -v --enable-logging --enable-stats --enable-tracing --enable-metrics --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --repo-tag=common:main  --repo-tag=core:main --repo-tag=backend:main --repo-tag=thirdparty:main --backend=ensemble --backend=identity:main --backend=repeat:main --backend=square:main --repoagent=checksum:main --cache=local:main --dryrun ;  grep -e "triton.*whl" build/*
...output omitted...
build/cmake_build:cp /tmp/tritonbuild/tritonserver/install/python/triton*.whl /tmp/tritonbuild/install/python
build/Dockerfile:    "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[all] && \
build/Dockerfile:    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all]
# Dry run on PR branch with option: --triton-wheels-dependencies-group=all
$ ./build.py --triton-wheels-dependencies-group=all -v --enable-logging --enable-stats --enable-tracing --enable-metrics --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --repo-tag=common:main  --repo-tag=core:main --repo-tag=backend:main --repo-tag=thirdparty:main --backend=ensemble --backend=identity:main --backend=repeat:main --backend=square:main --repoagent=checksum:main --cache=local:main --dryrun ;  grep -e "triton.*whl" build/*
...output omitted...
build/cmake_build:cp /tmp/tritonbuild/tritonserver/install/python/triton*.whl /tmp/tritonbuild/install/python
build/Dockerfile:    "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[all] && \
build/Dockerfile:    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[all]
# Dry run on PR branch with option: --triton-wheels-dependencies-group=cpu
$ ./build.py --triton-wheels-dependencies-group=cpu -v --enable-logging --enable-stats --enable-tracing --enable-metrics --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --repo-tag=common:main  --repo-tag=core:main --repo-tag=backend:main --repo-tag=thirdparty:main --backend=ensemble --backend=identity:main --backend=repeat:main --backend=square:main --repoagent=checksum:main --cache=local:main --dryrun ;  grep -e "triton.*whl" build/*
...output omitted...
build/cmake_build:cp /tmp/tritonbuild/tritonserver/install/python/triton*.whl /tmp/tritonbuild/install/python
build/Dockerfile:    "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[cpu] && \
build/Dockerfile:    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[cpu]
# Dry run on PR branch with option: --triton-wheels-dependencies-group=custom
$ ./build.py --triton-wheels-dependencies-group=custom -v --enable-logging --enable-stats --enable-tracing --enable-metrics --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --repo-tag=common:main  --repo-tag=core:main --repo-tag=backend:main --repo-tag=thirdparty:main --backend=ensemble --backend=identity:main --backend=repeat:main --backend=square:main --repoagent=checksum:main --cache=local:main --dryrun ;  grep -e "triton.*whl" build/*
...output omitted...
build/cmake_build:cp /tmp/tritonbuild/tritonserver/install/python/triton*.whl /tmp/tritonbuild/install/python
build/Dockerfile:    "tritonserver-*.whl" | xargs -I {} pip install --upgrade {}[custom] && \
build/Dockerfile:    "tritonfrontend-*.whl" | xargs -I {} pip install --upgrade {}[custom]
```



