### PR TITLE
fix: re-enable Torch-TensorRT model generation for SM 12.1

### DIFF
--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -284,7 +284,7 @@ chmod -R 777 $TRITON_MDLS_QA_VARIABLE_SEQUENCE_IMPLICIT_MODEL
 python3 $TRITON_MDLS_SRC_DIR/gen_qa_dyna_sequence_models.py --libtorch --models_dir=$TRITON_MDLS_QA_DYNA_SEQUENCE_MODEL
 chmod -R 777 $TRITON_MDLS_QA_DYNA_SEQUENCE_MODEL
 if [ -z "$MODEL_TYPE" ] || [ "$MODEL_TYPE" != "igpu" ]; then
-  nvidia-smi --query-gpu=compute_cap | grep -qz 12.1 && echo -e '${COLOR_WARNING}[WARNING]${COLOR_RESET} Skipping model generation for Torch TensorRT${COLOR_RESET}' || python3 $TRITON_MDLS_SRC_DIR/gen_qa_torchtrt_models.py --models_dir=$TRITON_MDLS_QA_TORCHTRT_MODEL
+  python3 $TRITON_MDLS_SRC_DIR/gen_qa_torchtrt_models.py --models_dir=$TRITON_MDLS_QA_TORCHTRT_MODEL
   chmod -R 777 $TRITON_MDLS_QA_TORCHTRT_MODEL
 fi
 python3 $TRITON_MDLS_SRC_DIR/gen_qa_ragged_models.py --libtorch --models_dir=$TRITON_MDLS_QA_RAGGED_MODEL


### PR DESCRIPTION
#### What does the PR do?
Re-enables Torch-TensorRT QA model generation on devices with compute capability
12.1 (NVIDIA GB10 / DGX Spark) by removing a temporary skip in
`qa/common/gen_qa_model_repository` that was added when TensorRT lacked the
required convolution kernels for SM 12.1.

The skip is no longer needed: TensorRT 10.16.1.11 (shipped in the current
pytorch:26.05 base image) generates the required kernels successfully, so
`torchtrt_model_store/resnet50_libtorch/1/model.pt` builds end-to-end on real
GB10 hardware. Without this change the downstream test
`L0_libtorch_torchtrt_image_models--PyTorch--DGX-Spark` fails because the
model store is empty.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added succinct git squash message before merging
- [x] All template sections are filled out.

#### Commit Type:
- [x] fix

#### Related PRs:
- A follow-up MR will be opened on the internal GitLab to remove
  `allow_failure: true` from the DGX Spark L0 test once a master nightly
  confirms it is green.

#### Where should the reviewer start?
- `qa/common/gen_qa_model_repository` — single-line change removing the
  `nvidia-smi --query-gpu=compute_cap | grep -qz 12.1 && echo WARNING || ...`
  guard that previously skipped Torch-TRT model generation on SM 12.1.

#### Test plan:
1. Verified on a real DGX Spark CI runner (SM 12.1 / GB10) that
   `gen_qa_torchtrt_models.py` produces a valid `resnet50_libtorch/1/model.pt`.
2. Ran the consuming test `L0_libtorch_torchtrt_image_models--PyTorch--DGX-Spark`
   end-to-end on the same hardware against the freshly generated model store.
3. Tritonserver loaded `resnet50_libtorch`, `image_client.py` produced the
   expected classification, test output: `*** Test Passed ***`.

- CI Pipeline ID: 55894843

#### Caveats:
- This change is a no-op on every compute capability other than SM 12.1
  (the guard only matched 12.1).
- Only the DGX Spark `GenModels-build` job's behavior changes (from
  "skip with warning" to "build"); the only downstream consumer of the
  generated artifact is `L0_libtorch_torchtrt_image_models`.

#### Background
The SM 12.1 skip was introduced as a temporary workaround for an upstream
TensorRT kernel gap on Blackwell GB10. That gap has since been resolved in
the TensorRT version pulled by the current PyTorch container, so the
workaround is no longer needed.

#### Related Issues:
- N/A (no public GitHub issue; tracked internally).