### PR TITLE
test: fix: L0_server_status

### DIFF
--- a/qa/L0_server_status/server_status_test.py
+++ b/qa/L0_server_status/server_status_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -428,6 +428,9 @@ class ServerMetadataTest(tu.TestResultCollector):
                 self.assertTrue(False, "unexpected error {}".format(ex))
 
 
+EXPECTED_MODEL_STATS: int = 144
+
+
 class ModelMetadataTest(tu.TestResultCollector):
     """
     These tests must be run after the ServerMetadataTest. See test.sh
@@ -723,8 +726,8 @@ class ModelMetadataTest(tu.TestResultCollector):
                     stats = infer_stats.model_stats
                 self.assertEqual(
                     len(stats),
-                    125,
-                    "expected 125 infer stats for all ready versions of all model",
+                    EXPECTED_MODEL_STATS,
+                    f"expected {EXPECTED_MODEL_STATS} infer stats for all ready versions of all model",
                 )
 
         except InferenceServerException as ex:

--- a/qa/L0_server_status/test.sh
+++ b/qa/L0_server_status/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2018-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -71,13 +71,13 @@ rm -f $CLIENT_LOG
 python $SERVER_STATUS_TEST ServerMetadataTest >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
-    echo -e "\n***\n*** Test Failed\n***"
+    echo -e "\n***\n*** ServerMetadataTest Failed\n***"
     RET=1
 else
     check_test_results $TEST_RESULT_FILE $EXPECTED_NUM_TESTS_SMDT
     if [ $? -ne 0 ]; then
         cat $CLIENT_LOG
-        echo -e "\n***\n*** Test Result Verification Failed\n***"
+        echo -e "\n***\n*** ServerMetadataTest Result Verification Failed\n***"
         RET=1
     fi
 fi
@@ -100,13 +100,13 @@ set +e
 python $SERVER_STATUS_TEST ModelMetadataTest >>$CLIENT_LOG 2>&1
 if [ $? -ne 0 ]; then
     cat $CLIENT_LOG
-    echo -e "\n***\n*** Test Failed\n***"
+    echo -e "\n***\n*** ModelMetadataTest Failed\n***"
     RET=1
 else
     check_test_results $TEST_RESULT_FILE $EXPECTED_NUM_TESTS_MMDT
     if [ $? -ne 0 ]; then
         cat $CLIENT_LOG
-        echo -e "\n***\n*** Test Result Verification Failed\n***"
+        echo -e "\n***\n*** ModelMetadataTest Result Verification Failed\n***"
         RET=1
     fi
 fi


### PR DESCRIPTION
Fixes the L0_server_status test by using the correct expected value for `model_stats` count.


