### PR TITLE
fix: Address SonarQube issues - clean up container files

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -59,9 +59,9 @@ RUN apt-get update && \
             libboost-dev \
             python3-dev \
             python3-pip \
-            python3-wheel \
             python3-setuptools \
             python3-venv \
+            python3-wheel \
             rapidjson-dev \
             software-properties-common && \
     rm -rf /var/lib/apt/lists/*
@@ -74,7 +74,7 @@ ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
 # in order to ensure the public facing docs are up-to-date.
 WORKDIR /workspace/docs/examples/model_repository
 RUN mkdir -p densenet_onnx/1 && \
-        wget -O densenet_onnx/1/model.onnx \
+    wget -O densenet_onnx/1/model.onnx \
             https://github.com/onnx/models/raw/main/validated/vision/classification/densenet-121/model/densenet-7.onnx
 
 # Update the qa/ directory with test executables, models, etc.
@@ -174,8 +174,8 @@ RUN mkdir -p qa/custom_models/custom_sequence_int32/1 && \
         qa/custom_models/custom_dyna_sequence_int32/1/.
 
 # L0_lifecycle needs No-GPU build of identity backend.
-RUN cd tritonbuild/identity && \
-    rm -rf install build && mkdir build && cd build && \
+WORKDIR  /workspace/tritonbuild/identity
+RUN rm -rf install build && mkdir build && cd build && \
     cmake -DTRITON_ENABLE_GPU=OFF \
         -DCMAKE_INSTALL_PREFIX:PATH=/workspace/tritonbuild/identity/install \
         -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
@@ -187,8 +187,8 @@ RUN cd tritonbuild/identity && \
 
 # L0_backend_python test require triton_shm_monitor
 ARG TRITON_BOOST_URL="https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz"
-RUN cd tritonbuild/python && \
-    rm -rf install build && mkdir build && cd build && \
+WORKDIR /workspace/tritonbuild/python
+RUN rm -rf install build && mkdir build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/workspace/tritonbuild/python/install \
         -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
         -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG} \
@@ -197,6 +197,7 @@ RUN cd tritonbuild/python && \
         -DTRITON_BACKEND_REPO_TAG:STRING=${TRITON_BACKEND_REPO_TAG} .. && \
     make -j16 triton-shm-monitor install
 
+WORKDIR /workspace/
 RUN cp tritonbuild/identity/install/backends/identity/libtriton_identity.so \
         qa/L0_lifecycle/. && \
     cp tritonbuild/python/install/backends/python/triton_shm_monitor*.so \
@@ -316,7 +317,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN if grep -qE '^VERSION_ID="(18\.04|20\.04|22\.04|24\.04)' /etc/os-release; then \
         apt-get update && \
         apt-get install -y --no-install-recommends \
-                libpng-dev; \
+                libpng-dev && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     else \
         echo "Ubuntu version must be either 18.04, 20.04, 22.04 or 24.04" && \
         exit 1; \
@@ -327,22 +330,23 @@ RUN if grep -qE '^VERSION_ID="(18\.04|20\.04|22\.04|24\.04)' /etc/os-release; th
 RUN apt-get update && apt-get install -y --no-install-recommends \
                               curl \
                               gdb \
-                              libopencv-dev \
                               libarchive-dev \
                               libopencv-core-dev \
+                              libopencv-dev \
                               libzmq3-dev \
-                              openjdk-11-jdk \
                               nginx \
                               npm \
+                              openjdk-11-jdk \
                               protobuf-compiler \
                               python3-dev \
                               python3-pip \
                               python3-protobuf \
-                              python3-wheel \
                               python3-setuptools \
+                              python3-wheel \
                               swig \
                               valgrind && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* \
 
 # CI/QA expects "python" executable (not python3).
 RUN rm -f /usr/bin/python && \

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -211,7 +211,7 @@ RUN pip3 install genai-perf
 RUN if [ "$TRITON_ENABLE_GPU" = "ON" ]; then \
         [ "$(uname -m)" != "x86_64" ] && arch="sbsa" || arch="x86_64" && \
         curl -o /tmp/cuda-keyring.deb \
-        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/"$arch"/cuda-keyring_1.1-1_all.deb \
+        "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${arch}/cuda-keyring_1.1-1_all.deb" \
         && apt -y install /tmp/cuda-keyring.deb && rm /tmp/cuda-keyring.deb && \
         apt update && \
         apt install --yes --no-install-recommends \

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -169,16 +169,20 @@ RUN apt-get update && \
             python3-wheel \
             vim \
             wget && \
-    pip3 install "grpcio<1.68" "grpcio-tools<1.68"
+    pip3 install "grpcio<1.68" "grpcio-tools<1.68" && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*;
 
 WORKDIR /workspace
 COPY TRITON_VERSION .
 COPY NVIDIA_Deep_Learning_Container_License.pdf .
 COPY --from=sdk_build /workspace/client/ client/
 COPY --from=sdk_build /workspace/install/ install/
-RUN cd install && \
-    export VERSION=`cat /workspace/TRITON_VERSION` && \
-    tar zcf /workspace/v$VERSION.clients.tar.gz *
+WORKDIR /workspace/install
+RUN export VERSION=`cat /workspace/TRITON_VERSION` && \
+    tar zcf /workspace/v"$VERSION".clients.tar.gz ./*
+
+WORKDIR /workspace
 
 # For CI testing need to copy over L0_sdk test and L0_client_build_variants test.
 RUN mkdir qa
@@ -207,8 +211,8 @@ RUN pip3 install genai-perf
 RUN if [ "$TRITON_ENABLE_GPU" = "ON" ]; then \
         [ "$(uname -m)" != "x86_64" ] && arch="sbsa" || arch="x86_64" && \
         curl -o /tmp/cuda-keyring.deb \
-        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/$arch/cuda-keyring_1.1-1_all.deb \
-        && apt install /tmp/cuda-keyring.deb && rm /tmp/cuda-keyring.deb && \
+        https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/"$arch"/cuda-keyring_1.1-1_all.deb \
+        && apt -y install /tmp/cuda-keyring.deb && rm /tmp/cuda-keyring.deb && \
         apt update && \
         apt install --yes --no-install-recommends \
                datacenter-gpu-manager-4-core=1:${DCGM_VERSION} \

--- a/docs/_static/rtd-data.js
+++ b/docs/_static/rtd-data.js
@@ -28,7 +28,7 @@
 
 // Dummy data for testing ReadTheDocs footer insertion
 // This mimics RTD data for a project that uses both versions + languages
-var READTHEDOCS_DATA = {
+let READTHEDOCS_DATA = {
   project: "frc-docs",
   version: "latest",
   language: "en",


### PR DESCRIPTION
Addressed some of the SonarQube issues. Changes include:

1. Sort package names alphanumerically.

2. Replace invocation of "wget" or “curl” with the ADD instruction. The ADD instruction is a built-in feature of Docker that is specifically designed for this purpose, making it a more efficient and safer choice. 

3. WORKDIR instruction should be used instead of "cd" command.

4. Variables declared with var are function-scoped, meaning they are accessible within the entire function in which they are defined. If a variable is declared using var outside of any function, it becomes a global variable and is accessible throughout the entire JavaScript program.Variables declared with let have block scope, meaning they are limited to the block of code in which they are defined. 

5. In Docker, when packages are installed via a package manager, an index is cached locally by default. This index should either be cleaned up or stored in a dedicated cache mount.Storing an index also increases the size of the Docker image. It should be reduced to speed up deployments and reduce storage and bandwidth.

6. Filename and pathname should be prefixed to avoid missing filenames starting with a dash when globbing files as program option.

7. Variable references should be encapsulated with double quotes to avoid globbing and word splitting. This causes issues if the variable contains whitespaces or shell pathname expansion (glob) characters like *.

8. Add consent flag so that this command doesn't require user confirmation. Various package and software management applications require manual input for execution confirmation by default. This confirmation is usually required when installing, updating, or removing programs and packages. General consent can be given to execute the command without manual input. If the -y flag is set, no manual input is expected, and the package manager can run non-interactively. 


Linear ticket: https://linear.app/nvidia/issue/TRI-845/clean-up-containerfiles-based-on-sonarqube-feedback

Testing: Ran `docker build` locally and verified the fix.

```
mudita@a1u1g-mil-0840:~/server$ docker build -t sdk --build-arg TRITON_MODEL_ANALYZER_REPO_TAG=main -f Dockerfile.sdk .
2026/04/21 20:10:39 in: []string{}
2026/04/21 20:10:39 Parsed entitlements: []
[+] Building 58.6s (37/37) FINISHED                                                                                                                                           docker:default
…
 => => writing image sha256:2bba36c1b3e68b4bc8ce1a7de241783b6cfe670ea64b97674da762f9e6bb697b                                                                                            0.0s 
 => => naming to docker.io/library/sdk                                                                                                                                                  0.0s 
mudita@a1u1g-mil-0840:~/server$ 
```

```
mudita@nvdiefuee5gdkc7:~/triton/server$ docker build --progress=plain --pull --platform linux/amd64 -t gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:master-py3.48896081-devel-amd64 --cache-from gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:master-py3.48896081-sdk --cache-from gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:master-py3.48896081-cibase-amd64 --cache-from gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:master-py3.48896081 -f Dockerfile.QA --build-arg SDK_IMAGE=gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:master-py3.48896081-sdk --build-arg CIBASE_IMAGE=gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:master-py3.48896081-cibase-amd64 --build-arg BASE_IMAGE=gitlab-master.nvidia.com:5005/dl/dgx/tritonserver:master-py3.48896081 --build-arg TRITON_REPO_ORGANIZATION=https://github.com/triton-inference-server --build-arg TRITON_COMMON_REPO_TAG=main --build-arg TRITON_CORE_REPO_TAG=main --build-arg TRITON_THIRD_PARTY_REPO_TAG=main --build-arg TRITON_BACKEND_REPO_TAG=main --build-arg TRITON_BOOST_URL=https://gitlab-master.nvidia.com/api/v4/projects/9533/packages/generic/boost/1.80.0/boost_1_80_0.tar.gz .
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile.QA
#1 transferring dockerfile: 19.67kB 0.0s done

#49 DONE 96.6s

 6 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 370)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 386)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 389)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 392)
 - NoEmptyContinuation: Empty continuation line (line 353)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 369)
mudita@nvdiefuee5gdkc7:~/triton/server$ 
```

