### PR TITLE
test: Launch Dynamo QA worker via python -m dynamo.triton

### DIFF
--- a/qa/common/dynamo_util.sh
+++ b/qa/common/dynamo_util.sh
@@ -34,7 +34,6 @@ source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
 SERVER_LAUNCH_MODE=${SERVER_LAUNCH_MODE:=dynamo}
 DYN_FRONTEND_LOG=${DYN_FRONTEND_LOG:=./frontend.log}
 DYN_FRONTEND_ARGS=${DYN_FRONTEND_ARGS:="--kserve-grpc-server"}
-DYN_WORKER_PY=${DYN_WORKER_PY:=/workspace/components/src/dynamo/triton/tritonworker.py}
 DYN_WORKER_ARGS=${DYN_WORKER_ARGS:=""}
 DYN_DISCOVERY_BACKEND=${DYN_DISCOVERY_BACKEND:=file}
 # The Dynamo frontend binds KServe gRPC to --http-port; serve it on 8001.
@@ -105,8 +104,8 @@ PY
     WAIT_RET=1
 }
 
-# Convert the given standalone tritonserver args (e.g. $SERVER_ARGS) into Triton
-# worker (tritonworker.py) flags on stdout, to auto-populate DYN_WORKER_ARGS.
+# Convert the given standalone tritonserver args (e.g. $SERVER_ARGS) into Dynamo
+# Triton worker flags on stdout, to auto-populate DYN_WORKER_ARGS.
 # Most flags pass through unchanged; the exception is --allow-* endpoint flags
 # (owned by the frontend) which are dropped. Accepts both --flag=value and
 # --flag value forms.
@@ -323,11 +322,6 @@ function run_server () {
         return
     fi
 
-    if [ ! -f "$DYN_WORKER_PY" ]; then
-        echo "=== $DYN_WORKER_PY does not exist"
-        return
-    fi
-
     # start_dynamo_discovery cleans up after itself on failure.
     if ! start_dynamo_discovery; then
         echo "=== Failed to bring up the etcd + NATS discovery services"
@@ -339,8 +333,8 @@ function run_server () {
         > $DYN_FRONTEND_LOG 2>&1 &
     DYN_FRONTEND_PID=$!
 
-    echo "=== Running $DYN_WORKER_PY $DYN_WORKER_ARGS --discovery-backend $DYN_DISCOVERY_BACKEND"
-    python3 $DYN_WORKER_PY $DYN_WORKER_ARGS --discovery-backend $DYN_DISCOVERY_BACKEND \
+    echo "=== Running dynamo.triton $DYN_WORKER_ARGS --discovery-backend $DYN_DISCOVERY_BACKEND"
+    python3 -m dynamo.triton $DYN_WORKER_ARGS --discovery-backend $DYN_DISCOVERY_BACKEND \
         > $SERVER_LOG 2>&1 &
     SERVER_PID=$!
 


### PR DESCRIPTION
#### What does the PR do?
Update Dynamo launch mode in `qa/common/dynamo_util.sh` to start the Triton worker with `python3 -m dynamo.triton`, matching the frontend (`python3 -m dynamo.frontend`) and the renamed Dynamo Triton entrypoint. Removes the old `DYN_WORKER_PY` script-path override and its file-existence check.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
- https://github.com/triton-inference-server/dynamo/pull/22

#### Where should the reviewer start?
- `qa/common/dynamo_util.sh` — worker launch in `run_server`

#### Test plan:
- Exercise L0_infer (or another Dynamo-mode suite) with `SERVER_LAUNCH_MODE=dynamo` against an image that includes the renamed `dynamo.triton` module
- Confirm worker log shows `Running dynamo.triton ...` and the process starts via `python3 -m dynamo.triton`

- CI Pipeline ID:
<!-- pending CI -->

#### Caveats:
Depends on the Dynamo rename landing (or an image that already ships `python -m dynamo.triton`).

#### Background
The Dynamo Triton worker entrypoint is now `main.py` / `python -m dynamo.triton`. QA still pointed at the old `tritonworker.py` path.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- No related GitHub issue