### PR TITLE
test: Special handling for ONNX bf16 models in tests

### DIFF
--- a/qa/L0_http_fuzz/test.sh
+++ b/qa/L0_http_fuzz/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2020-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -65,7 +65,7 @@ function_install_python38() {
 
     # Install test script dependencies
     pip3 install --upgrade wheel setuptools boofuzz==0.3.0 "numpy<2" pillow attrdict future grpcio requests gsutil \
-                            awscli six grpcio-channelz prettytable virtualenv
+                            awscli six grpcio-channelz prettytable virtualenv ml_dtypes
 }
 function_install_python38
 

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -163,6 +163,9 @@ function generate_model_repository() {
         # Types that need to use SubAdd instead of AddSub
         swap_types="float32 int32 int16 int8"
         for onnx_model in $onnx_models; do
+          # Skip BF16 models: Not yet supported by Python backend
+          [[ "$onnx_model" == *bf16* ]] && continue
+
           if [ "$BACKEND" == "python_dlpack" ]; then
             python_model=`echo $onnx_model | sed 's/onnx/python_dlpack/g' | sed 's,'"$DATADIR/qa_model_repository/"',,g'`
           else
@@ -256,10 +259,14 @@ function generate_model_repository() {
       if [ "$FW" == "onnx" ] && [ "$TEST_VALGRIND" -eq 1 ]; then
         # Reduce the instance count to make loading onnx models faster
         for MC in `ls models/${FW}*/config.pbtxt`; do
+            # Skip BF16 models: ORT CPU has no bf16 kernels
+            [[ "$MC" == *bf16* ]] && continue
             echo "instance_group [ { kind: ${KIND} count: 1 }]" >> $MC
         done
       elif [ "$FW" != "plan" ] && [ "$FW" != "python" ] && [ "$FW" != "python_dlpack" ] && [ "$FW" != "openvino" ];then
         for MC in `ls models/${FW}*/config.pbtxt`; do
+            # Skip BF16 models: ORT CPU has no bf16 kernels
+            [[ "$MC" == *bf16* ]] && continue
             echo "instance_group [ { kind: ${KIND} }]" >> $MC
         done
       elif [ "$FW" == "python" ] || [ "$FW" == "python_dlpack" ] || [ "$FW" == "openvino" ]; then

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -218,7 +218,7 @@ function generate_model_repository() {
       else
         cp -r ${DATADIR}/qa_model_repository/${BACKEND}* \
           models/.
-        # Remove ONNX BF16 models for CPU only containers
+        # Remove ONNX BF16 models from CPU models
         if [ "$BACKEND" == "onnx" ] && [ "$TARGET" == "cpu" ]; then
           rm -rf models/onnx_*bf16*
         fi

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -218,6 +218,10 @@ function generate_model_repository() {
       else
         cp -r ${DATADIR}/qa_model_repository/${BACKEND}* \
           models/.
+        # Remove ONNX BF16 models for CPU only containers
+        if [ "$BACKEND" == "onnx" ] && [ "$TARGET" == "cpu" ]; then
+          rm -rf models/onnx_*bf16*
+        fi
       fi
     done
 
@@ -256,24 +260,24 @@ function generate_model_repository() {
 
     KIND="KIND_GPU" && [[ "$TARGET" == "cpu" ]] && KIND="KIND_CPU"
     for FW in $BACKENDS; do
-      if [ "$FW" == "onnx" ] && [ "$TEST_VALGRIND" -eq 1 ]; then
-        # Reduce the instance count to make loading onnx models faster
-        for MC in `ls models/${FW}*/config.pbtxt`; do
-            # Skip BF16 models: ORT CPU has no bf16 kernels
-            [[ "$MC" == *bf16* ]] && continue
-            echo "instance_group [ { kind: ${KIND} count: 1 }]" >> $MC
-        done
-      elif [ "$FW" != "plan" ] && [ "$FW" != "python" ] && [ "$FW" != "python_dlpack" ] && [ "$FW" != "openvino" ];then
-        for MC in `ls models/${FW}*/config.pbtxt`; do
-            # Skip BF16 models: ORT CPU has no bf16 kernels
-            [[ "$MC" == *bf16* ]] && continue
-            echo "instance_group [ { kind: ${KIND} }]" >> $MC
-        done
-      elif [ "$FW" == "python" ] || [ "$FW" == "python_dlpack" ] || [ "$FW" == "openvino" ]; then
-        for MC in `ls models/${FW}*/config.pbtxt`; do
-            echo "instance_group [ { kind: KIND_CPU }]" >> $MC
-        done
-      fi
+      [ "$FW" == "plan" ] && continue
+      for MC in `ls models/${FW}*/config.pbtxt`; do
+        # BF16 models: ORT CPU has no BF16 kernels, force GPU
+        if [ "$FW" == "onnx" ] && [ "$MC" == *bf16* ]; then
+          MC_KIND="KIND_GPU"
+        else
+          MC_KIND=${KIND}
+        fi
+
+        if [ "$FW" == "onnx" ] && [ "$TEST_VALGRIND" -eq 1 ]; then
+          # Reduce the instance count to make loading onnx models faster
+          echo "instance_group [ { kind: ${MC_KIND} count: 1 }]" >> $MC
+        elif [ "$FW" == "python" ] || [ "$FW" == "python_dlpack" ] || [ "$FW" == "openvino" ]; then
+          echo "instance_group [ { kind: KIND_CPU }]" >> $MC
+        else
+          echo "instance_group [ { kind: ${KIND} }]" >> $MC
+        fi
+      done
     done
 
     # Modify custom_zero_1_float32 and custom_nobatch_zero_1_float32 for relevant ensembles

--- a/qa/L0_infer_variable/test.sh
+++ b/qa/L0_infer_variable/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -63,6 +63,11 @@ for TARGET in cpu gpu; do
     rm -fr models && \
         cp -r /data/inferenceserver/${REPO_VERSION}/qa_variable_model_repository models && \
         cp -r /data/inferenceserver/${REPO_VERSION}/qa_ensemble_model_repository/qa_variable_model_repository/* models/.
+
+    # Remove ONNX BF16 models from CPU models
+    if [ "$TARGET" == "cpu" ]; then
+        rm -rf models/onnx_*bf16*
+    fi
 
     create_nop_version_dir `pwd`/models
 


### PR DESCRIPTION
- Skip bf16 models in L0_infer (unsupported by ORT CPU EP and Python backend).
- Add ml_dtypes to L0_http_fuzz virtual_env pip install.