### PR TITLE
Update compatibility.md

### DIFF
--- a/docs/introduction/compatibility.md
+++ b/docs/introduction/compatibility.md
@@ -38,6 +38,7 @@
 
 | Triton release version	 | NGC Tag	 | Python version	 | Torch version | TensorRT version | TensorRT-LLM version | CUDA version | CUDA Driver version | Size |
 | --- | ---  | --- | --- | --- | --- | --- | --- | --- |
+| 26.05 | nvcr.io/nvidia/tritonserver:26.05-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.22 GB |
 | 26.04 | nvcr.io/nvidia/tritonserver:26.04-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.22 GB |
 | 26.03 | nvcr.io/nvidia/tritonserver:26.03-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.0 | 13.1.0.036 | 590.44.01 | 14.18 GB |
 | 26.02 | nvcr.io/nvidia/tritonserver:26.02-trtllm-python-py3 | Python 3.12.3  | 2.9.0a0+145a3a7bda.nv25.10 | 10.13.3.9 | 1.1.0 | 13.0.2.006 | 580.95.05 | 16.17 GB |
@@ -68,6 +69,7 @@
 
 | Triton release version	 | NGC Tag	 | Python version	 | vLLM version | CUDA version | CUDA Driver version | Size |
 | --- | --- | --- | --- | --- | --- | --- |
+| 26.05 | nvcr.io/nvidia/tritonserver:26.05-vllm-python-py3 | Python 3.12.3  | 0.19.0+6bc3197f.nv26.04.48761268 | 13.2.1.009 | 595.58.03 | 9.3G |
 | 26.04 | nvcr.io/nvidia/tritonserver:26.04-vllm-python-py3 | Python 3.12.3  | 0.19.0+6bc3197f.nv26.04.48761268 | 13.2.1.009 | 595.58.03 | 9.09G |
 | 26.03 | nvcr.io/nvidia/tritonserver:26.03-vllm-python-py3 | Python 3.12.3  | 0.17.1+fb2e3ab6.nv26.3.46332470.cu132 | 13.2.0.046 | 595.45.04 | 9.22G |
 | 26.02 | nvcr.io/nvidia/tritonserver:26.02-vllm-python-py3 | Python 3.12.3  | 0.15.1+nv26.2 | 13.1.1.006 | 590.48.01 | 8.9G |
@@ -98,6 +100,7 @@
 
 | Triton release version	 | ONNX Runtime	 |
 | --- | --- |
+| 26.05 | 1.24.4 |
 | 26.04 | 1.24.4 |
 | 26.03 | 1.24.2 |
 | 26.02 | 1.24.1 |


### PR DESCRIPTION
## Why

[TRI-1059](https://linear.app/nvidia/issue/TRI-1059/before-ngc-release-update-compatibilitymd) — Update `docs/introduction/compatibility.md` to add the 26.05 row before NGC release.

## What

Add 26.05 rows to all three compatibility tables in `docs/introduction/compatibility.md`:

- **trtllm-python-py3**: Python 3.12.3, Torch 2.10.0a0+b4e4ee81d3.nv25.12, TensorRT 10.14.1.48, TensorRT-LLM 1.2.1, CUDA 13.1.0.036, Driver 590.44.01, Size 14.22 GB
- **vllm-python-py3**: Python 3.12.3, vLLM 0.19.0+6bc3197f.nv26.04.48761268, CUDA 13.2.1.009, Driver 595.58.03, Size 9.3G
- **ONNX Runtime**: 1.24.4 (per `build.py` build map for the 26.05 release)

The 26.05 release is built on the 26.04 upstream container (`upstream_container_version: "26.04"` in `build.py`), so the trtllm-python-py3 base toolchain matches 26.04. Only the vLLM container size differs (9.3G vs 9.09G).

## Test plan

- [x] Visual verification of table formatting matches existing rows
- [x] ORT version cross-checked against `build.py` build map on r26.05