### PR TITLE
Removing ABI compile option.

### DIFF
--- a/build.py
+++ b/build.py
@@ -841,7 +841,6 @@ def fastertransformer_cmake_args():
 
 def tensorrtllm_cmake_args(images):
     cargs = []
-    cargs.append(cmake_backend_enable("tensorrtllm", "USE_CXX11_ABI", True))
     return cargs
 
 


### PR DESCRIPTION
Shipped to public library shows that TensorRT-LLM wasn't compiled with ABI flag:
```bash
root@8c0274e6de9d:/tmp/tritonbuild/tensorrtllm/build# nm -Cj /usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/libtensorrt_llm.so | grep getLogger
guard variable for tensorrt_llm::common::Logger::getLogger()::instance
tensorrt_llm::common::Logger::getLogger()
tensorrt_llm::common::Logger::getLogger()::instance
```
Means namespace we trying to link is invalid and we need to omit `USE_CXX11_ABI` compiler flag:

* https://github.com/triton-inference-server/TensorRT-LLM/blob/release/1.1/triton_backend/inflight_batcher_llm/CMakeLists.txt#L38

* https://github.com/triton-inference-server/TensorRT-LLM/blob/main/cpp/include/tensorrt_llm/common/config.h#L28