### PR TITLE
docs: Update compatibility md

### DIFF
--- a/docs/introduction/compatibility.md
+++ b/docs/introduction/compatibility.md
@@ -38,6 +38,7 @@
 
 | Triton release version	 | NGC Tag	 | Python version	 | Torch version | TensorRT version | TensorRT-LLM version | CUDA version | CUDA Driver version | Size |
 | --- | ---  | --- | --- | --- | --- | --- | --- | --- |
+| 26.07 | nvcr.io/nvidia/tritonserver:26.07-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.20 GB |
 | 26.06 | nvcr.io/nvidia/tritonserver:26.06-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.24 GB |
 | 26.05 | nvcr.io/nvidia/tritonserver:26.05-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.22 GB |
 | 26.04 | nvcr.io/nvidia/tritonserver:26.04-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.22 GB |
@@ -70,6 +71,7 @@
 
 | Triton release version	 | NGC Tag	 | Python version	 | vLLM version | CUDA version | CUDA Driver version | Size |
 | --- | --- | --- | --- | --- | --- | --- |
+| 26.07 | nvcr.io/nvidia/tritonserver:26.07-vllm-python-py3 | Python 3.12.3  | 0.24.0+092c4842.nv26.7.57386851| 13.3.0.035 | 610.43.02 | 10.28 GB |
 | 26.06 | nvcr.io/nvidia/tritonserver:26.06-vllm-python-py3 | Python 3.12.3  | 0.22.1+7b9cb5b7.nv26.6.55098374 | 13.3.0.035 | 610.43.02 | 10.21 GB |
 | 26.05 | nvcr.io/nvidia/tritonserver:26.05-vllm-python-py3 | Python 3.12.3  | 0.19.0+6bc3197f.nv26.04.48761268 | 13.2.1.009 | 595.58.03 | 9.3G |
 | 26.04 | nvcr.io/nvidia/tritonserver:26.04-vllm-python-py3 | Python 3.12.3  | 0.19.0+6bc3197f.nv26.04.48761268 | 13.2.1.009 | 595.58.03 | 9.09G |
@@ -102,6 +104,7 @@
 
 | Triton release version	 | ONNX Runtime	 |
 | --- | --- |
+| 26.07 | 1.27.0 |
 | 26.06 | 1.24.4 |
 | 26.05 | 1.24.4 |
 | 26.04 | 1.24.4 |


### PR DESCRIPTION
#### What does the PR do?
Adds the `26.07` release row to the compatibility matrix in `docs/introduction/compatibility.md`, indexed by container train `26.07`. Rows added to all three tables:

- **trtllm-python-py3:** Python 3.12.3, Torch 2.10.0a0+b4e4ee81d3.nv25.12, TensorRT 10.14.1.48, TensorRT-LLM 1.2.1, CUDA 13.1.0.036, CUDA Driver 590.44.01, Size 14.20 GB
- **vllm-python-py3:** Python 3.12.3, vLLM 0.24.0+092c4842.nv26.7.57386851, CUDA 13.3.0.035, CUDA Driver 610.43.02, Size 10.28 GB
- **ONNX Runtime:** 1.27.0

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes. <!-- documentation-only; see Test plan -->
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
N/A — single-repo documentation change.

#### Where should the reviewer start?
`docs/introduction/compatibility.md` — three new `26.07` rows (trtllm-python-py3, vllm-python-py3, and ONNX Runtime tables). Confirm the version and size values against the published 26.07 NGC containers.

#### Test plan:
Documentation-only change; no automated tests apply. Verify the rendered markdown tables and that each `26.07` value matches the built/published 26.07 containers. Version fields cross-checked against `build.py` for the `r26.07` train: `ort_version` = 1.27.0, `release_version` = 2.71.0, `rhel_py_version` = 3.12.3; TensorRT-LLM = 1.2.1 (`TENSORRTLLM_VER`).

- CI Pipeline ID: N/A (documentation-only; no pipeline triggered)

#### Caveats:
The container `Size` column reflects the NGC-published (compressed) download sizes for the `26.07-trtllm-python-py3` and `26.07-vllm-python-py3` images — re-confirm against the NGC catalog once the containers are publicly published.

#### Background
Release checklist step "Before NGC Release — Update Compatibility.md" for the 26.07 train. See the release runbook: https://nvidia.atlassian.net/wiki/spaces/DL/pages/2822886305/#Update-Compatibility.md

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1597
