### PR TITLE
build: switch SDK Maven build to MAVEN_ARGS (Maven 3.9.9)

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -131,12 +131,12 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
           -DTRITON_ENABLE_EXAMPLES=ON -DTRITON_ENABLE_TESTS=ON \
           -DTRITON_ENABLE_GPU=${TRITON_ENABLE_GPU} /workspace/client
 RUN --mount=type=secret,id=maven_settings,target=/run/secrets/maven_settings,required=false \
-    if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="-s /run/secrets/maven_settings"; fi && \
+    if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="--settings /run/secrets/maven_settings"; fi && \
     cmake --build . -v --parallel --target cc-clients java-clients python-clients
 
 # Install Java API Bindings
 RUN --mount=type=secret,id=maven_settings,target=/run/secrets/maven_settings,required=false \
-    if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="-s /run/secrets/maven_settings"; fi && \
+    if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="--settings /run/secrets/maven_settings"; fi && \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         source /workspace/client/src/java-api-bindings/scripts/install_dependencies_and_build.sh \
         --maven-version ${JAVA_BINDINGS_MAVEN_VERSION} \

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -38,7 +38,7 @@ ARG TRITON_CORE_REPO_TAG=main
 ARG TRITON_CLIENT_REPO_TAG=main
 ARG TRITON_THIRD_PARTY_REPO_TAG=main
 ARG TRITON_ENABLE_GPU=ON
-ARG JAVA_BINDINGS_MAVEN_VERSION=3.8.4
+ARG JAVA_BINDINGS_MAVEN_VERSION=3.9.9
 ARG JAVA_BINDINGS_JAVACPP_PRESETS_TAG=1.5.8
 # DCGM version to install for Model Analyzer
 ARG DCGM_VERSION=4.5.3-1
@@ -71,7 +71,6 @@ RUN apt-get update && \
             libopencv-dev \
             libssl-dev \
             libtool \
-            maven \
             openjdk-11-jdk \
             pkg-config \
             python3 \
@@ -87,6 +86,16 @@ RUN apt-get update && \
     pip3 install --upgrade "grpcio-tools<1.68" cmake==4.0.3 auditwheel
 
 ENV CMAKE_POLICY_MINIMUM_REQUIRED=3.5
+
+# Install Maven 3.9+ manually -- the distro-provided maven is too old to
+# honor the MAVEN_ARGS environment variable (added in Maven 3.9.0, MNG-7038).
+ARG JAVA_BINDINGS_MAVEN_VERSION
+RUN wget -nv -O /tmp/maven.tar.gz \
+        https://archive.apache.org/dist/maven/maven-3/${JAVA_BINDINGS_MAVEN_VERSION}/binaries/apache-maven-${JAVA_BINDINGS_MAVEN_VERSION}-bin.tar.gz && \
+    tar -xzf /tmp/maven.tar.gz -C /opt && \
+    ln -s /opt/apache-maven-${JAVA_BINDINGS_MAVEN_VERSION} /opt/maven && \
+    rm /tmp/maven.tar.gz
+ENV PATH="/opt/maven/bin:${PATH}"
 
 # Build expects "python" executable (not python3).
 RUN rm -f /usr/bin/python && \
@@ -121,11 +130,13 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
           -DTRITON_ENABLE_JAVA_HTTP=ON \
           -DTRITON_ENABLE_EXAMPLES=ON -DTRITON_ENABLE_TESTS=ON \
           -DTRITON_ENABLE_GPU=${TRITON_ENABLE_GPU} /workspace/client
-RUN --mount=type=secret,id=maven_settings,target=/root/.m2/settings.xml,required=false \
+RUN --mount=type=secret,id=maven_settings,target=/run/secrets/maven_settings,required=false \
+    if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="-s /run/secrets/maven_settings"; fi && \
     cmake --build . -v --parallel --target cc-clients java-clients python-clients
 
 # Install Java API Bindings
-RUN --mount=type=secret,id=maven_settings,target=/root/.m2/settings.xml,required=false \
+RUN --mount=type=secret,id=maven_settings,target=/run/secrets/maven_settings,required=false \
+    if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="-s /run/secrets/maven_settings"; fi && \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         source /workspace/client/src/java-api-bindings/scripts/install_dependencies_and_build.sh \
         --maven-version ${JAVA_BINDINGS_MAVEN_VERSION} \


### PR DESCRIPTION
<sup>
CI (internal): [#56289017](http://tritonserver.local/ci/pipelines/56289017)<br/>
</sup>

#### What does the PR do?
Follow-up to #8863. Switches the SDK Maven build from auto-discovered `~/.m2/settings.xml` to the explicit `MAVEN_ARGS="--settings /run/secrets/maven_settings"` mechanism, and bumps the default `JAVA_BINDINGS_MAVEN_VERSION` to 3.9.9 (the distro-provided Maven is too old: `MAVEN_ARGS` support was added in Maven 3.9.0, MNG-7038). Maven 3.9.9 is now installed manually into `/opt/maven` and prepended to PATH.

The mount target is moved to `/run/secrets/maven_settings`; `MAVEN_ARGS` is only set when the secret is actually present, so the no-secret fallback to Maven Central is preserved for local / external-contributor builds.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- The companion GitLab MR for the RHEL Dockerfile is tracked in Linear (TRI-1452). The original GitHub PR #8863 has already merged. -->

#### Where should the reviewer start?
- `Dockerfile.sdk` — three things to confirm:
  1. The manual Maven 3.9.9 install (lines ~90-98) overrides any distro maven via PATH prepend.
  2. Both `mvn`-triggering RUN steps now mount the secret at `/run/secrets/maven_settings` and conditionally export `MAVEN_ARGS` only when the file exists.
  3. The runtime stage (line ~175) still installs `apt maven` for end-user SDK use — intentional, not touched.

#### Test plan:
1. CI path: trigger the `py3-sdk` job with `MAVEN_SETTINGS_FILE` set as a GitLab file-type variable; confirm Maven resolves dependencies from `artifactory.nvidia.com/.../maven-central-remote/`.
2. Local sanity: `DOCKER_BUILDKIT=1 docker build -f Dockerfile.sdk --target sdk_build .` — no `--secret` flag; build succeeds via Maven Central (fallback).
3. Layer-leak check: `docker history --no-trunc <image> | grep -i 'nvidia-artifactory\|password'` — should be empty (BuildKit secrets are per-RUN).

- CI Pipeline ID: 56289017

#### Caveats:
The previous PR #8863 mounted to `/root/.m2/settings.xml` (auto-discovery). This PR moves to `/run/secrets/maven_settings` + `MAVEN_ARGS`, which is cleaner (doesn't shadow `~/.m2`) and explicit. Requires Maven ≥ 3.9.0, which is why we install it manually.

#### Background
Follow-up to #8863 per reviewer feedback / discussion in TRI-1452. The original auto-discovery approach worked but conflated implicit Maven configuration with our explicit injection — switching to `MAVEN_ARGS` makes the wiring obvious in the Dockerfile.

#### Related Issues:
- Resolves: TRI-1452