### PR TITLE
docs: Warn operators to bound grpc-max-response-pool-size

### DIFF
--- a/docs/customization_guide/deploy.md
+++ b/docs/customization_guide/deploy.md
@@ -293,7 +293,11 @@ Specifies the maximum number of states (inference request/response queues) that 
 Specifies the maximum number of inference response objects that can remain allocated in each response queue at any given time. This option is particularly useful in decoupled mode, where multiple responses are generated for a single request. By default, this value is set to `INT_MAX`.
 
 > [!Warning]
+> Operators exposing decoupled gRPC streaming to untrusted clients should
+> explicitly configure `--grpc-max-response-pool-size` to a bounded value
+> appropriate for their workload, rather than relying on the default
+> `INT_MAX`. Choose a value based on model behavior (decoupled vs
+> non-decoupled), expected concurrency, and available memory.
+
+> [!Warning]
 > Setting this value too low may negatively impact performance.
-
-
-


### PR DESCRIPTION
#### What does the PR do?
Adds a deployment warning under `--grpc-max-response-pool-size` in the secure deployment guide. Operators exposing decoupled gRPC streaming to untrusted clients should set an explicit bounded value for this option instead of relying on the default `INT_MAX`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
N/A

#### Where should the reviewer start?
`docs/customization_guide/deploy.md` — the new warning under `--grpc-max-response-pool-size`.

#### Test plan:
- Documentation-only change; no runtime tests required.
- Verified the added warning text matches the agreed deployment guidance.

- CI Pipeline ID:
N/A

#### Caveats:
None.

#### Background
External security researchers asked which deployment guideline documents the intended mitigation for unbounded decoupled gRPC response queue growth. This documents the recommended operator action for that scenario.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A