### PR TITLE
test: point Dynamo L0_infer worker at components triton path

### DIFF
--- a/qa/common/dynamo_util.sh
+++ b/qa/common/dynamo_util.sh
@@ -34,7 +34,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
 SERVER_LAUNCH_MODE=${SERVER_LAUNCH_MODE:=dynamo}
 DYN_FRONTEND_LOG=${DYN_FRONTEND_LOG:=./frontend.log}
 DYN_FRONTEND_ARGS=${DYN_FRONTEND_ARGS:="--kserve-grpc-server"}
-DYN_WORKER_PY=${DYN_WORKER_PY:=/workspace/examples/backends/tritonserver/src/tritonworker.py}
+DYN_WORKER_PY=${DYN_WORKER_PY:=/workspace/components/src/dynamo/triton/tritonworker.py}
 DYN_WORKER_ARGS=${DYN_WORKER_ARGS:=""}
 DYN_DISCOVERY_BACKEND=${DYN_DISCOVERY_BACKEND:=file}
 # The Dynamo frontend binds KServe gRPC to --http-port; serve it on 8001.


### PR DESCRIPTION
#### What does the PR do?
Updates the default `DYN_WORKER_PY` in `qa/common/dynamo_util.sh` to the path used after the Triton MVP moved from `examples/backends/tritonserver` to `components/src/dynamo/triton`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [ ] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging
- [x] All template sections are filled out.

#### Commit Type:
- [x] test

#### Related PRs:
- https://github.com/triton-inference-server/dynamo/pull/12