### PR TITLE
docs: fix incomplete TOC hyperlinks in debugging_guide.md

### DIFF
--- a/docs/user_guide/debugging_guide.md
+++ b/docs/user_guide/debugging_guide.md
@@ -31,9 +31,9 @@ This guide goes over first-step troubleshooting for common scenarios in which Tr
 
 - **[Configuration](#configuration-issues)**: Triton reports an error with your configuration file.
 - **[Model](#model-issues)**: Your model fails to load or perform inference.
-- Server: The server is crashing or unavailable.
-- Client: The client is failing in sending and receiving data to the server.
-- Performance: Triton is not achieving optimal performance.
+- **[Server](#server-issues)**: The server is crashing or unavailable.
+- **[Client](#client-issues)**: The client is failing in sending and receiving data to the server.
+- **[Performance](#performance-issues)**: Triton is not achieving optimal performance.
 
 Regardless of the category of your issue, it is worthwhile to try running in the latest Triton container, whenever possible. While we provide support to older containers, fixes get merged into the next release. By checking the latest release, you can spot whether this issue has already been resolved.
 


### PR DESCRIPTION
## What

Fix three missing hyperlinks in the Debugging Guide's table-of-contents. The `Server`, `Client`, and `Performance` entries were plain text while `Configuration` and `Model` were properly linked.

## Why

The Debugging Guide opens with a navigation list:

```markdown
- **[Configuration](#configuration-issues)**: ...
- **[Model](#model-issues)**: ...
- Server: ...          ← plain text, no link
- Client: ...          ← plain text, no link
- Performance: ...     ← plain text, no link
```

All five section headings (`## Configuration Issues`, `## Model Issues`, `## Server Issues`, `## Client Issues`, `## Performance Issues`) exist in the file, so the anchors are valid. The missing links prevent readers from navigating directly to those sections from the TOC.

## How

Changed the three plain-text TOC items to bold hyperlinks matching the style of the existing `Configuration` and `Model` entries:

- `Server` → `**[Server](#server-issues)**`
- `Client` → `**[Client](#client-issues)**`
- `Performance` → `**[Performance](#performance-issues)**`

## Testing

- Verified the anchor names match the actual heading IDs generated from the `## Server Issues`, `## Client Issues`, and `## Performance Issues` headings
- Rendered locally with a Markdown previewer to confirm links work

## Checklist

- [x] Documentation-only change
- [x] All five TOC entries now have working hyperlinks
- [x] Consistent formatting (bold + link) across all TOC items
- [x] No content changes to the guide itself