### PR TITLE
test: fix L0_lifecycle test_shutdown_dynamic exit timeout

### DIFF
--- a/qa/L0_lifecycle/test.sh
+++ b/qa/L0_lifecycle/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -1563,7 +1563,7 @@ cp -r ../custom_models/custom_zero_1_float32 models/. && \
         echo "{ key: \"execute_delay_ms\"; value: { string_value: \"5000\" }}" >> config.pbtxt && \
         echo "]" >> config.pbtxt)
 
-SERVER_ARGS="--model-repository=`pwd`/models --log-verbose=1"
+SERVER_ARGS="--model-repository=`pwd`/models --log-verbose=1 --exit-timeout-secs=${SERVER_TIMEOUT}"
 SERVER_LOG="./inference_server_$LOG_IDX.log"
 run_server
 if [ "$SERVER_PID" == "0" ]; then
@@ -1585,7 +1585,7 @@ if [ `grep -c "Found 1 gRPC service connections and inference handlers" $SERVER_
 fi
 
 kill $SERVER_PID || true
-wait $SERVER_PID
+wait $SERVER_PID || true
 
 rm -f $CLIENT_LOG
 


### PR DESCRIPTION
#### What does the PR do?

Fix `L0_lifecycle` failures on Luna where `LifeCycleTest.test_shutdown_dynamic` passes pytest but the QA script aborts during server cleanup.

#### Root cause

- `test_shutdown_dynamic` starts the server without `--exit-timeout-secs`, so Triton uses the default 30s shutdown window.
- The test sends 6 async inferences with `execute_delay_ms=5000`, then SIGINT while they are in flight; draining can exceed 30s on Luna (~80% failure rate).
- The server logs `Exit timeout expired` and exits non-zero; `wait $SERVER_PID` under `set -e` aborts the rest of `L0_lifecycle` (silent failure in the main log).

#### Fix

- `qa/L0_lifecycle/test.sh`:
  - Set `--exit-timeout-secs=${SERVER_TIMEOUT}` (120s) for the `test_shutdown_dynamic` server launch so draining has room to complete.
  - Use `wait $SERVER_PID || true` after cleanup so a non-zero server exit does not abort the suite.

Previous revisions of this branch also touched `qa/L0_lifecycle/lifecycle_test.py` (gRPC error-string assertions and pre-existing flake8 lints). Those changes are redundant with #8888, which landed on main after this PR was opened, so this PR now carries only the `test.sh` fix.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.

#### Commit Type:
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:

- #8888 (aligned gRPC error-string assertions in `lifecycle_test.py` for gRPC v1.81.1)

#### Where should the reviewer start?

- `qa/L0_lifecycle/test.sh` — `test_shutdown_dynamic` server args (`--exit-timeout-secs`) and cleanup `wait`.

#### Test plan:

- GitLab Luna: `L0_lifecycle--base` green at commit `721e9c07` (job [368596258](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/368596258), pipeline [58809167](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/pipelines/58809167)); log shows `test_shutdown_dynamic` ran and `*** Test Passed ***`.
- Earlier Luna runs on same pipeline: `d41ea55` failed on `(111)` assertion mismatch (job [368365178](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/368365178)); `8ba9e9fb` and `38c233da` also green.
- CI used `TRITON_SERVER_BRANCH_NAME=vinyak/nvbug-6450088-l0-lifecycle-shutdown-timeout` and `TRITON_THIRD_PARTY_REPO_TAG=4d8c8cec` to work around a transient `master` py3 build break (gRPC patch); that pin is CI-only, not part of this PR.
- CI Pipeline ID: 58809167

#### Caveats:

- Targeted Luna pipeline pinned `third_party` for CI verification only; `main` py3 builds were failing independently (gRPC `CMakeLists.txt` patch mismatch).
- After #8888 landed on main, this PR was rebased and force-pushed; the earlier Luna verification runs remain valid because the `test.sh` fix is unchanged.

#### Background

- Linear TRI-1580 / NVBUG 6450088 / DLIS-8700
- Same shutdown-timeout family as Jetson lifecycle work (TRI-1330), but a different test (`L0_lifecycle`) and platform (Luna x86).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to NVBUG 6450088