### PR TITLE
fix: Enable OpenVINO model generation for SBSA

### DIFF
--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -470,30 +470,28 @@ if [ "$TRITON_MODELS_USE_DOCKER" -eq 1 ] && which docker ; then
     log_message.status "docker container: copy script to container"
     docker cp . $DOCKER_VOLUME_CONTAINER:/mnt/$CI_JOB_ID/gen_srcdir
 
-    if [[ "aarch64" != $(uname -m) ]] ; then
 
-        log_message.status "docker run: $OPENVINOSCRIPT"
-        log_message.info "docker run $DOCKER_GPU_ARGS -v $DOCKER_VOLUME:/mnt $UBUNTU_IMAGE bash -e $TRITON_MDLS_SRC_DIR/$OPENVINOSCRIPT"
-        docker run \
-            --rm \
-            -e TRITON_GENSRCDIR=$TRITON_MDLS_SRC_DIR \
-            --label RUNNER_ID=$RUNNER_ID \
-            --label PROJECT_NAME=$PROJECT_NAME \
-            $DOCKER_GPU_ARGS \
-            -v $DOCKER_VOLUME:/mnt \
-            -t \
-            $UBUNTU_IMAGE \
-            bash -e $TRITON_MDLS_SRC_DIR/$OPENVINOSCRIPT
+    log_message.status "docker run: $OPENVINOSCRIPT"
+    log_message.info "docker run $DOCKER_GPU_ARGS -v $DOCKER_VOLUME:/mnt $UBUNTU_IMAGE bash -e $TRITON_MDLS_SRC_DIR/$OPENVINOSCRIPT"
+    docker run \
+        --rm \
+        -e TRITON_GENSRCDIR=$TRITON_MDLS_SRC_DIR \
+        --label RUNNER_ID=$RUNNER_ID \
+        --label PROJECT_NAME=$PROJECT_NAME \
+        $DOCKER_GPU_ARGS \
+        -v $DOCKER_VOLUME:/mnt \
+        -t \
+        $UBUNTU_IMAGE \
+        bash -e $TRITON_MDLS_SRC_DIR/$OPENVINOSCRIPT
 
-        exit_code=$?
+    exit_code=$?
 
-        if [ $exit_code -ne 0 ]; then
-            log_message.error "docker run: ${OPENVINOSCRIPT} failed"
-            exit 1
-        fi
+    if [ $exit_code -ne 0 ]; then
+        log_message.error "docker run: ${OPENVINOSCRIPT} failed"
+        exit 1
+    fi
 
-        rm $OPENVINOSCRIPT
-    fi # [[ "aarch64" != $(uname -m) ]]
+    rm $OPENVINOSCRIPT
 
     log_message.status "docker run: $ONNXSCRIPT"
     log_message.info "docker run $DOCKER_GPU_ARGS -v $DOCKER_VOLUME:/mnt $UBUNTU_IMAGE bash -e $TRITON_MDLS_SRC_DIR/$ONNXSCRIPT"


### PR DESCRIPTION
<sup>
CI (internal): [#57889355](http://tritonserver.local/ci/pipelines/57889355)<br/>
</sup>

#### What does the PR do?

Remove the `[[ "aarch64" != $(uname -m) ]]` guard around the OpenVINO model generation step in `qa/common/gen_qa_model_repository`. OpenVINO now supports aarch64 (SBSA) targets, so the QA model repository can generate OpenVINO test models on SBSA runners the same way it does on x86 — closing a gap that caused downstream CI failures (empty `openvino/*` directories → `tar: Cowardly refusing to create an empty archive` in the per-framework upload loop, e.g. `GenModels-build--sbsa-dgx_spark-12.1` job 360691523).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
_(none — this change is contained in `server`)_

#### Where should the reviewer start?

`qa/common/gen_qa_model_repository:470-497` — the `[[ "aarch64" != $(uname -m) ]]` conditional wrapping the OpenVINO docker run, its error handling, and the cleanup of `$OPENVINOSCRIPT` is removed. Every line inside the removed conditional is unindented back to the parent scope; no other logic changes. Diff is `+18/-20` on a single file.

#### Test plan:

- Trigger a full `GenModels-build` matrix run and confirm OpenVINO models are produced on SBSA runners: `GenModels-build--sbsa-a100-8.0`, `GenModels-build--sbsa-agx_thor-11.0`, `GenModels-build--sbsa-dgx_spark-12.1`, `GenModels-build--sbsa-h100-9.0`, `GenModels-build--sbsa-gb300-10.3`, `GenModels-build--sbsa-rubin-10.7`, `GenModels-build--sbsa-gb200-10.0`.
- Inspect SBSA build output (`ls -d */openvino_*`) to confirm openvino model directories now exist.
- Confirm the downstream per-framework upload loop no longer errors on `tar -cvf openvino.tar $(find …)` on SBSA — the previous silent-skip / hard-fail path in job 360691523 must be gone.
- Verify no regression on x86 jobs (`GenModels-build--x86-a100-8.0`, `GenModels-build--x86-rtx50-12.0`, `GenModels-build--x86-rubin-10.7`) — the OpenVINO generation path is unchanged for x86, just no longer gated.

- CI Pipeline ID: 57889355

#### Caveats:

Assumes the base `$UBUNTU_IMAGE` used inside the OpenVINO generation step provides an OpenVINO runtime with aarch64 support. If any specific SBSA runner still resolves to an older OpenVINO that lacks ARM support, this will now surface as a real failure inside `$OPENVINOSCRIPT` rather than the previous silent skip — visible failure is preferable, but worth calling out in case one of the runner images needs a bump.

#### Background

The prior guard was written when OpenVINO had no aarch64 support and the check avoided a hard failure on SBSA runners. OpenVINO gained ARM support (2024+) and the Triton OpenVINO backend now publishes aarch64 artifacts, so the guard is no longer needed. Keeping it caused SBSA CI to attempt to publish an `openvino.tar` with zero contents, which GNU `tar` refuses with `Cowardly refusing to create an empty archive`, failing `GenModels-build--sbsa-*` end-to-end. Full analysis in TRI-1105.

#### Related Issues:
- Resolves: TRI-1105
