### PR TITLE
docs: document Backblaze B2 (S3-compatible) as a model repository backend

### DIFF
--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -167,7 +167,7 @@ export TRITON_AWS_MOUNT_DIRECTORY=/path/to/your/local/directory
 
 **Make sure, that `TRITON_AWS_MOUNT_DIRECTORY` exists on your local machine and it is empty.**
 
-#### S3-compatible object stores
+##### S3-compatible object stores
 
 The S3 backend also works with any endpoint that implements the S3-compatible API, such as Backblaze B2, Cloudflare R2, and MinIO. The repository path uses the private-instance form described above, with the provider's endpoint as the host, and the credentials and region are passed through the same environment variables as Amazon S3.
 
@@ -175,7 +175,7 @@ The S3 backend also works with any endpoint that implements the S3-compatible AP
 $ tritonserver --model-repository=s3://https://s3.us-west-2.amazonaws.com:443/bucket/path/to/model/repository ...
 ```
 
-Replace `s3.us-west-2.amazonaws.com` with the S3-compatible endpoint for your provider and region.
+Replace `s3.us-west-2.amazonaws.com:443` with the S3-compatible endpoint and port for your provider and region.
 
 ```bash
 $ export AWS_ACCESS_KEY_ID="<access_key_id>"

--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -167,6 +167,39 @@ export TRITON_AWS_MOUNT_DIRECTORY=/path/to/your/local/directory
 
 **Make sure, that `TRITON_AWS_MOUNT_DIRECTORY` exists on your local machine and it is empty.**
 
+##### S3-compatible object stores
+
+The S3 backend also works with S3-compatible object stores such as Backblaze B2, Cloudflare R2, and MinIO. The repository path uses the private-instance form described above, with the provider's endpoint as the host, and the credentials and region are passed through the same environment variables as Amazon S3.
+
+```bash
+$ tritonserver --model-repository=s3://https://s3.us-west-004.backblazeb2.com:443/bucket/path/to/model/repository ...
+```
+
+Replace `s3.us-west-004.backblazeb2.com` with the endpoint for your provider and region.
+
+```bash
+$ export AWS_ACCESS_KEY_ID="<access_key_id>"
+$ export AWS_SECRET_ACCESS_KEY="<secret_access_key>"
+$ export AWS_DEFAULT_REGION="us-west-004"
+$ tritonserver --model-repository=s3://https://s3.us-west-004.backblazeb2.com:443/my-bucket/models ...
+```
+
+The credential file described [above](#cloud-storage-with-credential-file-beta) can also be used for an S3-compatible endpoint by adding an `s3://` entry keyed by the full bucket path.
+
+```json
+{
+  "s3": {
+    "s3://https://s3.us-west-004.backblazeb2.com:443/my-bucket": {
+      "secret_key": "<secret_access_key>",
+      "key_id": "<access_key_id>",
+      "region": "us-west-004",
+      "session_token": "",
+      "profile": ""
+    }
+  }
+}
+```
+
 #### Azure Storage
 
 For a model repository residing in Azure Storage, the repository path must be prefixed with as://.

--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -184,7 +184,7 @@ $ export AWS_DEFAULT_REGION="us-west-2"
 $ tritonserver --model-repository=s3://https://s3.us-west-2.amazonaws.com:443/my-bucket/models ...
 ```
 
-The credential file described [above](#cloud-storage-with-credential-file-beta) can also be used for an S3-compatible endpoint by adding an `s3://` entry keyed by the full bucket path.
+The credential file described in [Cloud Storage with Credential file (Beta)](#cloud-storage-with-credential-file-beta) can also be used for an S3-compatible endpoint by adding an `s3` entry keyed by the bucket URI, including the custom endpoint when used.
 
 ```json
 {

--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -167,7 +167,7 @@ export TRITON_AWS_MOUNT_DIRECTORY=/path/to/your/local/directory
 
 **Make sure, that `TRITON_AWS_MOUNT_DIRECTORY` exists on your local machine and it is empty.**
 
-##### S3-compatible object stores
+#### S3-compatible object stores
 
 The S3 backend also works with S3-compatible object stores such as Backblaze B2, Cloudflare R2, and MinIO. The repository path uses the private-instance form described above, with the provider's endpoint as the host, and the credentials and region are passed through the same environment variables as Amazon S3.
 

--- a/docs/user_guide/model_repository.md
+++ b/docs/user_guide/model_repository.md
@@ -169,19 +169,19 @@ export TRITON_AWS_MOUNT_DIRECTORY=/path/to/your/local/directory
 
 #### S3-compatible object stores
 
-The S3 backend also works with S3-compatible object stores such as Backblaze B2, Cloudflare R2, and MinIO. The repository path uses the private-instance form described above, with the provider's endpoint as the host, and the credentials and region are passed through the same environment variables as Amazon S3.
+The S3 backend also works with any endpoint that implements the S3-compatible API, such as Backblaze B2, Cloudflare R2, and MinIO. The repository path uses the private-instance form described above, with the provider's endpoint as the host, and the credentials and region are passed through the same environment variables as Amazon S3.
 
 ```bash
-$ tritonserver --model-repository=s3://https://s3.us-west-004.backblazeb2.com:443/bucket/path/to/model/repository ...
+$ tritonserver --model-repository=s3://https://s3.us-west-2.amazonaws.com:443/bucket/path/to/model/repository ...
 ```
 
-Replace `s3.us-west-004.backblazeb2.com` with the endpoint for your provider and region.
+Replace `s3.us-west-2.amazonaws.com` with the S3-compatible endpoint for your provider and region.
 
 ```bash
 $ export AWS_ACCESS_KEY_ID="<access_key_id>"
 $ export AWS_SECRET_ACCESS_KEY="<secret_access_key>"
-$ export AWS_DEFAULT_REGION="us-west-004"
-$ tritonserver --model-repository=s3://https://s3.us-west-004.backblazeb2.com:443/my-bucket/models ...
+$ export AWS_DEFAULT_REGION="us-west-2"
+$ tritonserver --model-repository=s3://https://s3.us-west-2.amazonaws.com:443/my-bucket/models ...
 ```
 
 The credential file described [above](#cloud-storage-with-credential-file-beta) can also be used for an S3-compatible endpoint by adding an `s3://` entry keyed by the full bucket path.
@@ -189,10 +189,10 @@ The credential file described [above](#cloud-storage-with-credential-file-beta) 
 ```json
 {
   "s3": {
-    "s3://https://s3.us-west-004.backblazeb2.com:443/my-bucket": {
+    "s3://https://s3.us-west-2.amazonaws.com:443/my-bucket": {
       "secret_key": "<secret_access_key>",
       "key_id": "<access_key_id>",
-      "region": "us-west-004",
+      "region": "us-west-2",
       "session_token": "",
       "profile": ""
     }


### PR DESCRIPTION
Hello :) 

#### What does the PR do?

Documents using S3-compatible object stores (for example Backblaze B2, Cloudflare R2, and MinIO) as a Triton model repository. The existing S3 backend already supports custom endpoints through the private-instance URI form, so this is a docs-only addition: a short "S3-compatible object stores" subsection under the existing `#### S3` section in `docs/user_guide/model_repository.md`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
None.

#### Where should the reviewer start?

`docs/user_guide/model_repository.md`, the new `##### S3-compatible object stores` subsection under `#### S3`. It reuses the private-instance `s3://https://<endpoint>:443/<bucket>/<path>` form already documented above, the AWS credential environment variables, and the existing credential-file form.

#### Test plan:

Built the documentation locally with the repo's Sphinx configuration and confirmed the rendered page. Separately validated the documented mechanism end to end: started `tritonserver` with `--model-repository` pointed at an S3-compatible endpoint and confirmed the model loaded and reported READY. Verified against both MinIO and Backblaze B2, using the AWS environment-variable credentials and the `TRITON_CLOUD_CREDENTIAL_PATH` credential-file form.

- CI Pipeline ID: N/A (external contributor; docs-only change)

#### Caveats:

Docs only; no code or behavior changes. Opened as draft pending a signed Triton CCLA.

#### Background

Triton's S3 backend communicates with any store that accepts the S3 protocol, using the custom-endpoint URI form already documented for private S3 instances. That capability was not called out for non-AWS providers, so it was not obvious that Backblaze B2, Cloudflare R2, MinIO, and similar stores work with no code changes.

#### Related Issues:
None.
