### PR TITLE
test: Add Dynamo launch mode to L0_infer

### DIFF
--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -44,8 +44,26 @@ CPU_ONLY = os.environ.get("TRITON_SERVER_CPU_ONLY") is not None
 TEST_VALGRIND = bool(int(os.environ.get("TEST_VALGRIND", 0)))
 VALGRIND_TESTS = bool(int(os.environ.get("VALGRIND_TESTS", 0)))
 
+# Dynamo's KServe gRPC tensor path does not yet cover every Triton/KServe
+# feature, so the cases that exercise an unsupported path are skipped in dynamo
+# mode (see the Dynamo Triton backend "Known limitations"). Gate every such
+# divergence on this flag.
+DYNAMO = os.environ.get("SERVER_LAUNCH_MODE") == "dynamo"
+
+# Reasons the corresponding tests are skipped under Dynamo.
+DYNAMO_SKIP_FP16 = (
+    "FP16/BF16 tensors: Dynamo tensor DataType has no half-precision variant"
+)
+DYNAMO_SKIP_CLASS = (
+    "classification output: Dynamo frontend drops the KServe classification parameter"
+)
+DYNAMO_SKIP_VERSION = "model version selection: Dynamo routes by model name only, serving the default version"
+
 USE_GRPC = os.environ.get("USE_GRPC", 1) != "0"
 USE_HTTP = os.environ.get("USE_HTTP", 1) != "0"
+# The Dynamo frontend exposes only the KServe gRPC endpoint, not HTTP/REST.
+if DYNAMO:
+    USE_HTTP = False
 assert USE_GRPC or USE_HTTP, "USE_GRPC or USE_HTTP must be non-zero"
 
 BACKENDS = os.environ.get(
@@ -334,6 +352,7 @@ class InferTest(tu.TestResultCollector):
             np.int64, np.int64, np.int64, output0_raw=True, output1_raw=True, swap=False
         )
 
+    @unittest.skipIf(DYNAMO, DYNAMO_SKIP_FP16)
     def test_raw_hhh(self):
         self._full_exact(
             np.float16,
@@ -354,6 +373,7 @@ class InferTest(tu.TestResultCollector):
             swap=True,
         )
 
+    @unittest.skipIf(DYNAMO, DYNAMO_SKIP_FP16)
     def test_raw_hff(self):
         self._full_exact(
             np.float16,
@@ -399,6 +419,7 @@ class InferTest(tu.TestResultCollector):
             swap=False,
         )
 
+    @unittest.skipIf(DYNAMO, DYNAMO_SKIP_FP16)
     def test_raw_fuh(self):
         self._full_exact(
             np.float32,
@@ -429,6 +450,7 @@ class InferTest(tu.TestResultCollector):
             swap=False,
         )
 
+    @unittest.skipIf(DYNAMO, DYNAMO_SKIP_FP16)
     def test_raw_ihs(self):
         self._full_exact(
             np.int32,
@@ -512,6 +534,7 @@ class InferTest(tu.TestResultCollector):
     # shared memory does not support class output
     if not (TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY):
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_bbb(self):
             self._full_exact(
                 np.int8,
@@ -522,6 +545,7 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_sss(self):
             self._full_exact(
                 np.int16,
@@ -532,6 +556,7 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_iii(self):
             self._full_exact(
                 np.int32,
@@ -542,6 +567,7 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_lll(self):
             self._full_exact(
                 np.int64,
@@ -552,6 +578,7 @@ class InferTest(tu.TestResultCollector):
                 swap=False,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_fff(self):
             self._full_exact(
                 np.float32,
@@ -562,6 +589,7 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_iff(self):
             self._full_exact(
                 np.int32,
@@ -572,6 +600,7 @@ class InferTest(tu.TestResultCollector):
                 swap=False,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_bbb(self):
             self._full_exact(
                 np.int8,
@@ -582,6 +611,7 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_sss(self):
             self._full_exact(
                 np.int16,
@@ -592,6 +622,7 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_iii(self):
             self._full_exact(
                 np.int32,
@@ -602,6 +633,7 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_lll(self):
             self._full_exact(
                 np.int64,
@@ -612,6 +644,7 @@ class InferTest(tu.TestResultCollector):
                 swap=False,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_fff(self):
             self._full_exact(
                 np.float32,
@@ -622,6 +655,7 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_iff(self):
             self._full_exact(
                 np.int32,
@@ -634,6 +668,7 @@ class InferTest(tu.TestResultCollector):
 
     if not VALGRIND_TESTS:
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_VERSION)
         def test_raw_version_latest_1(self):
             input_size = 16
             tensor_shape = (1, input_size)
@@ -701,6 +736,7 @@ class InferTest(tu.TestResultCollector):
                     use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
                 )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_VERSION)
         def test_raw_version_latest_2(self):
             input_size = 16
             tensor_shape = (1, input_size)
@@ -762,6 +798,7 @@ class InferTest(tu.TestResultCollector):
                     use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
                 )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_VERSION)
         def test_raw_version_all(self):
             input_size = 16
             tensor_shape = (1, input_size)
@@ -817,6 +854,7 @@ class InferTest(tu.TestResultCollector):
                     use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
                 )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_VERSION)
         def test_raw_version_specific_1(self):
             input_size = 16
             tensor_shape = (1, input_size)
@@ -884,6 +922,7 @@ class InferTest(tu.TestResultCollector):
                         ex.message().startswith("Request for unknown model")
                     )
 
+        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_VERSION)
         def test_raw_version_specific_1_3(self):
             input_size = 16
 
@@ -1062,6 +1101,7 @@ class InferTest(tu.TestResultCollector):
 
             if not (TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY):
 
+                @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
                 def test_ensemble_label_lookup(self):
                     if all(x in BACKENDS for x in ["onnx", "libtorch"]):
                         # Ensemble needs to look up label from the actual model

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -37,6 +37,8 @@ fi
 if [ ! -z "$TEST_REPO_ARCH" ]; then
     REPO_VERSION=${REPO_VERSION}_${TEST_REPO_ARCH}
 fi
+export SERVER_LAUNCH_MODE=${SERVER_LAUNCH_MODE:="triton"}
+echo "========== SERVER_LAUNCH_MODE=$SERVER_LAUNCH_MODE =========="
 
 ldconfig || true
 
@@ -114,7 +116,14 @@ if [ "$TEST_SYSTEM_SHARED_MEMORY" -eq 1 ] || [ "$TEST_CUDA_SHARED_MEMORY" -eq 1 
 fi
 SERVER_ARGS="--model-repository=${MODELDIR} ${SERVER_ARGS_EXTRA}"
 SERVER_LOG_BASE="./inference_server"
-source ../common/util.sh
+
+if [ "$SERVER_LAUNCH_MODE" == "dynamo" ]; then
+    # Remove after TRI-1450 is fixed
+    export DYN_DISCOVERY_BACKEND=etcd
+    source ../common/dynamo_util.sh
+else
+    source ../common/util.sh
+fi
 
 rm -f $SERVER_LOG_BASE* $CLIENT_LOG_BASE*
 

--- a/qa/common/dynamo_util.sh
+++ b/qa/common/dynamo_util.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Dynamo launch mode for the Triton QA suite. Sourced in place of util.sh when
+# SERVER_LAUNCH_MODE=dynamo. Overrides run_server / kill_server to launch Triton
+# through Dynamo (frontend on KServe gRPC + in-process Triton worker) instead of
+# the standalone tritonserver binary.
+source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
+
+SERVER_LAUNCH_MODE=${SERVER_LAUNCH_MODE:=dynamo}
+DYN_FRONTEND_LOG=${DYN_FRONTEND_LOG:=./frontend.log}
+DYN_FRONTEND_ARGS=${DYN_FRONTEND_ARGS:="--kserve-grpc-server"}
+DYN_WORKER_PY=${DYN_WORKER_PY:=/workspace/examples/backends/tritonserver/src/tritonworker.py}
+DYN_WORKER_ARGS=${DYN_WORKER_ARGS:=""}
+DYN_DISCOVERY_BACKEND=${DYN_DISCOVERY_BACKEND:=file}
+# The Dynamo frontend binds KServe gRPC to --http-port; serve it on 8001.
+DYN_HTTP_PORT=${DYN_HTTP_PORT:=8001}
+DYN_FRONTEND_PID=0
+# etcd + NATS back the etcd discovery backend. The Dynamo container has no docker
+# but ships the etcd and nats-server binaries, so run_server launches them
+# directly; kill_server tears down only what it started.
+DYN_ETCD_LOG=${DYN_ETCD_LOG:=./etcd.log}
+DYN_NATS_LOG=${DYN_NATS_LOG:=./nats.log}
+DYN_ETCD_DATA_DIR=${DYN_ETCD_DATA_DIR:=/tmp/dynamo_qa_etcd.data}
+DYN_ETCD_PID=0
+DYN_NATS_PID=0
+# KServe ServerReady flips after the first model wires up, but the worker
+# registers a whole repo as a burst. When DYN_WAIT_ALL_MODELS=1, run_server also
+# waits (per-model is_model_ready) until every model is ready or readiness
+# settles, so the registration burst drains before tests run.
+DYN_WAIT_ALL_MODELS=${DYN_WAIT_ALL_MODELS:=1}
+DYN_MODELS_SETTLE_SECS=${DYN_MODELS_SETTLE_SECS:=15}
+
+# Wait until the KServe gRPC server (Dynamo frontend on DYN_HTTP_PORT) reports
+# ready. Sets WAIT_RET to 0 on success, 1 on failure.
+function wait_for_grpc_server_ready() {
+    local spid="$1"; shift
+    local wait_time_secs="${1:-30}"; shift
+
+    WAIT_RET=0
+
+    local wait_secs=$wait_time_secs
+    until test $wait_secs -eq 0 ; do
+        if ! kill -0 $spid > /dev/null 2>&1; then
+            echo "=== Server not running."
+            WAIT_RET=1
+            return
+        fi
+
+        # If the frontend dies, the gRPC endpoint is gone; stop probing.
+        if [ "${DYN_FRONTEND_PID:-0}" != "0" ] && \
+           ! kill -0 $DYN_FRONTEND_PID > /dev/null 2>&1; then
+            echo "=== Dynamo frontend not running (see $DYN_FRONTEND_LOG)."
+            WAIT_RET=1
+            return
+        fi
+
+        sleep 1;
+
+        set +e
+        python3 - "$SERVER_IPADDR" "$DYN_HTTP_PORT" <<'PY' > /dev/null 2>&1
+import sys
+import tritonclient.grpc as grpcclient
+
+try:
+    client = grpcclient.InferenceServerClient(url=f"{sys.argv[1]}:{sys.argv[2]}", verbose=False)
+    sys.exit(0 if client.is_server_ready() else 1)
+except Exception:
+    sys.exit(1)
+PY
+        local ready=$?
+        set -e
+        if [ "$ready" == "0" ]; then
+            return
+        fi
+
+        ((wait_secs--));
+    done
+
+    echo "=== Timeout $wait_time_secs secs. gRPC server not ready."
+    WAIT_RET=1
+}
+
+# Convert the given standalone tritonserver args (e.g. $SERVER_ARGS) into Triton
+# worker (tritonworker.py) flags on stdout, to auto-populate DYN_WORKER_ARGS.
+# Most flags pass through unchanged; the exception is --allow-* endpoint flags
+# (owned by the frontend) which are dropped. Accepts both --flag=value and
+# --flag value forms.
+# Args: <server_arg>...
+function dynamo_worker_args_from_server_args () {
+    local out=()
+    local tokens=("$@")
+    local n=${#tokens[@]}
+    local i=0
+
+    while [ $i -lt $n ]; do
+        local tok="${tokens[$i]}"
+        case "$tok" in
+            --allow-*)
+                # Endpoints are owned by the Dynamo frontend, not the worker;
+                # drop the flag and its value (--allow-x=v or --allow-x v).
+                if [[ "$tok" != *=* ]] && [ $((i + 1)) -lt $n ] \
+                        && [[ "${tokens[$((i + 1))]}" != --* ]]; then
+                    ((i++))
+                fi ;;
+            *)
+                out+=("$tok") ;;
+        esac
+        ((i++))
+    done
+
+    echo "${out[*]}"
+}
+
+# Start etcd + NATS for the etcd discovery backend. No-op unless
+# DYN_DISCOVERY_BACKEND is etcd. Each service is reused if already listening on
+# its default port (etcd 2379, NATS 4222); only services started here record a
+# PID, so kill_server tears down only those. Returns 0 once both accept
+# connections (or were reused / not needed), non-zero on any failure.
+function start_dynamo_discovery () {
+    DYN_ETCD_PID=0
+    DYN_NATS_PID=0
+
+    if [ "$DYN_DISCOVERY_BACKEND" != "etcd" ]; then
+        return 0
+    fi
+
+    if (exec 3<>/dev/tcp/localhost/2379) 2>/dev/null; then
+        echo "=== Reusing etcd already listening on localhost:2379"
+    else
+        if ! command -v etcd > /dev/null 2>&1; then
+            echo "=== etcd not found; cannot start it for DYN_DISCOVERY_BACKEND=etcd"
+            return 1
+        fi
+        echo "=== Starting etcd (log: $DYN_ETCD_LOG)"
+        rm -rf "$DYN_ETCD_DATA_DIR"
+        etcd --data-dir "$DYN_ETCD_DATA_DIR" \
+            --listen-client-urls http://0.0.0.0:2379 \
+            --advertise-client-urls http://localhost:2379 \
+            > "$DYN_ETCD_LOG" 2>&1 &
+        DYN_ETCD_PID=$!
+    fi
+
+    if (exec 3<>/dev/tcp/localhost/4222) 2>/dev/null; then
+        echo "=== Reusing NATS already listening on localhost:4222"
+    else
+        if ! command -v nats-server > /dev/null 2>&1; then
+            echo "=== nats-server not found; cannot start it for DYN_DISCOVERY_BACKEND=etcd"
+            stop_dynamo_discovery
+            return 1
+        fi
+        echo "=== Starting NATS with JetStream (log: $DYN_NATS_LOG)"
+        nats-server -js > "$DYN_NATS_LOG" 2>&1 &
+        DYN_NATS_PID=$!
+    fi
+
+    # Wait for both ports, but fail fast if a service we launched dies.
+    local wait_secs=30
+    until test $wait_secs -eq 0 ; do
+        if (exec 3<>/dev/tcp/localhost/2379) 2>/dev/null && \
+           (exec 4<>/dev/tcp/localhost/4222) 2>/dev/null; then
+            return 0
+        fi
+        if [ "$DYN_ETCD_PID" != "0" ] && ! kill -0 "$DYN_ETCD_PID" 2>/dev/null; then
+            echo "=== etcd exited early (see $DYN_ETCD_LOG)"
+            stop_dynamo_discovery
+            return 1
+        fi
+        if [ "$DYN_NATS_PID" != "0" ] && ! kill -0 "$DYN_NATS_PID" 2>/dev/null; then
+            echo "=== NATS exited early (see $DYN_NATS_LOG)"
+            stop_dynamo_discovery
+            return 1
+        fi
+        sleep 1; ((wait_secs--))
+    done
+
+    echo "=== Timeout waiting for etcd + NATS to accept connections"
+    stop_dynamo_discovery
+    return 1
+}
+
+# Stop the etcd + NATS services started by start_dynamo_discovery. Reused
+# services have no recorded PID and are left untouched.
+function stop_dynamo_discovery () {
+    if [ "${DYN_NATS_PID:-0}" != "0" ]; then
+        kill $DYN_NATS_PID > /dev/null 2>&1 || true
+        wait $DYN_NATS_PID 2>/dev/null || true
+        DYN_NATS_PID=0
+    fi
+    if [ "${DYN_ETCD_PID:-0}" != "0" ]; then
+        kill $DYN_ETCD_PID > /dev/null 2>&1 || true
+        wait $DYN_ETCD_PID 2>/dev/null || true
+        DYN_ETCD_PID=0
+    fi
+}
+
+# Wait until every model in the worker's repository reports ready on the
+# frontend, not just the first. Best-effort: returns once all models are ready,
+# readiness settles (ready count unchanged for $settle_secs), or the wait times
+# out, since the server is already up.
+# Args: <wait_time_secs> <settle_secs> <model_repository>...
+function wait_for_dynamo_models_ready() {
+    local wait_time_secs="${1:-300}"; shift
+    local settle_secs="${1:-15}"; shift
+
+    if [ "$#" -eq 0 ]; then
+        echo "=== wait_for_dynamo_models_ready: no model repository given; skipping"
+        return
+    fi
+
+    python3 - "$SERVER_IPADDR" "$DYN_HTTP_PORT" "$wait_time_secs" "$settle_secs" "$@" <<'PY'
+import os
+import sys
+import time
+
+import tritonclient.grpc as grpcclient
+
+host, port = sys.argv[1], sys.argv[2]
+wait_secs, settle_secs = float(sys.argv[3]), float(sys.argv[4])
+repos = sys.argv[5:]
+
+
+def model_name(repo, d):
+    # Triton model name defaults to the directory name; honor a `name:` override
+    # in config.pbtxt when present.
+    try:
+        with open(os.path.join(repo, d, "config.pbtxt")) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("name:"):
+                    return line.split(":", 1)[1].strip().strip('"')
+    except OSError:
+        pass
+    return d
+
+
+expected = set()
+for repo in repos:
+    try:
+        for d in sorted(os.listdir(repo)):
+            if os.path.isdir(os.path.join(repo, d)):
+                expected.add(model_name(repo, d))
+    except OSError:
+        pass
+expected = sorted(expected)
+if not expected:
+    sys.exit(0)
+
+client = grpcclient.InferenceServerClient(url=f"{host}:{port}", verbose=False)
+deadline = time.time() + wait_secs
+last_count = -1
+stable_since = time.time()
+while time.time() < deadline:
+    ready = 0
+    missing = []
+    for name in expected:
+        try:
+            if client.is_model_ready(name):
+                ready += 1
+                continue
+        except Exception:
+            pass
+        missing.append(name)
+    if ready == len(expected):
+        print(f"=== All {ready} models ready")
+        sys.exit(0)
+    if ready != last_count:
+        last_count = ready
+        stable_since = time.time()
+    elif time.time() - stable_since >= settle_secs:
+        print(
+            f"=== Model readiness settled at {ready}/{len(expected)}; proceeding "
+            f"(missing e.g. {missing[:5]})"
+        )
+        sys.exit(0)
+    time.sleep(2)
+print(f"=== Timeout waiting for all models: {last_count}/{len(expected)} ready")
+sys.exit(0)
+PY
+}
+
+# Launch Triton through Dynamo: the frontend (KServe gRPC on DYN_HTTP_PORT) and
+# the in-process Triton worker, both wired to DYN_DISCOVERY_BACKEND. Sets
+# SERVER_PID to the worker pid (so the existing kill/debug paths apply) and
+# DYN_FRONTEND_PID to the frontend pid. Returns once the gRPC server is ready or
+# the timeout expires (SERVER_PID reset to 0 on failure).
+function run_server () {
+    SERVER_PID=0
+    DYN_FRONTEND_PID=0
+
+    # Auto-infer worker args from the standard SERVER_ARGS when not provided.
+    if [ -z "$DYN_WORKER_ARGS" ]; then
+        DYN_WORKER_ARGS="$(dynamo_worker_args_from_server_args $SERVER_ARGS)"
+        echo "=== Inferred DYN_WORKER_ARGS from SERVER_ARGS: $DYN_WORKER_ARGS"
+    fi
+
+    if [ -z "$DYN_WORKER_ARGS" ]; then
+        echo "=== DYN_WORKER_ARGS is empty (SERVER_ARGS must include --model-repository <path>)"
+        return
+    fi
+
+    if [ ! -f "$DYN_WORKER_PY" ]; then
+        echo "=== $DYN_WORKER_PY does not exist"
+        return
+    fi
+
+    # start_dynamo_discovery cleans up after itself on failure.
+    if ! start_dynamo_discovery; then
+        echo "=== Failed to bring up the etcd + NATS discovery services"
+        return
+    fi
+
+    echo "=== Running dynamo.frontend $DYN_FRONTEND_ARGS --http-port $DYN_HTTP_PORT --discovery-backend $DYN_DISCOVERY_BACKEND"
+    python3 -m dynamo.frontend $DYN_FRONTEND_ARGS --http-port $DYN_HTTP_PORT --discovery-backend $DYN_DISCOVERY_BACKEND \
+        > $DYN_FRONTEND_LOG 2>&1 &
+    DYN_FRONTEND_PID=$!
+
+    echo "=== Running $DYN_WORKER_PY $DYN_WORKER_ARGS --discovery-backend $DYN_DISCOVERY_BACKEND"
+    python3 $DYN_WORKER_PY $DYN_WORKER_ARGS --discovery-backend $DYN_DISCOVERY_BACKEND \
+        > $SERVER_LOG 2>&1 &
+    SERVER_PID=$!
+
+    wait_for_grpc_server_ready $SERVER_PID $SERVER_TIMEOUT
+    if [ "$WAIT_RET" != "0" ]; then
+        # Get further debug information about server startup failure.
+        gdb_helper || true
+
+        kill_server
+        SERVER_PID=0
+        return
+    fi
+
+    # server_ready only guarantees one model; wait for the whole repo to wire up.
+    if [ "$DYN_WAIT_ALL_MODELS" != "0" ]; then
+        local repos
+        repos=$(echo "$DYN_WORKER_ARGS" | grep -oE -- '--model-repository[ =][^ ]+' | sed -E 's/--model-repository[ =]//')
+        wait_for_dynamo_models_ready $SERVER_TIMEOUT $DYN_MODELS_SETTLE_SECS $repos
+    fi
+}
+
+# Tear down the Triton worker, the Dynamo frontend, and the etcd + NATS
+# discovery services. Dynamo mode runs on Linux only, so the WSL/MSYS teardown
+# branches do not apply here.
+function kill_server () {
+    # Signal the worker and frontend first, then reap them, so they shut down in
+    # parallel instead of serially.
+    kill $SERVER_PID > /dev/null 2>&1 || true
+    if [ "${DYN_FRONTEND_PID:-0}" != "0" ]; then
+        kill $DYN_FRONTEND_PID > /dev/null 2>&1 || true
+    fi
+
+    # Tolerate a non-zero wait status (e.g. the SIGTERM exit code) so teardown
+    # still runs under a caller's `set -e`.
+    wait $SERVER_PID 2>/dev/null || true
+    if [ "${DYN_FRONTEND_PID:-0}" != "0" ]; then
+        wait $DYN_FRONTEND_PID 2>/dev/null || true
+        DYN_FRONTEND_PID=0
+    fi
+
+    stop_dynamo_discovery
+}

--- a/qa/common/infer_util.py
+++ b/qa/common/infer_util.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -34,7 +34,11 @@ import numpy as np
 import shm_util as su
 import test_util as tu
 import tritonclient.grpc as grpcclient
-import tritonclient.http as httpclient
+
+if os.environ.get("SERVER_LAUNCH_MODE") == "dynamo":
+    httpclient = None
+else:
+    import tritonclient.http as httpclient
 from tritonclient.utils import *
 
 if sys.version_info >= (3, 0):

--- a/qa/common/shm_util.py
+++ b/qa/common/shm_util.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -33,7 +33,11 @@ from ctypes import *
 from os import listdir
 
 import numpy as np
-import tritonclient.http as httpclient
+
+if os.environ.get("SERVER_LAUNCH_MODE") == "dynamo":
+    httpclient = None
+else:
+    import tritonclient.http as httpclient
 from tritonclient.utils import *
 
 CREATION_LOCK = threading.Lock()


### PR DESCRIPTION
#### What does the PR do?
Adds a `SERVER_LAUNCH_MODE=dynamo` path to the L0_infer test so it can run Triton through the Dynamo frontend (KServe gRPC) plus an in-process Triton worker, backed by etcd + NATS discovery, instead of the standalone `tritonserver` binary.

- New `qa/common/dynamo_util.sh`: sourced in place of `util.sh` when `SERVER_LAUNCH_MODE=dynamo`. Overrides `run_server`/`kill_server` to launch the Dynamo frontend + Triton worker, bring up etcd + NATS (binaries shipped in the Dynamo container), translate `SERVER_ARGS` into worker flags, and wait until all models in the repository are ready.
- `qa/L0_infer/test.sh`: selects the launch mode and sources the matching util script.
- `qa/L0_infer/infer_test.py`: skips cases that exercise KServe features the Dynamo gRPC path does not yet support (FP16/BF16 tensors, classification output, model version selection) and disables HTTP-client paths (the Dynamo frontend exposes only KServe gRPC).
- `qa/common/infer_util.py`, `qa/common/shm_util.py`: guard the `tritonclient.http` import behind non-dynamo mode.

The default (`triton`) path is unchanged.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added succinct git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] test

#### Related PRs:

#### Where should the reviewer start?

#### Test plan:
- Default mode unchanged: `qa/L0_infer/test.sh` with `SERVER_LAUNCH_MODE` unset/`triton`.
- Dynamo mode: run inside the Dynamo Triton container with `SERVER_LAUNCH_MODE=dynamo`; frontend + worker come up against etcd + NATS, all models report ready, and the supported subset of L0_infer passes (FP16/classification/version cases skipped).

- CI Pipeline ID: 55686086

#### Caveats:

#### Background
Enables L0_infer to validate the Dynamo Triton backend frontend/worker path alongside the standalone server.

#### Related Issues:
N/A