### PR TITLE
test: Fix flaky L0_http test_large_string_in_json

### DIFF
--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -499,8 +499,8 @@ class InferSizeLimitTest(TestResultCollector):
             f"Expected shape {[1, shape_size]}, got {result['outputs'][0]['shape']}",
         )
 
-    def _build_json_string_body_of_size(self, target_size):
-        """Build a JSON inference request body that is exactly target_size bytes."""
+    def _build_payload_of_json_size(self, target_size):
+        """Build an inference request payload whose JSON serialization is exactly target_size bytes."""
         payload = {
             "inputs": [
                 {
@@ -513,21 +513,17 @@ class InferSizeLimitTest(TestResultCollector):
         }
         overhead = len(json.dumps(payload))
         pad = target_size - overhead
-        assert pad >= 0, "target_size smaller than payload overhead"
+        self.assertGreaterEqual(pad, 0, "target_size smaller than payload overhead")
         payload["inputs"][0]["data"] = ["A" * pad]
-        body = json.dumps(payload)
-        assert len(body) == target_size, (len(body), target_size)
-        return body
+        self.assertEqual(len(json.dumps(payload)), target_size)
+        return payload
 
     def test_large_string_in_json(self):
         """Verify the server's JSON size limit at the byte boundary."""
         model = "simple_identity"
-        headers = {"Content-Type": "application/json"}
 
-        body_over = self._build_json_string_body_of_size(DEFAULT_LIMIT_BYTES + 1)
-        response = requests.post(
-            self._get_infer_url(model), data=body_over, headers=headers
-        )
+        payload_over = self._build_payload_of_json_size(DEFAULT_LIMIT_BYTES + 1)
+        response = requests.post(self._get_infer_url(model), json=payload_over)
         self.assertEqual(
             400,
             response.status_code,
@@ -540,10 +536,8 @@ class InferSizeLimitTest(TestResultCollector):
         self.assertIn(" bytes exceeds the maximum allowed input size of ", error_msg)
         self.assertIn("Use --http-max-input-size to increase the limit.", error_msg)
 
-        body_at = self._build_json_string_body_of_size(DEFAULT_LIMIT_BYTES)
-        response = requests.post(
-            self._get_infer_url(model), data=body_at, headers=headers
-        )
+        payload_at = self._build_payload_of_json_size(DEFAULT_LIMIT_BYTES)
+        response = requests.post(self._get_infer_url(model), json=payload_at)
         self.assertEqual(
             200,
             response.status_code,

--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -499,54 +499,65 @@ class InferSizeLimitTest(TestResultCollector):
             f"Expected shape {[1, shape_size]}, got {result['outputs'][0]['shape']}",
         )
 
-    def test_large_string_in_json(self):
-        """Test JSON request with large string input"""
-        model = "simple_identity"
-
-        # Create a string larger than the default 64MB limit but well below INT32
-        # Content-Length max (~2GB) so the server validates JSON size, not header
-        # parsing.
-        large_string_size = DEFAULT_LIMIT_BYTES + OFFSET_ELEMENTS
-        large_string = "A" * large_string_size
-
+    def _build_string_body_of_size(self, target_size):
+        """Build a JSON inference request body that is exactly target_size bytes."""
         payload = {
             "inputs": [
                 {
                     "name": "INPUT0",
                     "datatype": "BYTES",
                     "shape": [1, 1],
-                    "data": [large_string],
+                    "data": [""],
                 }
             ]
         }
+        overhead = len(json.dumps(payload))
+        pad = target_size - overhead
+        assert pad >= 0, "target_size smaller than payload overhead"
+        payload["inputs"][0]["data"] = ["A" * pad]
+        body = json.dumps(payload)
+        assert len(body) == target_size, (len(body), target_size)
+        return body
 
+    def test_large_string_in_json(self):
+        """Verify the server's JSON size limit at the byte boundary.
+
+        Uses a body well below the INT32 Content-Length max (~2GB) so the
+        server's JSON-size check fires deterministically rather than failing
+        in Content-Length header parsing.
+        """
+        model = "simple_identity"
         headers = {"Content-Type": "application/json"}
-        response = requests.post(
-            self._get_infer_url(model), headers=headers, json=payload
-        )
 
-        # Should fail with 400 bad request
+        # 1 byte over the 64 MiB default limit must be rejected with the
+        # size-limit error.
+        body_over = self._build_string_body_of_size(DEFAULT_LIMIT_BYTES + 1)
+        response = requests.post(
+            self._get_infer_url(model), data=body_over, headers=headers
+        )
         self.assertEqual(
             400,
             response.status_code,
-            "Expected error code for oversized JSON request, got: {}".format(
-                response.status_code
+            "Expected 400 for body of DEFAULT_LIMIT_BYTES + 1, got: {} ({!r})".format(
+                response.status_code, response.content[:200]
             ),
         )
-
-        # Verify error message
         error_msg = response.content.decode()
-        self.assertIn(
-            "request JSON size of ",
-            error_msg,
+        self.assertIn("request JSON size of ", error_msg)
+        self.assertIn(" bytes exceeds the maximum allowed input size of ", error_msg)
+        self.assertIn("Use --http-max-input-size to increase the limit.", error_msg)
+
+        # Exactly at the limit must pass the size check.
+        body_at = self._build_string_body_of_size(DEFAULT_LIMIT_BYTES)
+        response = requests.post(
+            self._get_infer_url(model), data=body_at, headers=headers
         )
-        self.assertIn(
-            " bytes exceeds the maximum allowed input size of ",
-            error_msg,
-        )
-        self.assertIn(
-            "Use --http-max-input-size to increase the limit.",
-            error_msg,
+        self.assertEqual(
+            200,
+            response.status_code,
+            "Expected 200 for body of exactly DEFAULT_LIMIT_BYTES, got: {} ({!r})".format(
+                response.status_code, response.content[:200]
+            ),
         )
 
     def _create_compressed_payload(self, target_size):

--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -499,7 +499,7 @@ class InferSizeLimitTest(TestResultCollector):
             f"Expected shape {[1, shape_size]}, got {result['outputs'][0]['shape']}",
         )
 
-    def _build_string_body_of_size(self, target_size):
+    def _build_json_string_body_of_size(self, target_size):
         """Build a JSON inference request body that is exactly target_size bytes."""
         payload = {
             "inputs": [
@@ -520,18 +520,11 @@ class InferSizeLimitTest(TestResultCollector):
         return body
 
     def test_large_string_in_json(self):
-        """Verify the server's JSON size limit at the byte boundary.
-
-        Uses a body well below the INT32 Content-Length max (~2GB) so the
-        server's JSON-size check fires deterministically rather than failing
-        in Content-Length header parsing.
-        """
+        """Verify the server's JSON size limit at the byte boundary."""
         model = "simple_identity"
         headers = {"Content-Type": "application/json"}
 
-        # 1 byte over the 64 MiB default limit must be rejected with the
-        # size-limit error.
-        body_over = self._build_string_body_of_size(DEFAULT_LIMIT_BYTES + 1)
+        body_over = self._build_json_string_body_of_size(DEFAULT_LIMIT_BYTES + 1)
         response = requests.post(
             self._get_infer_url(model), data=body_over, headers=headers
         )
@@ -547,8 +540,7 @@ class InferSizeLimitTest(TestResultCollector):
         self.assertIn(" bytes exceeds the maximum allowed input size of ", error_msg)
         self.assertIn("Use --http-max-input-size to increase the limit.", error_msg)
 
-        # Exactly at the limit must pass the size check.
-        body_at = self._build_string_body_of_size(DEFAULT_LIMIT_BYTES)
+        body_at = self._build_json_string_body_of_size(DEFAULT_LIMIT_BYTES)
         response = requests.post(
             self._get_infer_url(model), data=body_at, headers=headers
         )

--- a/qa/L0_http/http_input_size_limit_test.py
+++ b/qa/L0_http/http_input_size_limit_test.py
@@ -503,9 +503,10 @@ class InferSizeLimitTest(TestResultCollector):
         """Test JSON request with large string input"""
         model = "simple_identity"
 
-        # Create a string that is larger (large payload about 2GB) than the default limit of 64MB
-        # (2^31 + 64) elements * 1 bytes = 2GB + 64 bytes = 2,147,483,712 bytes
-        large_string_size = 2 * GIB + 64
+        # Create a string larger than the default 64MB limit but well below INT32
+        # Content-Length max (~2GB) so the server validates JSON size, not header
+        # parsing.
+        large_string_size = DEFAULT_LIMIT_BYTES + OFFSET_ELEMENTS
         large_string = "A" * large_string_size
 
         payload = {


### PR DESCRIPTION
#### What does the PR do?
Fixes a deterministic failure in `qa/L0_http/http_input_size_limit_test.py::test_large_string_in_json`.

The test built a ~2 GiB JSON body to exercise the server's `--http-max-input-size` guard, but that body produces a `Content-Length` header beyond `INT32_MAX`. After the recent `std::atoi` → `std::stoi` change in `Content-Length` parsing (#8794), the server now rejects the request at the header-parse step (with an INT32 range error) before ever reaching the JSON-size check the test asserts on, so the test fails on every nightly.

The fix shrinks the request body to byte-precise boundaries around the JSON-size limit, so the test actually exercises the guard it claims to.

#### Checklist
- [x] PR title reflects the change and is of format `<type>: <description>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] test

#### Related PRs:

- #8794 — the upstream `std::atoi` → `std::stoi` change in `Content-Length` parsing that exposed the latent issue. Before this change, `atoi` silently returned a wrong-but-non-throwing value on overflow, so the test happened to still reach the JSON-size check. After, `stoi` throws and the server returns a different error than the test expects.
- #8432 — the original PR that introduced `test_large_string_in_json`. /cc @spolisetty for design intent on the original 2 GiB sizing.

#### Where should the reviewer start?

`qa/L0_http/http_input_size_limit_test.py` — the change is contained to one file. Look at the new `_build_payload_of_json_size` helper and the rewritten `test_large_string_in_json`.

#### Test plan:

Verified locally in a `triton-devel` container against `main`:

- `InferSizeLimitTest.test_large_string_in_json` — 10/10 pass
- Full `qa/L0_http/test.sh` — passes, no other regressions

The new test asserts both sides of the boundary:
- Body of exactly `DEFAULT_LIMIT_BYTES` (64 MiB) → must succeed (200)
- Body of `DEFAULT_LIMIT_BYTES + 1` → must fail with the JSON-size error

Body length is asserted byte-exact in the helper via `assertEqual(len(json.dumps(payload)), target_size)` before being posted with `requests.post(json=payload)`, so the boundary is byte-precise and not skewed by JSON wrapper overhead.

- CI Pipeline ID: 53762086 — targeted run via `RULE_WORKFLOW` + `EXTRA_BUILD_BACKENDS=python onnxruntime` per reviewer tips. L0_http--base job retried for commit `f9b4e0b`: https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/334699597 — passed in 8 min 29 sec, no rebuild needed for test-only change.

`test_chunked_infer_over_max_chunks_reject_with_bounded_rss_growth` (in `qa/L0_http/http_request_many_chunks.py`) also occasionally fails in nightly runs with intermittent RSS-growth assertions (`4.2 MiB > 1 MiB`). That failure is intermittent, unrelated to this fix, and should be tracked separately.

#### Background

`test_large_string_in_json` was added to verify the server's `--http-max-input-size` JSON-body limit. The original test built a body large enough to clearly exceed the default 64 MiB limit, but also large enough that the resulting `Content-Length` header overflows a signed 32-bit integer (`Content-Length: 2147483796` vs `INT32_MAX = 2147483647`).

Before #8794, `Content-Length` was parsed with `std::atoi`, which silently returned an undefined-but-non-throwing value on overflow, so the body still reached the JSON-size check. After #8794 switched to `std::stoi`, that parse now throws `std::out_of_range` and the server returns 400 with:

```
Unable to parse Content-Length, value is out of range [ -2147483648, 2147483647 ], got: 2147483796
```

which doesn't match the JSON-size error the test expects. The fix keeps the test focused on the JSON-size guard by constructing a body just at and just above the limit (well below INT32 Content-Length).

#### Related Issues: 
- Relates to #8794
- Relates to #8432