### PR TITLE
build: bump upstream container to 26.06 and ONNX Runtime to 1.27.0

### DIFF
--- a/build.py
+++ b/build.py
@@ -74,8 +74,8 @@ import requests
 DEFAULT_TRITON_VERSION_MAP = {
     "release_version": "2.71.0dev",
     "triton_container_version": "26.07dev",
-    "upstream_container_version": "26.05",
-    "ort_version": "1.26.0",
+    "upstream_container_version": "26.06",
+    "ort_version": "1.27.0",
     "ort_openvino_version": "2026.2.0",
     "standalone_openvino_version": "2026.2.0",
     "dcgm_version": "4.5.3-1",

--- a/build.py
+++ b/build.py
@@ -75,7 +75,7 @@ DEFAULT_TRITON_VERSION_MAP = {
     "release_version": "2.71.0dev",
     "triton_container_version": "26.07dev",
     "upstream_container_version": "26.05",
-    "ort_version": "1.24.4",
+    "ort_version": "1.26.0",
     "ort_openvino_version": "2026.2.0",
     "standalone_openvino_version": "2026.2.0",
     "dcgm_version": "4.5.3-1",


### PR DESCRIPTION
#### What does the PR do?
Bumps the default Triton version map for the Vera Rubin (R100 / R200) build train:
`upstream_container_version` `26.05` → `26.06` and `ort_version` `1.24.4` → `1.27.0`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [ ] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added succinct git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
triton-inference-server/onnxruntime_backend#347

#### Where should the reviewer start?
`build.py` — `DEFAULT_TRITON_VERSION_MAP`.

#### Test plan:
Rubin build pipeline on the internal GitLab mirror builds the `py3` image set with the
bumped upstream / ORT versions.

- CI Pipeline ID: 56420653

#### Caveats:
Version-map bump only; no source or behavior change.

#### Background
Part of Vera Rubin (R100 / R200) CI enablement — aligns the build train with the 26.06
upstream and ONNX Runtime 1.27.0 used by the rubin images.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to TRI-1167
