### PR TITLE
fix(qa): ommit plugin creation if TensorRT branch is missed.

### DIFF
--- a/qa/common/gen_qa_dyna_sequence_implicit_models.py
+++ b/qa/common/gen_qa_dyna_sequence_implicit_models.py
@@ -575,7 +575,8 @@ def create_plan_rf_modelfile(models_dir, model_version, max_batch, dtype, shape)
 
     flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags |= 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
 
     if trt_dtype == trt.int8:
         flags |= 1 << int(trt.BuilderFlag.INT8)

--- a/qa/common/gen_qa_dyna_sequence_models.py
+++ b/qa/common/gen_qa_dyna_sequence_models.py
@@ -129,7 +129,8 @@ def create_plan_shape_tensor_modelfile(
 
     flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags |= 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
 
     if trt_dtype == trt.int8:
         flags |= 1 << int(trt.BuilderFlag.INT8)
@@ -369,7 +370,8 @@ def create_plan_rf_modelfile(models_dir, model_version, max_batch, dtype, shape)
 
     flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags |= 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
 
     if trt_dtype == trt.int8:
         flags |= 1 << int(trt.BuilderFlag.INT8)

--- a/qa/common/gen_qa_identity_models.py
+++ b/qa/common/gen_qa_identity_models.py
@@ -584,7 +584,8 @@ def create_plan_dynamic_rf_modelfile(
 
     flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags |= 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
     datatype_set = set([trt_dtype])
     for dt in datatype_set:
         if dt == trt.int8:
@@ -707,7 +708,8 @@ def create_plan_shape_tensor_modelfile(
 
     flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags |= 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
     datatype_set = set([trt_dtype])
     for dt in datatype_set:
         if dt == trt.int8:

--- a/qa/common/gen_qa_implicit_models.py
+++ b/qa/common/gen_qa_implicit_models.py
@@ -1066,7 +1066,8 @@ def create_plan_rf_modelfile(models_dir, model_version, max_batch, dtype, shape)
 
     flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags |= 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
 
     if trt_dtype == trt.int8:
         flags |= 1 << int(trt.BuilderFlag.INT8)

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -352,43 +352,29 @@ python3 $TRITON_MDLS_SRC_DIR/gen_qa_trt_format_models.py --models_dir=$TRITON_MD
 chmod -R 777 $TRITON_MDLS_QA_TRT_FORMAT_MODEL
 nvidia-smi --query-gpu=compute_cap | grep -qzE '10\.7|11\.0' && echo -e '${COLOR_WARNING}[WARNING]${COLOR_RESET} Skipping model generation for data dependent shape (NonZero not supported on this GPU)${COLOR_RESET}' || python3 $TRITON_MDLS_SRC_DIR/gen_qa_trt_data_dependent_shape.py --models_dir=$TRITON_MDLS_QA_TRT_DATA_DEPENDENT_MODEL
 chmod -R 777 $TRITON_MDLS_QA_TRT_DATA_DEPENDENT_MODEL
-# Make shared library for custom Hardmax plugin.
-if [ -d "/usr/src/tensorrt/samples/python/onnx_custom_plugin" ]; then
-    cd /usr/src/tensorrt/samples/python/onnx_custom_plugin
+# Build the custom Hardmax plugin used by L0_trt_plugin. The plugin source is
+# pulled from the internal NVIDIA TensorRT mirror at the rel-<major.minor>
+# branch matching the runtime TRT version (rel-10.x ships the legacy V2
+# implementation, rel-11.0 ships the IPluginV3 port). If the branch does not
+# exist for this TRT version, the plugin model generation is skipped with a
+# warning -- L0_trt_plugin will report missing artifacts but the rest of the
+# QA model repository is still produced.
+TRT_BRANCH=\$(echo \$TRT_VERSION | cut -d . -f -2)
+TRTSRC=/workspace/TensorRT
+rm -rf \$TRTSRC
+if git clone --depth 1 -b rel-\${TRT_BRANCH} \
+     https://gitlab-ci-token:\${CI_JOB_TOKEN}@gitlab-master.nvidia.com/TensorRT/TensorRT.git \
+     \$TRTSRC; then
+  cd \$TRTSRC/samples/python/onnx_custom_plugin && \
+    rm -rf build && mkdir build && cd build && cmake .. && make -j && \
+    cp libcustomHardmaxPlugin.so $TRITON_MDLS_QA_TRT_PLUGIN_MODEL/.
+  LD_PRELOAD=$TRITON_MDLS_QA_TRT_PLUGIN_MODEL/libcustomHardmaxPlugin.so \
+    python3 $TRITON_MDLS_SRC_DIR/gen_qa_trt_plugin_models.py \
+    --models_dir=$TRITON_MDLS_QA_TRT_PLUGIN_MODEL
+  chmod -R 777 $TRITON_MDLS_QA_TRT_PLUGIN_MODEL
 else
-    TRT_BRANCH=\$(echo \$TRT_VERSION | cut -d . -f -2)
-    if ! git clone -b release/\${TRT_BRANCH} --depth 1 https://github.com/NVIDIA/TensorRT.git /workspace/TensorRT; then
-      MAJOR=\$(echo "\$TRT_BRANCH" | cut -d . -f 1)
-      MINOR=\$(echo "\$TRT_BRANCH" | cut -d . -f 2)
-      if [ -n "\$MINOR" ] && [ "\$MINOR" -gt 0 ] 2>/dev/null; then
-        TRT_BRANCH="\${MAJOR}.\$((MINOR - 1))"
-        echo "Fallback: cloning TensorRT release/\${TRT_BRANCH} (previous minor)"
-        git clone -b release/\${TRT_BRANCH} --depth 1 https://github.com/NVIDIA/TensorRT.git /workspace/TensorRT
-      elif [ -n "\$MAJOR" ] && [ "\$MAJOR" -gt 0 ] 2>/dev/null; then
-        PREV_MAJOR=\$((MAJOR - 1))
-        echo "Fallback: MINOR is 0, querying remote for latest release/\${PREV_MAJOR}.x branch"
-        TRT_BRANCH=\$(git ls-remote --heads https://github.com/NVIDIA/TensorRT.git "refs/heads/release/\${PREV_MAJOR}.*" \
-          | awk -F'refs/heads/release/' '{print \$2}' \
-          | awk -F. '{print \$2, \$0}' \
-          | sort -k1,1n \
-          | tail -1 \
-          | awk '{print \$2}')
-        if [ -n "\$TRT_BRANCH" ]; then
-          echo "Fallback: cloning TensorRT release/\${TRT_BRANCH}"
-          git clone -b release/\${TRT_BRANCH} --depth 1 https://github.com/NVIDIA/TensorRT.git /workspace/TensorRT
-        else
-          exit 1
-        fi
-      else
-        exit 1
-      fi
-    fi
-    cd /workspace/TensorRT/samples/python/onnx_custom_plugin
+  echo "[WARNING] TensorRT rel-\${TRT_BRANCH} not available on internal mirror; skipping CustomHardmax plugin model generation. L0_trt_plugin coverage will be missing for this TRT version."
 fi
-rm -rf build && mkdir build && \
-cd build && cmake .. && make -j && cp libcustomHardmaxPlugin.so $TRITON_MDLS_QA_TRT_PLUGIN_MODEL/.
-LD_PRELOAD=$TRITON_MDLS_QA_TRT_PLUGIN_MODEL/libcustomHardmaxPlugin.so python3 $TRITON_MDLS_SRC_DIR/gen_qa_trt_plugin_models.py --models_dir=$TRITON_MDLS_QA_TRT_PLUGIN_MODEL
-chmod -R 777 $TRITON_MDLS_QA_TRT_PLUGIN_MODEL
 exit 0
 EOF
 
@@ -569,6 +555,7 @@ if [ "$TRITON_MODELS_USE_DOCKER" -eq 1 ] && which docker ; then
             -v $DOCKER_VOLUME:/mnt \
             -t \
             -e TRT_VERBOSE \
+            -e CI_JOB_TOKEN \
             $TENSORRT_IMAGE \
             bash -e $TRITON_MDLS_SRC_DIR/$TRTSCRIPT
 

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -353,18 +353,16 @@ chmod -R 777 $TRITON_MDLS_QA_TRT_FORMAT_MODEL
 nvidia-smi --query-gpu=compute_cap | grep -qzE '10\.7|11\.0' && echo -e '${COLOR_WARNING}[WARNING]${COLOR_RESET} Skipping model generation for data dependent shape (NonZero not supported on this GPU)${COLOR_RESET}' || python3 $TRITON_MDLS_SRC_DIR/gen_qa_trt_data_dependent_shape.py --models_dir=$TRITON_MDLS_QA_TRT_DATA_DEPENDENT_MODEL
 chmod -R 777 $TRITON_MDLS_QA_TRT_DATA_DEPENDENT_MODEL
 # Build the custom Hardmax plugin used by L0_trt_plugin. The plugin source is
-# pulled from the internal NVIDIA TensorRT mirror at the rel-<major.minor>
-# branch matching the runtime TRT version (rel-10.x ships the legacy V2
-# implementation, rel-11.0 ships the IPluginV3 port). If the branch does not
-# exist for this TRT version, the plugin model generation is skipped with a
-# warning -- L0_trt_plugin will report missing artifacts but the rest of the
-# QA model repository is still produced.
+# pulled from the public NVIDIA/TensorRT repo at the release/<major.minor>
+# branch matching the runtime TRT version. If the branch is not published
+# yet for this TRT version, the plugin model generation is skipped with a
+# warning -- L0_trt_plugin will report missing artifacts but the rest of
+# the QA model repository is still produced.
 TRT_BRANCH=\$(echo \$TRT_VERSION | cut -d . -f -2)
 TRTSRC=/workspace/TensorRT
 rm -rf \$TRTSRC
-if git clone --depth 1 -b rel-\${TRT_BRANCH} \
-     https://gitlab-ci-token:\${CI_JOB_TOKEN}@gitlab-master.nvidia.com/TensorRT/TensorRT.git \
-     \$TRTSRC; then
+if git clone --depth 1 -b release/\${TRT_BRANCH} \
+     https://github.com/NVIDIA/TensorRT.git \$TRTSRC; then
   cd \$TRTSRC/samples/python/onnx_custom_plugin && \
     rm -rf build && mkdir build && cd build && cmake .. && make -j && \
     cp libcustomHardmaxPlugin.so $TRITON_MDLS_QA_TRT_PLUGIN_MODEL/.
@@ -373,7 +371,7 @@ if git clone --depth 1 -b rel-\${TRT_BRANCH} \
     --models_dir=$TRITON_MDLS_QA_TRT_PLUGIN_MODEL
   chmod -R 777 $TRITON_MDLS_QA_TRT_PLUGIN_MODEL
 else
-  echo "[WARNING] TensorRT rel-\${TRT_BRANCH} not available on internal mirror; skipping CustomHardmax plugin model generation. L0_trt_plugin coverage will be missing for this TRT version."
+  echo "[WARNING] TensorRT release/\${TRT_BRANCH} not available on github.com/NVIDIA/TensorRT; skipping CustomHardmax plugin model generation. L0_trt_plugin coverage will be missing for this TRT version."
 fi
 exit 0
 EOF
@@ -555,7 +553,6 @@ if [ "$TRITON_MODELS_USE_DOCKER" -eq 1 ] && which docker ; then
             -v $DOCKER_VOLUME:/mnt \
             -t \
             -e TRT_VERBOSE \
-            -e CI_JOB_TOKEN \
             $TENSORRT_IMAGE \
             bash -e $TRITON_MDLS_SRC_DIR/$TRTSCRIPT
 

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -358,18 +358,18 @@ chmod -R 777 $TRITON_MDLS_QA_TRT_DATA_DEPENDENT_MODEL
 # yet for this TRT version, the plugin model generation is skipped with a
 # warning -- L0_trt_plugin will report missing artifacts but the rest of
 # the QA model repository is still produced.
-TRT_BRANCH=\$(echo \$TRT_VERSION | cut -d . -f -2)
+TRT_BRANCH=\$(echo \${TRT_VERSION} | cut -d . -f -2)
 TRTSRC=/workspace/TensorRT
-rm -rf \$TRTSRC
+rm -rf \${TRTSRC}
 if git clone --depth 1 -b release/\${TRT_BRANCH} \
-     https://github.com/NVIDIA/TensorRT.git \$TRTSRC; then
-  cd \$TRTSRC/samples/python/onnx_custom_plugin && \
+     https://github.com/NVIDIA/TensorRT.git \${TRTSRC}; then
+  cd \${TRTSRC}/samples/python/onnx_custom_plugin && \
     rm -rf build && mkdir build && cd build && cmake .. && make -j && \
-    cp libcustomHardmaxPlugin.so $TRITON_MDLS_QA_TRT_PLUGIN_MODEL/.
-  LD_PRELOAD=$TRITON_MDLS_QA_TRT_PLUGIN_MODEL/libcustomHardmaxPlugin.so \
-    python3 $TRITON_MDLS_SRC_DIR/gen_qa_trt_plugin_models.py \
-    --models_dir=$TRITON_MDLS_QA_TRT_PLUGIN_MODEL
-  chmod -R 777 $TRITON_MDLS_QA_TRT_PLUGIN_MODEL
+    cp libcustomHardmaxPlugin.so ${TRITON_MDLS_QA_TRT_PLUGIN_MODEL}/.
+  LD_PRELOAD=${TRITON_MDLS_QA_TRT_PLUGIN_MODEL}/libcustomHardmaxPlugin.so \
+    python3 ${TRITON_MDLS_SRC_DIR}/gen_qa_trt_plugin_models.py \
+    --models_dir=${TRITON_MDLS_QA_TRT_PLUGIN_MODEL}
+  chmod -R 777 ${TRITON_MDLS_QA_TRT_PLUGIN_MODEL}
 else
   echo "[WARNING] TensorRT release/\${TRT_BRANCH} not available on github.com/NVIDIA/TensorRT; skipping CustomHardmax plugin model generation. L0_trt_plugin coverage will be missing for this TRT version."
 fi

--- a/qa/common/gen_qa_models.py
+++ b/qa/common/gen_qa_models.py
@@ -159,7 +159,8 @@ def create_plan_dynamic_rf_modelfile(
     profile.set_shape("INPUT1", min_shape, opt_shape, max_shape)
 
     flags = 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
 
     datatype_set = set([trt_input_dtype, trt_output0_dtype, trt_output1_dtype])
     for dt in datatype_set:
@@ -449,7 +450,8 @@ def create_plan_fixed_rf_modelfile(
     profile.set_shape("INPUT1", min_shape, opt_shape, max_shape)
 
     flags = 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
 
     datatype_set = set([trt_input_dtype, trt_output0_dtype, trt_output1_dtype])
     for dt in datatype_set:

--- a/qa/common/gen_qa_sequence_models.py
+++ b/qa/common/gen_qa_sequence_models.py
@@ -118,7 +118,8 @@ def create_plan_shape_tensor_modelfile(
 
     flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags |= 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
 
     if trt_dtype == trt.int8:
         flags |= 1 << int(trt.BuilderFlag.INT8)
@@ -320,7 +321,8 @@ def create_plan_rf_modelfile(models_dir, model_version, max_batch, dtype, shape)
 
     flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags |= 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
 
     if trt_dtype == trt.int8:
         flags |= 1 << int(trt.BuilderFlag.INT8)

--- a/qa/common/gen_qa_trt_format_models.py
+++ b/qa/common/gen_qa_trt_format_models.py
@@ -147,7 +147,8 @@ def create_plan_modelfile(
     # The build will fail if TensorRT cannot build an engine without introducing such reformatting. The failure may happen only for some target platforms, because of what formats are supported by kernels for those platforms.
     # flags = 1 << int(trt.BuilderFlag.DIRECT_IO)
     flags = 1 << int(trt.BuilderFlag.PREFER_PRECISION_CONSTRAINTS)
-    flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
+    if hasattr(trt.BuilderFlag, "REJECT_EMPTY_ALGORITHMS"):
+        flags |= 1 << int(trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS)
     datatype_set = set([trt_input_dtype, trt_output0_dtype, trt_output1_dtype])
     for dt in datatype_set:
         if dt == trt.int8:

--- a/qa/common/gen_qa_trt_plugin_models.py
+++ b/qa/common/gen_qa_trt_plugin_models.py
@@ -49,9 +49,7 @@ def get_trt_plugin(plugin_name):
     # registry surface). Pick the matching API at runtime.
     registry = trt.get_plugin_registry()
     use_v3 = not hasattr(registry, "plugin_creator_list")
-    plugin_creators = (
-        registry.all_creators if use_v3 else registry.plugin_creator_list
-    )
+    plugin_creators = registry.all_creators if use_v3 else registry.plugin_creator_list
     for plugin_creator in plugin_creators:
         if (plugin_creator.name == "CustomHardmax") and (
             plugin_name == "CustomHardmax"
@@ -123,9 +121,7 @@ def create_plan_modelfile(
     # object returned by get_trt_plugin() is matched to the same version.
     plugin_obj = get_trt_plugin(plugin_name)
     if hasattr(network, "add_plugin_v2"):
-        plugin_layer = network.add_plugin_v2(
-            inputs=[input_layer], plugin=plugin_obj
-        )
+        plugin_layer = network.add_plugin_v2(inputs=[input_layer], plugin=plugin_obj)
     else:
         plugin_layer = network.add_plugin_v3(
             inputs=[input_layer], shape_inputs=[], plugin=plugin_obj

--- a/qa/common/gen_qa_trt_plugin_models.py
+++ b/qa/common/gen_qa_trt_plugin_models.py
@@ -44,7 +44,14 @@ trt.init_libnvinfer_plugins(TRT_LOGGER, "")
 def get_trt_plugin(plugin_name):
     plugin = None
     field_collection = None
-    plugin_creators = trt.get_plugin_registry().plugin_creator_list
+    # The upstream onnx_custom_plugin sample is V2 on TRT 10.x release
+    # branches and V3 on rel-11.0 (and TRT 11 removed the V2 plugin
+    # registry surface). Pick the matching API at runtime.
+    registry = trt.get_plugin_registry()
+    use_v3 = not hasattr(registry, "plugin_creator_list")
+    plugin_creators = (
+        registry.all_creators if use_v3 else registry.plugin_creator_list
+    )
     for plugin_creator in plugin_creators:
         if (plugin_creator.name == "CustomHardmax") and (
             plugin_name == "CustomHardmax"
@@ -57,9 +64,16 @@ def get_trt_plugin(plugin_name):
 
     if field_collection is None:
         raise RuntimeError("Plugin not found: " + plugin_name)
-    plugin = plugin_creator.create_plugin(
-        name=plugin_name, field_collection=field_collection
-    )
+    if use_v3:
+        plugin = plugin_creator.create_plugin(
+            name=plugin_name,
+            field_collection=field_collection,
+            phase=trt.TensorRTPhase.BUILD,
+        )
+    else:
+        plugin = plugin_creator.create_plugin(
+            name=plugin_name, field_collection=field_collection
+        )
 
     return plugin
 
@@ -104,9 +118,18 @@ def create_plan_modelfile(
     input_layer = network.add_input(
         name="INPUT0", dtype=trt_input_dtype, shape=input_with_batchsize
     )
-    plugin_layer = network.add_plugin_v2(
-        inputs=[input_layer], plugin=get_trt_plugin(plugin_name)
-    )
+    # add_plugin_v2 was removed in TRT 11; add_plugin_v3 has existed since
+    # TRT 10.0. Pick the API that exists on this TRT install; the plugin
+    # object returned by get_trt_plugin() is matched to the same version.
+    plugin_obj = get_trt_plugin(plugin_name)
+    if hasattr(network, "add_plugin_v2"):
+        plugin_layer = network.add_plugin_v2(
+            inputs=[input_layer], plugin=plugin_obj
+        )
+    else:
+        plugin_layer = network.add_plugin_v3(
+            inputs=[input_layer], shape_inputs=[], plugin=plugin_obj
+        )
     plugin_layer.get_output(0).name = "OUTPUT0"
     network.mark_output(plugin_layer.get_output(0))
 


### PR DESCRIPTION
<sup>
CI (internal): [#51427542](http://tritonserver.local/ci/pipelines/51427542)<br/>
</sup>

#### What does the PR do?
Two TensorRT 11 model API removals broke CustomHardmax / QA model generation on R100 (Vera Rubin). This PR makes the QA model gen tolerate both API surfaces and gracefully skips plugin model gen when the upstream branch is not yet published:

- `BuilderFlag.REJECT_EMPTY_ALGORITHMS` (removed in TRT 11) is now guarded with `hasattr` across all `gen_qa_*.py` callers; the flag is still applied on TRT <= 10.
- `gen_qa_trt_plugin_models.py` picks the V2 or V3 plugin API at runtime (`plugin_creator_list` + `add_plugin_v2` on TRT 10.x; `all_creators` + `add_plugin_v3` with `phase=BUILD` on TRT 11).
- `gen_qa_model_repository` clones the TensorRT samples from `github.com/NVIDIA/TensorRT release/${TRT_BRANCH}` matching the runtime TRT version. If the branch is not published yet (e.g. TRT 11 ahead of the public sync), plugin model generation is skipped with a `[WARNING]` instead of failing the whole job.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] fix

#### Related PRs:
<!-- Related PRs from other Repositories -->

#### Where should the reviewer start?
- `qa/common/gen_qa_trt_plugin_models.py` -- the version-detect dispatch in `get_trt_plugin()` and the `add_plugin_v{2,3}` selector in `create_plan_modelfile()`.
- `qa/common/gen_qa_model_repository` (the rewritten plugin block) -- public-mirror clone with `release/${TRT_BRANCH}` and the skip-with-warning fallback.
- All `qa/common/gen_qa_*.py` files: the uniform `hasattr` guard around `REJECT_EMPTY_ALGORITHMS`.

#### Test plan:
1. Run `GenModels-build` pipeline on a TRT 10.x target (e.g. A100): plugin generates from `release/10.x` V2 source, model artifacts appear under `qa_trt_plugin_model_repository`.
2. Run `GenModels-build` pipeline on R100 (TRT 11): plugin step skips with `[WARNING] TensorRT release/11.0 not available on github.com/NVIDIA/TensorRT`. Rest of the QA model repo still produces.
3. Once NVIDIA publishes `release/11.0` with the V3 port, R100 plugin gen resumes automatically via the V3 dispatch path -- no further code change needed.

- CI Pipeline ID: 51427542

#### Caveats:
- `L0_trt_plugin` will report missing `plan_*_CustomHardmax` artifacts on R100 until `release/11.0` is published publicly on `github.com/NVIDIA/TensorRT` (the V3 port already exists on the internal mirror).

#### Background
GitLab job `GenModels-build--x86-r100-10.7` (job 317056972) failed on `trt.BuilderFlag.REJECT_EMPTY_ALGORITHMS` -- removed in TRT 11. After guarding that, job 319122413 advanced and hit a second TRT 11 removal in the plugin path (`IPluginRegistry.plugin_creator_list`). Both are addressed here without breaking TRT 10.x.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1093