### PR TITLE
docs: clean README main-branch references for r26.07

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Major features include:
 - Provides [Backend API](https://github.com/triton-inference-server/backend) that
   allows adding custom backends and pre/post processing operations
 - Supports writing custom backends in python, a.k.a.
-  [Python-based backends.](https://github.com/triton-inference-server/backend/blob/main/docs/python_based_backends.md#python-based-backends)
+  [Python-based backends.](https://github.com/triton-inference-server/backend/blob/r26.07/docs/python_based_backends.md#python-based-backends)
 - Model pipelines using
   [Ensembling](docs/user_guide/architecture.md#ensemble-models) or [Business
   Logic Scripting
@@ -166,10 +166,10 @@ configuration](docs/user_guide/model_configuration.md) for the model.
   [Python](https://github.com/triton-inference-server/python_backend), and more
 - Not all the above backends are supported on every platform supported by Triton.
   Look at the
-  [Backend-Platform Support Matrix](https://github.com/triton-inference-server/backend/blob/main/docs/backend_platform_support_matrix.md)
+  [Backend-Platform Support Matrix](https://github.com/triton-inference-server/backend/blob/r26.07/docs/backend_platform_support_matrix.md)
   to learn which backends are supported on your target platform.
 - Learn how to [optimize performance](docs/user_guide/optimization.md) using the
-  [Performance Analyzer](https://github.com/triton-inference-server/perf_analyzer/blob/main/README.md)
+  [Performance Analyzer](https://github.com/triton-inference-server/perf_analyzer/blob/r26.07/README.md)
   and
   [Model Analyzer](https://github.com/triton-inference-server/model_analyzer)
 - Learn how to [manage loading and unloading models](docs/user_guide/model_management.md) in
@@ -183,14 +183,14 @@ A Triton *client* application sends inference and other requests to Triton. The
 [Python and C++ client libraries](https://github.com/triton-inference-server/client)
 provide APIs to simplify this communication.
 
-- Review client examples for [C++](https://github.com/triton-inference-server/client/blob/main/src/c%2B%2B/examples),
-  [Python](https://github.com/triton-inference-server/client/blob/main/src/python/examples),
-  and [Java](https://github.com/triton-inference-server/client/blob/main/src/java/src/main/java/triton/client/examples)
+- Review client examples for [C++](https://github.com/triton-inference-server/client/blob/r26.07/src/c%2B%2B/examples),
+  [Python](https://github.com/triton-inference-server/client/blob/r26.07/src/python/examples),
+  and [Java](https://github.com/triton-inference-server/client/blob/r26.07/src/java/src/main/java/triton/client/examples)
 - Configure [HTTP](https://github.com/triton-inference-server/client#http-options)
   and [gRPC](https://github.com/triton-inference-server/client#grpc-options)
   client options
 - Send input data (e.g. a jpeg image) directly to Triton in the [body of an HTTP
-  request without any additional metadata](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_binary_data.md#raw-binary-request)
+  request without any additional metadata](https://github.com/triton-inference-server/server/blob/r26.07/docs/protocol/extension_binary_data.md#raw-binary-request)
 
 ### Extend Triton
 
@@ -199,7 +199,7 @@ designed for modularity and flexibility
 
 - [Customize Triton Inference Server container](docs/customization_guide/compose.md) for your use case
 - [Create custom backends](https://github.com/triton-inference-server/backend)
-  in either [C/C++](https://github.com/triton-inference-server/backend/blob/main/README.md#triton-backend-api)
+  in either [C/C++](https://github.com/triton-inference-server/backend/blob/r26.07/README.md#triton-backend-api)
   or [Python](https://github.com/triton-inference-server/python_backend)
 - Create [decoupled backends and models](docs/user_guide/decoupled_models.md) that can send
   multiple responses for a request or not send any responses for a request
@@ -208,7 +208,7 @@ designed for modularity and flexibility
   decryption, or conversion
 - Deploy Triton on [Jetson and JetPack](docs/user_guide/jetson.md)
 - [Use Triton on AWS
-   Inferentia](https://github.com/triton-inference-server/python_backend/tree/main/inferentia)
+   Inferentia](https://github.com/triton-inference-server/python_backend/tree/r26.07/inferentia)
 
 ### Additional Documentation
 


### PR DESCRIPTION
#### What does the PR do?
Converts the 9 remaining GitHub documentation links in the top-level `README.md` from the `main` branch to the `r26.07` release branch, so the release-branch README points readers at release-branch docs.

Links updated (`/blob/main/` → `/blob/r26.07/`, `/tree/main/` → `/tree/r26.07/`):
- `backend/docs/python_based_backends.md`
- `backend/docs/backend_platform_support_matrix.md`
- `backend/README.md`
- `perf_analyzer/README.md`
- `client/src/c++/examples`, `src/python/examples`, `src/java/.../examples`
- `server/docs/protocol/extension_binary_data.md`
- `python_backend/inferentia`

All target paths were verified to exist on each repo's `r26.07` branch. The Java source-path segment `src/main/java/...` is intentionally left unchanged (it is a source directory, not a branch ref). The `git clone -b r26.07` line and the `LATEST RELEASE`/`main` disclaimer were already handled at code-freeze.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
None — single-repo change (`server`).

#### Where should the reviewer start?
`README.md` — the 9 documentation links converted from `main` to `r26.07`.

#### Test plan:
Docs-only change; no functional tests. Verify each converted link resolves on GitHub against the `r26.07` branch.

- CI Pipeline ID: N/A (docs-only; no build pipeline)

#### Caveats:
Sibling-repo links (`backend`, `perf_analyzer`, `client`, `python_backend`) are now pinned to `r26.07`. Prior releases (r26.04–r26.06) left these on `main`; pinning them here is intentional per TRI-1594's "clean any remaining `main`-branch references."

#### Background
Part of the "Update release docs" step in the Before-NGC-Release checklist — the release-branch README should not point readers at `main`-branch documentation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1594
