### PR TITLE
fix: Improve bounds checking on integer conversions

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -609,7 +609,8 @@ ReadDataFromJsonHelper(
         if (len > INT64_MAX) {
           return TRITONSERVER_ErrorNew(
               TRITONSERVER_ERROR_INTERNAL,
-              "Unable to parse 'data' field: string length exceeds size limitation");
+              "Unable to parse 'data' field: string length exceeds size"
+              " limitation");
         }
         // Quick sanity check to ensure we don't write beyond `expected_cnt`.
         int64_t tmp_cnt = static_cast<int64_t>(*counter) +


### PR DESCRIPTION
This change improves the handling of values which could cause int32 values of over/underflow leading to undefined behavior.

[TRI-557](https://linear.app/nvidia/issue/TRI-557)
