### PR TITLE
build(TRI-1421): add libssl-dev to base image

### DIFF
--- a/build.py
+++ b/build.py
@@ -1315,6 +1315,7 @@ RUN apt-get update \\
               libgoogle-perftools-dev \\
               libjemalloc-dev \\
               libnuma-dev \\
+              libssl-dev \\
               wget \\
               {backend_dependencies} \\
               python3-pip \\


### PR DESCRIPTION
<sup>
CI (internal): [#55736172](http://tritonserver.local/ci/pipelines/55736172)<br/>
</sup>

#### What does the PR do?
Adds `libssl-dev` to the apt-get install list used by `create_dockerfile_buildbase` in `build.py`, so the base image carries OpenSSL development headers/libraries. This lets dependent components link against `libssl` during the in-container build, and makes the OpenSSL package available for in-place updates (CVE remediation, OSRB patching) without rebuilding the base layer.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] build

#### Related PRs:
<!-- none -->

#### Where should the reviewer start?
- `build.py` — single-line addition of `libssl-dev` to the `apt-get install` list inside `create_dockerfile_buildbase`.

#### Test plan:
- `./build.py -v --enable-all --dryrun` → confirm the generated `Dockerfile.buildbase` contains `libssl-dev` in the apt-get install list.
- Full container build (`./build.py -v --enable-all`) on the affected base image → verify `libssl-dev` is installed and existing build steps that link OpenSSL still succeed.
- Run `dpkg -l libssl-dev` inside the resulting `tritonserver` image to confirm presence and version.

- CI Pipeline ID: 55736172

#### Caveats:
- Adds a small amount to the base image size; expected to be negligible (~MBs) and offset by enabling in-place OpenSSL patching without a base rebuild.

#### Background
Required for the OSRB approval flow (TRI-1421) where OpenSSL needs to be patched/updated inside the final container image. Without `libssl-dev` present, downstream rebuilds against a patched OpenSSL cannot be performed inside the running image.

#### Related Issues:
- Resolves: TRI-1421
