### PR TITLE
test: Add HTTP test for deep JSON in repository index requests

### DIFF
--- a/qa/L0_cuda_shared_memory/cuda_shared_memory_test.py
+++ b/qa/L0_cuda_shared_memory/cuda_shared_memory_test.py
@@ -760,7 +760,7 @@ class CudaSharedMemoryTestRawHttpRequest(unittest.TestCase):
                 error_message,
             )
             self.assertIn(
-                "exceeds the maximum allowed value",
+                "exceeds the maximum allowed input size",
                 error_message,
             )
         except ValueError:

--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -423,6 +423,34 @@ class HttpTest(tu.TestResultCollector):
                     except ValueError:
                         self.fail("Response is not valid JSON")
 
+    def test_repository_index_deeply_nested_json(self):
+        """Test for deeply nested JSON on model repository index."""
+        depth = 250000
+        nested = ("[" * depth) + "true" + ("]" * depth)
+        payload = '{"ready":' + nested + "}"
+
+        # Keep request below default --http-max-input-size so parsing path is exercised.
+        self.assertLess(len(payload), 64 * 1024 * 1024)
+
+        response = requests.post(
+            "http://localhost:8000/v2/repository/index",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=60,
+        )
+        self.assertNotEqual(
+            500,
+            response.status_code,
+            "Expected repository index request to fail on invalid 'ready' type.",
+        )
+
+        live_response = requests.get("http://localhost:8000/v2/health/live", timeout=10)
+        self.assertEqual(
+            200,
+            live_response.status_code,
+            "Expected server to remain live after deeply nested JSON request.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -439,9 +439,14 @@ class HttpTest(tu.TestResultCollector):
             timeout=60,
         )
         self.assertEqual(
-            500,
+            400,
             response.status_code,
             "Expected repository index request to fail on invalid 'ready' type.",
+        )
+        self.assertIn("error", response.json())
+        self.assertIn(
+            "Invalid value for 'ready': expected a boolean",
+            response.json()["error"],
         )
 
         live_response = requests.get("http://localhost:8000/v2/health/live", timeout=10)

--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -438,7 +438,7 @@ class HttpTest(tu.TestResultCollector):
             headers={"Content-Type": "application/json"},
             timeout=60,
         )
-        self.assertNotEqual(
+        self.assertEqual(
             500,
             response.status_code,
             "Expected repository index request to fail on invalid 'ready' type.",

--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -499,6 +499,38 @@ class HttpTest(tu.TestResultCollector):
             "Server is not healthy after duplicate output request",
         )
 
+    def test_repository_index_deeply_nested_json(self):
+        """Test for deeply nested JSON on model repository index."""
+        depth = 250000
+        nested = ("[" * depth) + "true" + ("]" * depth)
+        payload = '{"ready":' + nested + "}"
+
+        # Keep request below default --http-max-input-size so parsing path is exercised.
+        self.assertLess(len(payload), 64 * 1024 * 1024)
+
+        response = requests.post(
+            "http://localhost:8000/v2/repository/index",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=60,
+        )
+        self.assertEqual(
+            400,
+            response.status_code,
+            "Expected repository index request to fail on invalid 'ready' type.",
+        )
+        self.assertIn(
+            "Invalid value for 'ready': expected a boolean",
+            response.json()["error"],
+        )
+
+        live_response = requests.get("http://localhost:8000/v2/health/live", timeout=10)
+        self.assertEqual(
+            200,
+            live_response.status_code,
+            "Expected server to remain live after deeply nested JSON request.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qa/L0_http/http_test.py
+++ b/qa/L0_http/http_test.py
@@ -443,7 +443,6 @@ class HttpTest(tu.TestResultCollector):
             response.status_code,
             "Expected repository index request to fail on invalid 'ready' type.",
         )
-        self.assertIn("error", response.json())
         self.assertIn(
             "Invalid value for 'ready': expected a boolean",
             response.json()["error"],

--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -672,7 +672,7 @@ fi
 
 TEST_RESULT_FILE='test_results.txt'
 PYTHON_TEST=http_test.py
-EXPECTED_NUM_TESTS=13
+EXPECTED_NUM_TESTS=14
 set +e
 python $PYTHON_TEST >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then

--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -672,7 +672,7 @@ fi
 
 TEST_RESULT_FILE='test_results.txt'
 PYTHON_TEST=http_test.py
-EXPECTED_NUM_TESTS=15
+EXPECTED_NUM_TESTS=16
 set +e
 python $PYTHON_TEST >$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -1413,7 +1413,13 @@ HTTPAPIServer::HandleRepositoryIndex(
   if (buffer_len > 0) {
     triton::common::TritonJson::Value ready_json;
     if (index_request.Find("ready", &ready_json)) {
-      err = ready_json.AsBool(&ready);
+      if (!ready_json.IsBool()) {
+        err = TRITONSERVER_ErrorNew(
+            TRITONSERVER_ERROR_INVALID_ARG,
+            "Invalid value for 'ready': expected a boolean");
+      } else {
+        err = ready_json.AsBool(&ready);
+      }
     }
   }
 


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR adds a new HTTP QA regression test intended to ensure Triton’s `/v2/repository/index` request handling remains robust (and the server stays live) when presented with extremely deeply nested JSON input.

#### Related PRs: https://github.com/triton-inference-server/common/pull/156
<!-- Related PRs from other Repositories -->

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test


#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID: 48692947
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
