### PR TITLE
fix: Prevent memory retention on failed compressed HTTP requests

### DIFF
--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -72,11 +72,11 @@ class InferSizeLimitTest(tu.TestResultCollector):
         """
         pid_str = os.environ.get("SERVER_PID")
         if not pid_str:
-            self.fail("SERVER_PID env var is not set")
+            raise AssertionError("SERVER_PID env var is not set")
         try:
             return psutil.Process(int(pid_str))
         except (ValueError, psutil.NoSuchProcess) as e:
-            self.fail(f"Invalid or stale SERVER_PID={pid_str!r}: {e}")
+            raise AssertionError(f"Invalid or stale SERVER_PID={pid_str!r}: {e}")
 
     def test_json_dtype_size_expansion_exceeds_limit_error(self):
         """

--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -72,11 +72,11 @@ class InferSizeLimitTest(tu.TestResultCollector):
         """
         pid_str = os.environ.get("SERVER_PID")
         if not pid_str:
-            self.Fail("SERVER_PID env var is not set")
+            self.fail("SERVER_PID env var is not set")
         try:
             return psutil.Process(int(pid_str))
         except (ValueError, psutil.NoSuchProcess) as e:
-            self.Fail(f"Invalid or stale SERVER_PID={pid_str!r}: {e}")
+            self.fail(f"Invalid or stale SERVER_PID={pid_str!r}: {e}")
 
     def test_json_dtype_size_expansion_exceeds_limit_error(self):
         """
@@ -750,8 +750,8 @@ class InferSizeLimitTest(tu.TestResultCollector):
         self.assertIn("outputs", result, "Response missing outputs field")
 
     def test_no_leak_on_invalid_inference_header_length(self):
-        """Test that sending multiple malformed compressed requests does
-        not cause memory growth on the server.
+        """
+        Test that sending multiple malformed compressed requests does not cause memory growth on the server.
         """
         leak_request_count = 100
         max_rss_growth_bytes = 32 * MB

--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -66,6 +66,18 @@ class InferSizeLimitTest(tu.TestResultCollector):
     def _get_infer_url(self, model_name):
         return f"http://localhost:8000/v2/models/{model_name}/infer"
 
+    def _get_server_process(self):
+        """
+        Return a psutil.Process for the tritonserver under test.
+        """
+        pid_str = os.environ.get("SERVER_PID")
+        if not pid_str:
+            self.Fail("SERVER_PID env var is not set")
+        try:
+            return psutil.Process(int(pid_str))
+        except (ValueError, psutil.NoSuchProcess) as e:
+            self.Fail(f"Invalid or stale SERVER_PID={pid_str!r}: {e}")
+
     def test_json_dtype_size_expansion_exceeds_limit_error(self):
         """
         Test that when the client sends a JSON input of byte[], that when it
@@ -737,62 +749,43 @@ class InferSizeLimitTest(tu.TestResultCollector):
         result = response.json()
         self.assertIn("outputs", result, "Response missing outputs field")
 
-
-class DecompressionLeakRegressionTest(tu.TestResultCollector):
-    """
-    Test that sending multiple malformed compressed requests does not cause memory leaks on the server.
-    """
-
-    LEAK_REQUEST_COUNT = 100
-    MAX_RSS_GROWTH_BYTES = 32 * MB
-    MODEL_NAME = "onnx_zero_1_float32"
-
-    def _get_server_process(self):
-        """
-        Return a psutil.Process for the tritonserver process.
-        """
-        pid_str = os.environ.get("SERVER_PID")
-        if not pid_str:
-            self.skipTest(
-                "SERVER_PID env var is not set"
-            )
-        try:
-            return psutil.Process(int(pid_str))
-        except (ValueError, psutil.NoSuchProcess) as e:
-            self.skipTest(f"Invalid or stale SERVER_PID={pid_str!r}: {e}")
-
-    def _assert_invalid_compressed_request_rejected(
-        self, session, url, body, headers
-    ):
-        resp = session.post(url, data=body, headers=headers)
-        self.assertEqual(
-            400,
-            resp.status_code,
-            f"Expected status code 400, got {resp.status_code}: {resp.content[:200]!r}",
-        )
-
     def test_no_leak_on_invalid_inference_header_length(self):
+        """Test that sending multiple malformed compressed requests does
+        not cause memory growth on the server.
+        """
+        leak_request_count = 100
+        max_rss_growth_bytes = 32 * MB
+        model = "onnx_zero_1_float32"
+
         body = gzip.compress(b" " * MB)
         headers = {
             "Content-Type": "application/json",
             "Content-Encoding": "gzip",
             "Inference-Header-Content-Length": "9999999",
         }
-        url = f"http://localhost:8000/v2/models/{self.MODEL_NAME}/infer"
+        url = self._get_infer_url(model)
 
         server = self._get_server_process()
 
         with requests.Session() as session:
-            # Warm up this exact error path so one-time allocations do not
-            # look like leaks.
-            self._assert_invalid_compressed_request_rejected(
-                session, url, body, headers
+            # Warm up the failure path so one-time allocations do not look
+            # like leaks.
+            resp = session.post(url, data=body, headers=headers)
+            self.assertEqual(
+                400,
+                resp.status_code,
+                f"Expected status code 400, got {resp.status_code}: "
+                f"{resp.content[:200]!r}",
             )
 
             rss_before = server.memory_info().rss
-            for _ in range(self.LEAK_REQUEST_COUNT):
-                self._assert_invalid_compressed_request_rejected(
-                    session, url, body, headers
+            for _ in range(leak_request_count):
+                resp = session.post(url, data=body, headers=headers)
+                self.assertEqual(
+                    400,
+                    resp.status_code,
+                    f"Expected status code 400, got {resp.status_code}: "
+                    f"{resp.content[:200]!r}",
                 )
             rss_after = server.memory_info().rss
 
@@ -801,15 +794,15 @@ class DecompressionLeakRegressionTest(tu.TestResultCollector):
             f"RSS: before={rss_before / MB:.1f} MiB, "
             f"after={rss_after / MB:.1f} MiB, "
             f"growth={growth / MB:.1f} MiB, "
-            f"limit={self.MAX_RSS_GROWTH_BYTES / MB:.0f} MiB",
+            f"limit={max_rss_growth_bytes / MB:.0f} MiB",
             flush=True,
         )
         self.assertLess(
             growth,
-            self.MAX_RSS_GROWTH_BYTES,
+            max_rss_growth_bytes,
             f"Server RSS grew by {growth / MB:.1f} MiB after "
-            f"{self.LEAK_REQUEST_COUNT} malformed compressed requests "
-            f"(limit {self.MAX_RSS_GROWTH_BYTES / MB:.0f} MiB).",
+            f"{leak_request_count} malformed compressed requests "
+            f"(limit {max_rss_growth_bytes / MB:.0f} MiB).",
         )
 
 

--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -33,9 +33,11 @@ import base64
 import gzip
 import io
 import json
+import os
 import unittest
 
 import numpy as np
+import psutil
 import requests
 import test_util as tu
 
@@ -734,6 +736,81 @@ class InferSizeLimitTest(tu.TestResultCollector):
         # Verify we got a valid response
         result = response.json()
         self.assertIn("outputs", result, "Response missing outputs field")
+
+
+class DecompressionLeakRegressionTest(tu.TestResultCollector):
+    """
+    Test that sending multiple malformed compressed requests does not cause memory leaks on the server.
+    """
+
+    LEAK_REQUEST_COUNT = 100
+    MAX_RSS_GROWTH_BYTES = 32 * MB
+    MODEL_NAME = "onnx_zero_1_float32"
+
+    def _get_server_process(self):
+        """
+        Return a psutil.Process for the tritonserver process.
+        """
+        pid_str = os.environ.get("SERVER_PID")
+        if not pid_str:
+            self.skipTest(
+                "SERVER_PID env var is not set"
+            )
+        try:
+            return psutil.Process(int(pid_str))
+        except (ValueError, psutil.NoSuchProcess) as e:
+            self.skipTest(f"Invalid or stale SERVER_PID={pid_str!r}: {e}")
+
+    def _assert_invalid_compressed_request_rejected(
+        self, session, url, body, headers
+    ):
+        resp = session.post(url, data=body, headers=headers)
+        self.assertEqual(
+            400,
+            resp.status_code,
+            f"Expected status code 400, got {resp.status_code}: {resp.content[:200]!r}",
+        )
+
+    def test_no_leak_on_invalid_inference_header_length(self):
+        body = gzip.compress(b" " * MB)
+        headers = {
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+            "Inference-Header-Content-Length": "9999999",
+        }
+        url = f"http://localhost:8000/v2/models/{self.MODEL_NAME}/infer"
+
+        server = self._get_server_process()
+
+        with requests.Session() as session:
+            # Warm up this exact error path so one-time allocations do not
+            # look like leaks.
+            self._assert_invalid_compressed_request_rejected(
+                session, url, body, headers
+            )
+
+            rss_before = server.memory_info().rss
+            for _ in range(self.LEAK_REQUEST_COUNT):
+                self._assert_invalid_compressed_request_rejected(
+                    session, url, body, headers
+                )
+            rss_after = server.memory_info().rss
+
+        growth = rss_after - rss_before
+        print(
+            f"RSS: before={rss_before / MB:.1f} MiB, "
+            f"after={rss_after / MB:.1f} MiB, "
+            f"growth={growth / MB:.1f} MiB, "
+            f"limit={self.MAX_RSS_GROWTH_BYTES / MB:.0f} MiB",
+            flush=True,
+        )
+        self.assertLess(
+            growth,
+            self.MAX_RSS_GROWTH_BYTES,
+            f"Server RSS grew by {growth / MB:.1f} MiB after "
+            f"{self.LEAK_REQUEST_COUNT} malformed compressed requests "
+            f"(limit {self.MAX_RSS_GROWTH_BYTES / MB:.0f} MiB).",
+        )
 
 
 if __name__ == "__main__":

--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -695,7 +695,7 @@ wait $SERVER_PID
 
 # Helper library to parse SSE events
 # https://github.com/mpetazzoni/sseclient
-pip install sseclient-py
+pip install sseclient-py psutil
 
 SERVER_ARGS="--model-repository=`pwd`/../python_models/generate_models --log-verbose=1"
 SERVER_LOG="./inference_server_generate_endpoint_test.log"

--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -854,7 +854,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Test that sending multiple malformed compressed requests does not cause memory leaks on the server.
-SERVER_PID=$SERVER_PID python http_input_size_limit_test.py DecompressionLeakRegressionTest.test_no_leak_on_invalid_inference_header_length >> $CLIENT_LOG 2>&1
+SERVER_PID=$SERVER_PID python http_input_size_limit_test.py InferSizeLimitTest.test_no_leak_on_invalid_inference_header_length >> $CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
     echo -e "\n***\n*** Decompression Leak Regression Failed\n***\n***"

--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -852,6 +852,14 @@ if [ $? -ne 0 ]; then
     echo -e "\n***\n*** Default Input Size Limit Test Failed for type size explosion\n***"
     RET=1
 fi
+
+# Test that sending multiple malformed compressed requests does not cause memory leaks on the server.
+SERVER_PID=$SERVER_PID python http_input_size_limit_test.py DecompressionLeakRegressionTest.test_no_leak_on_invalid_inference_header_length >> $CLIENT_LOG 2>&1
+if [ $? -ne 0 ]; then
+    cat $CLIENT_LOG
+    echo -e "\n***\n*** Decompression Leak Regression Failed\n***\n***"
+    RET=1
+fi
 set -e
 
 kill $SERVER_PID

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3265,10 +3265,9 @@ HTTPAPIServer::DecompressBuffer(
     case DataCompressor::Type::DEFLATE:
     case DataCompressor::Type::GZIP: {
       decompressed_buffer->reset(evbuffer_new());
-      RETURN_IF_ERR(
-          DataCompressor::DecompressData(
-              compression_type, req->buffer_in, decompressed_buffer->get(),
-              max_input_size_));
+      RETURN_IF_ERR(DataCompressor::DecompressData(
+            compression_type, req->buffer_in, decompressed_buffer->get(),
+            max_input_size_));
       break;
     }
     case DataCompressor::Type::UNKNOWN: {

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3258,16 +3258,17 @@ HTTPAPIServer::StartTrace(
 
 TRITONSERVER_Error*
 HTTPAPIServer::DecompressBuffer(
-    evhtp_request_t* req, evbuffer** decompressed_buffer)
+    evhtp_request_t* req, EvbufferUniquePtr* decompressed_buffer)
 {
   auto compression_type = GetRequestCompressionType(req);
   switch (compression_type) {
     case DataCompressor::Type::DEFLATE:
     case DataCompressor::Type::GZIP: {
-      *decompressed_buffer = evbuffer_new();
-      RETURN_IF_ERR(DataCompressor::DecompressData(
-          compression_type, req->buffer_in, *decompressed_buffer,
-          max_input_size_));
+      decompressed_buffer->reset(evbuffer_new());
+      RETURN_IF_ERR(
+          DataCompressor::DecompressData(
+              compression_type, req->buffer_in, decompressed_buffer->get(),
+              max_input_size_));
       break;
     }
     case DataCompressor::Type::UNKNOWN: {
@@ -3777,13 +3778,13 @@ HTTPAPIServer::HandleInfer(
   }
 
   // Decompress request body if it is compressed in supported type
-  evbuffer* decompressed_buffer = nullptr;
+  EvbufferUniquePtr decompressed_buffer;
   RETURN_AND_RESPOND_IF_ERR(req, DecompressBuffer(req, &decompressed_buffer));
 
   // Get content length as a default header_length if no header specified
   int32_t content_length = 0;
   RETURN_AND_RESPOND_IF_ERR(
-      req, GetContentLength(req, decompressed_buffer, &content_length));
+      req, GetContentLength(req, decompressed_buffer.get(), &content_length));
 
   // Get the header length
   size_t header_length = 0;
@@ -3835,8 +3836,8 @@ HTTPAPIServer::HandleInfer(
   // Parse EV request and fill Triton request fields from it
   RETURN_AND_CALLBACK_IF_ERR(
       EVRequestToTritonRequest(
-          req, model_name, irequest, decompressed_buffer, infer_request.get(),
-          header_length),
+          req, model_name, irequest, decompressed_buffer.get(),
+          infer_request.get(), header_length),
       error_callback);
 
   // Get request ID for logging in case of error.
@@ -3851,7 +3852,7 @@ HTTPAPIServer::HandleInfer(
   RETURN_AND_CALLBACK_IF_ERR(ForwardHeaders(req, irequest), error_callback);
 
   auto request_release_payload = std::make_unique<RequestReleasePayload>(
-      irequest_shared, decompressed_buffer);
+      irequest_shared, decompressed_buffer.release());
   RETURN_AND_CALLBACK_IF_ERR(
       TRITONSERVER_InferenceRequestSetReleaseCallback(
           irequest, InferRequestClass::InferRequestComplete,

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3266,8 +3266,8 @@ HTTPAPIServer::DecompressBuffer(
     case DataCompressor::Type::GZIP: {
       decompressed_buffer->reset(evbuffer_new());
       RETURN_IF_ERR(DataCompressor::DecompressData(
-            compression_type, req->buffer_in, decompressed_buffer->get(),
-            max_input_size_));
+          compression_type, req->buffer_in, decompressed_buffer->get(),
+          max_input_size_));
       break;
     }
     case DataCompressor::Type::UNKNOWN: {

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -3258,15 +3258,15 @@ HTTPAPIServer::StartTrace(
 
 TRITONSERVER_Error*
 HTTPAPIServer::DecompressBuffer(
-    evhtp_request_t* req, EvbufferUniquePtr* decompressed_buffer)
+    evhtp_request_t* req, EvbufferUniquePtr& decompressed_buffer)
 {
   auto compression_type = GetRequestCompressionType(req);
   switch (compression_type) {
     case DataCompressor::Type::DEFLATE:
     case DataCompressor::Type::GZIP: {
-      decompressed_buffer->reset(evbuffer_new());
+      decompressed_buffer.reset(evbuffer_new());
       RETURN_IF_ERR(DataCompressor::DecompressData(
-          compression_type, req->buffer_in, decompressed_buffer->get(),
+          compression_type, req->buffer_in, decompressed_buffer.get(),
           max_input_size_));
       break;
     }
@@ -3778,7 +3778,7 @@ HTTPAPIServer::HandleInfer(
 
   // Decompress request body if it is compressed in supported type
   EvbufferUniquePtr decompressed_buffer;
-  RETURN_AND_RESPOND_IF_ERR(req, DecompressBuffer(req, &decompressed_buffer));
+  RETURN_AND_RESPOND_IF_ERR(req, DecompressBuffer(req, decompressed_buffer));
 
   // Get content length as a default header_length if no header specified
   int32_t content_length = 0;

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -475,6 +475,16 @@ class HTTPAPIServer : public HTTPServer {
     bool end_{false};
   };
 
+  struct ReleaseEvbuffer {
+    void operator()(evbuffer* b) const noexcept
+    {
+      if (b != nullptr) {
+        evbuffer_free(b);
+      }
+    }
+  };
+  using EvbufferUniquePtr = std::unique_ptr<evbuffer, ReleaseEvbuffer>;
+
   // Simple structure that carries the userp payload needed for
   // request release callback.
   struct RequestReleasePayload final {
@@ -535,7 +545,7 @@ class HTTPAPIServer : public HTTPServer {
       evhtp_request_t* req, evbuffer* decompressed_buffer,
       int32_t* content_length);
   TRITONSERVER_Error* DecompressBuffer(
-      evhtp_request_t* req, evbuffer** decompressed_buffer);
+      evhtp_request_t* req, EvbufferUniquePtr* decompressed_buffer);
   TRITONSERVER_Error* CheckTransactionPolicy(
       evhtp_request_t* req, const std::string& model_name,
       int64_t requested_model_version);

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -545,7 +545,7 @@ class HTTPAPIServer : public HTTPServer {
       evhtp_request_t* req, evbuffer* decompressed_buffer,
       int32_t* content_length);
   TRITONSERVER_Error* DecompressBuffer(
-      evhtp_request_t* req, EvbufferUniquePtr* decompressed_buffer);
+      evhtp_request_t* req, EvbufferUniquePtr& decompressed_buffer);
   TRITONSERVER_Error* CheckTransactionPolicy(
       evhtp_request_t* req, const std::string& model_name,
       int64_t requested_model_version);

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -476,6 +476,7 @@ class HTTPAPIServer : public HTTPServer {
   };
 
   struct ReleaseEvbuffer {
+    // Custom deleter for evbuffer
     void operator()(evbuffer* b) const noexcept
     {
       if (b != nullptr) {


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
This PR updates the HTTP inference path to release decompressed request buffers automatically on early failures, so malformed compressed requests do not retain server memory. It also adds an HTTP QA regression intended to catch that leak scenario.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID:
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx
