### PR TITLE
build: route py3-sdk Maven build through NVIDIA Artifactory via MAVEN_SETTINGS_FILE

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -121,10 +121,12 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
           -DTRITON_ENABLE_JAVA_HTTP=ON \
           -DTRITON_ENABLE_EXAMPLES=ON -DTRITON_ENABLE_TESTS=ON \
           -DTRITON_ENABLE_GPU=${TRITON_ENABLE_GPU} /workspace/client
-RUN cmake --build . -v --parallel --target cc-clients java-clients python-clients
+RUN --mount=type=secret,id=maven_settings,target=/root/.m2/settings.xml,required=false \
+    cmake --build . -v --parallel --target cc-clients java-clients python-clients
 
 # Install Java API Bindings
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+RUN --mount=type=secret,id=maven_settings,target=/root/.m2/settings.xml,required=false \
+    if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         source /workspace/client/src/java-api-bindings/scripts/install_dependencies_and_build.sh \
         --maven-version ${JAVA_BINDINGS_MAVEN_VERSION} \
         --core-tag ${TRITON_CORE_REPO_TAG} \


### PR DESCRIPTION
<sup>
CI (internal): [#56270454](http://tritonserver.local/ci/pipelines/56270454)<br/>
</sup>

#### What does the PR do?
Routes the Java client/SDK Maven build through NVIDIA Artifactory's `maven-central-remote` as the primary mirror, with Maven Central as a fallback. Delivery is via the GitLab CI/CD file-type variable `MAVEN_SETTINGS_FILE`, mounted into the build with BuildKit `--mount=type=secret`. Because the mount uses `required=false`, builds invoked without the secret (local dev, external/OSS contributors) keep working — Maven simply falls back to `repo1.maven.org`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- The companion GitLab MR that wires the secret through the CI templates is tracked in Linear (TRI-1452). -->

#### Where should the reviewer start?
- `Dockerfile.sdk` — the two `RUN` steps that invoke Maven (via `cmake --target java-clients` and `install_dependencies_and_build.sh`) now mount the `maven_settings` BuildKit secret to `/root/.m2/settings.xml` with `required=false`. Maven discovers `~/.m2/settings.xml` automatically; no changes to client `pom.xml` or to `install_dependencies_and_build.sh` are needed.

#### Test plan:
1. With the GitLab file-type variable `MAVEN_SETTINGS_FILE` set (Artifactory mirror + creds + MC fallback profile), trigger a `py3-sdk` build. Confirm build logs resolve dependencies from `artifactory.nvidia.com/artifactory/maven-central-remote/...` rather than `repo1.maven.org/...`.
2. Local sanity build without the secret: `DOCKER_BUILDKIT=1 docker build -f Dockerfile.sdk --target sdk_build .` — completes successfully (fallback path).
3. `docker history --no-trunc <image> | grep -i 'nvidia-artifactory\|password'` — should print no credential content (secret is per-RUN, never persisted to a layer).

- CI Pipeline ID: 56270454

#### Caveats:
This change alone is harmless when no `--secret id=maven_settings,...` is provided. The actual routing through Artifactory only takes effect once the companion GitLab CI templates pass the file in.

#### Background
The Java client/SDK build currently pulls every Maven dependency directly from `repo1.maven.org`. When Maven Central is rate-limiting or unreachable from the build runner, the `py3-sdk` image build fails. Mirroring through NVIDIA Artifactory removes that single point of failure for internal CI without breaking external contributor builds.

#### Related Issues:
- Resolves: TRI-1452