### PR TITLE
fix: Avoid Reusing Closed File Descriptor

### DIFF
--- a/src/shared_memory_manager.cc
+++ b/src/shared_memory_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/shared_memory_manager.cc
+++ b/src/shared_memory_manager.cc
@@ -357,7 +357,7 @@ SharedMemoryManager::RegisterSystemSharedMemory(
   // Check if the shared memory key starts with the reserved prefix
   RETURN_IF_ERR(ValidateSharedMemoryKey(name, shm_key));
 
-  std::lock_guard<std::mutex> lock(mu_);
+  std::lock_guard<std::mutex> lock{mu_};
 
   if (shared_memory_map_.find(name) != shared_memory_map_.end()) {
     return TRITONSERVER_ErrorNew(
@@ -367,23 +367,10 @@ SharedMemoryManager::RegisterSystemSharedMemory(
   }
 
   // register
-  void* mapped_addr;
-  int shm_fd = -1;
+  void* mapped_addr{nullptr};
+  int shm_fd{-1};
 
-  // don't re-open if shared memory is already open
-  for (auto itr = shared_memory_map_.begin(); itr != shared_memory_map_.end();
-       ++itr) {
-    if (itr->second->shm_key_ == shm_key) {
-      // FIXME: Consider invalid file descriptors after close
-      shm_fd = itr->second->shm_fd_;
-      break;
-    }
-  }
-
-  // open and set new shm_fd if new shared memory key
-  if (shm_fd == -1) {
-    RETURN_IF_ERR(OpenSharedMemoryRegion(shm_key, &shm_fd));
-  }
+  RETURN_IF_ERR(OpenSharedMemoryRegion(shm_key, &shm_fd));
 
   // Enforce that registered region is in-bounds of shm file object.
   RETURN_IF_ERR(
@@ -426,7 +413,7 @@ SharedMemoryManager::RegisterCUDASharedMemory(
     const size_t byte_size, const int device_id)
 {
   // Serialize all operations that write/read current shared memory regions
-  std::lock_guard<std::mutex> lock(mu_);
+  std::lock_guard<std::mutex> lock{mu_};
 
   // If name is already in shared_memory_map_ then return error saying already
   // registered

--- a/src/shared_memory_manager.h
+++ b/src/shared_memory_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/shared_memory_manager.h
+++ b/src/shared_memory_manager.h
@@ -59,8 +59,8 @@ class SharedMemoryManager {
         void* mapped_addr, const TRITONSERVER_MemoryType kind,
         const int64_t device_id)
         : name_(name), shm_key_(shm_key), offset_(offset),
-          byte_size_(byte_size), mapped_addr_(mapped_addr),
-          kind_(kind), device_id_(device_id), awaiting_unregister_(false)
+          byte_size_(byte_size), mapped_addr_(mapped_addr), kind_(kind),
+          device_id_(device_id), awaiting_unregister_(false)
     {
     }
 

--- a/src/shared_memory_manager.h
+++ b/src/shared_memory_manager.h
@@ -59,7 +59,7 @@ class SharedMemoryManager {
         void* mapped_addr, const TRITONSERVER_MemoryType kind,
         const int64_t device_id)
         : name_(name), shm_key_(shm_key), offset_(offset),
-          byte_size_(byte_size), shm_fd_(shm_fd), mapped_addr_(mapped_addr),
+          byte_size_(byte_size), mapped_addr_(mapped_addr),
           kind_(kind), device_id_(device_id), awaiting_unregister_(false)
     {
     }
@@ -68,7 +68,6 @@ class SharedMemoryManager {
     std::string shm_key_;
     size_t offset_;
     size_t byte_size_;
-    int shm_fd_;
     void* mapped_addr_;
     TRITONSERVER_MemoryType kind_;
     int64_t device_id_;


### PR DESCRIPTION
This change removes caching of file descriptors that are immediately closed. Removing the caching, removes the temptation to use the cached values to use the closed file descriptor.

CI Pipeline ID: 48236947
