### PR TITLE
test: Drop no-op perf_analyzer pip install

### DIFF
--- a/qa/L0_memory_growth/test.sh
+++ b/qa/L0_memory_growth/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -42,7 +42,6 @@ fi
 export CUDA_VISIBLE_DEVICES=0
 
 # Clients
-pip3 install perf_analyzer
 PERF_ANALYZER=perf_analyzer
 IMAGE=../images/vulture.jpeg
 

--- a/qa/L0_passive_instance/test.sh
+++ b/qa/L0_passive_instance/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2021-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -45,7 +45,6 @@ CLIENT_LOG="./client.log"
 TEST_SCRIPT_PY=passive_instance_test.py
 EXPECTED_NUM_TESTS="1"
 
-pip3 install perf_analyzer
 PERF_ANALYZER=perf_analyzer
 MODEL=distributed_int32_int32_int32
 

--- a/qa/L0_perf_deeprecommender/run_test.sh
+++ b/qa/L0_perf_deeprecommender/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,8 +28,6 @@
 STATIC_BATCH_SIZES=${STATIC_BATCH_SIZES:=1}
 DYNAMIC_BATCH_SIZES=${DYNAMIC_BATCH_SIZES:=1}
 INSTANCE_COUNTS=${INSTANCE_COUNTS:=1}
-
-pip3 install perf_analyzer
 
 PERF_CLIENT=perf_analyzer
 REPORTER=../common/reporter.py

--- a/qa/L0_perf_nomodel/run_test.sh
+++ b/qa/L0_perf_nomodel/run_test.sh
@@ -52,7 +52,6 @@ MODEL_REPO="${PWD}/models"
 PERF_CLIENT=perf_analyzer
 SERVER_ARGS="--model-repository=${MODEL_REPO} --backend-directory=${BACKEND_DIR}"
 source ../common/util.sh
-pip3 install perf_analyzer
 
 # DATADIR is already set in environment variable for aarch64
 if [ "$ARCH" != "aarch64" ]; then

--- a/qa/L0_perf_resnet/run_test.sh
+++ b/qa/L0_perf_resnet/run_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -52,8 +52,6 @@ rm -fr models && mkdir -p models && \
     (cd models/$MODEL_NAME && \
             sed -i "s/^max_batch_size:.*/max_batch_size: ${MAX_BATCH}/" config.pbtxt && \
             echo "instance_group [ { count: ${INSTANCE_CNT} }]")
-
-pip3 install perf_analyzer
 
 MEASUREMENT_WINDOW=5000
 PERF_CLIENT=perf_analyzer

--- a/qa/L0_pinned_memory/test.sh
+++ b/qa/L0_pinned_memory/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2019-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,8 +37,6 @@ fi
 if [ ! -z "$TEST_REPO_ARCH" ]; then
     REPO_VERSION=${REPO_VERSION}_${TEST_REPO_ARCH}
 fi
-
-pip3 install perf_analyzer
 
 # Use "--request-count" throughout the test to PA stability criteria and
 # reduce flaky failures from PA unstable measurements.

--- a/qa/L0_response_cache/test.sh
+++ b/qa/L0_response_cache/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -425,8 +425,6 @@ if [ "$SERVER_PID" == "0" ]; then
     cat $SERVER_LOG
     exit 1
 fi
-
-pip3 install perf_analyzer
 
 TEMP_RET=0
 REPETITION=10

--- a/qa/L0_trt_dynamic_shape/test.sh
+++ b/qa/L0_trt_dynamic_shape/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -40,8 +40,6 @@ fi
 
 TEST_RESULT_FILE='test_results.txt'
 export CUDA_VISIBLE_DEVICES=0
-
-pip3 install perf_analyzer
 
 CLIENT_LOG="./client.log"
 PERF_CLIENT=perf_analyzer


### PR DESCRIPTION
#### What does the PR do?
Removes the `pip3 install perf_analyzer` line from several L0 test scripts. The Triton test images already provide `perf_analyzer` on `PATH`, so this install resolves to an already-satisfied requirement and never fetches anything — it is a no-op. Dropping it removes a confusing, ineffective step and leaves the tests relying on the image-provided `perf_analyzer`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added succinct git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [x] test

#### Related PRs:
Companion change in the internal RHEL QA image build (same branch name) that puts the SDK-built `perf_analyzer` on `PATH`.

#### Where should the reviewer start?
The removed `pip3 install perf_analyzer` lines in `qa/L0_*/*.sh`.

#### Test plan:
Run the affected L0 perf/test jobs and confirm `perf_analyzer` still resolves and the tests pass on both standard and RHEL images.
- CI Pipeline ID: 54260459

#### Caveats:
None.

#### Background
`pip3 install perf_analyzer` finds the package already installed in the image and so never installs the binary itself; the binary is provided by the image build. The line was therefore dead weight.

#### Related Issues:
N/A

## Test plan
- CI Pipeline: https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/pipelines/54260459
- Rebuilds the RHEL/standard/SBSA devel images and runs the affected RHEL jobs plus the modified tests. The companion internal tritonserver MR carries the RHEL QA image change that puts perf_analyzer on PATH, making these redundant `pip install perf_analyzer` lines safe to drop.