### PR TITLE
build: set OpenSSL3 paths on RHEL-like Linux (TRI-938)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -130,6 +130,8 @@ if(LINUX)
   file(STRINGS "/etc/os-release" DISTRO_ID_LIKE REGEX "ID_LIKE")
   if(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
     set (LIB_DIR "lib64")
+    set(OPENSSL_ROOT_DIR "/usr/lib64/openssl3")
+    set(OPENSSL_INCLUDE_DIR "/usr/include/openssl3")
   endif(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
 endif(LINUX)
 set(TRITON_CORE_HEADERS_ONLY OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -160,6 +160,8 @@ if(LINUX)
   file(STRINGS "/etc/os-release" DISTRO_ID_LIKE REGEX "ID_LIKE")
   if(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
     set (LIB_DIR "lib64")
+    set(OPENSSL_ROOT_DIR "/usr/lib64/openssl3")
+    set(OPENSSL_INCLUDE_DIR "/usr/include/openssl3")
   endif(${DISTRO_ID_LIKE} MATCHES "rhel|centos")
 endif(LINUX)
 set(TRITON_CORE_HEADERS_ONLY OFF)


### PR DESCRIPTION
#### What does the PR do?
Updates CMake so OpenSSL 3 library paths are set on RHEL-like Linux for manylinux/repack builds.

#### Checklist
- [ ] PR title reflects the change and is of format `<commit_type>: <Title>`
- [ ] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [ ] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
triton-inference-server/core#488
triton-inference-server/client#886
triton-inference-server/third_party#73
triton-inference-server/tensorrt_backend#119
triton-inference-server/python_backend#434
triton-inference-server/pytorch_backend#186

#### Where should the reviewer start?
`CMakeLists.txt` and `src/CMakeLists.txt` — OpenSSL3 path logic for RHEL-like Linux.

#### Test plan:
- CI Pipeline ID:
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:


#### Background
Part of ManyLinux / OpenSSL repack work.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves Linear issue: TRI-938

## Changes
- c0dd31974 build: set OpenSSL3 paths on RHEL-like Linux (TRI-938)

## Affected Files
- CMakeLists.txt
- src/CMakeLists.txt
