### PR TITLE
docs: clean README main-branch references for r26.07

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Major features include:
 - Provides [Backend API](https://github.com/triton-inference-server/backend) that
   allows adding custom backends and pre/post processing operations
 - Supports writing custom backends in python, a.k.a.
-  [Python-based backends.](https://github.com/triton-inference-server/backend/blob/main/docs/python_based_backends.md#python-based-backends)
+  [Python-based backends.](https://github.com/triton-inference-server/backend/blob/r26.07/docs/python_based_backends.md#python-based-backends)
 - Model pipelines using
   [Ensembling](docs/user_guide/architecture.md#ensemble-models) or [Business
   Logic Scripting
@@ -166,10 +166,10 @@ configuration](docs/user_guide/model_configuration.md) for the model.
   [Python](https://github.com/triton-inference-server/python_backend), and more
 - Not all the above backends are supported on every platform supported by Triton.
   Look at the
-  [Backend-Platform Support Matrix](https://github.com/triton-inference-server/backend/blob/main/docs/backend_platform_support_matrix.md)
+  [Backend-Platform Support Matrix](https://github.com/triton-inference-server/backend/blob/r26.07/docs/backend_platform_support_matrix.md)
   to learn which backends are supported on your target platform.
 - Learn how to [optimize performance](docs/user_guide/optimization.md) using the
-  [Performance Analyzer](https://github.com/triton-inference-server/perf_analyzer/blob/main/README.md)
+  [Performance Analyzer](https://github.com/triton-inference-server/perf_analyzer/blob/r26.07/README.md)
   and
   [Model Analyzer](https://github.com/triton-inference-server/model_analyzer)
 - Learn how to [manage loading and unloading models](docs/user_guide/model_management.md) in
@@ -183,14 +183,14 @@ A Triton *client* application sends inference and other requests to Triton. The
 [Python and C++ client libraries](https://github.com/triton-inference-server/client)
 provide APIs to simplify this communication.
 
-- Review client examples for [C++](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/examples),
-  [Python](https://github.com/triton-inference-server/client/blob/main/src/python/examples),
-  and [Java](https://github.com/triton-inference-server/client/blob/main/src/java/src/main/java/triton/client/examples)
+- Review client examples for [C++](https://github.com/triton-inference-server/client/blob/r26.07/src/c%2B%2B/examples),
+  [Python](https://github.com/triton-inference-server/client/blob/r26.07/src/python/examples),
+  and [Java](https://github.com/triton-inference-server/client/blob/r26.07/src/java/src/main/java/triton/client/examples)
 - Configure [HTTP](https://github.com/triton-inference-server/client#http-options)
   and [gRPC](https://github.com/triton-inference-server/client#grpc-options)
   client options
 - Send input data (e.g. a jpeg image) directly to Triton in the [body of an HTTP
-  request without any additional metadata](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_binary_data.md#raw-binary-request)
+  request without any additional metadata](https://github.com/triton-inference-server/server/blob/r26.07/docs/protocol/extension_binary_data.md#raw-binary-request)
 
 ### Extend Triton
 
@@ -199,7 +199,7 @@ designed for modularity and flexibility
 
 - [Customize Triton Inference Server container](docs/customization_guide/compose.md) for your use case
 - [Create custom backends](https://github.com/triton-inference-server/backend)
-  in either [C/C++](https://github.com/triton-inference-server/backend/blob/main/README.md#triton-backend-api)
+  in either [C/C++](https://github.com/triton-inference-server/backend/blob/r26.07/README.md#triton-backend-api)
   or [Python](https://github.com/triton-inference-server/python_backend)
 - Create [decoupled backends and models](docs/user_guide/decoupled_models.md) that can send
   multiple responses for a request or not send any responses for a request
@@ -208,7 +208,7 @@ designed for modularity and flexibility
   decryption, or conversion
 - Deploy Triton on [Jetson and JetPack](docs/user_guide/jetson.md)
 - [Use Triton on AWS
-   Inferentia](https://github.com/triton-inference-server/python_backend/tree/main/inferentia)
+   Inferentia](https://github.com/triton-inference-server/python_backend/tree/r26.07/inferentia)
 
 ### Additional Documentation
 


### PR DESCRIPTION
## What does the PR do?

Converts the 9 remaining GitHub documentation links in the top-level `README.md` from the `main` branch to the `r26.07` release branch, so that the release-branch README points readers at release-branch docs.

Links updated (`/blob/main/` → `/blob/r26.07/`, `/tree/main/` → `/tree/r26.07/`):
- `backend/docs/python_based_backends.md`
- `backend/docs/backend_platform_support_matrix.md`
- `backend/README.md`
- `perf_analyzer/README.md`
- `client/src/c++/examples`, `src/python/examples`, `src/java/.../examples`
- `server/docs/protocol/extension_binary_data.md`
- `python_backend/inferentia`

All target paths were verified to exist on each repo's `r26.07` branch. The Java source path segment `src/main/java/...` is intentionally left unchanged (it is a source directory, not a branch ref).

## Checklist
- [x] PR title follows Conventional Commits
- [x] Only `README.md` changed
- [x] Links verified against `r26.07` branches

## Related
Linear: TRI-1594 — [Before NGC Release] Update release docs