### PR TITLE
fix: Cap chunked HTTP request chunk count at 65536 to prevent memory exhaustion

### DIFF
--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -33,12 +33,11 @@ import base64
 import gzip
 import io
 import json
-import os
 import unittest
 
 import numpy as np
 import requests
-from test_util import MIB, TestResultCollector, get_server_process_from_env
+from test_util import GIB, MIB, TestResultCollector, get_server_process_from_env
 
 # Constants for size calculations
 # Each FP32 value is 4 bytes, so we need to divide target byte sizes by 4 to get element counts

--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -37,9 +37,8 @@ import os
 import unittest
 
 import numpy as np
-import psutil
 import requests
-import test_util as tu
+from test_util import MIB, TestResultCollector, get_server_process_from_env
 
 # Constants for size calculations
 # Each FP32 value is 4 bytes, so we need to divide target byte sizes by 4 to get element counts
@@ -47,10 +46,8 @@ BYTES_PER_FP32 = 4
 BYTES_PER_INT64 = (
     8  # For the type size explosion test, we use int64 which is 8 bytes per element
 )
-MB = 2**20  # 1 MB = 1,048,576 bytes
-GB = 2**30  # 1 GB = 1,073,741,824 bytes
-DEFAULT_LIMIT_BYTES = 64 * MB  # 64MB default limit
-INCREASED_LIMIT_BYTES = 128 * MB  # 128MB increased limit
+DEFAULT_LIMIT_BYTES = 64 * MIB  # 64MB default limit
+INCREASED_LIMIT_BYTES = 128 * MIB  # 128MB increased limit
 
 # Calculate element counts for size limits
 DEFAULT_LIMIT_ELEMENTS = DEFAULT_LIMIT_BYTES // BYTES_PER_FP32  # 16,777,216 elements
@@ -62,21 +59,9 @@ INCREASED_LIMIT_ELEMENTS = (
 OFFSET_ELEMENTS = 32
 
 
-class InferSizeLimitTest(tu.TestResultCollector):
+class InferSizeLimitTest(TestResultCollector):
     def _get_infer_url(self, model_name):
         return f"http://localhost:8000/v2/models/{model_name}/infer"
-
-    def _get_server_process(self):
-        """
-        Return a psutil.Process for the tritonserver under test.
-        """
-        pid_str = os.environ.get("SERVER_PID")
-        if not pid_str:
-            raise AssertionError("SERVER_PID env var is not set")
-        try:
-            return psutil.Process(int(pid_str))
-        except (ValueError, psutil.NoSuchProcess) as e:
-            raise AssertionError(f"Invalid or stale SERVER_PID={pid_str!r}: {e}")
 
     def test_json_dtype_size_expansion_exceeds_limit_error(self):
         """
@@ -201,7 +186,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
             DEFAULT_LIMIT_ELEMENTS + OFFSET_ELEMENTS, dtype=np.float32
         )
         input_bytes = large_input.tobytes()
-        assert len(input_bytes) > 64 * MB  # Verify we're actually over the 64MB limit
+        assert len(input_bytes) > 64 * MIB  # Verify we're actually over the 64MB limit
 
         headers = {"Inference-Header-Content-Length": "0"}
         response = requests.post(
@@ -231,7 +216,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
             DEFAULT_LIMIT_ELEMENTS - OFFSET_ELEMENTS, dtype=np.float32
         )
         input_bytes = small_input.tobytes()
-        assert len(input_bytes) < 64 * MB  # Verify we're actually under the 64MB limit
+        assert len(input_bytes) < 64 * MIB  # Verify we're actually under the 64MB limit
 
         response = requests.post(
             self._get_infer_url(model), data=input_bytes, headers=headers
@@ -276,7 +261,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
             ]
         }
         assert (
-            shape_size * BYTES_PER_FP32 > 64 * MB
+            shape_size * BYTES_PER_FP32 > 64 * MIB
         )  # Verify we're actually over the 64MB limit
 
         headers = {"Content-Type": "application/json"}
@@ -361,7 +346,9 @@ class InferSizeLimitTest(tu.TestResultCollector):
             INCREASED_LIMIT_ELEMENTS + OFFSET_ELEMENTS, dtype=np.float32
         )
         input_bytes = large_input.tobytes()
-        assert len(input_bytes) > 128 * MB  # Verify we're actually over the 128MB limit
+        assert (
+            len(input_bytes) > 128 * MIB
+        )  # Verify we're actually over the 128MB limit
 
         headers = {"Inference-Header-Content-Length": "0"}
         response = requests.post(
@@ -392,7 +379,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
         )
         input_bytes = small_input.tobytes()
         assert (
-            len(input_bytes) < 128 * MB
+            len(input_bytes) < 128 * MIB
         )  # Verify we're actually under the 128MB limit
 
         response = requests.post(
@@ -438,7 +425,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
             ]
         }
         assert (
-            shape_size * BYTES_PER_FP32 > 128 * MB
+            shape_size * BYTES_PER_FP32 > 128 * MIB
         )  # Verify we're actually over the 128MB limit
 
         headers = {"Content-Type": "application/json"}
@@ -519,7 +506,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
 
         # Create a string that is larger (large payload about 2GB) than the default limit of 64MB
         # (2^31 + 64) elements * 1 bytes = 2GB + 64 bytes = 2,147,483,712 bytes
-        large_string_size = 2 * GB + 64
+        large_string_size = 2 * GIB + 64
         large_string = "A" * large_string_size
 
         payload = {
@@ -602,7 +589,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
         }
 
         # Test case 1: Payload that decompresses to 64MB + 1MB (over limit) should fail
-        large_target_size = DEFAULT_LIMIT_BYTES + MB
+        large_target_size = DEFAULT_LIMIT_BYTES + MIB
         (
             large_compressed_data,
             large_uncompressed_size,
@@ -642,7 +629,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
         )
 
         # Test case 2: Payload that decompresses to 64MB - 1MB (under limit) should succeed
-        small_target_size = DEFAULT_LIMIT_BYTES - MB
+        small_target_size = DEFAULT_LIMIT_BYTES - MIB
         (
             small_compressed_data,
             small_uncompressed_size,
@@ -684,7 +671,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
         }
 
         # Test case 1: Input that decompresses to 128MB + 1MB (over limit) should fail
-        large_target_size = INCREASED_LIMIT_BYTES + MB
+        large_target_size = INCREASED_LIMIT_BYTES + MIB
         (
             large_compressed_data,
             large_uncompressed_size,
@@ -716,7 +703,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
         )
 
         # Test case 2: Input that decompresses to 128MB - 1MB (under limit) should succeed
-        small_target_size = INCREASED_LIMIT_BYTES - MB
+        small_target_size = INCREASED_LIMIT_BYTES - MIB
         (
             small_compressed_data,
             small_uncompressed_size,
@@ -754,10 +741,10 @@ class InferSizeLimitTest(tu.TestResultCollector):
         Test that sending multiple malformed compressed requests does not cause memory growth on the server.
         """
         leak_request_count = 100
-        max_rss_growth_bytes = 32 * MB
+        max_rss_growth_bytes = 32 * MIB
         model = "onnx_zero_1_float32"
 
-        body = gzip.compress(b" " * MB)
+        body = gzip.compress(b" " * MIB)
         headers = {
             "Content-Type": "application/json",
             "Content-Encoding": "gzip",
@@ -765,7 +752,7 @@ class InferSizeLimitTest(tu.TestResultCollector):
         }
         url = self._get_infer_url(model)
 
-        server = self._get_server_process()
+        server = get_server_process_from_env()
 
         with requests.Session() as session:
             # Warm up the failure path so one-time allocations do not look
@@ -791,18 +778,18 @@ class InferSizeLimitTest(tu.TestResultCollector):
 
         growth = rss_after - rss_before
         print(
-            f"RSS: before={rss_before / MB:.1f} MiB, "
-            f"after={rss_after / MB:.1f} MiB, "
-            f"growth={growth / MB:.1f} MiB, "
-            f"limit={max_rss_growth_bytes / MB:.0f} MiB",
+            f"RSS: before={rss_before / MIB:.1f} MIB, "
+            f"after={rss_after / MIB:.1f} MIB, "
+            f"growth={growth / MIB:.1f} MIB, "
+            f"limit={max_rss_growth_bytes / MIB:.0f} MIB",
             flush=True,
         )
         self.assertLess(
             growth,
             max_rss_growth_bytes,
-            f"Server RSS grew by {growth / MB:.1f} MiB after "
+            f"Server RSS grew by {growth / MIB:.1f} MIB after "
             f"{leak_request_count} malformed compressed requests "
-            f"(limit {max_rss_growth_bytes / MB:.0f} MiB).",
+            f"(limit {max_rss_growth_bytes / MIB:.0f} MIB).",
         )
 
 

--- a/qa/L0_http/http_request_many_chunks.py
+++ b/qa/L0_http/http_request_many_chunks.py
@@ -78,6 +78,8 @@ class HTTPRequestManyChunksTest(unittest.TestCase):
             try:
                 s.sendall(b"0\r\n\r\n")
             except (BrokenPipeError, ConnectionResetError):
+                # Server may close/reset early after deciding on an error response.
+                # Ignore send failure here and continue reading any available response bytes.
                 pass
 
             response = b""

--- a/qa/L0_http/http_request_many_chunks.py
+++ b/qa/L0_http/http_request_many_chunks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -26,23 +26,34 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import socket
+import sys
 import unittest
+
+sys.path.append("../common")
+from test_util import MIB, get_server_process_from_env, wait_for_stable_rss
 
 
 class HTTPRequestManyChunksTest(unittest.TestCase):
     def setUp(self):
-        self._model_name = "simple"
         self._local_host = "localhost"
         self._http_port = 8000
-        self._malicious_chunk_count = (
-            1000000  # large enough to cause a stack overflow if using alloca()
-        )
-        self._parse_error = (
-            "failed to parse the request JSON buffer: Invalid value. at 0"
+        self._model_name = "simple"
+        # Must match server kMaxChunkedChunks (http_server.cc).
+        self._k_max_chunked_chunks = 65536
+        self._over_max_chunks_error = f"Chunked request body exceeds maximum of {self._k_max_chunked_chunks} non-empty chunks. Send fewer or larger HTTP chunks."
+
+    def _infer_chunked_header(self):
+        return (
+            f"POST /v2/models/{self._model_name}/infer HTTP/1.1\r\n"
+            f"Inference-Header-Content-Length: 0\r\n"
         )
 
     def send_chunked_request(
-        self, header: str, chunk_count: int, expected_response: str
+        self,
+        header: str,
+        chunk_count: int,
+        expected_response: str,
+        expected_http_status=400,
     ):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         header = (
@@ -60,11 +71,15 @@ class HTTPRequestManyChunksTest(unittest.TestCase):
 
             # Send chunked payload
             for _ in range(chunk_count):
-                s.send(b"1\r\nA\r\n")
-            # End chunked encoding
-            s.sendall(b"0\r\n\r\n")
+                try:
+                    s.send(b"1\r\nA\r\n")
+                except (BrokenPipeError, ConnectionResetError):
+                    break
+            try:
+                s.sendall(b"0\r\n\r\n")
+            except (BrokenPipeError, ConnectionResetError):
+                pass
 
-            # Receive response
             response = b""
             while True:
                 try:
@@ -72,80 +87,88 @@ class HTTPRequestManyChunksTest(unittest.TestCase):
                     if not chunk:
                         break
                     response += chunk
+                except ConnectionResetError:
+                    break
                 except socket.timeout:
                     break
+            self.assertTrue(
+                response,
+                "expected error response body, but socket closed/reset before any bytes",
+            )
+            status_line = response.split(b"\r\n", 1)[0].decode(errors="replace")
+            self.assertTrue(
+                status_line.startswith(f"HTTP/1.1 {expected_http_status} "),
+                f"expected HTTP status {expected_http_status}, got {status_line!r}",
+            )
             self.assertIn(expected_response, response.decode())
         except Exception as e:
             raise (e)
         finally:
             s.close()
 
-    def test_infer(self):
-        request_header = (
-            f"POST /v2/models/{self._model_name}/infer HTTP/1.1\r\n"
-            f"Inference-Header-Content-Length: 0\r\n"
-        )
-
+    def test_chunked_infer_at_max_chunks(self):
+        """Exactly kMaxChunkedChunks non-empty chunks: 400 request input error."""
         self.send_chunked_request(
-            request_header,
-            self._malicious_chunk_count,
-            "Raw request must only have 1 input (found 1) to be deduced but got 2 inputs in 'simple' model configuration",
+            self._infer_chunked_header(),
+            self._k_max_chunked_chunks,
+            "Raw request must only have 1 input (found 1) to be deduced but got 2 "
+            "inputs in 'simple' model configuration",
         )
 
-    def test_registry_index(self):
-        request_header = f"POST /v2/repository/index HTTP/1.1\r\n"
+    def test_chunked_infer_rejected_over_max_chunks(self):
+        """kMaxChunkedChunks+1 chunks: 400 request error with bounded RSS growth."""
 
+        # Warm up failure path to avoid one-time allocation noise in RSS checks.
         self.send_chunked_request(
-            request_header, self._malicious_chunk_count, self._parse_error
+            self._infer_chunked_header(),
+            self._k_max_chunked_chunks + 1,
+            self._over_max_chunks_error,
         )
 
-    def test_model_control(self):
-        load_request_header = (
-            f"POST /v2/repository/models/{self._model_name}/load HTTP/1.1\r\n"
-        )
-        unload_request_header = load_request_header.replace("/load", "/unload")
+    def test_chunked_infer_over_max_chunks_reject_with_bounded_rss_growth(self):
+        many_chunks = 1000000
 
+        # verify server is running
+        server = get_server_process_from_env("SERVER_PID")
+        self.assertTrue(server.is_running())
+
+        # warm up and wait until RSS is stable.
         self.send_chunked_request(
-            load_request_header, self._malicious_chunk_count, self._parse_error
+            self._infer_chunked_header(),
+            many_chunks,  # way over max chunks
+            self._over_max_chunks_error,
         )
-        self.send_chunked_request(
-            unload_request_header, self._malicious_chunk_count, self._parse_error
+        # Wait until RSS is stable across several measurements before continuing.
+        server = get_server_process_from_env("SERVER_PID")
+        wait_for_stable_rss(server)
+
+        # Monitor RSS growth over 100 requests.
+        repeat_request_count = 100
+        rss_before = server.memory_info().rss
+        max_rss_growth_bytes = 1 * MIB
+
+        for _ in range(repeat_request_count):
+            self.send_chunked_request(
+                self._infer_chunked_header(),
+                many_chunks,  # way over max chunks
+                self._over_max_chunks_error,
+            )
+
+        rss_after = server.memory_info().rss
+        growth = rss_after - rss_before
+        print(
+            f"RSS: before={rss_before / MIB:.1f} MiB, "
+            f"after={rss_after / MIB:.1f} MiB, "
+            f"growth={growth / MIB:.1f} MiB, "
+            f"limit={max_rss_growth_bytes / MIB:.0f} MiB",
+            flush=True,
         )
-
-    def test_trace(self):
-        request_header = (
-            f"POST /v2/models/{self._model_name}/trace/setting HTTP/1.1\r\n"
-        )
-
-        self.send_chunked_request(
-            request_header, self._malicious_chunk_count, self._parse_error
-        )
-
-    def test_logging(self):
-        request_header = f"POST /v2/logging HTTP/1.1\r\n"
-
-        self.send_chunked_request(
-            request_header, self._malicious_chunk_count, self._parse_error
-        )
-
-    def test_system_shm_register(self):
-        request_header = f"POST /v2/systemsharedmemory/region/test_system_shm_register/register HTTP/1.1\r\n"
-
-        self.send_chunked_request(
-            request_header, self._malicious_chunk_count, self._parse_error
-        )
-
-    def test_cuda_shm_register(self):
-        request_header = f"POST /v2/cudasharedmemory/region/test_cuda_shm_register/register HTTP/1.1\r\n"
-
-        self.send_chunked_request(
-            request_header, self._malicious_chunk_count, self._parse_error
-        )
-
-    def test_generate(self):
-        request_header = f"POST /v2/models/{self._model_name}/generate HTTP/1.1\r\n"
-        self.send_chunked_request(
-            request_header, self._malicious_chunk_count, self._parse_error
+        self.assertLess(
+            growth,
+            max_rss_growth_bytes,
+            f"Server RSS grew by {growth / MIB:.1f} MiB after "
+            f"{repeat_request_count} over-limit chunked infer requests "
+            f"(limit {max_rss_growth_bytes / MIB:.0f} MiB).",
         )
 
 

--- a/qa/L0_http/test.sh
+++ b/qa/L0_http/test.sh
@@ -950,7 +950,7 @@ if [ "$SERVER_PID" == "0" ]; then
 fi
 
 set +e
-python $REQUEST_MANY_CHUNKS_PY -v >> ${CLIENT_LOG} 2>&1
+SERVER_PID=$SERVER_PID python $REQUEST_MANY_CHUNKS_PY -v >> ${CLIENT_LOG} 2>&1
 if [ $? -ne 0 ]; then
     echo -e "\n***\n*** HTTP Request Many Chunks Test Failed\n***"
     cat $SERVER_LOG

--- a/qa/L0_sagemaker/sagemaker_request_many_chunks.py
+++ b/qa/L0_sagemaker/sagemaker_request_many_chunks.py
@@ -78,6 +78,7 @@ class SagemakerRequestManyChunksTest(unittest.TestCase):
             except (BrokenPipeError, ConnectionResetError):
                 # Server may close/reset early after detecting chunk-limit violation.
                 # In that case, failing to send the terminating chunk is expected.
+                pass
 
             # Receive response
             response = b""

--- a/qa/L0_sagemaker/sagemaker_request_many_chunks.py
+++ b/qa/L0_sagemaker/sagemaker_request_many_chunks.py
@@ -141,7 +141,7 @@ class SagemakerRequestManyChunksTest(unittest.TestCase):
         # Monitor RSS growth over 100 requests.
         repeat_request_count = 100
         rss_before = server.memory_info().rss
-        # TODO: Why sagemaker server ocassionly grows >10 MiB but http server always smaller than 1 MiB?
+        # TODO: Why sagemaker server occasionally grows >10 MiB but http server always smaller than 1 MiB?
         max_rss_growth_bytes = 20 * MIB
 
         for _ in range(repeat_request_count):

--- a/qa/L0_sagemaker/sagemaker_request_many_chunks.py
+++ b/qa/L0_sagemaker/sagemaker_request_many_chunks.py
@@ -76,7 +76,8 @@ class SagemakerRequestManyChunksTest(unittest.TestCase):
             try:
                 s.sendall(b"0\r\n\r\n")
             except (BrokenPipeError, ConnectionResetError):
-                pass
+                # Server may close/reset early after detecting chunk-limit violation.
+                # In that case, failing to send the terminating chunk is expected.
 
             # Receive response
             response = b""

--- a/qa/L0_sagemaker/sagemaker_request_many_chunks.py
+++ b/qa/L0_sagemaker/sagemaker_request_many_chunks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -26,19 +26,32 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import socket
+import sys
 import unittest
+
+sys.path.append("../common")
+from test_util import MIB, get_server_process_from_env, wait_for_stable_rss
 
 
 class SagemakerRequestManyChunksTest(unittest.TestCase):
     def setUp(self):
         self._local_host = "localhost"
         self._sagemaker_port = 8080
-        self._malicious_chunk_count = (
-            1000000  # large enough to cause a stack overflow if using alloca()
+        # Must match server kMaxChunkedChunks (http_server.cc).
+        self._k_max_chunked_chunks = 65536
+        self._over_max_chunks_error = f"Chunked request body exceeds maximum of {self._k_max_chunked_chunks} non-empty chunks. Send fewer or larger HTTP chunks."
+
+    def _sagemaker_chunked_header(self):
+        return (
+            f"POST /models HTTP/1.1\r\n" f"X-Amzn-SageMaker-Target-Model: ZZZZZZZ\r\n"
         )
 
     def send_chunked_request(
-        self, header: str, chunk_count: int, expected_response: str
+        self,
+        header: str,
+        chunk_count: int,
+        expected_response: str,
+        expected_http_status=400,
     ):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         header = (
@@ -54,11 +67,16 @@ class SagemakerRequestManyChunksTest(unittest.TestCase):
             # HTTP request with chunked encoding
             s.sendall((header.encode()))
 
-            # Send chunked payload
+            # Send chunked payload (server may close early when over chunk limit)
             for _ in range(chunk_count):
-                s.send(b"1\r\nA\r\n")
-            # End chunked encoding
-            s.sendall(b"0\r\n\r\n")
+                try:
+                    s.send(b"1\r\nA\r\n")
+                except (BrokenPipeError, ConnectionResetError):
+                    break
+            try:
+                s.sendall(b"0\r\n\r\n")
+            except (BrokenPipeError, ConnectionResetError):
+                pass
 
             # Receive response
             response = b""
@@ -68,22 +86,84 @@ class SagemakerRequestManyChunksTest(unittest.TestCase):
                     if not chunk:
                         break
                     response += chunk
+                except ConnectionResetError:
+                    break
                 except socket.timeout:
                     break
+            self.assertTrue(
+                response,
+                "expected error response body, but socket closed/reset before any bytes",
+            )
+            status_line = response.split(b"\r\n", 1)[0].decode(errors="replace")
+            self.assertTrue(
+                status_line.startswith(f"HTTP/1.1 {expected_http_status} "),
+                f"expected HTTP status {expected_http_status}, got {status_line!r}",
+            )
             self.assertIn(expected_response, response.decode())
         except Exception as e:
             raise (e)
         finally:
             s.close()
 
-    def test_load_model(self):
-        request_header = (
-            f"POST /models HTTP/1.1\r\n" f"X-Amzn-SageMaker-Target-Model: ZZZZZZZ\r\n"
-        )
+    def test_chunked_at_max_chunks(self):
         self.send_chunked_request(
-            request_header,
-            self._malicious_chunk_count,
+            self._sagemaker_chunked_header(),
+            self._k_max_chunked_chunks,
             "failed to parse the request JSON buffer: Invalid value. at 0",
+        )
+
+    def test_chunked_rejected_over_max_chunks(self):
+        self.send_chunked_request(
+            self._sagemaker_chunked_header(),
+            self._k_max_chunked_chunks + 1,
+            self._over_max_chunks_error,
+        )
+
+    def test_chunked_over_max_chunks_reject_with_bounded_rss_growth(self):
+        many_chunks = 1000000
+
+        # verify server is running
+        server = get_server_process_from_env("SERVER_PID")
+        self.assertTrue(server.is_running())
+
+        # warm up and wait until RSS is stable.
+        self.send_chunked_request(
+            self._sagemaker_chunked_header(),
+            1000000,  # way over max chunks
+            self._over_max_chunks_error,
+        )
+        # Wait until RSS is stable across several measurements before continuing.
+        server = get_server_process_from_env("SERVER_PID")
+        wait_for_stable_rss(server)
+
+        # Monitor RSS growth over 100 requests.
+        repeat_request_count = 100
+        rss_before = server.memory_info().rss
+        # TODO: Why sagemaker server ocassionly grows >10 MiB but http server always smaller than 1 MiB?
+        max_rss_growth_bytes = 20 * MIB
+
+        for _ in range(repeat_request_count):
+            self.send_chunked_request(
+                self._sagemaker_chunked_header(),
+                many_chunks,  # way over max chunks
+                self._over_max_chunks_error,
+            )
+
+        rss_after = server.memory_info().rss
+        growth = rss_after - rss_before
+        print(
+            f"RSS: before={rss_before / MIB:.1f} MiB, "
+            f"after={rss_after / MIB:.1f} MiB, "
+            f"growth={growth / MIB:.1f} MiB, "
+            f"limit={max_rss_growth_bytes / MIB:.0f} MiB",
+            flush=True,
+        )
+        self.assertLess(
+            growth,
+            max_rss_growth_bytes,
+            f"Server RSS grew by {growth / MIB:.1f} MiB after "
+            f"{repeat_request_count} over-limit chunked infer requests "
+            f"(limit {max_rss_growth_bytes / MIB:.0f} MiB).",
         )
 
 

--- a/qa/L0_sagemaker/test.sh
+++ b/qa/L0_sagemaker/test.sh
@@ -327,7 +327,7 @@ fi
 
 # Helper library to parse SSE events
 # https://github.com/mpetazzoni/sseclient
-pip install sseclient-py
+pip install sseclient-py psutil
 
 # Inference with generate_stream inference type
 set +e
@@ -608,7 +608,7 @@ if [ "$code" != "200" ]; then
 fi
 
 set +e
-python $REQUEST_MANY_CHUNKS_PY >>$CLIENT_LOG 2>&1
+SERVER_PID=$SERVER_PID python $REQUEST_MANY_CHUNKS_PY >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     echo -e "\n***\n*** Sagemaker Request Many Chunks Test Failed\n***"
     cat $SERVER_LOG

--- a/qa/common/test_util.py
+++ b/qa/common/test_util.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import os
 import unittest
 
 import numpy as np
@@ -36,6 +37,45 @@ _last_request_id = 0
 # Numpy does not support the BF16 datatype natively.
 # We use this dummy dtype as a representative for BF16.
 np_dtype_bfloat16 = np.dtype([("bf16", object)])
+
+MIB = 2**20  # 1 MIB = 1,048,576 bytes
+GIB = 2**30  # 1 GIB = 1,073,741,824 bytes
+
+
+def get_server_process_from_env(env_var="SERVER_PID"):
+    """
+    Return a psutil.Process for the tritonserver under test.
+    """
+    import psutil
+
+    pid_str = os.environ.get(env_var)
+    if not pid_str:
+        raise AssertionError(f"{env_var} env var is not set")
+    try:
+        return psutil.Process(int(pid_str))
+    except (ValueError, psutil.NoSuchProcess) as e:
+        raise AssertionError(f"Invalid or stale {env_var}={pid_str!r}: {e}")
+
+
+def wait_for_stable_rss(server, rss_tolerance_bytes=0.1 * MIB, stable_threshold=10):
+    """
+    Wait until the RSS of the server is stable.
+    """
+    import time
+
+    last_rss = None
+    stable_count = 0
+    while True:
+        rss = server.memory_info().rss
+        if last_rss is not None and abs(rss - last_rss) < rss_tolerance_bytes:
+            stable_count += 1
+        else:
+            stable_count = 0
+        last_rss = rss
+        if stable_count >= stable_threshold:
+            break
+        time.sleep(0.1)
+    return
 
 
 def shape_element_count(shape):

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -51,9 +51,7 @@
 namespace triton { namespace server {
 
 // Transfer-Encoding: chunked — count non-empty chunks per request (worker
-// thread); reset in ChunkCountReset, increment in ChunkCountIncrement. Caps
-// evbuffer fan-out / RSS.
-thread_local uint64_t tls_http_chunk_n = 0;
+// thread). Increment in ChunkCountIncrement. Caps evbuffer fan-out / RSS.
 constexpr uint64_t kMaxChunkedChunks =
     1 << 16;  // reject on chunk count > kMaxChunkedChunks (65536)
 
@@ -310,17 +308,6 @@ HTTPServer::NewConnection(evhtp_connection_t* conn, void* arg)
 }
 
 evhtp_res
-HTTPServer::ChunkCountReset(
-    evhtp_request_t* req, evhtp_headers_t* hdrs, void* arg)
-{
-  (void)req;
-  (void)hdrs;
-  (void)arg;
-  tls_http_chunk_n = 0;
-  return EVHTP_RES_OK;
-}
-
-evhtp_res
 HTTPServer::ChunkCountIncrement(
     evhtp_request_t* req, uint64_t chunk_len, void* arg)
 {
@@ -332,7 +319,7 @@ HTTPServer::ChunkCountIncrement(
   if (chunk_len == 0) {
     return EVHTP_RES_OK;
   }
-  if (++tls_http_chunk_n > kMaxChunkedChunks) {
+  if (++req->chunk_count > kMaxChunkedChunks) {
     AddContentTypeHeader(req, "application/json");
     const std::string msg =
         std::string("Chunked request body exceeds maximum of ") +

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -296,9 +296,6 @@ HTTPServer::NewConnection(evhtp_connection_t* conn, void* arg)
     server->conn_cnt_++;
   }
   evhtp_connection_set_hook(
-      conn, evhtp_hook_on_headers,
-      (evhtp_hook)(void*)HTTPServer::ChunkCountReset, arg);
-  evhtp_connection_set_hook(
       conn, evhtp_hook_on_new_chunk,
       (evhtp_hook)(void*)HTTPServer::ChunkCountIncrement, arg);
   evhtp_connection_set_hook(

--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -31,9 +31,11 @@
 #include "http_server.h"
 
 #include <event2/buffer.h>
+#include <event2/bufferevent.h>
 #include <re2/re2.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <list>
 #include <regex>
 #include <thread>
@@ -47,6 +49,13 @@
 #include "triton/common/triton_json.h"
 
 namespace triton { namespace server {
+
+// Transfer-Encoding: chunked — count non-empty chunks per request (worker
+// thread); reset in ChunkCountReset, increment in ChunkCountIncrement. Caps
+// evbuffer fan-out / RSS.
+thread_local uint64_t tls_http_chunk_n = 0;
+constexpr uint64_t kMaxChunkedChunks =
+    1 << 16;  // reject on chunk count > kMaxChunkedChunks (65536)
 
 #define RETURN_AND_CALLBACK_IF_ERR(X, CALLBACK) \
   do {                                          \
@@ -289,8 +298,57 @@ HTTPServer::NewConnection(evhtp_connection_t* conn, void* arg)
     server->conn_cnt_++;
   }
   evhtp_connection_set_hook(
+      conn, evhtp_hook_on_headers,
+      (evhtp_hook)(void*)HTTPServer::ChunkCountReset, arg);
+  evhtp_connection_set_hook(
+      conn, evhtp_hook_on_new_chunk,
+      (evhtp_hook)(void*)HTTPServer::ChunkCountIncrement, arg);
+  evhtp_connection_set_hook(
       conn, evhtp_hook_on_connection_fini,
       (evhtp_hook)(void*)HTTPServer::EndConnection, arg);
+  return EVHTP_RES_OK;
+}
+
+evhtp_res
+HTTPServer::ChunkCountReset(
+    evhtp_request_t* req, evhtp_headers_t* hdrs, void* arg)
+{
+  (void)req;
+  (void)hdrs;
+  (void)arg;
+  tls_http_chunk_n = 0;
+  return EVHTP_RES_OK;
+}
+
+evhtp_res
+HTTPServer::ChunkCountIncrement(
+    evhtp_request_t* req, uint64_t chunk_len, void* arg)
+{
+  (void)arg;
+  if ((req->flags & EVHTP_REQ_FLAG_FINISHED) != 0) {
+    return EVHTP_RES_OK;
+  }
+
+  if (chunk_len == 0) {
+    return EVHTP_RES_OK;
+  }
+  if (++tls_http_chunk_n > kMaxChunkedChunks) {
+    AddContentTypeHeader(req, "application/json");
+    const std::string msg =
+        std::string("Chunked request body exceeds maximum of ") +
+        std::to_string(kMaxChunkedChunks) +
+        " non-empty chunks. Send fewer or larger HTTP chunks.";
+    EVBufferAddErrorJson(req->buffer_out, msg.c_str());
+    // Force connection close after flushing this error response.
+    req->flags &= ~EVHTP_REQ_FLAG_KEEPALIVE;
+    if ((req->conn != nullptr) && (req->conn->bev != nullptr)) {
+      // Stop ingesting request bytes once over limit so memory won't keep
+      // growing while we flush the error response.
+      bufferevent_disable(req->conn->bev, EV_READ);
+    }
+    evhtp_send_reply(req, EVHTP_RES_BADREQ);
+    return EVHTP_RES_OK;
+  }
   return EVHTP_RES_OK;
 }
 

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -105,10 +105,7 @@ class HTTPServer {
 
   static void StopCallback(evutil_socket_t sock, short events, void* arg);
 
-  // Transfer-Encoding: chunked — reset counter on new request; increment count
-  // per non-empty chunk (capped).
-  static evhtp_res ChunkCountReset(
-      evhtp_request_t* req, evhtp_headers_t* hdrs, void* arg);
+  // Transfer-Encoding: chunked — increment count per non-empty chunk (capped).
   static evhtp_res ChunkCountIncrement(
       evhtp_request_t* req, uint64_t chunk_len, void* arg);
 

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -105,6 +105,13 @@ class HTTPServer {
 
   static void StopCallback(evutil_socket_t sock, short events, void* arg);
 
+  // Transfer-Encoding: chunked — reset counter on new request; increment count
+  // per non-empty chunk (capped).
+  static evhtp_res ChunkCountReset(
+      evhtp_request_t* req, evhtp_headers_t* hdrs, void* arg);
+  static evhtp_res ChunkCountIncrement(
+      evhtp_request_t* req, uint64_t chunk_len, void* arg);
+
   static evhtp_res NewConnection(evhtp_connection_t* conn, void* arg);
   static evhtp_res EndConnection(evhtp_connection_t* conn, void* arg);
 


### PR DESCRIPTION
#### What does the PR do?
Caps the number of non-empty chunks per chunked HTTP request at 65536 (`1 << 16`) to mitigate a memory-exhaustion vector where a client streams many tiny chunks and libevhtp retains each one in its evbuffer, growing server RSS without bound.

Implementation:
- Hooks `evhtp_hook_on_headers` (`ChunkCountReset`) and `evhtp_hook_on_new_chunk` (`ChunkCountIncrement`) per connection.
- Counter is `thread_local` on the worker thread and reset per request.
- On exceeding the cap: emits a JSON 400 error, drops keepalive, and calls `bufferevent_disable(req->conn->bev, EV_READ)` so the server stops ingesting bytes while it flushes the error response (otherwise memory continues growing during the flush).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] fix

#### Related PRs:
https://github.com/triton-inference-server/third_party/pull/75

#### Where should the reviewer start?

#### Test plan:
- `L0_http` — `http_request_many_chunks.py` covers under-limit (accepted) and over-limit (rejected with 400, connection closed) paths.
- `L0_sagemaker` — equivalent over-limit coverage on the SageMaker endpoint.

- CI Pipeline ID: 50576040

#### Caveats:
- Limit is a compile-time constant (`kMaxChunkedChunks = 1 << 16`); not configurable at runtime.
- Counter is per-request, not per-connection — keepalive reuse is unaffected.

#### Background
Triton Inference Server high memory usage when receiving HTTP requests composed of a large number of small chunks. libevhtp accumulates each chunk in its evbuffer, so an attacker can drive RSS up without sending much total bytes. Capping the chunk count bounds the fan-out and the early `EV_READ` disable bounds memory while the error response drains.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
