### PR TITLE
feat(docker): add auditwheel to Dockerfile.sdk sdk_build stage

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -376,7 +376,7 @@ COPY --chown=1000:1000 --from=sdk /workspace/qa/ qa/
 # install the tritonserver/triton python client APIs.
 RUN rm -fr qa/L0_copyrights qa/L0_build_variants && \
     find qa/pkgs/ -maxdepth 1 -type f -name \
-    "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
+    "tritonclient-*-py3-none-any.whl" | xargs printf -- '%s[all]' | \
     xargs pip3 install --upgrade
 
 ENV LD_LIBRARY_PATH /opt/tritonserver/qa/clients:${LD_LIBRARY_PATH}

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -197,7 +197,7 @@ COPY qa/images/mug.jpg images/mug.jpg
 # be used to run the client examples.
 RUN pip3 install --upgrade "numpy<2" pillow attrdict && \
     find install/python/ -maxdepth 1 -type f -name \
-         "tritonclient-*-any.whl" | xargs printf -- '%s[all]' | \
+         "tritonclient-*-py3-none-any.whl" | xargs printf -- '%s[all]' | \
     xargs pip3 install --upgrade
 
 # Install GenAI-Perf

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -84,7 +84,7 @@ RUN apt-get update && \
             software-properties-common \
             vim \
             wget && \
-    pip3 install --upgrade "grpcio-tools<1.68" cmake==4.0.3
+    pip3 install --upgrade "grpcio-tools<1.68" cmake==4.0.3 auditwheel
 
 ENV CMAKE_POLICY_MINIMUM_REQUIRED=3.5
 

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -197,7 +197,7 @@ COPY qa/images/mug.jpg images/mug.jpg
 # be used to run the client examples.
 RUN pip3 install --upgrade "numpy<2" pillow attrdict && \
     find install/python/ -maxdepth 1 -type f -name \
-         "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
+         "tritonclient-*-any.whl" | xargs printf -- '%s[all]' | \
     xargs pip3 install --upgrade
 
 # Install GenAI-Perf

--- a/qa/L0_backend_python/setup_python_enviroment.sh
+++ b/qa/L0_backend_python/setup_python_enviroment.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -109,7 +109,7 @@ rm -f /usr/bin/python3 && \
 ln -s "/usr/bin/python3.${PYTHON_ENV_VERSION}" /usr/bin/python3
 pip3 install --upgrade requests numpy virtualenv protobuf
 find /opt/tritonserver/qa/pkgs/ -maxdepth 1 -type f -name \
-    "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
+    "tritonclient-*-py3-none-any.whl" | xargs printf -- '%s[all]' | \
     xargs pip3 install --upgrade
 
 # Build triton-shm-monitor for the test

--- a/qa/L0_sdk/test.sh
+++ b/qa/L0_sdk/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -153,11 +153,9 @@ fi
 # we need to replace the text here as well to match the normalized version.
 WHLVERSION=`cat /workspace/TRITON_VERSION | sed 's/dev/\.dev0/'`
 if [[ "aarch64" != $(uname -m) ]] ; then
-    WHLS="tritonclient-${WHLVERSION}-py3-none-any.whl \
-          tritonclient-${WHLVERSION}-py3-none-manylinux1_x86_64.whl"
+    WHLS="tritonclient-${WHLVERSION}-py3-none-any.whl"
 else
-    WHLS="tritonclient-${WHLVERSION}-py3-none-any.whl \
-          tritonclient-${WHLVERSION}-py3-none-manylinux2014_aarch64.whl"
+    WHLS="tritonclient-${WHLVERSION}-py3-none-any.whl"
 fi
 for l in $WHLS; do
     if [[ ! -f "triton_client/python/$l" ]]; then


### PR DESCRIPTION
<sup>
Resolves: TRI-286<br/>
triton-inference-server/client#888<br/>
triton-inference-server/model_analyzer#1019<br/>
</sup>

#### What does the PR do?

Add `auditwheel` to the `pip3 install` command in the `sdk_build` stage of `Dockerfile.sdk`. This ensures `auditwheel repair` is available when building the tritonclient wheel, so the correct `manylinux_X_Y_{arch}` platform tag is auto-discovered from the glibc symbol dependencies of the native extensions (fixes the incorrect tag produced on Ubuntu 24.04 builds).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/client#888
- triton-inference-server/model_analyzer#1019

#### Where should the reviewer start?
`Dockerfile.sdk` line 87 — the `pip3 install` line in `sdk_build` stage.

#### Test plan:
- Build the SDK container and verify `auditwheel --version` is available in the `sdk_build` stage.
- Run `py3-wheel-publish` CI job and confirm the produced `.whl` file has a correct `manylinux_*` tag.

- CI Pipeline ID: (to be added after CI run)

#### Caveats:
None.

#### Background
`auditwheel repair` inspects native extensions in a built wheel and emits a correctly-tagged manylinux wheel. Wheels built on Ubuntu 24.04 (glibc 2.39) cannot claim `manylinux1` or `manylinux2014` tags. The auto-discovery removes the need to maintain the tag manually per OS.

#### Related Issues:
- Relates to Linear TRI-286 (Kitmaker 2.0 process enablement)