### PR TITLE
fix: Remove `all_special_tokens_extended` for transformers v5 compatibility in OpenAI frontend

### DIFF
--- a/python/openai/openai_frontend/engine/utils/tokenizer.py
+++ b/python/openai/openai_frontend/engine/utils/tokenizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -47,7 +47,6 @@ def get_cached_tokenizer(
     function caches these properties for faster access."""
 
     tokenizer_all_special_ids = set(tokenizer.all_special_ids)
-    tokenizer_all_special_tokens_extended = tokenizer.all_special_tokens_extended
     tokenizer_all_special_tokens = set(tokenizer.all_special_tokens)
     tokenizer_len = len(tokenizer)
 
@@ -59,10 +58,6 @@ def get_cached_tokenizer(
         @property
         def all_special_tokens(self):
             return tokenizer_all_special_tokens
-
-        @property
-        def all_special_tokens_extended(self):
-            return tokenizer_all_special_tokens_extended
 
         def __len__(self):
             return tokenizer_len


### PR DESCRIPTION
#### What does the PR do?
Removes the cached `all_special_tokens_extended` property from the OpenAI frontend tokenizer helper. This attribute was removed in `transformers` v5 (the `PreTrainedTokenizer*` classes were replaced by backend classes such as `TokenizersBackend`), so accessing it raises `AttributeError: TokenizersBackend has no attribute all_special_tokens_extended` and crashes the OpenAI frontend on startup.

The attribute is equivalent to `all_special_tokens`, is not used anywhere in the frontend, and removing it restores forward compatibility with `transformers` v5 (the vLLM test container currently ships `transformers 5.6.0`). This mirrors the equivalent upstream change in vLLM ([vllm-project/vllm#29686](https://github.com/vllm-project/vllm/pull/29686)).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- Upstream equivalent: [vllm-project/vllm#29686](https://github.com/vllm-project/vllm/pull/29686)

#### Where should the reviewer start?
`python/openai/openai_frontend/engine/utils/tokenizer.py` — the `get_cached_tokenizer()` function (removed the `all_special_tokens_extended` read and its cached `@property`).

#### Test plan:
- CI Pipeline ID: 53600268

#### Caveats:
HuggingFace documents `_special_tokens_map` / `_extra_special_tokens` as the v5 replacements for the extended special-token maps, but those are not needed here since the value was only an alias of `all_special_tokens` and is unused by the frontend.

#### Background
The vLLM test container was upgraded to `transformers >= 5.0.0` (currently 5.6.0). `transformers` v5 removed `special_tokens_map_extended` and `all_special_tokens_extended` ([huggingface/transformers#40936](https://github.com/huggingface/transformers/pull/40936), [v5 tokenization migration guide](https://github.com/huggingface/transformers/commit/fa3cf839123bfdf1a12129b1e9267f27076580ed)). This frontend tokenizer helper was adapted from older vLLM code and still referenced the removed attribute.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
