### PR TITLE
fix: Correct error variable pointer in Sagemaker server

### DIFF
--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -735,7 +735,7 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
       server_.get(), repo_parent_path.c_str());
 
   if (unregister_err != nullptr) {
-    EVBufferAddErrorJson(req->buffer_out, unload_err);
+    EVBufferAddErrorJson(req->buffer_out, unregister_err);
     evhtp_send_reply(req, EVHTP_RES_BADREQ);
     LOG_ERROR << "Unable to unregister model repository for path: "
               << repo_parent_path << std::endl;


### PR DESCRIPTION
#### What does the PR do?
At lines 732-733, the code checks `unregister_err` but passes `unload_err` to the error handler:

```cpp
// Line 732-733: Wrong variable used
if (unregister_err != nullptr) {
  EVBufferAddErrorJson(req->buffer_out, unload_err);  // BUG: should be unregister_err
  evhtp_send_reply(req, EVHTP_RES_BADREQ);
  LOG_ERROR << "Unable to unregister model repository for path: "
            << repo_parent_path << std::endl;
}
```
[View on GitHub (Line 732)](https://github.com/triton-inference-server/server/blob/main/src/sagemaker_server.cc#L732)

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] fix

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID:
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
