### PR TITLE
test: Validate AOTI package device at model generation (#8855)

### DIFF
--- a/qa/common/gen_qa_models.py
+++ b/qa/common/gen_qa_models.py
@@ -1470,6 +1470,9 @@ def create_torch_aoti_model_file(
             exported_model,
             package_path=package_path,
         )
+        # Load the package back to verify it was generated correctly and
+        # targets a valid device.
+        torch._inductor.aoti_load_package(package_path)
     except Exception as e:
         print(
             f"{_color_red}error: Failed to create model {model_name}{_color_reset}",


### PR DESCRIPTION
Cherry-pick of https://github.com/triton-inference-server/server/pull/8855 into r26.06.

