### PR TITLE
feat: Extend histogram metrics to non-decoupled models

### DIFF
--- a/docs/user_guide/metrics.md
+++ b/docs/user_guide/metrics.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -215,9 +215,9 @@ By default, the following
 [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram)
 metrics are used for latencies:
 
-|Category      |Metric          |Metric Name |Description                |Granularity|Frequency    |Model Type
-|--------------|----------------|------------|---------------------------|-----------|-------------|-------------|
-|Latency       |Request to First Response Time    |`nv_inference_first_response_histogram_ms` |Histogram of end-to-end inference request to the first response time |Per model  |Per request  | Decoupled |
+|Category      |Metric          |Metric Name |Description                |Granularity|Frequency    |
+|--------------|----------------|------------|---------------------------|-----------|-------------|
+|Latency       |Request to First Response Time    |`nv_inference_first_response_histogram_ms` |Histogram of end-to-end inference request to the first response time |Per model  |Per request  |
 
 To enable these metrics specifically, you can set `--metrics-config histogram_latencies=true`
 

--- a/qa/L0_metrics/ensemble_decoupled/async_execute_decouple/1/model.py
+++ b/qa/L0_metrics/ensemble_decoupled/async_execute_decouple/1/model.py
@@ -1,4 +1,4 @@
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,9 +45,9 @@ class TritonPythonModel:
         ]
 
         # Wait
-        time.sleep(wait_secs.item())
         response_sender = request.get_response_sender()
         for i in range(response_num):
+            time.sleep(wait_secs.item())
             response = pb_utils.InferenceResponse(output_tensors)
             if i != response_num - 1:
                 response_sender.send(response)

--- a/qa/L0_metrics/metrics_config_test.py
+++ b/qa/L0_metrics/metrics_config_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -44,7 +44,7 @@ INF_COUNTER_PATTERNS = [
     "nv_inference_compute_infer_duration",
     "nv_inference_compute_output_duration",
 ]
-INF_HISTOGRAM_DECOUPLED_PATTERNS = ["nv_inference_first_response_histogram_ms"]
+INF_HISTOGRAM_PATTERNS = ["nv_inference_first_response_histogram_ms"]
 INF_SUMMARY_PATTERNS = [
     "nv_inference_request_summary",
     "nv_inference_queue_summary",
@@ -99,15 +99,15 @@ class MetricsConfigTest(tu.TestResultCollector):
             self.assertNotIn(metric, metrics)
 
     # Histograms
-    def test_inf_histograms_decoupled_exist(self):
+    def test_inf_histograms_exist(self):
         metrics = self._get_metrics()
-        for metric in INF_HISTOGRAM_DECOUPLED_PATTERNS:
+        for metric in INF_HISTOGRAM_PATTERNS:
             for suffix in ["_count", "_sum", "_bucket"]:
                 self.assertIn(metric + suffix, metrics)
 
-    def test_inf_histograms_decoupled_missing(self):
+    def test_inf_histograms_missing(self):
         metrics = self._get_metrics()
-        for metric in INF_HISTOGRAM_DECOUPLED_PATTERNS:
+        for metric in INF_HISTOGRAM_PATTERNS:
             self.assertNotIn(metric, metrics)
 
     # Summaries

--- a/qa/L0_metrics/test.sh
+++ b/qa/L0_metrics/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -276,7 +276,7 @@ SERVER_ARGS="${BASE_SERVER_ARGS} --load-model=identity_cache_off"
 run_and_check_server
 python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_counters_exist 2>&1 | tee ${CLIENT_LOG}
 check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_decoupled_missing 2>&1 | tee ${CLIENT_LOG}
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_missing 2>&1 | tee ${CLIENT_LOG}
 check_unit_test
 python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_summaries_missing 2>&1 | tee ${CLIENT_LOG}
 check_unit_test
@@ -286,47 +286,12 @@ python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_summaries_missing 2>&1 | tee
 check_unit_test
 kill_server
 
-# Check default settings: Histograms should be always disabled in non-decoupled model.
+# Enable histograms
 SERVER_ARGS="${BASE_SERVER_ARGS} --load-model=identity_cache_off --metrics-config histogram_latencies=true"
 run_and_check_server
 python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_counters_exist 2>&1 | tee ${CLIENT_LOG}
 check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_decoupled_missing 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_summaries_missing 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_counters_missing 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_summaries_missing 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-kill_server
-
-# Check default settings: Histograms should be disabled in decoupled model
-decoupled_model="async_execute_decouple"
-mkdir -p "${MODELDIR}/${decoupled_model}/1/"
-cp ../python_models/${decoupled_model}/model.py ${MODELDIR}/${decoupled_model}/1/
-cp ../python_models/${decoupled_model}/config.pbtxt ${MODELDIR}/${decoupled_model}/
-
-SERVER_ARGS="${BASE_SERVER_ARGS} --load-model=${decoupled_model}"
-run_and_check_server
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_counters_exist 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_decoupled_missing 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_summaries_missing 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_counters_missing 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_cache_summaries_missing 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-kill_server
-
-# Enable histograms in decoupled model
-SERVER_ARGS="${BASE_SERVER_ARGS} --load-model=${decoupled_model} --metrics-config histogram_latencies=true"
-run_and_check_server
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_counters_exist 2>&1 | tee ${CLIENT_LOG}
-check_unit_test
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_decoupled_exist 2>&1 | tee ${CLIENT_LOG}
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_exist 2>&1 | tee ${CLIENT_LOG}
 check_unit_test
 python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_summaries_missing 2>&1 | tee ${CLIENT_LOG}
 check_unit_test
@@ -465,6 +430,7 @@ SERVER_LOG="./histogram_ensemble_decoupled_server.log"
 CLIENT_LOG="./histogram_ensemble_decoupled_client.log"
 SERVER_ARGS="--model-repository=${MODELDIR} --metrics-config histogram_latencies=true --log-verbose=1"
 mkdir -p "${MODELDIR}"/ensemble/1
+rm -rf "${MODELDIR}"/async_execute
 cp -r "${MODELDIR}"/async_execute_decouple "${MODELDIR}"/async_execute
 sed -i "s/model_transaction_policy { decoupled: True }//" "${MODELDIR}"/async_execute/config.pbtxt
 
@@ -510,7 +476,7 @@ kill_server
 PYTHON_TEST="metrics_config_test.py"
 SERVER_ARGS="--model-repository=${MODELDIR} --model-control-mode=explicit --load-model=${decoupled_model} --metrics-config histogram_latencies=false --log-verbose=1"
 run_and_check_server
-python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_decoupled_missing 2>&1 | tee ${CLIENT_LOG}
+python3 ${PYTHON_TEST} MetricsConfigTest.test_inf_histograms_missing 2>&1 | tee ${CLIENT_LOG}
 check_unit_test
 kill_server
 


### PR DESCRIPTION
#### What does the PR do?
Currently `nv_inference_first_response_histogram_ms` is only shown in decoupled models. Extending to non-decoupled models based on user request.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] feat

#### Related PRs:
https://github.com/triton-inference-server/core/pull/464

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID:
40388685

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #8561
