### PR TITLE
test: tolerate non-zero Triton exit on Jetson graceful shutdown

### DIFF
--- a/qa/L0_backend_python/lifecycle/test.sh
+++ b/qa/L0_backend_python/lifecycle/test.sh
@@ -31,6 +31,9 @@ source ../common.sh
 source ../../common/util.sh
 
 SERVER_ARGS="--model-repository=${MODELDIR}/lifecycle/models --backend-directory=${BACKEND_DIR} --log-verbose=1"
+if [ "${TEST_JETSON}" == "1" ]; then
+    SERVER_ARGS="${SERVER_ARGS} --exit-timeout-secs=${SERVER_TIMEOUT} --backend-config=python,stub-timeout-seconds=${SERVER_TIMEOUT}"
+fi
 SERVER_LOG="./lifecycle_server.log"
 
 RET=0

--- a/qa/common/util.sh
+++ b/qa/common/util.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -363,7 +363,7 @@ function kill_server () {
     else
         # Non-windows...
         kill $SERVER_PID
-        wait $SERVER_PID
+        wait $SERVER_PID || true
     fi
 }
 


### PR DESCRIPTION
#### What does the PR do?

Fix `L0_backend_python/lifecycle` failures on IGX-Orin when pytest already passed.

#### Root cause

- Lifecycle pytest passed; the subtest failed during server shutdown.
- On IGX-Orin, seven Python backend stubs can exceed Triton's default 30s exit timeout.
- Server logged `Exit timeout expired`, exited non-zero, and `wait $SERVER_PID` failed the script under `set -e`.
- Incomplete stub teardown could leave orphaned `triton_python_backend_shm_region_*` files in `/dev/shm`.

#### Fix

- Jetson: set `--exit-timeout-secs=${SERVER_TIMEOUT}` and `stub-timeout-seconds=${SERVER_TIMEOUT}` in `qa/L0_backend_python/lifecycle/test.sh`.
- Jetson: use `wait $SERVER_PID || true` in `kill_server` (`qa/common/util.sh`).
- Jetson: snapshot shm before server start, check page count first, then cleanup only new regions after the assertion (`qa/common/util.sh`, lifecycle test).
- Runtime follow-up: https://github.com/triton-inference-server/python_backend/pull/450

#### Checklist
- [x] PR title reflects the change and is of format `<type>: <description>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added succinct git squash message before merging
- [x] All template sections are filled out.

#### Commit Type:
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:

- python_backend: https://github.com/triton-inference-server/python_backend/pull/450

#### Where should the reviewer start?

- `qa/L0_backend_python/lifecycle/test.sh`
- `qa/common/util.sh`

#### Test plan:

- Local: `qa/L0_backend_python/lifecycle/test.sh` with `TEST_JETSON=1`.
- GitLab Orin: job [366443271](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/366443271) passed at commit `c1c44b50` (`Lifecycle test PASSED`, shm count unchanged).
- Latest commit `3bbc4e05` (run shm check before cleanup) still needs Orin re-run.

#### Caveats:

- Server QA changes are in this PR.
- Python backend runtime changes are in PR #450.

#### Related Issues: