### PR TITLE
Reject negative TRT-LLM seed values

### DIFF
--- a/python/openai/openai_frontend/engine/utils/triton.py
+++ b/python/openai/openai_frontend/engine/utils/triton.py
@@ -216,6 +216,8 @@ def _create_trtllm_generate_request(
     if request.presence_penalty is not None:
         inputs["presence_penalty"] = np.float32([[request.presence_penalty]])
     if request.seed is not None:
+        if request.seed < 0:
+            raise ClientError("seed must be non-negative")
         inputs["seed"] = np.uint64([[request.seed]])
     if request.temperature is not None:
         inputs["temperature"] = np.float32([[request.temperature]])

--- a/python/openai/tests/test_triton_utils.py
+++ b/python/openai/tests/test_triton_utils.py
@@ -1,0 +1,62 @@
+# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+
+from openai_frontend.engine.utils.triton import _create_trtllm_generate_request
+from openai_frontend.schemas.openai import (
+    CreateChatCompletionRequest,
+    CreateCompletionRequest,
+)
+from utils.utils import ClientError
+
+
+class _UnexpectedCreateRequestModel:
+    def create_request(self, inputs):
+        raise AssertionError("create_request should not be called")
+
+
+@pytest.mark.parametrize(
+    "request",
+    [
+        CreateCompletionRequest(model="test-model", prompt="hello", seed=-1),
+        CreateChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hello"}],
+            seed=-1,
+        ),
+    ],
+)
+def test_trtllm_generate_request_rejects_negative_seed(request):
+    with pytest.raises(ClientError, match="seed must be non-negative"):
+        _create_trtllm_generate_request(
+            _UnexpectedCreateRequestModel(),
+            "hello",
+            request,
+            lora_config=None,
+            echo_tensor_name=None,
+            default_max_tokens=16,
+        )


### PR DESCRIPTION
## Summary

This rejects negative `seed` values when building TRT-LLM-format generation requests.

The public OpenAI schemas currently allow signed 64-bit seeds, but the TRT-LLM request path sends the value as a `uint64` tensor. Without this check, schema-valid negative values fail during NumPy conversion instead of returning a clear client error.

## Why

A request such as `seed: -1` should be handled as invalid input for this request format before request tensor construction. Returning `seed must be non-negative` keeps the error actionable and prevents an implementation-level overflow failure.

## Tests

- `git diff --check -- python/openai/openai_frontend/engine/utils/triton.py python/openai/tests/test_triton_utils.py`
- `python3 -m py_compile python/openai/openai_frontend/engine/utils/triton.py python/openai/tests/test_triton_utils.py`

I could not run the targeted pytest locally because this checkout's Python environment is missing the OpenAI frontend test/runtime packages (`numpy`, `pydantic`, `pytest`, and `tritonserver`).
