### PR TITLE
fix: Replace std:atoi with std:stoi

### DIFF
--- a/src/http_server.cc
+++ b/src/http_server.cc
@@ -2440,7 +2440,7 @@ HTTPAPIServer::GetContentLength(
         evhtp_kv_find(req->headers_in, kContentLengthHeader);
     if (content_length_c_str != nullptr) {
       try {
-        lcontent_length = std::atoi(content_length_c_str);
+        lcontent_length = std::stoi(content_length_c_str);
       }
       catch (const std::invalid_argument& ia) {
         err = TRITONSERVER_ErrorNew(
@@ -2484,7 +2484,7 @@ HTTPAPIServer::GetInferenceHeaderLength(
   if (header_length_c_str != NULL) {
     int parsed_value;
     try {
-      parsed_value = std::atoi(header_length_c_str);
+      parsed_value = std::stoi(header_length_c_str);
     }
     catch (const std::invalid_argument& ia) {
       return TRITONSERVER_ErrorNew(

--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -98,7 +98,7 @@ SagemakerAPIServer::GetInferenceHeaderLength(
       int32_t parsed_value;
       try {
         parsed_value =
-            std::atoi(content_type_c_str + binary_mime_type_.length());
+            std::stoi(content_type_c_str + binary_mime_type_.length());
       }
       catch (const std::invalid_argument& ia) {
         return TRITONSERVER_ErrorNew(
@@ -508,7 +508,7 @@ SagemakerAPIServer::SageMakerMMEHandleInfer(
           evhtp_kv_find(req->headers_in, kContentLengthHeader);
       if (content_length_c_str != nullptr) {
         try {
-          content_length = std::atoi(content_length_c_str);
+          content_length = std::stoi(content_length_c_str);
         }
         catch (const std::invalid_argument& ia) {
           err = TRITONSERVER_ErrorNew(

--- a/src/vertex_ai_server.cc
+++ b/src/vertex_ai_server.cc
@@ -79,7 +79,7 @@ VertexAiAPIServer::GetInferenceHeaderLength(
       int32_t parsed_value;
       try {
         parsed_value =
-            std::atoi(content_type_c_str + binary_mime_type_.length());
+            std::stoi(content_type_c_str + binary_mime_type_.length());
       }
       catch (const std::invalid_argument& ia) {
         return TRITONSERVER_ErrorNew(


### PR DESCRIPTION
Fixes an issue where exception handling was relied upon to detect errors when exceptions would not be generated, allowing errors to occur unnoticed.



