### PR TITLE
docs: Update container copyright banner year to 2026

### DIFF
--- a/docker/entrypoint.d/15-container-copyright.txt
+++ b/docker/entrypoint.d/15-container-copyright.txt
@@ -1,2 +1,2 @@
 
-Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+Copyright (c) 2018-2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.


### PR DESCRIPTION
#### What does the PR do?
Updates the container startup copyright banner (`docker/entrypoint.d/15-container-copyright.txt`) year range from `2018-2025` to `2018-2026` so the banner printed at container start reflects the current year.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
N/A

#### Where should the reviewer start?
`docker/entrypoint.d/15-container-copyright.txt` — single-line year bump.

#### Test plan:
Cosmetic banner text only; no functional code path is affected. Verified the entrypoint (`docker/cpu_only/nvidia_entrypoint.sh`) simply `cat`s this file at startup, so the only change is the displayed year range.

- CI Pipeline ID:

#### Caveats:
None.

#### Background
The startup banner still advertised `2018-2025` after the calendar rolled into 2026.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A