### PR TITLE
fix: Reject Triton reserved keys in parameters and forward headers

### DIFF
--- a/docs/protocol/extension_parameters.md
+++ b/docs/protocol/extension_parameters.md
@@ -42,11 +42,12 @@ The following parameters are reserved for Triton's usage and should not be
 used as custom parameters:
 
 - sequence_id
-- priority
-- timeout
 - sequence_start
 - sequence_end
+- priority
+- timeout
 - headers
+- binary_data_output
 - All the keys that start with `"triton_"` prefix. Some examples used today:
   - `"triton_enable_empty_final_response"` request parameter
   - `"triton_final_response"` response parameter

--- a/qa/L0_parameters/parameters_test.py
+++ b/qa/L0_parameters/parameters_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,66 +30,86 @@ import sys
 
 sys.path.append("../common")
 
-import os
 import queue
 import unittest
 from functools import partial
-from unittest import IsolatedAsyncioTestCase
 
 import numpy as np
+import requests
 import tritonclient.grpc as grpcclient
 import tritonclient.grpc.aio as asyncgrpcclient
 import tritonclient.http as httpclient
 import tritonclient.http.aio as asynchttpclient
 from tritonclient.utils import InferenceServerException
 
-TEST_HEADER = os.environ.get("TEST_HEADER")
+_TRITON_RESERVED_CLIENT_ERROR = "is a reserved parameter and cannot be specified"
+_TRITON_RESERVED_SERVER_ERROR = "reserved for Triton usage"
+
+# docs/protocol/extension_parameters.md — reserved names
+_RESERVED_PARAMETER_KEYS = (
+    "sequence_id",
+    "sequence_start",
+    "sequence_end",
+    "priority",
+    "timeout",
+    "headers",
+    "binary_data_output",
+    "triton_enable_empty_final_response",
+    "triton_final_response",
+    "triton_injected_via_header",
+)
+
+_HTTP_LOCALHOST = "http://localhost:8000"
 
 
-class InferenceParametersTest(IsolatedAsyncioTestCase):
-    async def asyncSetUp(self):
-        self.http = httpclient.InferenceServerClient(url="localhost:8000")
-        self.async_http = asynchttpclient.InferenceServerClient(url="localhost:8000")
-        self.grpc = grpcclient.InferenceServerClient(url="localhost:8001")
-        self.async_grpc = asyncgrpcclient.InferenceServerClient(url="localhost:8001")
+def _infer_url(model_name="parameter"):
+    return f"{_HTTP_LOCALHOST}/v2/models/{model_name}/infer"
 
-        self.parameter_list = []
-        self.parameter_list.append({"key1": "value1", "key2": "value2"})
-        self.parameter_list.append({"key1": 1, "key2": 2})
-        self.parameter_list.append({"key1": 123.123, "key2": 321.321})
-        self.parameter_list.append({"key1": True, "key2": "value2"})
-        self.parameter_list.append({"triton_": True, "key2": "value2"})
 
-        # Only "test_params" tests parameters without headers.
-        if TEST_HEADER != "test_params":
-            self.headers = {
-                "header_1": "value_1",
-                "header_2": "value_2",
-                "my_header_1": "my_value_1",
-                "my_header_2": "my_value_2",
-                "my_header_3": 'This is a "quoted" string with a backslash\ ',
+def _minimal_fp32_infer_body(parameters=None):
+    """KServe HTTP infer JSON matching qa/L0_parameters model `parameter` (INPUT0 FP32 [1])."""
+    body = {
+        "inputs": [
+            {
+                "name": "INPUT0",
+                "shape": [1],
+                "datatype": "FP32",
+                "data": [1.0],
             }
+        ],
+    }
+    if parameters is not None:
+        body["parameters"] = parameters
+    return body
 
-            # only these headers should be forwarded to the model.
-            if TEST_HEADER == "test_grpc_header_forward_pattern_case_sensitive":
-                self.expected_headers = {}
-            else:
-                self.expected_headers = {
-                    "my_header_1": "my_value_1",
-                    "my_header_2": "my_value_2",
-                    "my_header_3": 'This is a "quoted" string with a backslash\ ',
-                }
-        else:
-            self.headers = {}
-            self.expected_headers = {}
 
-        def callback(user_data, result, error):
-            if error:
-                user_data.put(error)
-            else:
-                user_data.put(result)
+_FORWARD_HEADERS = {
+    "header_1": "value_1",
+    "header_2": "value_2",
+    "my_header_1": "my_value_1",
+    "my_header_2": "my_value_2",
+    "my_header_3": 'This is a "quoted" string with a backslash\\ ',
+}
 
-        self.grpc_callback = callback
+
+def _grpc_stream_callback(user_data, result, error):
+    if error:
+        user_data.put(error)
+    else:
+        user_data.put(result)
+
+
+class InferenceParametersTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.httpclient = httpclient.InferenceServerClient(url="localhost:8000")
+        self.async_httpclient = asynchttpclient.InferenceServerClient(
+            url="localhost:8000"
+        )
+        self.grpcclient = grpcclient.InferenceServerClient(url="localhost:8001")
+        self.async_grpcclient = asyncgrpcclient.InferenceServerClient(
+            url="localhost:8001"
+        )
+        self.grpcclient_callback = _grpc_stream_callback
 
     def create_inputs(self, client_type):
         inputs = []
@@ -100,128 +120,257 @@ class InferenceParametersTest(IsolatedAsyncioTestCase):
         return inputs
 
     async def send_request_and_verify(
-        self, client_type, client, is_async=False, model_name="parameter"
+        self,
+        client_type,
+        client,
+        parameters,
+        headers,
+        expected_headers,
+        is_async_infer=False,
+        model_name="parameter",
     ):
         inputs = self.create_inputs(client_type)
-        for parameters in self.parameter_list:
-            # Setup infer callable to re-use below for brevity
+
+        if is_async_infer:
+            if client_type == httpclient:
+                result = client.async_infer(
+                    model_name=model_name,
+                    inputs=inputs,
+                    parameters=parameters,
+                    headers=headers,
+                ).get_result()
+            elif client_type == grpcclient:
+                user_data = queue.Queue()
+                client.async_infer(
+                    model_name=model_name,
+                    inputs=inputs,
+                    parameters=parameters,
+                    headers=headers,
+                    callback=partial(self.grpcclient_callback, user_data),
+                )
+                result = user_data.get()
+                self.assertFalse(result is InferenceServerException)
+            else:
+                raise ValueError(f"Unsupported client type: {client_type}")
+        else:
             infer_callable = partial(
                 client.infer,
                 model_name=model_name,
                 inputs=inputs,
                 parameters=parameters,
-                headers=self.headers,
+                headers=headers,
             )
-
-            # The `triton_` prefix is reserved for Triton usage
-            should_error = False
-            if "triton_" in parameters.keys():
-                should_error = True
-
-            if is_async:
-                if should_error:
-                    with self.assertRaises(InferenceServerException):
-                        await infer_callable()
-                    return
-                else:
-                    result = await infer_callable()
+            if client_type == asynchttpclient or client_type == asyncgrpcclient:
+                result = await infer_callable()
             else:
-                if should_error:
-                    with self.assertRaises(InferenceServerException):
-                        infer_callable()
-                    return
-                else:
-                    result = infer_callable()
+                result = infer_callable()
 
-            self.verify_outputs(result, parameters)
+        self.verify_outputs(result, parameters, expected_headers)
 
-    def verify_outputs(self, result, parameters):
+    def verify_outputs(self, result, parameters, expected_headers):
         keys = result.as_numpy("key")
         values = result.as_numpy("value")
         keys = keys.astype(str).tolist()
-        expected_keys = list(parameters.keys()) + list(self.expected_headers.keys())
-        self.assertEqual(set(keys), set(expected_keys))
+        expected_keys = list(parameters.keys()) + list(expected_headers.keys())
+        self.assertEqual(
+            set(keys),
+            set(expected_keys),
+            msg=f"keys: {keys}, expected_keys: {expected_keys}",
+        )
 
         # We have to convert the parameter values to string
         expected_values = []
         for expected_value in list(parameters.values()):
             expected_values.append(str(expected_value))
-        for value in self.expected_headers.values():
+        for value in expected_headers.values():
             expected_values.append(value)
-        self.assertEqual(set(values.astype(str).tolist()), set(expected_values))
-
-    async def test_grpc_parameter(self):
-        await self.send_request_and_verify(grpcclient, self.grpc)
-
-    async def test_http_parameter(self):
-        await self.send_request_and_verify(httpclient, self.http)
-
-    async def test_async_http_parameter(self):
-        await self.send_request_and_verify(
-            asynchttpclient, self.async_http, is_async=True
+        self.assertEqual(
+            set(values.astype(str).tolist()),
+            set(expected_values),
+            msg=f"values: {values.astype(str).tolist()}, expected_values: {expected_values}",
         )
 
-    async def test_async_grpc_parameter(self):
-        await self.send_request_and_verify(
-            asyncgrpcclient, self.async_grpc, is_async=True
-        )
-
-    def test_http_async_parameter(self):
-        inputs = self.create_inputs(httpclient)
-        # Skip the parameter that returns an error
-        parameter_list = self.parameter_list[:-1]
-        for parameters in parameter_list:
-            result = self.http.async_infer(
-                model_name="parameter",
-                inputs=inputs,
-                parameters=parameters,
-                headers=self.headers,
-            ).get_result()
-            self.verify_outputs(result, parameters)
-
-    def test_grpc_async_parameter(self):
+    async def _verify_grpc_stream_infer(self, parameters, headers, expected_headers):
         user_data = queue.Queue()
-        inputs = self.create_inputs(grpcclient)
-        # Skip the parameter that returns an error
-        parameter_list = self.parameter_list[:-1]
-        for parameters in parameter_list:
-            self.grpc.async_infer(
-                model_name="parameter",
-                inputs=inputs,
-                parameters=parameters,
-                headers=self.headers,
-                callback=partial(self.grpc_callback, user_data),
-            )
-            result = user_data.get()
-            self.assertFalse(result is InferenceServerException)
-            self.verify_outputs(result, parameters)
-
-    def test_grpc_stream_parameter(self):
-        user_data = queue.Queue()
-        self.grpc.start_stream(
-            callback=partial(self.grpc_callback, user_data), headers=self.headers
+        self.grpcclient.start_stream(
+            callback=partial(self.grpcclient_callback, user_data), headers=headers
         )
         inputs = self.create_inputs(grpcclient)
-        # Skip the parameter that returns an error
-        parameter_list = self.parameter_list[:-1]
-        for parameters in parameter_list:
-            # async stream infer
-            self.grpc.async_stream_infer(
-                model_name="parameter", inputs=inputs, parameters=parameters
-            )
-            result = user_data.get()
-            self.assertFalse(result is InferenceServerException)
-            self.verify_outputs(result, parameters)
-        self.grpc.stop_stream()
+        self.grpcclient.async_stream_infer(
+            model_name="parameter", inputs=inputs, parameters=parameters
+        )
+        result = user_data.get()
+        self.assertFalse(result is InferenceServerException)
+        self.verify_outputs(result, parameters, expected_headers)
+        self.grpcclient.stop_stream()
 
-    async def test_ensemble_parameter_forwarding(self):
-        await self.send_request_and_verify(httpclient, self.http, model_name="ensemble")
+    def _raw_http_post_infer(self, body_dict, extra_headers=None):
+        """POST /v2/models/.../infer without tritonclient (no header normalization)."""
+        headers = {"Content-Type": "application/json"}
+        if extra_headers:
+            headers.update(extra_headers)
+        return requests.post(
+            _infer_url("parameter"),
+            json=body_dict,
+            headers=headers,
+            timeout=60,
+        )
+
+    def _assert_raw_http_400(self, response, text_substr):
+        """Assert status 400 and body contains `text_substr`."""
+        snippet = response.text[:2000] if response.text else ""
+        self.assertEqual(response.status_code, 400, msg=snippet)
+        self.assertIn(text_substr, response.text, msg=snippet)
+
+    async def _run_client_infer_suite(self, parameters, headers, expected_headers):
+        """
+        Full client matrix: gRPC/HTTP sync+async, stream, ensemble.
+        """
+        await self.send_request_and_verify(
+            grpcclient, self.grpcclient, parameters, headers.copy(), expected_headers
+        )
+        await self.send_request_and_verify(
+            httpclient, self.httpclient, parameters, headers.copy(), expected_headers
+        )
+        await self.send_request_and_verify(
+            asynchttpclient,
+            self.async_httpclient,
+            parameters,
+            headers.copy(),
+            expected_headers,
+        )
+        await self.send_request_and_verify(
+            asyncgrpcclient,
+            self.async_grpcclient,
+            parameters,
+            headers.copy(),
+            expected_headers,
+        )
+        await self.send_request_and_verify(
+            httpclient,
+            self.httpclient,
+            parameters,
+            headers.copy(),
+            expected_headers,
+            is_async_infer=True,
+        )
+        await self.send_request_and_verify(
+            grpcclient,
+            self.grpcclient,
+            parameters,
+            headers.copy(),
+            expected_headers,
+            is_async_infer=True,
+        )
+        await self._verify_grpc_stream_infer(
+            parameters, headers.copy(), expected_headers
+        )
+        await self.send_request_and_verify(
+            httpclient,
+            self.httpclient,
+            parameters,
+            headers.copy(),
+            expected_headers,
+            model_name="ensemble",
+        )
+
+    async def test_params(self):
+        for parameters in [
+            {"key1": "value1", "key2": "value2"},
+            {"key1": 1, "key2": 2},
+            {"key1": 123.123, "key2": 321.321},
+            {"key1": True, "key2": "value2"},
+        ]:
+            await self._run_client_infer_suite(parameters, {}, {})
+
+    async def test_params_reserved_rejected(self):
+        for reserved_key in _RESERVED_PARAMETER_KEYS:
+            parameters = {reserved_key: "dummy-value"}
+            body = _minimal_fp32_infer_body(parameters)
+
+            # Raw HTTP
+            if reserved_key.startswith("triton_"):
+                r = self._raw_http_post_infer(body)
+                self._assert_raw_http_400(r, _TRITON_RESERVED_SERVER_ERROR)
+
+            # Python clients
+            for client_type, client in (
+                (httpclient, self.httpclient),
+                (asynchttpclient, self.async_httpclient),
+                (grpcclient, self.grpcclient),
+                (asyncgrpcclient, self.async_grpcclient),
+            ):
+                inputs = self.create_inputs(client_type)
+                with self.assertRaises(InferenceServerException) as cm:
+                    if client_type in (asynchttpclient, asyncgrpcclient):
+                        await client.infer(
+                            model_name="parameter",
+                            inputs=inputs,
+                            parameters=parameters,
+                        )
+                    else:
+                        client.infer(
+                            model_name="parameter",
+                            inputs=inputs,
+                            parameters=parameters,
+                        )
+                msg = str(cm.exception)
+                # Reserved parameters are rejected by the client
+                self.assertIn(_TRITON_RESERVED_CLIENT_ERROR, msg, msg=msg)
+
+    async def test_headers(self):
+        expected_headers = {
+            "my_header_1": "my_value_1",
+            "my_header_2": "my_value_2",
+            "my_header_3": 'This is a "quoted" string with a backslash\\ ',
+        }
+        await self._run_client_infer_suite({}, _FORWARD_HEADERS, expected_headers)
+
+    async def test_grpc_header_forward_pattern_case_sensitive(self):
+        expected_headers = {}
+        await self._run_client_infer_suite({}, _FORWARD_HEADERS, expected_headers)
+
+    async def test_headers_reserved_rejected(self):
+        body = _minimal_fp32_infer_body({})
+        for reserved_key in _RESERVED_PARAMETER_KEYS:
+            # Raw HTTP
+            r = self._raw_http_post_infer(
+                body, extra_headers={reserved_key: "dummy-value"}
+            )
+            self._assert_raw_http_400(r, _TRITON_RESERVED_SERVER_ERROR)
+
+            # Python clients
+            for client_type, client in (
+                (httpclient, self.httpclient),
+                (asynchttpclient, self.async_httpclient),
+                (grpcclient, self.grpcclient),
+                (asyncgrpcclient, self.async_grpcclient),
+            ):
+                inputs = self.create_inputs(client_type)
+                with self.assertRaises(InferenceServerException) as cm:
+                    if client_type in (asynchttpclient, asyncgrpcclient):
+                        await client.infer(
+                            model_name="parameter",
+                            inputs=inputs,
+                            parameters={},
+                            headers={reserved_key: "dummy-value"},
+                        )
+                    else:
+                        client.infer(
+                            model_name="parameter",
+                            inputs=inputs,
+                            parameters={},
+                            headers={reserved_key: "dummy-value"},
+                        )
+                msg = str(cm.exception)
+                # Headers are not rejected by the client
+                self.assertIn(_TRITON_RESERVED_SERVER_ERROR, msg, msg=msg)
 
     async def asyncTearDown(self):
-        self.http.close()
-        self.grpc.close()
-        await self.async_grpc.close()
-        await self.async_http.close()
+        self.httpclient.close()
+        self.grpcclient.close()
+        await self.async_grpcclient.close()
+        await self.async_httpclient.close()
 
 
 if __name__ == "__main__":

--- a/qa/L0_parameters/parameters_test.py
+++ b/qa/L0_parameters/parameters_test.py
@@ -149,7 +149,7 @@ class InferenceParametersTest(unittest.IsolatedAsyncioTestCase):
                     callback=partial(self.grpcclient_callback, user_data),
                 )
                 result = user_data.get()
-                self.assertFalse(result is InferenceServerException)
+                self.assertIsNot(result, InferenceServerException)
             else:
                 raise ValueError(f"Unsupported client type: {client_type}")
         else:
@@ -200,7 +200,7 @@ class InferenceParametersTest(unittest.IsolatedAsyncioTestCase):
             model_name="parameter", inputs=inputs, parameters=parameters
         )
         result = user_data.get()
-        self.assertFalse(result is InferenceServerException)
+        self.assertIsNot(result, InferenceServerException)
         self.verify_outputs(result, parameters, expected_headers)
         self.grpcclient.stop_stream()
 

--- a/qa/L0_parameters/test.sh
+++ b/qa/L0_parameters/test.sh
@@ -39,8 +39,6 @@ if [ ! -z "$TEST_REPO_ARCH" ]; then
 fi
 
 CLIENT_LOG="./client.log"
-TEST_SCRIPT_PY="parameters_test.py"
-
 SERVER=/opt/tritonserver/bin/tritonserver
 SERVER_LOG="./inference_server.log"
 source ../common/util.sh
@@ -54,27 +52,27 @@ mkdir -p "${MODELDIR}/ensemble/1"
 # https://jirasw.nvidia.com/browse/DLIS-4673
 
 all_tests=("test_params"
+           "test_params_reserved_rejected"
            "test_headers"
-           "test_header_forward_pattern_case_insensitive"
-           "test_grpc_header_forward_pattern_case_sensitive")
+           "test_grpc_header_forward_pattern_case_sensitive"
+           "test_headers_reserved_rejected")
 
 RET=0
-for i in "${all_tests[@]}"; do
-  # TEST_HEADER is a parameter used by `parameters_test.py` that controls
-  # whether the script will test for inclusion of headers in parameters or not.
+for test in "${all_tests[@]}"; do
   SERVER_ARGS="--model-repository=${MODELDIR} --exit-timeout-secs=120"
-  if [ "$i" == "test_headers" ]; then
-    SERVER_ARGS+=" --grpc-header-forward-pattern my_header.*"
-    SERVER_ARGS+=" --http-header-forward-pattern my_header.*"
-  elif [ "$i" == "test_header_forward_pattern_case_insensitive" ]; then
+  if [ "$test" == "test_headers" ]; then
+    # gRPC lowercases metadata keys; HTTP may lowercase too — match prefix case-insensitively.
     SERVER_ARGS+=" --grpc-header-forward-pattern MY_HEADER.*"
     SERVER_ARGS+=" --http-header-forward-pattern MY_HEADER.*"
   # NOTE: headers sent through the python HTTP client may be automatically
   # lowercased by internal libraries like geventhttpclient, so we only test
   # GRPC client for case-sensitivity here:
   # https://github.com/geventhttpclient/geventhttpclient/blob/d1e14356c3b02099c879cf9b3bdb684a0cbd8bf5/src/geventhttpclient/header.py#L62-L63
-  elif [ "$i" == "test_grpc_header_forward_pattern_case_sensitive" ]; then
+  elif [ "$test" == "test_grpc_header_forward_pattern_case_sensitive" ]; then
     SERVER_ARGS+=" --grpc-header-forward-pattern (?-i)MY_HEADER.*"
+  elif [ "$test" == "test_headers_reserved_rejected" ]; then
+    SERVER_ARGS+=" --grpc-header-forward-pattern .*"
+    SERVER_ARGS+=" --http-header-forward-pattern .*"
   fi
   run_server
   if [ "$SERVER_PID" == "0" ]; then
@@ -84,7 +82,7 @@ for i in "${all_tests[@]}"; do
   fi
 
   set +e
-  TEST_HEADER="$i" python3 $TEST_SCRIPT_PY >$CLIENT_LOG 2>&1
+  python3 -m unittest "parameters_test.InferenceParametersTest.${test}" >$CLIENT_LOG 2>&1
   if [ $? -ne 0 ]; then
       cat $CLIENT_LOG
       echo -e "\n***\n*** Test Failed\n***"

--- a/src/common.h
+++ b/src/common.h
@@ -25,10 +25,12 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <array>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <typeinfo>
 #include <unordered_map>
 #include <variant>
@@ -66,7 +68,15 @@ constexpr int32_t HTTP_MAX_JSON_NESTING_DEPTH = 100;
 // Default maximum allowed HTTP request input size in bytes (64MB)
 constexpr size_t HTTP_DEFAULT_MAX_INPUT_SIZE = 1 << 26;
 
-/// Request parameter keys that start with a "triton_" prefix for internal use
+/// Reserved parameter keys for Triton usage (also HTTP/gRPC header forward).
+/// Other locations:
+/// - client/src/python/library/tritonclient/utils/__init__.py
+/// - server/docs/protocol/extension_parameters.md
+constexpr std::array<std::string_view, 7> kReservedParameterKeys{
+    "sequence_id", "sequence_start", "sequence_end",      "priority",
+    "timeout",     "headers",        "binary_data_output"};
+
+// Request parameter keys that start with a "triton_" prefix for internal use
 const std::vector<std::string> TRITON_RESERVED_REQUEST_PARAMS{
     "triton_enable_empty_final_response"};
 

--- a/src/grpc/infer_handler.cc
+++ b/src/grpc/infer_handler.cc
@@ -1,4 +1,4 @@
-// Copyright 2023-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -291,8 +291,8 @@ SetInferenceRequestMetadata(
             TRITONSERVER_ERROR_INVALID_ARG,
             (std::string(
                  "parameter keys starting with 'triton_' are reserved for "
-                 "Triton "
-                 "usage. Only the following keys starting with 'triton_' are "
+                 "Triton usage. Only the following keys starting with "
+                 "'triton_' are "
                  "allowed: ") +
              Join(TRITON_RESERVED_REQUEST_PARAMS, " "))
                 .c_str());

--- a/src/grpc/infer_handler.h
+++ b/src/grpc/infer_handler.h
@@ -1601,11 +1601,22 @@ InferHandler<ServiceType, ServerResponderType, RequestType, ResponseType>::
     for (const auto& pair : metadata) {
       auto& key = pair.first;
       auto& value = pair.second;
-      std::string param_key = std::string(key.begin(), key.end());
-      if (RE2::PartialMatch(param_key, header_forward_regex_)) {
-        std::string param_value = std::string(value.begin(), value.end());
+      std::string header_key = std::string(key.begin(), key.end());
+      if (RE2::PartialMatch(header_key, header_forward_regex_)) {
+        if (std::find(
+                kReservedParameterKeys.begin(), kReservedParameterKeys.end(),
+                header_key) != kReservedParameterKeys.end() ||
+            header_key.rfind("triton_", 0) == 0) {
+          return TRITONSERVER_ErrorNew(
+              TRITONSERVER_ERROR_INVALID_ARG,
+              ("Header '" + header_key +
+               "' is reserved for Triton usage and cannot be forwarded.")
+                  .c_str());
+        }
+
+        std::string header_value = std::string(value.begin(), value.end());
         err = TRITONSERVER_InferenceRequestSetStringParameter(
-            irequest, param_key.c_str(), param_value.c_str());
+            irequest, header_key.c_str(), header_value.c_str());
         if (err != nullptr) {
           break;
         }

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2888,8 +2888,7 @@ HTTPAPIServer::ParseJsonTritonParams(
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INVALID_ARG,
             ("parameter keys starting with 'triton_' are reserved for Triton "
-             "usage "
-             "and should not be specified."));
+             "usage and should not be specified."));
       } else {
         RETURN_IF_ERR(SetTritonParameterFromJsonParameter(
             parameter, params_json, irequest));
@@ -3192,14 +3191,25 @@ struct HeaderSearchPayload {
 int
 ForEachHeader(evhtp_header_t* header, void* arg)
 {
-  HeaderSearchPayload* header_search_payload =
-      reinterpret_cast<HeaderSearchPayload*>(arg);
+  auto* header_search_payload = reinterpret_cast<HeaderSearchPayload*>(arg);
 
   TRITONSERVER_InferenceRequest* request = header_search_payload->request_;
   const re2::RE2& regex = header_search_payload->regex_;
+  std::string header_key{header->key};
 
-  std::string matched_string;
-  if (RE2::PartialMatch(std::string(header->key), regex)) {
+  if (RE2::PartialMatch(header_key, regex)) {
+    if (std::find(
+            kReservedParameterKeys.begin(), kReservedParameterKeys.end(),
+            header_key) != kReservedParameterKeys.end() ||
+        header_key.rfind("triton_", 0) == 0) {
+      header_search_payload->error_ = TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          ("Header '" + header_key +
+           "' is reserved for Triton usage and cannot be forwarded.")
+              .c_str());
+      return 1;
+    }
+
     header_search_payload->error_ =
         TRITONSERVER_InferenceRequestSetStringParameter(
             request, header->key, header->val);


### PR DESCRIPTION
#### What does the PR do?
Reject Triton reserved keys in parameters and forward headers in HTTP and gRPC.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] fix

#### Related PRs:
https://github.com/triton-inference-server/client/pull/894

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID:
50210103

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx