### PR TITLE
feat: allow override of SageMaker single-model repository path

### DIFF
--- a/docker/sagemaker/serve
+++ b/docker/sagemaker/serve
@@ -25,7 +25,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-SAGEMAKER_SINGLE_MODEL_REPO=/opt/ml/model/
+SAGEMAKER_SINGLE_MODEL_REPO=${SAGEMAKER_TRITON_MODEL_REPOSITORY:-/opt/ml/model/}
 
 # Use 'ready' for ping check in single-model endpoint mode, and use 'live' for ping check in multi-model endpoint model
 # https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/rest_predict_v2.yaml#L10-L26

--- a/qa/L0_sagemaker/test.sh
+++ b/qa/L0_sagemaker/test.sh
@@ -165,6 +165,48 @@ set -e
 kill $SERVER_PID
 wait $SERVE_PID
 
+# Test custom model repository via SAGEMAKER_TRITON_MODEL_REPOSITORY
+CUSTOM_REPO_DIR=`pwd`/custom_repo
+mkdir -p ${CUSTOM_REPO_DIR}
+cp -r `pwd`/models/sm_model ${CUSTOM_REPO_DIR}/sm_model
+
+export SAGEMAKER_TRITON_MODEL_REPOSITORY=${CUSTOM_REPO_DIR}
+export SAGEMAKER_TRITON_DEFAULT_MODEL_NAME=sm_model
+serve > $SERVER_LOG 2>&1 &
+SERVE_PID=$!
+sleep 1
+SERVER_PID=`ps | grep tritonserver | awk '{ printf $1 }'`
+sagemaker_wait_for_server_ready $SERVER_PID 10
+if [ "$WAIT_RET" != "0" ]; then
+    echo -e "\n***\n*** Failed to start $SERVER with custom model repository\n***"
+    kill $SERVER_PID || true
+    cat $SERVER_LOG
+    exit 1
+fi
+
+# Inference with custom model repository
+set +e
+python $SAGEMAKER_TEST SageMakerTest >>$CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    echo -e "\n***\n*** Test Failed (custom model repository)\n***"
+    cat $CLIENT_LOG
+    RET=1
+else
+    check_test_results $TEST_RESULT_FILE $UNIT_TEST_COUNT
+    if [ $? -ne 0 ]; then
+        cat $CLIENT_LOG
+        echo -e "\n***\n*** Test Result Verification Failed (custom model repository)\n***"
+        RET=1
+    fi
+fi
+set -e
+
+unset SAGEMAKER_TRITON_MODEL_REPOSITORY
+
+kill $SERVER_PID
+wait $SERVE_PID
+rm -rf ${CUSTOM_REPO_DIR}
+
 # Change SageMaker port
 export SAGEMAKER_BIND_TO_PORT=8000
 serve > $SERVER_LOG 2>&1 &


### PR DESCRIPTION
#### What does the PR do?

The SageMaker `serve` script hardcodes the single-model repository path to `/opt/ml/model/`. This makes it impossible to use a custom model directory without replacing the entrypoint entirely.

This PR introduces the `SAGEMAKER_TRITON_MODEL_REPOSITORY` environment variable, which allows users to override the default model repository path whilst keeping full backwards compatibility — when the variable is unset the behaviour is identical to before.

This follows the same pattern already used by other configurable values in the script (e.g. `SAGEMAKER_TRITON_OVERRIDE_PING_MODE`, `SAGEMAKER_BIND_TO_PORT`, etc.).

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] I ran pre-commit locally (`pre-commit install, pre-commit run --all`)
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [x] feat

#### Related PRs:
None

#### Where should the reviewer start?
`docker/sagemaker/serve` — the one-line change on line 28 is the core of this PR.

#### Test plan:
1. Existing `L0_sagemaker` tests pass unchanged (the env var is not set so the default `/opt/ml/model/` is used).
2. A new test block in `qa/L0_sagemaker/test.sh` copies the model to a seperate directory, sets `SAGEMAKER_TRITON_MODEL_REPOSITORY` to that path, starts `serve`, and verifies inference succeeds.
3. After inference the env var is unset and the temporary directory is removed so subsequent tests are unaffected.

#### Caveats:
- Only the single-model endpoint path is made configurable. The multi-model endpoint path (`/tmp/sagemaker`) is a dummy placeholder used when `SAGEMAKER_MULTI_MODEL=true` and does not benefit from the same treatment.

#### Background
When deploying custom models on SageMaker that are not packaged in the standard Triton model-repository layout at `/opt/ml/model/`, users currently have no straightforward way to point `serve` at a different directory. The only workaround is to override the container entrypoint altogether, which is cumbersome and error-prone.

#### Related Issues:
- Closes #8668