### PR TITLE
security: redact OpenAI restriction secrets in logs

### DIFF
--- a/python/openai/openai_frontend/frontend/fastapi/middleware/api_restriction.py
+++ b/python/openai/openai_frontend/frontend/fastapi/middleware/api_restriction.py
@@ -102,6 +102,15 @@ class RestrictedFeatures:
         """
         return self._restrictions.copy()
 
+    def RedactedRestrictionDict(self) -> dict[str, tuple[str, str]]:
+        """
+        Get a copy of the restrictions dictionary safe for logging.
+
+        Returns:
+            dict: Copy of the restrictions mapping API names to (header_key, redacted_value)
+        """
+        return {api: (key, "***") for api, (key, _) in self._restrictions.items()}
+
     def Insert(self, api: str, restriction: tuple[str, str]):
         """
         Add a restriction for a specific API.

--- a/python/openai/openai_frontend/frontend/fastapi_frontend.py
+++ b/python/openai/openai_frontend/frontend/fastapi_frontend.py
@@ -140,7 +140,7 @@ class FastApiFrontend(OpenAIFrontend):
             APIRestrictionMiddleware, restricted_apis=self.restricted_apis
         )
         print(
-            f"[INFO] API restrictions enabled. Restricted API endpoints: {self.restricted_apis.RestrictionDict()}"
+            f"[INFO] API restrictions enabled. Restricted API endpoints: {self.restricted_apis.RedactedRestrictionDict()}"
         )
 
     def _add_request_size_limit_middleware(self, app: FastAPI):

--- a/python/openai/tests/test_openai_restricted_apis.py
+++ b/python/openai/tests/test_openai_restricted_apis.py
@@ -33,6 +33,8 @@ import pytest
 import requests
 from tests.utils import OpenAIServer
 
+from frontend.fastapi.middleware.api_restriction import RestrictedFeatures
+
 
 def assert_response_success(
     response: requests.Response, expected_status: int = 200, description: str = ""
@@ -256,6 +258,26 @@ class TestRestrictedAPIInvalidArguments:
             malformed_arg,
             expected_error_pattern="restricted api 'inference' can not be specified in multiple config groups",
         )
+
+    def test_restriction_log_view_redacts_secret_values(self):
+        """Restriction secrets are used for auth and must not be printed to logs."""
+        restrictions = RestrictedFeatures(
+            [
+                ["inference", "api-key", "my-secret-key"],
+                ["model-repository", "admin-key", "admin-secret"],
+            ]
+        )
+
+        assert restrictions.RestrictionDict() == {
+            "inference": ("api-key", "my-secret-key"),
+            "model-repository": ("admin-key", "admin-secret"),
+        }
+        assert restrictions.RedactedRestrictionDict() == {
+            "inference": ("api-key", "***"),
+            "model-repository": ("admin-key", "***"),
+        }
+        assert "my-secret-key" not in repr(restrictions.RedactedRestrictionDict())
+        assert "admin-secret" not in repr(restrictions.RedactedRestrictionDict())
 
     @pytest.mark.parametrize(
         "malformed_arg",


### PR DESCRIPTION
## Summary

Redacts `--openai-restricted-api` header values from the OpenAI frontend startup log while preserving the configured header names and the internal values used for request authentication.

The restriction values are shared secrets for protected API groups. The current startup log prints `RestrictionDict()` directly, which includes both the header key and the expected value. In deployments where stdout/container logs are available to operators or log aggregation readers, this can disclose the same value required to access restricted endpoints such as model listing and model load/unload.

## Changes

- Add `RestrictedFeatures.RedactedRestrictionDict()` for log-safe reporting.
- Use the redacted view in the FastAPI frontend restriction startup log.
- Add coverage that confirms the auth dictionary still contains the real values while the logging view does not expose them.

## Verification

```text
python -m py_compile python\openai\openai_frontend\frontend\fastapi\middleware\api_restriction.py python\openai\openai_frontend\frontend\fastapi_frontend.py python\openai\tests\test_openai_restricted_apis.py

git diff --check

lightweight direct check:
redaction verification passed
```

I could not run the focused pytest target in this local environment because the test conftest imports the `tritonserver` Python package, which is not installed here.