### PR TITLE
Catch potential out of range exception

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1094,9 +1094,11 @@ CompressionTypeUsed(const std::string accept_encoding)
         type_weight = std::stod(encoding.substr(weight_pos + 3));
       }
       catch (const std::out_of_range& oor) {
+        type_weight = 0;
         continue;
       }
       catch (const std::invalid_argument& ia) {
+        type_weight = 0;
         continue;
       }
     }


### PR DESCRIPTION
Catch a potential out-of-range exception that can occur when parsing Accept-Encoding type weights.

[TRI-633](https://linear.app/nvidia/issue/TRI-633)



