### PR TITLE
fix: mistral tool parser drops calls with leading whitespace

### DIFF
--- a/python/openai/openai_frontend/engine/utils/tool_call_parsers/mistral_tool_call_parser.py
+++ b/python/openai/openai_frontend/engine/utils/tool_call_parsers/mistral_tool_call_parser.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -87,7 +87,8 @@ class MistralToolParser(ToolCallParser):
         """
 
         # case -- if a tool call token is not present, return a text response
-        if not (full_text.startswith(self.bot_token) or full_text.startswith("[")):
+        stripped = full_text.lstrip()
+        if not (stripped.startswith(self.bot_token) or stripped.startswith("[")):
             return ChatCompletionResponseMessage(
                 tool_calls=None, content=full_text, role=role
             )


### PR DESCRIPTION
## Summary

The Mistral tool-call parser bails on detection when the model output has leading whitespace before `[TOOL_CALLS]` or `[`. This is the common case for Mistral on TRT-LLM — the chat template's BOS handling produces a leading space token, so generated text starts with `" [{...}]"` rather than `"[{...}]"`. With the strict `startswith` check, neither branch matches and the parser falls through to the content-only path.

**Symptom**: `tool_choice: "auto"` returns the tool call as a raw JSON string in `content` rather than a structured `tool_calls` array. Most visible on parallel tool calls, which almost always come back with the leading space.

## Reproduction

Against a Mistral Small 3.x model served via Triton with `--tool-call-parser=mistral`:

```bash
curl -s -X POST http://localhost:9000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model":"ensemble",
    "messages":[{"role":"user","content":"Weather in SF AND book a hotel for next Friday"}],
    "tool_choice":"auto",
    "tools":[
      {"type":"function","function":{"name":"get_weather","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}},
      {"type":"function","function":{"name":"search_hotels","parameters":{"type":"object","properties":{"city":{"type":"string"},"checkin_date":{"type":"string"}},"required":["city","checkin_date"]}}}
    ]
  }'
```

**Before**: `content: " [{\"name\": \"get_weather\", ...}, {...}]"`, `tool_calls: null`, `finish_reason: stop`
**After**: `content: null`, `tool_calls: [{...}, {...}]`, `finish_reason: tool_calls`

## Fix

```diff
-        if not (full_text.startswith(self.bot_token) or full_text.startswith("[")):
+        stripped = full_text.lstrip()
+        if not (stripped.startswith(self.bot_token) or stripped.startswith("[")):
```

`stripped` is used only for the detection. The response still uses the original `full_text` for `content`, so non-tool responses where the model legitimately starts with whitespace pass through unchanged.

## Testing

Manual end-to-end testing with Mistral Small 24B Instruct 2501 on Triton `26.03-trtllm-python-py3` (NVFP4, TP=2):

- Single tool call with `tool_choice: "required"` — passes before and after
- Single tool call with `tool_choice: "auto"` — **fails before**, passes after
- Parallel tool calls with `tool_choice: "auto"` — **fails before**, passes after
- Decline path (model chooses prose over tool) — passes before and after

I have not exercised the `L0_*` test suite locally — happy to add or run any specific tests if helpful.

## CLA

CLA submission in flight to triton-cla@nvidia.com.
