### PR TITLE
docs: Add HSTU guide to Getting Started toc

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -40,6 +40,7 @@
    LLM With TensorRT-LLM <getting_started/trtllm_user_guide.md>
    Multimodal model <../tutorials/Popular_Models_Guide/Llava1.5/llava_trtllm_guide.md>
    Stable diffusion <../tutorials/Popular_Models_Guide/StableDiffusion/README.md>
+   HSTU (Generative Recommenders) <../tutorials/Popular_Models_Guide/HSTU/README.md>
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
#### What does the PR do?
Adds a Getting Started table-of-contents entry for Hierarchical Sequential Transduction Units (HSTU) / Generative Recommenders, linking to the tutorials HSTU guide (Torch AOTI serving path with pointers to recsys-examples).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
Part of the HSTU documentation set (suggested merge order: tutorials → pytorch_backend → server):
- tutorials: HSTU Popular Models guide — https://github.com/triton-inference-server/tutorials/pull/159 (land first so the toc link resolves)
- pytorch_backend: AOTI see-also link to the HSTU guide — https://github.com/triton-inference-server/pytorch_backend/pull/201

#### Where should the reviewer start?
- `docs/contents.rst` (Getting Started toctree entry)

#### Test plan:
- Confirm the new toc entry points at `../tutorials/Popular_Models_Guide/HSTU/README.md`
- After the tutorials HSTU guide PR merges, verify the docs site Getting Started section lists **HSTU (Generative Recommenders)** and the link resolves

- CI Pipeline ID:
N/A (docs-only toc change)

#### Caveats:
- The linked tutorials page must exist (or be merged) for the published docs link to resolve. Prefer merging the tutorials guide before or with this PR.

#### Background
Triton can serve HSTU generative recommender models via the PyTorch backend (`platform: "torch_aoti"`). This toc entry surfaces that path next to other popular-model Getting Started links.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to accompanying tutorials (#159) and pytorch_backend (#201) documentation PRs for HSTU / Torch AOTI
