### PR TITLE
fix: Redact restriction header values from OpenAI frontend startup log

### DIFF
--- a/python/openai/openai_frontend/frontend/fastapi/middleware/api_restriction.py
+++ b/python/openai/openai_frontend/frontend/fastapi/middleware/api_restriction.py
@@ -102,6 +102,18 @@ class RestrictedFeatures:
         """
         return self._restrictions.copy()
 
+    def RestrictionSummary(self) -> dict[str, str]:
+        """
+        Get a log-safe copy of the restrictions dictionary.
+
+        Returns:
+            dict: Mapping of API names to header names without secret values.
+        """
+        return {
+            api: header_name
+            for api, (header_name, _header_value) in self._restrictions.items()
+        }
+
     def Insert(self, api: str, restriction: tuple[str, str]):
         """
         Add a restriction for a specific API.

--- a/python/openai/openai_frontend/frontend/fastapi_frontend.py
+++ b/python/openai/openai_frontend/frontend/fastapi_frontend.py
@@ -140,7 +140,7 @@ class FastApiFrontend(OpenAIFrontend):
             APIRestrictionMiddleware, restricted_apis=self.restricted_apis
         )
         print(
-            f"[INFO] API restrictions enabled. Restricted API endpoints: {self.restricted_apis.RestrictionDict()}"
+            f"[INFO] API restrictions enabled. Restricted API endpoints: {self.restricted_apis.RestrictionSummary()}"
         )
 
     def _add_request_size_limit_middleware(self, app: FastAPI):

--- a/python/openai/tests/test_openai_restricted_apis.py
+++ b/python/openai/tests/test_openai_restricted_apis.py
@@ -31,6 +31,7 @@ from typing import Dict, List, Optional
 
 import pytest
 import requests
+from frontend.fastapi.middleware.api_restriction import RestrictedFeatures
 from tests.utils import OpenAIServer
 
 
@@ -50,6 +51,43 @@ def assert_response_unauthorized(
     assert (
         response.status_code == expected_status
     ), f"{description} should be unauthorized with {expected_status}, got {response.status_code} {response.text}"
+
+
+def test_restricted_feature_summary_omits_header_values():
+    restricted = RestrictedFeatures(
+        [["inference", "synthetic-header", "synthetic-secret-value"]]
+    )
+
+    assert restricted.RestrictionSummary() == {"inference": "synthetic-header"}
+    assert "synthetic-secret-value" not in str(restricted.RestrictionSummary())
+
+
+def test_startup_log_does_not_leak_restriction_header_values(capsys):
+    """Regression test for the startup log line that announces enabled API
+    restrictions. The line must not contain configured header values, but
+    must still surface the API group names and header names so operators can
+    verify the configuration that was applied."""
+    from frontend.fastapi_frontend import FastApiFrontend
+
+    secret_value = "do-not-log-this-restriction-value-XYZ"
+    FastApiFrontend(
+        engine=None,
+        restricted_apis=[["inference", "x-syn-key", secret_value]],
+    )
+
+    captured = capsys.readouterr().out
+    assert (
+        secret_value not in captured
+    ), "Startup log leaks the configured restriction header value"
+    assert (
+        "API restrictions enabled" in captured
+    ), "Startup log line is missing entirely"
+    assert (
+        "inference" in captured
+    ), "Startup log should still surface the API group name"
+    assert (
+        "x-syn-key" in captured
+    ), "Startup log should still surface the configured header name"
 
 
 def make_get_request(


### PR DESCRIPTION
#### What does the PR do?
Removes configured restriction header values from the OpenAI FastAPI
frontend's startup log line. The `--openai-restricted-api` startup log
serialized the full restriction dictionary, which contained the
configured header values in addition to the API group and header name.

Adds a log-safe `RestrictionSummary()` helper on `RestrictedFeatures`
that returns `{api: header_name}` (no values), and switches the startup
log line to use it. Header names and API group names remain visible so
operators can verify the configuration; the authentication check itself
is unchanged.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] fix

#### Related PRs:
None.

#### Where should the reviewer start?
- `python/openai/openai_frontend/frontend/fastapi/middleware/api_restriction.py`
  — new `RestrictionSummary()` method (12 lines)
- `python/openai/openai_frontend/frontend/fastapi_frontend.py`
  — single-line caller switch from `RestrictionDict()` to `RestrictionSummary()`
- `python/openai/tests/test_openai_restricted_apis.py`
  — two new regression tests guarding the redaction at both unit and live-frontend layers

#### Test plan:
1. `pytest python/openai/tests/test_openai_restricted_apis.py::test_restricted_feature_summary_omits_header_values`
   — asserts `RestrictionSummary()` returns `{api: header_name}` without the value.
2. `pytest python/openai/tests/test_openai_restricted_apis.py::test_startup_log_does_not_leak_restriction_header_values`
   — constructs `FastApiFrontend` with a synthetic secret header value and
   asserts (via `capsys`) that the value never appears on stdout while the
   `API restrictions enabled` line, API group name, and header name remain
   visible.
3. Full OpenAI test suite under `qa/L0_openai`: 221 passed, 21 skipped across
   5 independent runs.

- CI Pipeline ID: 55610358

#### Caveats:
None.

#### Background
The startup log line was intended to help operators verify which APIs
have restrictions enabled, but it inadvertently surfaced the configured
header values too. This change keeps the operator-facing diagnostic
information (API group and header name) while removing the value.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
None to reference publicly.
