### PR TITLE
build:  remove vllm flags

### DIFF
--- a/build.py
+++ b/build.py
@@ -78,7 +78,6 @@ DEFAULT_TRITON_VERSION_MAP = {
     "ort_openvino_version": "2026.0.0",
     "standalone_openvino_version": "2026.0.0",
     "dcgm_version": "4.5.3-1",
-    "vllm_version": "0.16.0",
     "rhel_py_version": "3.12.3",
 }
 
@@ -2728,12 +2727,6 @@ if __name__ == "__main__":
         required=False,
         default=DEFAULT_TRITON_VERSION_MAP["dcgm_version"],
         help="This flag sets the DCGM version for Triton Inference Server to be built. Default: the latest supported version.",
-    )
-    parser.add_argument(
-        "--vllm-version",
-        required=False,
-        default=DEFAULT_TRITON_VERSION_MAP["vllm_version"],
-        help="This flag sets the vLLM version for Triton Inference Server to be built. Default: the latest supported version.",
     )
     parser.add_argument(
         "--rhel-py-version",


### PR DESCRIPTION
<sub>
Closes: TRI-926 <br>
Related: #8698
</sub>

----

## Description 
Removing unused vllm flags as container now sourcing pre-installed version from DLFW vLLM image

