### PR TITLE
Remove Windows server build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,22 +166,9 @@ if (OPENSSL_ROOT_DIR)
   set(_CMAKE_ARGS_OPENSSL_ROOT_DIR "-DOPENSSL_ROOT_DIR:PATH=${OPENSSL_ROOT_DIR}")
 endif()
 
-# Location where protobuf-config.cmake will be installed varies by
-# platform
-if (WIN32)
-  set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/cmake")
-else()
-  set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/${LIB_DIR}/cmake/protobuf")
-endif()
+set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/protobuf/${LIB_DIR}/cmake/protobuf")
 
-# Triton with Opentelemetry is not supported on Windows
-# FIXME: add location for Windows, when support is added
-# JIRA DLIS-4786
-if (WIN32)
-  set(_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR "")
-else()
-  set(_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/${LIB_DIR}/cmake/opentelemetry-cpp")
-endif()
+set(_FINDPACKAGE_OPENTELEMETRY_CONFIG_DIR "${TRITON_THIRD_PARTY_INSTALL_PREFIX}/opentelemetry-cpp/${LIB_DIR}/cmake/opentelemetry-cpp")
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(TRITON_INSTALL_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/install)
@@ -202,7 +189,7 @@ endif() # TRITON_ENABLE_HTTP || TRITON_ENABLE_METRICS || TRITON_ENABLE_SAGEMAKER
 if(${TRITON_ENABLE_GRPC})
   set(TRITON_DEPENDS ${TRITON_DEPENDS} grpc)
 endif() # TRITON_ENABLE_GRPC
-if(NOT WIN32 AND ${TRITON_ENABLE_TRACING})
+if(${TRITON_ENABLE_TRACING})
   set(TRITON_DEPENDS ${TRITON_DEPENDS} opentelemetry-cpp)
 endif() # TRITON_ENABLE_TRACING
 

--- a/build.py
+++ b/build.py
@@ -118,6 +118,8 @@ def fail_if(p, msg):
 def target_platform():
     # When called by compose.py, FLAGS will be None
     if FLAGS and FLAGS.target_platform is not None:
+        if FLAGS.target_platform == "windows":
+            fail("Windows is no longer a supported target platform.")
         return FLAGS.target_platform
     platform_string = platform.system().lower()
     if platform_string == "linux":
@@ -128,6 +130,8 @@ def target_platform():
             return "linux"
         else:
             return "rhel"
+    elif platform_string == "windows":
+        fail("Windows is no longer a supported target platform.")
     else:
         return platform_string
 
@@ -167,13 +171,6 @@ class BuildScript:
 
     def close(self):
         if self._file is not None:
-            if target_platform() == "windows":
-                self.blankln()
-                self._file.write("}\n")
-                self._file.write("catch {\n")
-                self._file.write("    $_;\n")
-                self._file.write("    ExitWithCode 1;\n")
-                self._file.write("}\n")
             """Close the file"""
             self._file.close()
             self._file = None
@@ -201,8 +198,7 @@ class BuildScript:
             self.comment(msg)
 
     def header(self, desc=None):
-        if target_platform() != "windows":
-            self._file.write("#!/usr/bin/env bash\n\n")
+        self._file.write("#!/usr/bin/env bash\n\n")
 
         if desc is not None:
             self.comment()
@@ -211,27 +207,12 @@ class BuildScript:
             self.blankln()
 
         self.comment("Exit script immediately if any command fails")
-        if target_platform() == "windows":
-            self._file.write("$UseStructuredOutput = $false\n")
-            self.blankln()
-            self._file.write("function ExitWithCode($exitcode) {\n")
-            self._file.write("    $host.SetShouldExit($exitcode)\n")
-            self._file.write("    exit $exitcode\n")
-            self._file.write("}\n")
-            self.blankln()
-            if self._verbose:
-                self._file.write("Set-PSDebug -Trace 1\n")
-            self.blankln()
-            self._file.write("try {\n")
-        else:
-            self._file.write("set -e\n")
-            if self._verbose:
-                self._file.write("set -x\n")
+        self._file.write("set -e\n")
+        if self._verbose:
+            self._file.write("set -x\n")
         self.blankln()
 
     def envvar_ref(self, v):
-        if target_platform() == "windows":
-            return f"${{env:{v}}}"
         return f"${{{v}}}"
 
     def cmd(self, clist, check_exitcode=False):
@@ -242,54 +223,23 @@ class BuildScript:
                 self._file.write(f"{c} ")
             self.blankln()
 
-        if check_exitcode:
-            if target_platform() == "windows":
-                self._file.write("if ($LASTEXITCODE -ne 0) {\n")
-                self._file.write(
-                    '  Write-Output "exited with status code $LASTEXITCODE";\n'
-                )
-                self._file.write("  ExitWithCode 1;\n")
-                self._file.write("}\n")
-
     def cwd(self, path):
-        if target_platform() == "windows":
-            self.cmd(f"Set-Location -EV Err -EA Stop {path}")
-        else:
-            self.cmd(f"cd {path}")
+        self.cmd(f"cd {path}")
 
     def cp(self, src, dest):
-        if target_platform() == "windows":
-            self.cmd(f"Copy-Item -EV Err -EA Stop {src} -Destination {dest}")
-        else:
-            self.cmd(f"cp {src} {dest}")
+        self.cmd(f"cp {src} {dest}")
 
     def mkdir(self, path):
-        if target_platform() == "windows":
-            self.cmd(
-                f"New-Item -EV Err -EA Stop -ItemType Directory -Force -Path {path}"
-            )
-        else:
-            self.cmd(f"mkdir -p {pathlib.Path(path)}")
+        self.cmd(f"mkdir -p {pathlib.Path(path)}")
 
     def rmdir(self, path):
-        if target_platform() == "windows":
-            self.cmd(f"if (Test-Path -Path {path}) {{")
-            self.cmd(f"  Remove-Item -EV Err -EA Stop -Recurse -Force {path}")
-            self.cmd("}")
-        else:
-            self.cmd(f"rm -fr {pathlib.Path(path)}")
+        self.cmd(f"rm -fr {pathlib.Path(path)}")
 
     def cpdir(self, src, dest):
-        if target_platform() == "windows":
-            self.cmd(f"Copy-Item -EV Err -EA Stop -Recurse {src} -Destination {dest}")
-        else:
-            self.cmd(f"cp -r {src} {dest}")
+        self.cmd(f"cp -r {src} {dest}")
 
     def tar(self, subdir, tar_filename):
-        if target_platform() == "windows":
-            fail("unsupported operation: tar")
-        else:
-            self.cmd(f"tar zcf {tar_filename} {subdir}")
+        self.cmd(f"tar zcf {tar_filename} {subdir}")
 
     def cmake(self, args):
         # Pass some additional envvars into cmake...
@@ -309,10 +259,7 @@ class BuildScript:
         if not FLAGS.no_force_clone:
             self.rmdir(clone_dir)
 
-        if target_platform() == "windows":
-            self.cmd(f"if (-Not (Test-Path -Path {clone_dir})) {{")
-        else:
-            self.cmd(f"if [[ ! -e {clone_dir} ]]; then")
+        self.cmd(f"if [[ ! -e {clone_dir} ]]; then")
 
         # FIXME [DLIS-4045 - Currently the tag starting with "pull/" is not
         # working with "--repo-tag" as the option is not forwarded to the
@@ -325,7 +272,7 @@ class BuildScript:
                 f"  git clone --recursive --depth=1 {org}/{repo}.git {subdir}; git --git-dir {subdir}/.git log --oneline -1",
                 check_exitcode=True,
             )
-            self.cmd("}" if target_platform() == "windows" else "fi")
+            self.cmd("fi")
             self.cwd(subdir)
             self.cmd(f"git fetch origin {tag}:tritonbuildref", check_exitcode=True)
             self.cmd(f"git checkout tritonbuildref", check_exitcode=True)
@@ -334,7 +281,7 @@ class BuildScript:
                 f"  git clone --recursive --single-branch --depth=1 -b {tag} {org}/{repo}.git {subdir}; git --git-dir {subdir}/.git log --oneline -1",
                 check_exitcode=True,
             )
-            self.cmd("}" if target_platform() == "windows" else "fi")
+            self.cmd("fi")
 
 
 def cmake_core_arg(name, type, value):
@@ -604,14 +551,7 @@ def backend_cmake_args(images, components, be, install_dir, library_paths):
         cmake_backend_enable(be, "TRITON_ENABLE_METRICS", FLAGS.enable_metrics)
     )
 
-    # [DLIS-4950] always enable below once Windows image is updated with CUPTI
-    # cargs.append(cmake_backend_enable(be, 'TRITON_ENABLE_MEMORY_TRACKER', True))
-    if (target_platform() == "windows") and (not FLAGS.no_container_build):
-        print(
-            "Warning: Detected docker build is used for Windows, backend utility 'device memory tracker' will be disabled due to missing library in CUDA Windows docker image."
-        )
-        cargs.append(cmake_backend_enable(be, "TRITON_ENABLE_MEMORY_TRACKER", False))
-    elif target_platform() == "igpu":
+    if target_platform() == "igpu":
         print(
             "Warning: Detected iGPU build, backend utility 'device memory tracker' will be disabled as iGPU doesn't contain required version of the library."
         )
@@ -690,59 +630,51 @@ def onnxruntime_cmake_args(images, library_paths):
                 )
             )
 
-    if target_platform() == "windows":
-        if "base" in images:
-            cargs.append(
-                cmake_backend_arg(
-                    "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["base"]
-                )
+    if "base" in images:
+        cargs.append(
+            cmake_backend_arg(
+                "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["base"]
             )
+        )
     else:
-        if "base" in images:
-            cargs.append(
-                cmake_backend_arg(
-                    "onnxruntime", "TRITON_BUILD_CONTAINER", None, images["base"]
-                )
+        cargs.append(
+            cmake_backend_arg(
+                "onnxruntime",
+                "TRITON_BUILD_CONTAINER_VERSION",
+                None,
+                FLAGS.upstream_container_version,
             )
-        else:
-            cargs.append(
-                cmake_backend_arg(
-                    "onnxruntime",
-                    "TRITON_BUILD_CONTAINER_VERSION",
-                    None,
-                    FLAGS.upstream_container_version,
-                )
-            )
+        )
 
-        # TODO: TPRD-333 OpenVino extension is not currently supported by our manylinux build
-        if (
-            (target_machine() != "aarch64")
-            and (target_platform() != "rhel")
-            and (FLAGS.ort_openvino_version is not None)
-        ):
-            cargs.append(
-                cmake_backend_enable(
-                    "onnxruntime", "TRITON_ENABLE_ONNXRUNTIME_OPENVINO", True
-                )
+    # TODO: TPRD-333 OpenVino extension is not currently supported by our manylinux build
+    if (
+        (target_machine() != "aarch64")
+        and (target_platform() != "rhel")
+        and (FLAGS.ort_openvino_version is not None)
+    ):
+        cargs.append(
+            cmake_backend_enable(
+                "onnxruntime", "TRITON_ENABLE_ONNXRUNTIME_OPENVINO", True
             )
-            cargs.append(
-                cmake_backend_arg(
-                    "onnxruntime",
-                    "TRITON_BUILD_ONNXRUNTIME_OPENVINO_VERSION",
-                    None,
-                    FLAGS.ort_openvino_version,
-                )
+        )
+        cargs.append(
+            cmake_backend_arg(
+                "onnxruntime",
+                "TRITON_BUILD_ONNXRUNTIME_OPENVINO_VERSION",
+                None,
+                FLAGS.ort_openvino_version,
             )
+        )
 
-        if (target_platform() == "igpu") or (target_platform() == "rhel"):
-            cargs.append(
-                cmake_backend_arg(
-                    "onnxruntime",
-                    "TRITON_BUILD_TARGET_PLATFORM",
-                    None,
-                    target_platform(),
-                )
+    if (target_platform() == "igpu") or (target_platform() == "rhel"):
+        cargs.append(
+            cmake_backend_arg(
+                "onnxruntime",
+                "TRITON_BUILD_TARGET_PLATFORM",
+                None,
+                target_platform(),
             )
+        )
 
     return cargs
 
@@ -756,29 +688,21 @@ def openvino_cmake_args():
             FLAGS.standalone_openvino_version,
         )
     ]
-    if target_platform() == "windows":
-        if "base" in images:
-            cargs.append(
-                cmake_backend_arg(
-                    "openvino", "TRITON_BUILD_CONTAINER", None, images["base"]
-                )
+    if "base" in images:
+        cargs.append(
+            cmake_backend_arg(
+                "openvino", "TRITON_BUILD_CONTAINER", None, images["base"]
             )
+        )
     else:
-        if "base" in images:
-            cargs.append(
-                cmake_backend_arg(
-                    "openvino", "TRITON_BUILD_CONTAINER", None, images["base"]
-                )
+        cargs.append(
+            cmake_backend_arg(
+                "openvino",
+                "TRITON_BUILD_CONTAINER_VERSION",
+                None,
+                FLAGS.upstream_container_version,
             )
-        else:
-            cargs.append(
-                cmake_backend_arg(
-                    "openvino",
-                    "TRITON_BUILD_CONTAINER_VERSION",
-                    None,
-                    FLAGS.upstream_container_version,
-                )
-            )
+        )
     return cargs
 
 
@@ -786,12 +710,6 @@ def tensorrt_cmake_args():
     cargs = [
         cmake_backend_enable("tensorrt", "TRITON_ENABLE_NVTX", FLAGS.enable_nvtx),
     ]
-    if target_platform() == "windows":
-        cargs.append(
-            cmake_backend_arg(
-                "tensorrt", "TRITON_TENSORRT_INCLUDE_PATHS", None, "c:/TensorRT/include"
-            )
-        )
 
     return cargs
 
@@ -1062,15 +980,7 @@ ENV BUILD_NUMBER={}
 """.format(
             argmap["NVIDIA_BUILD_ID"]
         )
-    # Install the windows- or linux-specific buildbase dependencies
-    if target_platform() == "windows":
-        df += """
-RUN python3 -m pip install build
-
-SHELL ["cmd", "/S", "/C"]
-"""
-    else:
-        df += """
+    df += """
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -1132,7 +1042,7 @@ RUN pip3 install --upgrade \\
           pybind11[global]
 """
 
-        df += f"""
+    df += f"""
 # Install boost version >= 1.78 for boost::span
 # Current libboost-dev apt packages are < 1.78, so install from tar.gz
 RUN wget -O /tmp/boost.tar.gz {FLAGS.boost_url} \\
@@ -1141,8 +1051,8 @@ RUN wget -O /tmp/boost.tar.gz {FLAGS.boost_url} \\
       && mv /tmp/boost_1_80_0/boost /usr/include/boost
 """
 
-        if FLAGS.enable_gpu:
-            df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine())
+    if FLAGS.enable_gpu:
+        df += install_dcgm_libraries(argmap["DCGM_VERSION"], target_machine())
 
     df += """
 ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
@@ -1166,14 +1076,7 @@ RUN apt-get update \\
 
     # Copy in the triton source. We remove existing contents first in
     # case the FROM container has something there already.
-    if target_platform() == "windows":
-        df += """
-WORKDIR /workspace
-RUN rmdir /S/Q * || exit 0
-COPY . .
-"""
-    else:
-        df += """
+    df += """
 WORKDIR /workspace
 RUN rm -fr *
 COPY . .
@@ -1614,55 +1517,6 @@ ENV PYTHON_BIN_PATH=${{PYBIN}}/python${{PYVER}} PATH=${{PYBIN}}:${{PATH}}
     return df
 
 
-def create_dockerfile_windows(
-    ddir, dockerfile_name, argmap, backends, repoagents, caches
-):
-    df = """
-ARG TRITON_VERSION={}
-ARG TRITON_CONTAINER_VERSION={}
-ARG BASE_IMAGE={}
-
-############################################################################
-##  Production stage: Create container with just inference server executable
-############################################################################
-FROM ${{BASE_IMAGE}}
-
-ARG TRITON_VERSION
-ARG TRITON_CONTAINER_VERSION
-
-ENV TRITON_SERVER_VERSION=${{TRITON_VERSION}}
-ENV NVIDIA_TRITON_SERVER_VERSION=${{TRITON_CONTAINER_VERSION}}
-LABEL com.nvidia.tritonserver.version="${{TRITON_SERVER_VERSION}}"
-
-RUN setx path "%path%;C:\\opt\\tritonserver\\bin"
-
-""".format(
-        argmap["TRITON_VERSION"],
-        argmap["TRITON_CONTAINER_VERSION"],
-        argmap["BASE_IMAGE"],
-    )
-    df += """
-WORKDIR /opt
-RUN rmdir /S/Q tritonserver || exit 0
-COPY --chown=1000:1000 build/install tritonserver
-
-WORKDIR /opt/tritonserver
-COPY --chown=1000:1000 NVIDIA_Deep_Learning_Container_License.pdf .
-
-"""
-    df += """
-ENTRYPOINT []
-ENV NVIDIA_BUILD_ID {}
-LABEL com.nvidia.build.id={}
-LABEL com.nvidia.build.ref={}
-""".format(
-        argmap["NVIDIA_BUILD_ID"], argmap["NVIDIA_BUILD_ID"], argmap["NVIDIA_BUILD_REF"]
-    )
-
-    with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
-        dfile.write(df)
-
-
 def create_build_dockerfiles(
     container_build_dir, images, backends, repoagents, caches, endpoints
 ):
@@ -1672,8 +1526,6 @@ def create_build_dockerfiles(
             print(
                 "warning: RHEL is not an officially supported target and you will probably experience errors attempting to build this container."
             )
-    elif target_platform() == "windows":
-        base_image = "mcr.microsoft.com/dotnet/framework/sdk:4.8"
     elif target_platform() == "rhel":
         raise KeyError("A base image must be specified when targeting RHEL")
     elif FLAGS.enable_gpu:
@@ -1700,11 +1552,7 @@ def create_build_dockerfiles(
 
     # For CPU-only image we need to copy some cuda libraries and dependencies
     # since we are using PyTorch containers that are not CPU-only.
-    if (
-        not FLAGS.enable_gpu
-        and ("pytorch" in backends)
-        and (target_platform() != "windows")
-    ):
+    if not FLAGS.enable_gpu and ("pytorch" in backends):
         if "gpu-base" in images:
             gpu_base_image = images["gpu-base"]
         else:
@@ -1722,25 +1570,15 @@ def create_build_dockerfiles(
             FLAGS.build_dir, "Dockerfile.buildbase", dockerfileargmap
         )
 
-    if target_platform() == "windows":
-        create_dockerfile_windows(
-            FLAGS.build_dir,
-            "Dockerfile",
-            dockerfileargmap,
-            backends,
-            repoagents,
-            caches,
-        )
-    else:
-        create_dockerfile_linux(
-            FLAGS.build_dir,
-            "Dockerfile",
-            dockerfileargmap,
-            backends,
-            repoagents,
-            caches,
-            endpoints,
-        )
+    create_dockerfile_linux(
+        FLAGS.build_dir,
+        "Dockerfile",
+        dockerfileargmap,
+        backends,
+        repoagents,
+        caches,
+        endpoints,
+    )
 
     # Dockerfile used for the creating the CI base image.
     create_dockerfile_cibase(FLAGS.build_dir, "Dockerfile.cibase", dockerfileargmap)
@@ -1782,14 +1620,7 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
                 "--pull",
             ]
 
-        # Windows docker runs in a VM and memory needs to be specified
-        # explicitly (at least for some configurations of docker).
-        if target_platform() == "windows":
-            if FLAGS.container_memory:
-                baseargs += ["--memory", FLAGS.container_memory]
-
-        if target_platform() != "windows":
-            baseargs += ["--cache-from={}".format(k) for k in cachefrommap]
+        baseargs += ["--cache-from={}".format(k) for k in cachefrommap]
 
         baseargs += ["."]
 
@@ -1822,35 +1653,24 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         if not FLAGS.no_container_interactive:
             runargs += ["-it"]
 
-        if target_platform() == "windows":
-            if FLAGS.container_memory:
-                runargs += ["--memory", FLAGS.container_memory]
-            runargs += ["-v", "\\\\.\\pipe\\docker_engine:\\\\.\\pipe\\docker_engine"]
-        else:
-            runargs += ["-v", "/var/run/docker.sock:/var/run/docker.sock"]
-            if FLAGS.use_user_docker_config:
-                if os.path.exists(FLAGS.use_user_docker_config):
-                    runargs += [
-                        "-v",
-                        os.path.expanduser(
-                            FLAGS.use_user_docker_config + ":/root/.docker/config.json"
-                        ),
-                    ]
+        runargs += ["-v", "/var/run/docker.sock:/var/run/docker.sock"]
+        if FLAGS.use_user_docker_config:
+            if os.path.exists(FLAGS.use_user_docker_config):
+                runargs += [
+                    "-v",
+                    os.path.expanduser(
+                        FLAGS.use_user_docker_config + ":/root/.docker/config.json"
+                    ),
+                ]
 
         runargs += ["tritonserver_buildbase"]
 
-        if target_platform() == "windows":
-            runargs += ["powershell.exe", "-noexit", "-File", "./cmake_build.ps1"]
-        else:
-            runargs += ["./cmake_build"]
+        runargs += ["./cmake_build"]
 
         # Remove existing tritonserver_builder container...
-        if target_platform() == "windows":
-            docker_script.cmd(["docker", "rm", "tritonserver_builder"])
-        else:
-            docker_script._file.write(
-                'if [ "$(docker ps -a | grep tritonserver_builder)" ]; then  docker rm -f tritonserver_builder; fi\n'
-            )
+        docker_script._file.write(
+            'if [ "$(docker ps -a | grep tritonserver_builder)" ]; then  docker rm -f tritonserver_builder; fi\n'
+        )
 
         docker_script.cmd(runargs, check_exitcode=True)
 
@@ -1941,21 +1761,7 @@ def core_build(
     )
     cmake_script.makeinstall()
 
-    if target_platform() == "windows":
-        cmake_script.mkdir(os.path.join(install_dir, "bin"))
-        cmake_script.cp(
-            os.path.join(repo_install_dir, "bin", "tritonserver.exe"),
-            os.path.join(install_dir, "bin"),
-        )
-        cmake_script.cp(
-            os.path.join(repo_install_dir, "bin", "tritonserver.dll"),
-            os.path.join(install_dir, "bin"),
-        )
-        cmake_script.cp(
-            os.path.join(repo_install_dir, "lib", "tritonserver.lib"),
-            os.path.join(install_dir, "bin"),
-        )
-    elif target_platform() == "rhel":
+    if target_platform() == "rhel":
         cmake_script.mkdir(os.path.join(install_dir, "bin"))
         cmake_script.cp(
             os.path.join(repo_install_dir, "bin", "tritonserver"),
@@ -1998,25 +1804,22 @@ def core_build(
     cmake_script.cp(os.path.join(repo_dir, "LICENSE"), install_dir)
     cmake_script.cp(os.path.join(repo_dir, "TRITON_VERSION"), install_dir)
 
-    # If requested, package the source code for all OSS used to build
-    # For windows, Triton is not delivered as a container so skip for
-    # windows platform.
-    if target_platform() != "windows":
-        if (
-            (not FLAGS.no_container_build)
-            and (not FLAGS.no_core_build)
-            and (not FLAGS.no_container_source)
-        ):
-            cmake_script.mkdir(os.path.join(install_dir, "third-party-src"))
-            cmake_script.cwd(repo_build_dir)
-            cmake_script.tar(
-                "third-party-src",
-                os.path.join(install_dir, "third-party-src", "src.tar.gz"),
-            )
-            cmake_script.cp(
-                os.path.join(repo_dir, "docker", "README.third-party-src"),
-                os.path.join(install_dir, "third-party-src", "README"),
-            )
+    # If requested, package the source code for all OSS used to build.
+    if (
+        (not FLAGS.no_container_build)
+        and (not FLAGS.no_core_build)
+        and (not FLAGS.no_container_source)
+    ):
+        cmake_script.mkdir(os.path.join(install_dir, "third-party-src"))
+        cmake_script.cwd(repo_build_dir)
+        cmake_script.tar(
+            "third-party-src",
+            os.path.join(install_dir, "third-party-src", "src.tar.gz"),
+        )
+        cmake_script.cp(
+            os.path.join(repo_dir, "docker", "README.third-party-src"),
+            os.path.join(install_dir, "third-party-src", "README"),
+        )
 
     cmake_script.comment()
     cmake_script.comment("end Triton core library and tritonserver executable")
@@ -2226,11 +2029,6 @@ def cibase_build(
 
     cmake_script.mkdir(ci_dir)
 
-    # On windows we are not yet using a CI/QA docker image for
-    # testing, so don't do anything...
-    if target_platform() == "windows":
-        return
-
     # The core build produces some artifacts that are needed for CI
     # testing, so include those in the install.
     cmake_script.cpdir(os.path.join(repo_dir, "qa"), ci_dir)
@@ -2259,12 +2057,9 @@ def cibase_build(
     cmake_script.mkdir(os.path.join(ci_dir, "backends"))
     for be in ("identity", "repeat", "square"):
         be_install_dir = os.path.join(build_dir, be, "install", "backends", be)
-        if target_platform() == "windows":
-            cmake_script.cmd(f"if (Test-Path -Path {be_install_dir}) {{")
-        else:
-            cmake_script.cmd(f"if [[ -e {be_install_dir} ]]; then")
+        cmake_script.cmd(f"if [[ -e {be_install_dir} ]]; then")
         cmake_script.cpdir(be_install_dir, os.path.join(ci_dir, "backends"))
-        cmake_script.cmd("}" if target_platform() == "windows" else "fi")
+        cmake_script.cmd("fi")
 
     # Some of the unit-test built backends are needed for CI testing
     cmake_script.mkdir(os.path.join(ci_dir, "tritonbuild", "tritonserver", "backends"))
@@ -2277,15 +2072,12 @@ def cibase_build(
         "iterative_sequence",
     ):
         be_install_dir = os.path.join(repo_install_dir, "backends", be)
-        if target_platform() == "windows":
-            cmake_script.cmd(f"if (Test-Path -Path {be_install_dir}) {{")
-        else:
-            cmake_script.cmd(f"if [[ -e {be_install_dir} ]]; then")
+        cmake_script.cmd(f"if [[ -e {be_install_dir} ]]; then")
         cmake_script.cpdir(
             be_install_dir,
             os.path.join(ci_dir, "tritonbuild", "tritonserver", "backends"),
         )
-        cmake_script.cmd("}" if target_platform() == "windows" else "fi")
+        cmake_script.cmd("fi")
 
     # The onnxruntime_backend build produces some artifacts that
     # are needed for CI testing.
@@ -2328,52 +2120,32 @@ def finalize_build(cmake_script, install_dir, ci_dir):
 
 
 def enable_all():
-    if target_platform() != "windows":
-        all_backends = [
-            "ensemble",
-            "identity",
-            "square",
-            "repeat",
-            "onnxruntime",
-            "python",
-            "dali",
-            "pytorch",
-            "openvino",
-            "fil",
-            "tensorrt",
-        ]
-        all_repoagents = ["checksum"]
-        all_caches = ["local", "redis"]
-        all_filesystems = ["gcs", "s3", "azure_storage"]
-        all_endpoints = ["http", "grpc", "sagemaker", "vertex-ai"]
+    all_backends = [
+        "ensemble",
+        "identity",
+        "square",
+        "repeat",
+        "onnxruntime",
+        "python",
+        "dali",
+        "pytorch",
+        "openvino",
+        "fil",
+        "tensorrt",
+    ]
+    all_repoagents = ["checksum"]
+    all_caches = ["local", "redis"]
+    all_filesystems = ["gcs", "s3", "azure_storage"]
+    all_endpoints = ["http", "grpc", "sagemaker", "vertex-ai"]
 
-        FLAGS.enable_logging = True
-        FLAGS.enable_stats = True
-        FLAGS.enable_metrics = True
-        FLAGS.enable_gpu_metrics = True
-        FLAGS.enable_cpu_metrics = True
-        FLAGS.enable_tracing = True
-        FLAGS.enable_nvtx = True
-        FLAGS.enable_gpu = True
-    else:
-        all_backends = [
-            "ensemble",
-            "identity",
-            "square",
-            "repeat",
-            "onnxruntime",
-            "openvino",
-            "tensorrt",
-        ]
-        all_repoagents = ["checksum"]
-        all_caches = ["local", "redis"]
-        all_filesystems = []
-        all_endpoints = ["http", "grpc"]
-
-        FLAGS.enable_logging = True
-        FLAGS.enable_stats = True
-        FLAGS.enable_tracing = True
-        FLAGS.enable_gpu = True
+    FLAGS.enable_logging = True
+    FLAGS.enable_stats = True
+    FLAGS.enable_metrics = True
+    FLAGS.enable_gpu_metrics = True
+    FLAGS.enable_cpu_metrics = True
+    FLAGS.enable_tracing = True
+    FLAGS.enable_nvtx = True
+    FLAGS.enable_gpu = True
 
     requested_backends = []
     for be in FLAGS.backend:
@@ -2461,13 +2233,13 @@ if __name__ == "__main__":
         "--container-memory",
         default=None,
         required=False,
-        help="Value for Docker --memory argument. Used only for windows builds.",
+        help="Value for Docker --memory argument.",
     )
     parser.add_argument(
         "--target-platform",
         required=False,
         default=None,
-        help='Target platform for build, can be "linux", "rhel", "windows" or "igpu". If not specified, build targets the current platform.',
+        help='Target platform for build, can be "linux", "rhel" or "igpu". If not specified, build targets the current platform.',
     )
     parser.add_argument(
         "--target-machine",
@@ -3021,21 +2793,12 @@ if __name__ == "__main__":
     script_install_dir = script_ci_dir = FLAGS.install_dir
     script_cmake_dir = FLAGS.cmake_dir
     if not FLAGS.no_container_build:
-        # FLAGS.tmp_dir may be specified with "\" on Windows, adjust
-        # to "/" for docker usage.
-        script_build_dir = os.path.normpath(
-            os.path.join(FLAGS.tmp_dir, "tritonbuild").replace("\\", "/")
-        )
+        script_build_dir = os.path.normpath(os.path.join(FLAGS.tmp_dir, "tritonbuild"))
         script_install_dir = os.path.normpath(os.path.join(script_build_dir, "install"))
         script_ci_dir = os.path.normpath(os.path.join(script_build_dir, "ci"))
-        if target_platform() == "windows":
-            script_repo_dir = script_cmake_dir = os.path.normpath("c:/workspace")
-        else:
-            script_repo_dir = script_cmake_dir = "/workspace"
+        script_repo_dir = script_cmake_dir = "/workspace"
 
     script_name = "cmake_build"
-    if target_platform() == "windows":
-        script_name += ".ps1"
 
     # Write the build script that invokes cmake for the core, backends, repo-agents, and caches.
     pathlib.Path(FLAGS.build_dir).mkdir(parents=True, exist_ok=True)
@@ -3136,8 +2899,7 @@ if __name__ == "__main__":
             # written to the build-dir while running the docker container
             # may have root ownership, so give them permissions to be
             # managed by all users on the host system.
-            if target_platform() != "windows":
-                finalize_build(cmake_script, script_install_dir, script_ci_dir)
+            finalize_build(cmake_script, script_install_dir, script_ci_dir)
 
     # If --no-container-build is not specified then we perform the
     # actual build within a docker container and from that create the
@@ -3146,8 +2908,6 @@ if __name__ == "__main__":
     # the build process.
     if not FLAGS.no_container_build:
         script_name = "docker_build"
-        if target_platform() == "windows":
-            script_name += ".ps1"
 
         create_build_dockerfiles(
             script_build_dir, images, backends, repoagents, caches, FLAGS.endpoint
@@ -3158,12 +2918,6 @@ if __name__ == "__main__":
     # container-based build is requested use 'docker_build' script,
     # otherwise build directly on this system using cmake script.
     if not FLAGS.dryrun:
-        if target_platform() == "windows":
-            p = subprocess.Popen(
-                ["powershell.exe", "-noexit", "-File", f"./{script_name}"],
-                cwd=FLAGS.build_dir,
-            )
-        else:
-            p = subprocess.Popen([f"./{script_name}"], cwd=FLAGS.build_dir)
+        p = subprocess.Popen([f"./{script_name}"], cwd=FLAGS.build_dir)
         p.wait()
         fail_if(p.returncode != 0, "build failed")

--- a/build.py
+++ b/build.py
@@ -2230,12 +2230,6 @@ if __name__ == "__main__":
         help="Do not use Docker --pull argument when building container.",
     )
     parser.add_argument(
-        "--container-memory",
-        default=None,
-        required=False,
-        help="Value for Docker --memory argument.",
-    )
-    parser.add_argument(
         "--target-platform",
         required=False,
         default=None,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 
 # OpenTelemetry
 #
-if (NOT WIN32 AND ${TRITON_ENABLE_TRACING})
+if (${TRITON_ENABLE_TRACING})
     find_package(absl CONFIG REQUIRED)
     find_package(CURL CONFIG REQUIRED)
     find_package(nlohmann_json CONFIG REQUIRED)
@@ -107,53 +107,21 @@ add_executable(
   triton_signal.h
 )
 
-# On windows a *.lib file can be generated for a exe. When creating
-# tritonserver.exe if we try to create tritonserver.lib it will fail
-# because there is already a trtionserver.lib for tritonserver.dll,
-# this causes the build to fail. To avoid we keep the build name as
-# main.exe and then for windows after installing we rename it to
-# tritonserver.exe (below in the install steps).
-if (NOT WIN32)
-  set_property(TARGET main PROPERTY OUTPUT_NAME tritonserver)
-endif()
+set_property(TARGET main PROPERTY OUTPUT_NAME tritonserver)
 
 target_compile_features(main PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-if(WIN32)
-  message("Using MSVC as compiler, default target on Windows 10. "
-    "If the target system is not Windows 10, please update _WIN32_WINNT "
-    "to corresponding value.")
-  target_compile_options(
-    main
-    PRIVATE
-      /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-  )
-  target_compile_definitions(main
-    PRIVATE
-      NOMINMAX)
+target_compile_options(
+  main
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Werror
+)
 
-  # Dependency from common.h
-  find_library(B64_LIBRARY NAMES b64)
-  target_link_libraries(
-    main
-    PRIVATE
-      ${B64_LIBRARY}
-  )
-
-else()
-
-  target_compile_options(
-    main
-    PRIVATE
-      -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Werror
-  )
-
-  # Dependency from common.h
-  target_link_libraries(
-    main
-    PRIVATE
-      b64
-  )
-  endif()
+# Dependency from common.h
+target_link_libraries(
+  main
+  PRIVATE
+    b64
+)
 
 set(LIB_DIR "lib")
 if(LINUX)
@@ -275,29 +243,17 @@ if(${TRITON_ENABLE_NVTX})
   )
 endif() # TRITON_ENABLE_NVTX
 
-if (NOT WIN32)
-  target_link_libraries(
-    main
-    PRIVATE
-      rt
-      dl
-  )
-endif() # NOT WIN32
+target_link_libraries(
+  main
+  PRIVATE
+    rt
+    dl
+)
 
-if (NOT WIN32)
-  install(
-    TARGETS main
-    RUNTIME DESTINATION bin
-  )
-else()
-  # See explanation above as to why we need to rename main.exe to
-  # tritonserver.exe as part of the install process on windows.
-  install(
-    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/main.exe
-    DESTINATION bin
-    RENAME tritonserver.exe
-  )
-endif()
+install(
+  TARGETS main
+  RUNTIME DESTINATION bin
+)
 
 if(${TRITON_ENABLE_GRPC})
   #
@@ -374,19 +330,11 @@ if(${TRITON_ENABLE_HTTP}
   )
 
   target_compile_features(http-endpoint-library PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    target_compile_options(
-      http-endpoint-library
-      PRIVATE
-        /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-    )
-  else()
-    target_compile_options(
-      http-endpoint-library
-      PRIVATE
-        -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=maybe-uninitialized -Werror
-    )
-  endif()
+  target_compile_options(
+    http-endpoint-library
+    PRIVATE
+      -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=maybe-uninitialized -Werror
+  )
 
   set_target_properties(
     http-endpoint-library
@@ -411,10 +359,7 @@ if(${TRITON_ENABLE_HTTP}
     PRIVATE $<TARGET_PROPERTY:libevhtp::evhtp,INTERFACE_INCLUDE_DIRECTORIES>
   )
 
-  # FIXME when Triton support of Opentelemetry is available on Windows
-  # add ${OPENTELEMETRY_CPP_INCLUDE_DIRS} to above target_include_directories
-  # JIRA DLIS-4786
-  if (NOT WIN32 AND ${TRITON_ENABLE_TRACING})
+  if (${TRITON_ENABLE_TRACING})
     target_link_libraries(
       http-endpoint-library
       PRIVATE tracing-library
@@ -491,23 +436,12 @@ if(${TRITON_ENABLE_HTTP}
     )
   endif() # TRITON_ENABLE_NVTX
 
-  if (WIN32)
-    find_library(B64_LIBRARY NAMES b64)
-    find_library(ZLIB_LIBRARY NAMES zlib)
-    target_link_libraries(
-      http-endpoint-library
-      PUBLIC
-        ${B64_LIBRARY}
-        ${ZLIB_LIBRARY}
-    )
-  else()
-    target_link_libraries(
-      http-endpoint-library
-      PUBLIC
-        b64
-        z
-    )
-  endif()
+  target_link_libraries(
+    http-endpoint-library
+    PUBLIC
+      b64
+      z
+  )
 
   target_link_libraries(
     main
@@ -528,18 +462,15 @@ if(${TRITON_ENABLE_TRACING})
   )
 
   target_compile_features(tracing-library PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-  # FIXME: remove, when Windows support is added for Opentelemetry
-  if (NOT WIN32)
-    target_include_directories(
-      tracing-library
-      PUBLIC ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
-    )
+  target_include_directories(
+    tracing-library
+    PUBLIC ${OPENTELEMETRY_CPP_INCLUDE_DIRS}
+  )
 
-    target_link_libraries(
-      tracing-library
-      PUBLIC
-      ${OPENTELEMETRY_CPP_LIBRARIES})
-  endif()
+  target_link_libraries(
+    tracing-library
+    PUBLIC
+    ${OPENTELEMETRY_CPP_LIBRARIES})
 
   set_target_properties(
     tracing-library
@@ -610,35 +541,130 @@ if(${TRITON_ENABLE_TRACING})
   )
 endif() # TRITON_ENABLE_TRACING
 
-if (NOT WIN32)
-  #
-  # simple
-  #
-  add_executable(
-    simple
-    simple.cc
+#
+# simple
+#
+add_executable(
+  simple
+  simple.cc
+)
+
+target_compile_features(simple PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+target_compile_options(
+  simple
+  PRIVATE
+    -Wall -Wextra -Wno-type-limits -Wno-unused-parameter -Wno-deprecated-declarations -Werror
+)
+
+set_target_properties(
+  simple
+  PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    SKIP_BUILD_RPATH TRUE
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH_USE_LINK_PATH FALSE
+    INSTALL_RPATH ""
+)
+
+target_link_libraries(
+  simple
+  PRIVATE
+    triton-common-async-work-queue  # from repo-common
+    triton-common-error             # from repo-common
+    triton-core-serverapi           # from repo-core
+    triton-core-serverstub          # from repo-core
   )
 
-  target_compile_features(simple PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    message("Using MSVC as compiler, default target on Windows 10. "
-            "If the target system is not Windows 10, please update _WIN32_WINNT "
-            "to corresponding value.")
-    target_compile_options(
-      simple
-      PRIVATE
-        /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-    )
-  else()
-    target_compile_options(
-      simple
-      PRIVATE
-        -Wall -Wextra -Wno-type-limits -Wno-unused-parameter -Wno-deprecated-declarations -Werror
-    )
-  endif()
+if(${TRITON_ENABLE_GPU})
+  target_compile_definitions(
+    simple
+    PRIVATE TRITON_ENABLE_GPU=1
+    PRIVATE TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
+  )
+
+  target_link_libraries(
+    simple
+    PRIVATE
+      CUDA::cudart
+  )
+endif() # TRITON_ENABLE_GPU
+
+install(
+  TARGETS simple
+  RUNTIME DESTINATION bin
+)
+
+#
+# multi_server example
+#
+add_executable(
+  multi_server
+  multi_server.cc
+)
+
+target_compile_features(multi_server PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+target_compile_options(
+  multi_server
+  PRIVATE
+    -Wall -Wextra -Wno-type-limits -Wno-unused-parameter -Wno-deprecated-declarations -Werror
+)
+
+set_target_properties(
+  multi_server
+  PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    SKIP_BUILD_RPATH TRUE
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH_USE_LINK_PATH FALSE
+    INSTALL_RPATH ""
+)
+
+target_link_libraries(
+  multi_server
+  PRIVATE
+    triton-common-async-work-queue  # from repo-common
+    triton-common-error             # from repo-common
+    triton-core-serverapi           # from repo-core
+    triton-core-serverstub          # from repo-core
+  )
+
+if(${TRITON_ENABLE_GPU})
+  target_compile_definitions(
+    multi_server
+    PRIVATE TRITON_ENABLE_GPU=1
+    PRIVATE TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
+  )
+
+  target_link_libraries(
+    multi_server
+    PRIVATE
+      CUDA::cudart
+  )
+endif() # TRITON_ENABLE_GPU
+
+install(
+  TARGETS multi_server
+  RUNTIME DESTINATION bin
+)
+
+if(${TRITON_ENABLE_GPU})
+  #
+  # memory_alloc example
+  #
+  add_executable(
+    memory_alloc
+    memory_alloc.cc
+  )
+
+  target_compile_features(memory_alloc PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
+  target_compile_options(
+    memory_alloc
+    PRIVATE
+      -Wall -Wextra -Wno-type-limits -Wno-unused-parameter -Wno-deprecated-declarations -Werror
+  )
 
   set_target_properties(
-    simple
+    memory_alloc
     PROPERTIES
       POSITION_INDEPENDENT_CODE ON
       SKIP_BUILD_RPATH TRUE
@@ -647,166 +673,30 @@ if (NOT WIN32)
       INSTALL_RPATH ""
   )
 
+  target_compile_definitions(
+    memory_alloc
+    PRIVATE TRITON_ENABLE_GPU=1
+    PRIVATE TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
+  )
+
   target_link_libraries(
-    simple
+    memory_alloc
     PRIVATE
       triton-common-async-work-queue  # from repo-common
       triton-common-error             # from repo-common
       triton-core-serverapi           # from repo-core
       triton-core-serverstub          # from repo-core
+      CUDA::cudart
     )
-
-  if(${TRITON_ENABLE_GPU})
-    target_compile_definitions(
-      simple
-      PRIVATE TRITON_ENABLE_GPU=1
-      PRIVATE TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
-    )
-
-    target_link_libraries(
-      simple
-      PRIVATE
-        CUDA::cudart
-    )
-  endif() # TRITON_ENABLE_GPU
 
   install(
-    TARGETS simple
+    TARGETS memory_alloc
     RUNTIME DESTINATION bin
   )
+endif() # TRITON_ENABLE_GPU
 
-  #
-  # multi_server example
-  #
-  add_executable(
-    multi_server
-    multi_server.cc
-  )
+# tritonfrontend python package
+add_subdirectory(python)
 
-  target_compile_features(multi_server PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    message("Using MSVC as compiler, default target on Windows 10. "
-            "If the target system is not Windows 10, please update _WIN32_WINNT "
-            "to corresponding value.")
-    target_compile_options(
-      multi_server
-      PRIVATE
-        /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-    )
-  else()
-    target_compile_options(
-      multi_server
-      PRIVATE
-        -Wall -Wextra -Wno-type-limits -Wno-unused-parameter -Wno-deprecated-declarations -Werror
-    )
-  endif()
-
-  set_target_properties(
-    multi_server
-    PROPERTIES
-      POSITION_INDEPENDENT_CODE ON
-      SKIP_BUILD_RPATH TRUE
-      BUILD_WITH_INSTALL_RPATH TRUE
-      INSTALL_RPATH_USE_LINK_PATH FALSE
-      INSTALL_RPATH ""
-  )
-
-  target_link_libraries(
-    multi_server
-    PRIVATE
-      triton-common-async-work-queue  # from repo-common
-      triton-common-error             # from repo-common
-      triton-core-serverapi           # from repo-core
-      triton-core-serverstub          # from repo-core
-    )
-
-  if(${TRITON_ENABLE_GPU})
-    target_compile_definitions(
-      multi_server
-      PRIVATE TRITON_ENABLE_GPU=1
-      PRIVATE TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
-    )
-
-    target_link_libraries(
-      multi_server
-      PRIVATE
-        CUDA::cudart
-    )
-  endif() # TRITON_ENABLE_GPU
-
-  install(
-    TARGETS multi_server
-    RUNTIME DESTINATION bin
-  )
-
-  if(${TRITON_ENABLE_GPU})
-    #
-    # memory_alloc example
-    #
-    add_executable(
-      memory_alloc
-      memory_alloc.cc
-    )
-
-    target_compile_features(memory_alloc PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-      message("Using MSVC as compiler, default target on Windows 10. "
-              "If the target system is not Windows 10, please update _WIN32_WINNT "
-              "to corresponding value.")
-      target_compile_options(
-        memory_alloc
-        PRIVATE
-          /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-      )
-    else()
-      target_compile_options(
-        memory_alloc
-        PRIVATE
-          -Wall -Wextra -Wno-type-limits -Wno-unused-parameter -Wno-deprecated-declarations -Werror
-      )
-    endif()
-
-    set_target_properties(
-      memory_alloc
-      PROPERTIES
-        POSITION_INDEPENDENT_CODE ON
-        SKIP_BUILD_RPATH TRUE
-        BUILD_WITH_INSTALL_RPATH TRUE
-        INSTALL_RPATH_USE_LINK_PATH FALSE
-        INSTALL_RPATH ""
-    )
-
-    target_compile_definitions(
-      memory_alloc
-      PRIVATE TRITON_ENABLE_GPU=1
-      PRIVATE TRITON_MIN_COMPUTE_CAPABILITY=${TRITON_MIN_COMPUTE_CAPABILITY}
-    )
-
-    target_link_libraries(
-      memory_alloc
-      PRIVATE
-        triton-common-async-work-queue  # from repo-common
-        triton-common-error             # from repo-common
-        triton-core-serverapi           # from repo-core
-        triton-core-serverstub          # from repo-core
-        CUDA::cudart
-      )
-
-    install(
-      TARGETS memory_alloc
-      RUNTIME DESTINATION bin
-    )
-  endif() # TRITON_ENABLE_GPU
-endif() # NOT WIN32
-
-# DLIS-7292: Extend tritonfrontend to build for Windows
-if (NOT WIN32)
-  # tritonfrontend python package
-  add_subdirectory(python)
-endif (NOT WIN32)
-
-# Currently unit tests do not build for windows...
-if ( NOT WIN32)
-  add_subdirectory(test test)
-endif() # NOT WIN32
+add_subdirectory(test test)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2023-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -38,19 +38,11 @@ add_library(
 )
 
 target_compile_features(grpc-endpoint-library PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(
-    grpc-endpoint-library
-    PRIVATE
-      /W1 /D_WIN32_WINNT=0x0A00 /EHsc /Zc:preprocessor
-  )
-else()
-  target_compile_options(
-    grpc-endpoint-library
-    PRIVATE
-      -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=maybe-uninitialized -Werror
-  )
-endif()
+target_compile_options(
+  grpc-endpoint-library
+  PRIVATE
+    -Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=maybe-uninitialized -Werror
+)
 
 set_target_properties(
   grpc-endpoint-library
@@ -79,10 +71,7 @@ target_include_directories(
   PRIVATE $<TARGET_PROPERTY:gRPC::grpc,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
-# FIXME when Triton support of OpenTelemetry is available on Windows
-# add ${OPENTELEMETRY_CPP_INCLUDE_DIRS} to above target_include_directories
-# JIRA DLIS-4786
-if (NOT WIN32 AND ${TRITON_ENABLE_TRACING})
+if (${TRITON_ENABLE_TRACING})
   target_link_libraries(
     grpc-endpoint-library
     PRIVATE


### PR DESCRIPTION
## Summary

This removes the Windows-specific server build path and keeps the server build flow focused on the supported Unix-style targets.

The change updates `build.py` to reject Windows explicitly as a target platform, removes PowerShell script generation and Windows container build handling, and simplifies the generated build scripts to always use the bash path. It also removes Windows-specific CMake branches from the server build files, including MSVC compile options, Windows protobuf and OpenTelemetry path handling, Windows install renaming for `tritonserver.exe`, and `NOT WIN32` guards around tracing, examples, Python frontend packaging, and tests.

## Rationale

Windows is no longer a supported server build target, so keeping parallel Windows build branches makes the build scripts harder to maintain and creates paths that are no longer expected to work. Failing early in `build.py` makes the unsupported platform behavior explicit, while simplifying CMake keeps the remaining build configuration aligned with the supported Linux/RHEL/iGPU targets.

## Validation

- Ran `python3 -m py_compile build.py` to verify the Python build script still parses.
- Ran `git diff --check origin/main...HEAD` to verify the committed changes do not introduce whitespace errors.
- Searched the updated build entry points for remaining Windows build conditionals in `build.py`, `CMakeLists.txt`, `src/CMakeLists.txt`, and `src/grpc/CMakeLists.txt`.