### PR TITLE
feat: Update build.py to skip libnvshmem3-cuda-13 for cpu only build.

### DIFF
--- a/build.py
+++ b/build.py
@@ -1509,8 +1509,9 @@ ENV PYTHONPATH=/opt/tritonserver/backends/dali/wheel/dali:$PYTHONPATH
 """
 
     if target_platform() not in ["igpu", "windows", "rhel"]:
-        repo_arch = "sbsa" if target_machine == "aarch64" else "x86_64"
-        df += f"""
+        if FLAGS.triton_wheels_dependencies_group != "cpu" :
+           repo_arch = "sbsa" if target_machine == "aarch64" else "x86_64"
+           df += f"""
 RUN curl -o /tmp/cuda-keyring.deb \\
         https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/{repo_arch}/cuda-keyring_1.1-1_all.deb \\
       && apt install /tmp/cuda-keyring.deb \\


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
https://github.com/triton-inference-server/server/pull/8329

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
Used below commands to create triton server docker instance and starting up the triton server:
1.sudo docker run --privileged -it -p8000:8000 --volume /model_repository:/var/models --name triton_server_test tritonserver
2../bin/tritonserver --model-repository=/var/models

Tested the simple identity model using below commands in a different session:
1.curl -X POST localhost:8000/v2/repository/index | jq

```
curl -X POST localhost:8000/v2/repository/index | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    58  100    58    0     0  29000      0 --:--:-- --:--:-- --:--:-- 29000
[
  {
    "name": "simple_identity",
    "version": "1",
    "state": "READY"
  }
]
```
2.curl localhost:8000/v2/models/simple_identity | jq
```
curl localhost:8000/v2/models/simple_identity | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   193  100   193    0     0   188k      0 --:--:-- --:--:-- --:--:--  188k
{
  "name": "simple_identity",
  "versions": [
    "1"
  ],
  "platform": "python",
  "inputs": [
    {
      "name": "INPUT0",
      "datatype": "BYTES",
      "shape": [
        -1,
        -1
      ]
    }
  ],
  "outputs": [
    {
      "name": "OUTPUT0",
      "datatype": "BYTES",
      "shape": [
        -1,
        -1
      ]
    }
  ]
}
```

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
Hi @whoisj , as mentioned in https://github.com/triton-inference-server/server/pull/8329#issuecomment-3555766708, this PR adds changes to skip the `libnvshmem3-cuda-13` library for cpu only build.
Please review/merge this PR.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx


