### PR TITLE
fix: Correct error variable pointer in Sagemaker server (#8608)

### DIFF
--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -735,7 +735,7 @@ SagemakerAPIServer::SageMakerMMEUnloadModel(
       server_.get(), repo_parent_path.c_str());
 
   if (unregister_err != nullptr) {
-    EVBufferAddErrorJson(req->buffer_out, unload_err);
+    EVBufferAddErrorJson(req->buffer_out, unregister_err);
     evhtp_send_reply(req, EVHTP_RES_BADREQ);
     LOG_ERROR << "Unable to unregister model repository for path: "
               << repo_parent_path << std::endl;


### PR DESCRIPTION
Thanks for submitting a PR to Triton!
Please go the the `Preview` tab above this description box and select the appropriate sub-template:

* [PR description template for Triton Engineers](?expand=1&template=pull_request_template_internal_contrib.md)
* [PR description template for External Contributors](?expand=1&template=pull_request_template_external_contrib.md)

If you already created the PR, please replace this message with one of
* [External contribution template](https://raw.githubusercontent.com/triton-inference-server/server/main/.github/PULL_REQUEST_TEMPLATE/pull_request_template_external_contrib.md)
* [Internal contribution template](https://raw.githubusercontent.com/triton-inference-server/server/main/.github/PULL_REQUEST_TEMPLATE/pull_request_template_internal_contrib.md)

and fill it out.


