### PR TITLE
[r26.07] maintenance: Update `grpcio` Dependencies (#8765)

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -352,8 +352,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN rm -f /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
-RUN pip3 install --upgrade "numpy<2" pillow attrdict future "grpcio<1.68" requests gsutil \
-                           "awscli<=1.36.40" six "grpcio-channelz<1.68" prettytable virtualenv \
+RUN pip3 install --upgrade "numpy<2" pillow attrdict future "grpcio>=1.81.1" requests gsutil \
+                           "awscli<=1.36.40" six grpcio-channelz prettytable virtualenv \
                            check-jsonschema
 
 # go needed for example go client test.

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -83,7 +83,7 @@ RUN apt-get update && \
             software-properties-common \
             vim \
             wget && \
-    pip3 install --upgrade "grpcio-tools<1.68" cmake==4.0.3 auditwheel
+    pip3 install --upgrade grpcio-tools cmake==4.0.3 auditwheel
 
 ENV CMAKE_POLICY_MINIMUM_REQUIRED=3.5
 
@@ -182,7 +182,7 @@ RUN apt-get update && \
             python3-wheel \
             vim \
             wget && \
-    pip3 install "grpcio<1.68" "grpcio-tools<1.68" && \
+    pip3 install "grpcio>=1.81.1" grpcio-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*;
 


### PR DESCRIPTION
#### What does the PR do?
Cherry-pick of #8765 onto `r26.07` — maintenance: Update `grpcio` Dependencies. Backport of the coordinated `grpcio` dependency update. Clean cherry-pick, no conflicts.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field (`cherry-pick`)
- [x] Verified copyright is correct on all changed files.
- [x] All template sections are filled out.

#### Commit Type:
Cherry-pick — preserves the original commit type from #8765.

#### Related PRs:
- triton-inference-server/client#907
- triton-inference-server/model_analyzer#1031
- triton-inference-server/third_party#78
- triton-inference-server/python_backend#448

#### Where should the reviewer start?
Changed file(s): `Dockerfile.QA`, `Dockerfile.sdk`. This is a direct cherry-pick of the already-reviewed #8765; the diff is identical.

#### Test plan:
Verified via existing CI on `r26.07`.
- CI Pipeline ID: N/A (clean cherry-pick of #8765)

#### Caveats:
None — clean cherry-pick, no conflicts.

#### Background
Backporting the `main` `grpcio` dependency update to the `r26.07` release branch.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: TRI-836
