### PR TITLE
fix: apply inference restriction to SageMaker MME invoke path

### DIFF
--- a/src/sagemaker_server.cc
+++ b/src/sagemaker_server.cc
@@ -199,6 +199,9 @@ SagemakerAPIServer::Handle(evhtp_request_t* req)
         if (action == "/invoke") {
           LOG_VERBOSE(1) << "SageMaker request: INVOKE MODEL";
 
+          RETURN_AND_RESPOND_IF_RESTRICTED(
+              req, RestrictedCategory::INFERENCE);
+
           {
             std::lock_guard<std::mutex> lock(models_list_mutex_);
             if (sagemaker_models_list_.find(multi_model_name.c_str()) ==


### PR DESCRIPTION
This PR applies the `--http-restricted-api=inference` restriction to the SageMaker multi-model (MME) custom-invoke route, which is currently the only inference path that does not honor it.

**Previously, `POST /models/{model}/invoke` was dispatched to `SageMakerMMEHandleInfer()` with no restriction check. When an operator configured an `inference` API restriction, the standard HTTP `/v2/.../infer`, the gRPC infer, and the SageMaker `/invocations` routes all enforced the required header (the last via the inherited `HandleInfer`), but the MME invoke route ran inference without it. This is the same alternate-channel gap that #8686 closed for the MME model-repository operations (load/unload/list/get); the invoke route was missed.**

_This change adds the existing `RETURN_AND_RESPOND_IF_RESTRICTED(req, RestrictedCategory::INFERENCE)` guard at the top of the `/invoke` branch, mirroring the base `HandleInfer`/`HandleGenerate` handlers and the sibling MME repository branches. There is no behavior change for deployments that do not set an inference restriction._

Reproduced on `nvcr.io/nvidia/tritonserver:26.04-py3` (CPU): with `--allow-sagemaker --http-restricted-api=inference:triton-secret=s3cr3t` and an MME model loaded, the same inference request with no header returns `403 "This API is restricted, expecting header 'triton-secret'"` on `POST /v2/models/<m>/infer`, but returned `200` with a full inference result on `POST :8080/models/<m>/invoke`. After this change the MME invoke route returns the same `403`.

Relates to the SageMaker HTTP-restriction hardening in #8686.
