### PR TITLE
ci: Enable Perf Analyzer + OpenVINO 2026.1.0

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -374,10 +374,17 @@ COPY --chown=1000:1000 --from=sdk /workspace/qa/ qa/
 
 # Remove CI tests that are meant to run only on build image and
 # install the tritonserver/triton python client APIs.
-RUN rm -fr qa/L0_copyrights qa/L0_build_variants && \
-    find qa/pkgs/ -maxdepth 1 -type f -name \
-    "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
-    xargs pip3 install --upgrade
+RUN rm -fr qa/L0_copyrights qa/L0_build_variants
+
+
+RUN --mount=type=secret,id=triton_ci_pip_extra_values,env=TRITON_CI_PYPI_EXTRA_VALUES \
+    if [ -n "${TRITON_CI_PYPI_EXTRA_VALUES}" ]; then \
+        find qa/pkgs/ -maxdepth 1 -type f -name \
+        "tritonclient-*linux*.whl" -exec pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} {} \; ; \
+    else \
+        find qa/pkgs/ -maxdepth 1 -type f -name \
+        "tritonclient-*linux*.whl" -exec pip3 install --upgrade {} \; ; \
+    fi
 
 ENV LD_LIBRARY_PATH /opt/tritonserver/qa/clients:${LD_LIBRARY_PATH}
 

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -380,10 +380,10 @@ RUN rm -fr qa/L0_copyrights qa/L0_build_variants
 RUN --mount=type=secret,id=triton_ci_pip_extra_values,env=TRITON_CI_PYPI_EXTRA_VALUES \
     if [ -n "${TRITON_CI_PYPI_EXTRA_VALUES}" ]; then \
         find qa/pkgs/ -maxdepth 1 -type f -name \
-        "tritonclient-*linux*.whl" -exec pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} {} \; ; \
+        "tritonclient-*linux*.whl" -exec pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} {}[all] \; ; \
     else \
         find qa/pkgs/ -maxdepth 1 -type f -name \
-        "tritonclient-*linux*.whl" -exec pip3 install --upgrade {} \; ; \
+        "tritonclient-*linux*.whl" -exec pip3 install --upgrade {}[all] \; ; \
     fi
 
 ENV LD_LIBRARY_PATH /opt/tritonserver/qa/clients:${LD_LIBRARY_PATH}

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -195,10 +195,16 @@ COPY qa/images/mug.jpg images/mug.jpg
 # Install the dependencies needed to run the client examples. These
 # are not needed for building but including them allows this image to
 # be used to run the client examples.
-RUN pip3 install --upgrade "numpy<2" pillow attrdict && \
-    find install/python/ -maxdepth 1 -type f -name \
-         "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
-    xargs pip3 install --upgrade
+RUN pip3 install --upgrade "numpy<2" pillow attrdict
+
+RUN --mount=type=secret,id=triton_ci_pip_extra_values,env=TRITON_CI_PYPI_EXTRA_VALUES \
+    if [ -n "${TRITON_CI_PYPI_EXTRA_VALUES}" ]; then \
+        find install/python/ -maxdepth 1 -type f -name \
+            "tritonclient-*linux*.whl" -exec pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} {} \; ; \
+    else \
+        find install/python/ -maxdepth 1 -type f -name \
+            "tritonclient-*linux*.whl" -exec pip3 install --upgrade {} \; ; \
+    fi
 
 # Install GenAI-Perf
 RUN --mount=type=secret,id=triton_ci_pip_extra_values,env=TRITON_CI_PYPI_EXTRA_VALUES \

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -200,10 +200,10 @@ RUN pip3 install --upgrade "numpy<2" pillow attrdict
 RUN --mount=type=secret,id=triton_ci_pip_extra_values,env=TRITON_CI_PYPI_EXTRA_VALUES \
     if [ -n "${TRITON_CI_PYPI_EXTRA_VALUES}" ]; then \
         find install/python/ -maxdepth 1 -type f -name \
-            "tritonclient-*linux*.whl" -exec pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} {} \; ; \
+            "tritonclient-*linux*.whl" -exec pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} {}[all] \; ; \
     else \
         find install/python/ -maxdepth 1 -type f -name \
-            "tritonclient-*linux*.whl" -exec pip3 install --upgrade {} \; ; \
+            "tritonclient-*linux*.whl" -exec pip3 install --upgrade {}[all] \; ; \
     fi
 
 # Install GenAI-Perf

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -195,10 +195,16 @@ COPY qa/images/mug.jpg images/mug.jpg
 # Install the dependencies needed to run the client examples. These
 # are not needed for building but including them allows this image to
 # be used to run the client examples.
-RUN pip3 install --upgrade "numpy<2" pillow attrdict && \
-    find install/python/ -maxdepth 1 -type f -name \
-         "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
-    xargs pip3 install --upgrade
+RUN pip3 install --upgrade "numpy<2" pillow attrdict
+
+RUN --mount=type=secret,id=triton_ci_pip_extra_values,env=TRITON_CI_PYPI_EXTRA_VALUES \
+    if [ -n "${TRITON_CI_PYPI_EXTRA_VALUES}" ]; then \
+        find install/python/ -maxdepth 1 -type f -name \
+        "tritonclient-*linux*.whl" -exec pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} {} \; ; \
+    else \
+        find install/python/ -maxdepth 1 -type f -name \
+        "tritonclient-*linux*.whl" -exec pip3 install --upgrade {} \; ; \
+    fi
 
 # Install GenAI-Perf
 RUN pip3 install genai-perf

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -195,19 +195,18 @@ COPY qa/images/mug.jpg images/mug.jpg
 # Install the dependencies needed to run the client examples. These
 # are not needed for building but including them allows this image to
 # be used to run the client examples.
-RUN pip3 install --upgrade "numpy<2" pillow attrdict
-
-RUN --mount=type=secret,id=triton_ci_pip_extra_values,env=TRITON_CI_PYPI_EXTRA_VALUES \
-    if [ -n "${TRITON_CI_PYPI_EXTRA_VALUES}" ]; then \
-        find install/python/ -maxdepth 1 -type f -name \
-        "tritonclient-*linux*.whl" -exec pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} {} \; ; \
-    else \
-        find install/python/ -maxdepth 1 -type f -name \
-        "tritonclient-*linux*.whl" -exec pip3 install --upgrade {} \; ; \
-    fi
+RUN pip3 install --upgrade "numpy<2" pillow attrdict && \
+    find install/python/ -maxdepth 1 -type f -name \
+         "tritonclient-*linux*.whl" | xargs printf -- '%s[all]' | \
+    xargs pip3 install --upgrade
 
 # Install GenAI-Perf
-RUN pip3 install genai-perf
+RUN --mount=type=secret,id=triton_ci_pip_extra_values,env=TRITON_CI_PYPI_EXTRA_VALUES \
+    if [ -n "${TRITON_CI_PYPI_EXTRA_VALUES}" ]; then \
+       pip3 install --upgrade ${TRITON_CI_PYPI_EXTRA_VALUES} genai-perf ; \
+    else \
+        pip3 install --upgrade genai-perf ; \
+    fi
 
 # Install DCGM
 RUN if [ "$TRITON_ENABLE_GPU" = "ON" ]; then \

--- a/build.py
+++ b/build.py
@@ -74,7 +74,7 @@ DEFAULT_TRITON_VERSION_MAP = {
     "release_version": "2.68.0",
     "triton_container_version": "26.04",
     "upstream_container_version": "26.04",
-    "ort_version": "1.25.0",
+    "ort_version": "1.24.4",
     "ort_openvino_version": "2026.1.0",
     "standalone_openvino_version": "2026.1.0",
     "dcgm_version": "4.5.3-1",

--- a/build.py
+++ b/build.py
@@ -74,11 +74,11 @@ DEFAULT_TRITON_VERSION_MAP = {
     "release_version": "2.68.0",
     "triton_container_version": "26.04",
     "upstream_container_version": "26.04",
-    "ort_version": "1.24.4",
-    "ort_openvino_version": "2026.0.0",
-    "standalone_openvino_version": "2026.0.0",
+    "ort_version": "1.25.0",
+    "ort_openvino_version": "2026.1.0",
+    "standalone_openvino_version": "2026.1.0",
     "dcgm_version": "4.5.3-1",
-    "vllm_version": "0.16.0",
+    "vllm_version": "0.19.0",
     "rhel_py_version": "3.12.3",
 }
 


### PR DESCRIPTION
<sup>
CI (internal): [#49332301](http://tritonserver.local/ci/pipelines/49332301)<br/>
</sup>

#### What does the PR do?
Enables Perf Analyzer + OpenVINO 2026.1.0 in the 26.04 SDK/QA build by:
- Using the Triton Artifactory PyPI index (extra-index-url) to install `tritonclient` deterministically in both `Dockerfile.QA` and `Dockerfile.sdk`.
- Bumping build versions in `build.py` to the 26.04 tag set.
- Reverting an ONNX Runtime version change that conflicts with the pinned OpenVINO 2026.1.0 build.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [ ] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added succinct git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [ ] build
- [x] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/onnxruntime_backend#340

#### Where should the reviewer start?
`Dockerfile.QA` and `Dockerfile.sdk` — new tritonclient install path via the Artifactory extra-index-url. Then `build.py` for the matching version bumps.

#### Test plan:
- CI Pipeline ID: 49332301

#### Caveats:
None known.

#### Background
Part of TRI-988 — "ci: Enable Perf Analyzer + OpenVINO 2026.1.0". perf_analyzer is installed from the internal Triton Artifactory PyPI index (`sw-dl-triton-pypi-local`) to keep installs reproducible and access-controlled across CI, QA, and release images.

#### Related Issues:
- Resolves: TRI-988