### PR TITLE
fix(qa): TRT 11 strongly-typed cast for plan_float* output dtype

### DIFF
--- a/qa/common/gen_qa_models.py
+++ b/qa/common/gen_qa_models.py
@@ -109,29 +109,19 @@ def create_plan_dynamic_rf_modelfile(
     out0 = add if not swap else sub
     out1 = sub if not swap else add
 
-    # uint8 conversion after operations
-    # FIXME: Remove support check when jetson supports TRT 8.5 (DLIS-4256)
-    if tu.support_trt_uint8():
-        if trt_output0_dtype == trt.uint8:
-            out0 = trt_cast_tensor(network, out0.get_output(0), trt.uint8)
-        if trt_output1_dtype == trt.uint8:
-            out1 = trt_cast_tensor(network, out1.get_output(0), trt.uint8)
+    # TRT 11 strongly-typed networks: ITensor.dtype setter no longer coerces
+    # output dtype, so insert an explicit cast whenever the elementwise op's
+    # natural output dtype differs from the declared output dtype. Covers
+    # both float<->float and uint8 cases.
+    if out0.get_output(0).dtype != trt_output0_dtype:
+        out0 = trt_cast_tensor(network, out0.get_output(0), trt_output0_dtype)
+    if out1.get_output(0).dtype != trt_output1_dtype:
+        out1 = trt_cast_tensor(network, out1.get_output(0), trt_output1_dtype)
 
     out0.get_output(0).name = "OUTPUT0"
     out1.get_output(0).name = "OUTPUT1"
     network.mark_output(out0.get_output(0))
     network.mark_output(out1.get_output(0))
-
-    # ITensor.dtype setter removed in TRT 11; cast above already produced
-    # the desired output dtype on modern TRT.
-    try:
-        out0.get_output(0).dtype = trt_output0_dtype
-    except AttributeError:
-        pass  # ITensor.dtype setter removed in TensorRT 11+
-    try:
-        out1.get_output(0).dtype = trt_output1_dtype
-    except AttributeError:
-        pass  # ITensor.dtype setter removed in TensorRT 11+
 
     in0.allowed_formats = 1 << int(trt_memory_format)
     in1.allowed_formats = 1 << int(trt_memory_format)
@@ -422,20 +412,18 @@ def create_plan_fixed_rf_modelfile(
     out0 = add if not swap else sub
     out1 = sub if not swap else add
 
+    # TRT 11 strongly-typed networks: ITensor.dtype setter no longer coerces
+    # output dtype, so insert an explicit cast whenever the elementwise op's
+    # natural output dtype differs from the declared output dtype.
+    if out0.get_output(0).dtype != trt_output0_dtype:
+        out0 = trt_cast_tensor(network, out0.get_output(0), trt_output0_dtype)
+    if out1.get_output(0).dtype != trt_output1_dtype:
+        out1 = trt_cast_tensor(network, out1.get_output(0), trt_output1_dtype)
+
     out0.get_output(0).name = "OUTPUT0"
     out1.get_output(0).name = "OUTPUT1"
     network.mark_output(out0.get_output(0))
     network.mark_output(out1.get_output(0))
-
-    # ITensor.dtype setter removed in TRT 11; output dtype already matches.
-    try:
-        out0.get_output(0).dtype = trt_output0_dtype
-    except AttributeError:
-        pass  # ITensor.dtype setter removed in TensorRT 11+
-    try:
-        out1.get_output(0).dtype = trt_output1_dtype
-    except AttributeError:
-        pass  # ITensor.dtype setter removed in TensorRT 11+
 
     in0.allowed_formats = 1 << int(trt_memory_format)
     in1.allowed_formats = 1 << int(trt_memory_format)


### PR DESCRIPTION
#### What does the PR do?

Fixes the TRT 11 strongly-typed-network migration of `gen_qa_models.py` so QA `plan_*` model engines come out with the declared output dtype.

`d898a0fe6` (TRI-1406) only inserted an explicit cast layer when the target output dtype was `uint8`. Float-to-float dtype changes were left to the now-removed `ITensor.dtype` setter, which silently no-ops on TRT 11.0. As a result, the generated engines silently inherited the elementwise op's natural output dtype (which equals the input dtype) instead of the declared output dtype, producing CI failures like:

```
unexpected datatype TYPE_FP32 for inference output 'OUTPUT1', expecting TYPE_FP16 for plan_float32_uint8_float16_0
unexpected datatype TYPE_FP16 for inference output 'OUTPUT0', expecting TYPE_FP32 for plan_float16_float32_float32_0
```

`create_plan_dynamic_rf_modelfile` and `create_plan_fixed_rf_modelfile` now insert `trt_cast_tensor()` whenever the elementwise op's output dtype differs from the declared output dtype — covers both `float<->float` and `uint8` cases. The dead `.dtype` setter `try/except AttributeError: pass` blocks are removed.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- Predecessor: #8828 (TRI-1406, commit `d898a0fe6` — original TRT 11 QA migration)

#### Where should the reviewer start?

`qa/common/gen_qa_models.py`:
- `create_plan_dynamic_rf_modelfile` (around line 109): cast block replaces the uint8-only cast + dead `.dtype` setter.
- `create_plan_fixed_rf_modelfile` (around line 412): cast block added, dead `.dtype` setter removed.

#### Test plan:

**Reproduction (before patch)** on `r26.06` HEAD with `tensorrt:26.06-py3-base` (TRT 11.0):

```bash
TENSORRT_IMAGE=gitlab-master.nvidia.com:5005/dl/dgx/tensorrt:26.06-py3-base \
PYTORCH_IMAGE=gitlab-master.nvidia.com:5005/dl/dgx/pytorch:26.06-py3-base \
bash -xe ./qa/common/gen_qa_model_repository

# Then inspect engines via trtexec --loadEngine=<model.plan>
```

Engines produced **before** patch (mismatch against `config.pbtxt`):

| Model | OUTPUT0 (config / engine) | OUTPUT1 (config / engine) |
|---|---|---|
| `plan_float32_uint8_float16` | UINT8 / uint8 | FP16 / **fp32** ✗ |
| `plan_float16_float32_float32` | FP32 / **fp16** ✗ | FP32 / **fp16** ✗ |

Engines produced **after** patch (all aligned):

| Model | OUTPUT0 (config / engine) | OUTPUT1 (config / engine) |
|---|---|---|
| `plan_float32_uint8_float16` | UINT8 / uint8 ✓ | FP16 / fp16 ✓ |
| `plan_nobatch_float32_uint8_float16` | UINT8 / uint8 ✓ | FP16 / fp16 ✓ |
| `plan_float16_float32_float32` | FP32 / fp32 ✓ | FP32 / fp32 ✓ |
| `plan_nobatch_float16_float32_float32` | FP32 / fp32 ✓ | FP32 / fp32 ✓ |

- CI Pipeline ID: (to be added — pipeline 54492155 originally exhibited the failure across 11 jobs; a new run from a regenerated `26.06_*` QA repo is needed for end-to-end confirmation.)

#### Caveats:

- QA `/data/inferenceserver/26.06_*` mounts that CI consumes must be **regenerated** from this PR before the affected `L0_infer*` / `L0_server_status` jobs will go green. The fix is in the model-generation script; the published model artifacts on shared storage still hold the broken engines until republished.
- Other generator scripts (`gen_qa_identity_models.py`, `gen_qa_sequence_models.py`, `gen_qa_implicit_models.py`, `gen_qa_dyna_sequence_models.py`, `gen_qa_dyna_sequence_implicit_models.py`, `gen_qa_reshape_models.py`, `gen_qa_sequence_models.py`) still carry the same dead `out.dtype = …` / `except AttributeError: pass` pattern. Audit shows most are harmless because input/output dtypes match in those generators, but a follow-up sweep is recommended.

#### Background

TRT 11.0 introduced strongly-typed networks (TRT release notes). As part of that change:
- `ITensor.dtype` is no longer a writable setter — engine output dtype is inferred from the network graph.
- `ILayer.set_output_type` was removed on identity layers in favour of `network.add_cast()`.
- `BuilderFlag.PREFER_PRECISION_CONSTRAINTS`, `FP16`, `INT8` were removed (strongly-typed networks make them redundant).

`d898a0fe6` added a `trt_cast_tensor()` helper to `gen_common.py` and used it for `uint8` conversion in `create_plan_dynamic_rf_modelfile`, but did not cover the float→float dtype change case in either `create_plan_dynamic_rf_modelfile` or `create_plan_fixed_rf_modelfile`. This PR completes the migration for those two functions. The same audit was performed on the other QA generators — most do not change dtypes between input and output, so the dead setter is a no-op there; no functional bugs are blocking the immediate CI failures.

Observed failure footprint on pipeline 54492155 (branch 26.06-devel): 11 affected jobs covering SBSA A100, SBSA GB300, AGX-Thor, RTX50-rhel, and the base `L0_server_status`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to TRI-1406 (this is a follow-up fix to that work)
- TRI-1417 (this PR)
