### PR TITLE
chore(post-release): Update default branches post-26.07

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -29,7 +29,7 @@
 #
 
 # Base image on the minimum Triton container
-ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:26.06-py3-min
+ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:26.07-py3-min
 
 ARG TRITON_CLIENT_REPO_SUBDIR=clientrepo
 ARG TRITON_REPO_ORGANIZATION=http://github.com/triton-inference-server

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
 
 >[!WARNING]
 >You are currently on the `main` branch which tracks under-development progress
->towards the next release. The current release is version [2.70.0](https://github.com/triton-inference-server/server/releases/latest)
->and corresponds to the 26.06 container release on NVIDIA GPU Cloud (NGC).
+>towards the next release. The current release is version [2.71.0](https://github.com/triton-inference-server/server/releases/latest)
+>and corresponds to the 26.07 container release on NVIDIA GPU Cloud (NGC).
 
 # Triton Inference Server
 
@@ -90,16 +90,16 @@ Inference Server with the
 
 ```bash
 # Step 1: Create the example model repository
-git clone -b r26.06 https://github.com/triton-inference-server/server.git
+git clone -b r26.07 https://github.com/triton-inference-server/server.git
 cd server/docs/examples
 ./fetch_models.sh
 
 # Step 2: Launch triton from the NGC Triton container
-docker run --gpus=1 --rm --net=host -v ${PWD}/model_repository:/models nvcr.io/nvidia/tritonserver:26.06-py3 tritonserver --model-repository=/models --model-control-mode explicit --load-model densenet_onnx
+docker run --gpus=1 --rm --net=host -v ${PWD}/model_repository:/models nvcr.io/nvidia/tritonserver:26.07-py3 tritonserver --model-repository=/models --model-control-mode explicit --load-model densenet_onnx
 
 # Step 3: Sending an Inference Request
 # In a separate console, launch the image_client example from the NGC Triton SDK container
-docker run -it --rm --net=host nvcr.io/nvidia/tritonserver:26.06-py3-sdk /workspace/install/bin/image_client -m densenet_onnx -c 3 -s INCEPTION /workspace/images/mug.jpg
+docker run -it --rm --net=host nvcr.io/nvidia/tritonserver:26.07-py3-sdk /workspace/install/bin/image_client -m densenet_onnx -c 3 -s INCEPTION /workspace/images/mug.jpg
 
 # Inference should return the following
 Image '/workspace/images/mug.jpg':

--- a/build.py
+++ b/build.py
@@ -74,7 +74,7 @@ import requests
 DEFAULT_TRITON_VERSION_MAP = {
     "release_version": "2.72.0dev",
     "triton_container_version": "26.08dev",
-    "upstream_container_version": "26.06",
+    "upstream_container_version": "26.07",
     "ort_version": "1.27.0",
     "ort_openvino_version": "2026.2.0",
     "standalone_openvino_version": "2026.2.0",

--- a/deploy/aws/values.yaml
+++ b/deploy/aws/values.yaml
@@ -27,7 +27,7 @@
 replicaCount: 1
 
 image:
-  imageName: nvcr.io/nvidia/tritonserver:26.06-py3
+  imageName: nvcr.io/nvidia/tritonserver:26.07-py3
   pullPolicy: IfNotPresent
   modelRepositoryPath: s3://triton-inference-server-repository/model_repository
   numGpus: 1

--- a/deploy/fleetcommand/Chart.yaml
+++ b/deploy/fleetcommand/Chart.yaml
@@ -26,7 +26,7 @@
 
 apiVersion: v1
 # appVersion is the Triton version; update when changing release
-appVersion: 2.70.0
+appVersion: 2.71.0
 description: Triton Inference Server (Fleet Command)
 name: triton-inference-server
 # version is the Chart version; update when changing anything in the chart

--- a/deploy/fleetcommand/values.yaml
+++ b/deploy/fleetcommand/values.yaml
@@ -27,7 +27,7 @@
 replicaCount: 1
 
 image:
-  imageName: nvcr.io/nvidia/tritonserver:26.06-py3
+  imageName: nvcr.io/nvidia/tritonserver:26.07-py3
   pullPolicy: IfNotPresent
   numGpus: 1
   serverCommand: tritonserver
@@ -47,13 +47,13 @@ image:
     #
     # To set model control mode, uncomment and configure below
     # TODO: Fix the following url, it is invalid
-    # See https://github.com/triton-inference-server/server/blob/r26.06/docs/user_guide/model_management.md
+    # See https://github.com/triton-inference-server/server/blob/r26.07/docs/user_guide/model_management.md
     #  for more details
     #- --model-control-mode=explicit|poll|none
     #
     # Additional server args
     #
-    # see https://github.com/triton-inference-server/server/blob/r26.06/README.md
+    # see https://github.com/triton-inference-server/server/blob/r26.07/README.md
     #  for more details
 
 service:

--- a/deploy/gcp/values.yaml
+++ b/deploy/gcp/values.yaml
@@ -27,7 +27,7 @@
 replicaCount: 1
 
 image:
-  imageName: nvcr.io/nvidia/tritonserver:26.06-py3
+  imageName: nvcr.io/nvidia/tritonserver:26.07-py3
   pullPolicy: IfNotPresent
   modelRepositoryPath: gs://triton-inference-server-repository/model_repository
   numGpus: 1

--- a/deploy/gke-marketplace-app/benchmark/perf-analyzer-script/triton_client.yaml
+++ b/deploy/gke-marketplace-app/benchmark/perf-analyzer-script/triton_client.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: default
 spec:
   containers:
-  - image: nvcr.io/nvidia/tritonserver:26.06-py3-sdk
+  - image: nvcr.io/nvidia/tritonserver:26.07-py3-sdk
     imagePullPolicy: Always
     name: nv-triton-client
     securityContext:

--- a/deploy/gke-marketplace-app/server-deployer/build_and_push.sh
+++ b/deploy/gke-marketplace-app/server-deployer/build_and_push.sh
@@ -28,8 +28,8 @@
 export REGISTRY=gcr.io/$(gcloud config get-value project | tr ':' '/')
 export APP_NAME=tritonserver
 export MAJOR_VERSION=2.67
-export MINOR_VERSION=2.70.0
-export NGC_VERSION=26.06-py3
+export MINOR_VERSION=2.71.0
+export NGC_VERSION=26.07-py3
 
 docker pull nvcr.io/nvidia/$APP_NAME:$NGC_VERSION
 

--- a/deploy/gke-marketplace-app/server-deployer/chart/triton/Chart.yaml
+++ b/deploy/gke-marketplace-app/server-deployer/chart/triton/Chart.yaml
@@ -28,4 +28,4 @@ apiVersion: v1
 appVersion: "2.68"
 description: Triton Inference Server
 name: triton-inference-server
-version: 2.70.0
+version: 2.71.0

--- a/deploy/gke-marketplace-app/server-deployer/chart/triton/values.yaml
+++ b/deploy/gke-marketplace-app/server-deployer/chart/triton/values.yaml
@@ -31,14 +31,14 @@ maxReplicaCount: 3
 tritonProtocol: HTTP
 # HPA GPU utilization autoscaling target
 HPATargetAverageValue: 85
-modelRepositoryPath: gs://triton_sample_models/26.06
-publishedVersion: '2.70.0'
+modelRepositoryPath: gs://triton_sample_models/26.07
+publishedVersion: '2.71.0'
 gcpMarketplace: true
 
 image:
   registry: gcr.io
   repository: nvidia-ngc-public/tritonserver
-  tag: 26.06-py3
+  tag: 26.07-py3
   pullPolicy: IfNotPresent
   # modify the model repository here to match your GCP storage bucket
   numGpus: 1

--- a/deploy/gke-marketplace-app/server-deployer/data-test/schema.yaml
+++ b/deploy/gke-marketplace-app/server-deployer/data-test/schema.yaml
@@ -27,7 +27,7 @@
 x-google-marketplace:
   schemaVersion: v2
   applicationApiVersion: v1beta1
-  publishedVersion: '2.70.0'
+  publishedVersion: '2.71.0'
   publishedVersionMetadata:
     releaseNote: >-
       Initial release.

--- a/deploy/gke-marketplace-app/server-deployer/schema.yaml
+++ b/deploy/gke-marketplace-app/server-deployer/schema.yaml
@@ -27,7 +27,7 @@
 x-google-marketplace:
   schemaVersion: v2
   applicationApiVersion: v1beta1
-  publishedVersion: '2.70.0'
+  publishedVersion: '2.71.0'
   publishedVersionMetadata:
     releaseNote: >-
       Initial release.
@@ -89,7 +89,7 @@ properties:
   modelRepositoryPath:
     type: string
     title: Bucket where models are stored. Please make sure the user/service account to create the GKE app has permission to this GCS bucket. Read Triton documentation on configs and formatting details, supporting TensorRT, TensorFlow, Pytorch, Onnx ... etc.
-    default: gs://triton_sample_models/26.06
+    default: gs://triton_sample_models/26.07
   image.ldPreloadPath:
     type: string
     title: Leave this empty by default. Triton allows users to create custom layers for backend such as TensorRT plugin, the compiled shared library must be provided via LD_PRELOAD environment variable.

--- a/deploy/gke-marketplace-app/trt-engine/README.md
+++ b/deploy/gke-marketplace-app/trt-engine/README.md
@@ -33,7 +33,7 @@
 ```
 docker run --gpus all -it --network host \
     --shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864 \
-    -v ~:/scripts nvcr.io/nvidia/tensorrt:26.06-py3
+    -v ~:/scripts nvcr.io/nvidia/tensorrt:26.07-py3
 
 pip install onnx six torch tf2onnx tensorflow
 
@@ -57,7 +57,7 @@ mkdir -p engines
 
 python3 builder.py -m models/fine-tuned/bert_tf_ckpt_large_qa_squad2_amp_128_v19.03.1/model.ckpt -o engines/bert_large_int8_bs1_s128.engine -b 1 -s 128 -c models/fine-tuned/bert_tf_ckpt_large_qa_squad2_amp_128_v19.03.1/ -v models/fine-tuned/bert_tf_ckpt_large_qa_squad2_amp_128_v19.03.1/vocab.txt --int8 --fp16 --strict --calib-num 1 -iln -imh
 
-gsutil cp bert_large_int8_bs1_s128.engine gs://triton_sample_models/26.06/bert/1/model.plan
+gsutil cp bert_large_int8_bs1_s128.engine gs://triton_sample_models/26.07/bert/1/model.plan
 ```
 
-For each Triton upgrade, container version used to generate the model, and the model path in GCS `gs://triton_sample_models/26.06/` should be updated accordingly with the correct version.
+For each Triton upgrade, container version used to generate the model, and the model path in GCS `gs://triton_sample_models/26.07/` should be updated accordingly with the correct version.

--- a/deploy/k8s-onprem/values.yaml
+++ b/deploy/k8s-onprem/values.yaml
@@ -30,7 +30,7 @@ tags:
   openshift: false
 
 image:
-  imageName: nvcr.io/nvidia/tritonserver:26.06-py3
+  imageName: nvcr.io/nvidia/tritonserver:26.07-py3
   pullPolicy: IfNotPresent
   modelRepositoryServer: < Replace with the IP Address of your file server >
   modelRepositoryPath: /srv/models

--- a/deploy/oci/values.yaml
+++ b/deploy/oci/values.yaml
@@ -27,7 +27,7 @@
 replicaCount: 1
 
 image:
-  imageName: nvcr.io/nvidia/tritonserver:26.06-py3
+  imageName: nvcr.io/nvidia/tritonserver:26.07-py3
   pullPolicy: IfNotPresent
   modelRepositoryPath: s3://https://<OCI_NAMESPACE>.compat.objectstorage.<OCI_REGION>.oraclecloud.com:443/triton-inference-server-repository
   numGpus: 1

--- a/docs/customization_guide/compose.md
+++ b/docs/customization_guide/compose.md
@@ -46,8 +46,8 @@ The `compose.py` script can be found in the
 Simply clone the repository and run `compose.py` to create a custom container.
 Note: Created container version will depend on the branch that was cloned.
 For example branch
- [r26.06](https://github.com/triton-inference-server/server/tree/r26.06)
-should be used to create a image based on the NGC 26.06 Triton release.
+ [r26.07](https://github.com/triton-inference-server/server/tree/r26.07)
+should be used to create a image based on the NGC 26.07 Triton release.
 
 `compose.py` provides `--backend`, `--repoagent` options that allow you to
 specify which backends and repository agents to include in the custom image.
@@ -78,20 +78,20 @@ For example, running
 ```
 python3 compose.py --backend pytorch --repoagent checksum
 ```
-on branch [r26.06](https://github.com/triton-inference-server/server/tree/r26.06) pulls:
-- `min` container `nvcr.io/nvidia/tritonserver:26.06-py3-min`
-- `full` container `nvcr.io/nvidia/tritonserver:26.06-py3`
+on branch [r26.07](https://github.com/triton-inference-server/server/tree/r26.07) pulls:
+- `min` container `nvcr.io/nvidia/tritonserver:26.07-py3-min`
+- `full` container `nvcr.io/nvidia/tritonserver:26.07-py3`
 
 Alternatively, users can specify the version of Triton container to pull from
 any branch by either:
 1. Adding flag `--container-version <container version>` to branch
 ```
-python3 compose.py --backend pytorch --repoagent checksum --container-version 26.06
+python3 compose.py --backend pytorch --repoagent checksum --container-version 26.07
 ```
 2. Specifying `--image min,<min container image name> --image full,<full container image name>`.
    The user is responsible for specifying compatible `min` and `full` containers.
 ```
-python3 compose.py --backend pytorch --repoagent checksum --image min,nvcr.io/nvidia/tritonserver:26.06-py3-min --image full,nvcr.io/nvidia/tritonserver:26.06-py3
+python3 compose.py --backend pytorch --repoagent checksum --image min,nvcr.io/nvidia/tritonserver:26.07-py3-min --image full,nvcr.io/nvidia/tritonserver:26.07-py3
 ```
 Method 1 and 2 will result in the same composed container. Furthermore,
 `--image` flag overrides the `--container-version` flag when both are specified.
@@ -102,8 +102,8 @@ Note:
 2. vLLM and TensorRT-LLM backends are currently not supported backends for
 `compose.py`. If you want to build additional backends on top of these backends,
 it would be better to [build it yourself](#build-it-yourself) by using
-`nvcr.io/nvidia/tritonserver:26.06-vllm-python-py3` or
-`nvcr.io/nvidia/tritonserver:26.06-trtllm-python-py3` as a `min` container.
+`nvcr.io/nvidia/tritonserver:26.07-vllm-python-py3` or
+`nvcr.io/nvidia/tritonserver:26.07-trtllm-python-py3` as a `min` container.
 
 
 ### CPU-only container composition

--- a/docs/getting_started/llm.md
+++ b/docs/getting_started/llm.md
@@ -282,7 +282,7 @@ The above needs to be done manually with your favorite editor. Once finished, pl
     -v $(pwd)/all_models:/opt/all_models \
     -v $(pwd)/scripts:/opt/scripts \
     -v $(pwd)/Phi-3-mini-4k-instruct:/opt/Phi-3-mini-4k-instruct \
-    nvcr.io/nvidia/tritonserver:26.06-trtllm-python-py3
+    nvcr.io/nvidia/tritonserver:26.07-trtllm-python-py3
 
     # Launch Server
     python3 ../scripts/launch_triton_server.py --model_repo ../all_models/inflight_batcher_llm --world_size 1
@@ -308,7 +308,7 @@ The above needs to be done manually with your favorite editor. Once finished, pl
 
 <!---->
 
-    export RELEASE="26.06"
+    export RELEASE="26.07"
     docker run -it --net=host --gpus '"device=0"'  nvcr.io/nvidia/tritonserver:${RELEASE}-py3-sdk
 
 17. ## Download the Phi-3 tokenizer

--- a/docs/introduction/compatibility.md
+++ b/docs/introduction/compatibility.md
@@ -38,6 +38,7 @@
 
 | Triton release version	 | NGC Tag	 | Python version	 | Torch version | TensorRT version | TensorRT-LLM version | CUDA version | CUDA Driver version | Size |
 | --- | ---  | --- | --- | --- | --- | --- | --- | --- |
+| 26.07 | nvcr.io/nvidia/tritonserver:26.07-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.20 GB |
 | 26.06 | nvcr.io/nvidia/tritonserver:26.06-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.24 GB |
 | 26.05 | nvcr.io/nvidia/tritonserver:26.05-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.22 GB |
 | 26.04 | nvcr.io/nvidia/tritonserver:26.04-trtllm-python-py3 | Python 3.12.3  | 2.10.0a0+b4e4ee81d3.nv25.12 | 10.14.1.48 | 1.2.1 | 13.1.0.036 | 590.44.01 | 14.22 GB |
@@ -70,6 +71,7 @@
 
 | Triton release version	 | NGC Tag	 | Python version	 | vLLM version | CUDA version | CUDA Driver version | Size |
 | --- | --- | --- | --- | --- | --- | --- |
+| 26.07 | nvcr.io/nvidia/tritonserver:26.07-vllm-python-py3 | Python 3.12.3  | 0.24.0+092c4842.nv26.7.57386851| 13.3.0.035 | 610.43.02 | 10.28 GB |
 | 26.06 | nvcr.io/nvidia/tritonserver:26.06-vllm-python-py3 | Python 3.12.3  | 0.22.1+7b9cb5b7.nv26.6.55098374 | 13.3.0.035 | 610.43.02 | 10.21 GB |
 | 26.05 | nvcr.io/nvidia/tritonserver:26.05-vllm-python-py3 | Python 3.12.3  | 0.19.0+6bc3197f.nv26.04.48761268 | 13.2.1.009 | 595.58.03 | 9.3G |
 | 26.04 | nvcr.io/nvidia/tritonserver:26.04-vllm-python-py3 | Python 3.12.3  | 0.19.0+6bc3197f.nv26.04.48761268 | 13.2.1.009 | 595.58.03 | 9.09G |
@@ -102,6 +104,7 @@
 
 | Triton release version	 | ONNX Runtime	 |
 | --- | --- |
+| 26.07 | 1.27.0 |
 | 26.06 | 1.24.4 |
 | 26.05 | 1.24.4 |
 | 26.04 | 1.24.4 |

--- a/docs/introduction/release_notes.md
+++ b/docs/introduction/release_notes.md
@@ -25,9 +25,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
-# [Triton Inference Server Release 26.06](https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/rel-26-06.html#rel-26-06)
+# [Triton Inference Server Release 26.07](https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/rel-26-07.html#rel-26-07)
 
-The Triton Inference Server container image, release 26.06, is available
+The Triton Inference Server container image, release 26.07, is available
 on [NGC](https://ngc.nvidia.com/catalog/containers/nvidia:tritonserver) and
 is open source
 on [GitHub](https://github.com/triton-inference-server/server). Release notes can

--- a/docs/user_guide/performance_tuning.md
+++ b/docs/user_guide/performance_tuning.md
@@ -235,7 +235,7 @@ with a `tritonserver` binary.
 
 ```bash
 # Start server container
-docker run -ti --rm --gpus=all --network=host -v $PWD:/mnt --name triton-server nvcr.io/nvidia/tritonserver:26.06-py3
+docker run -ti --rm --gpus=all --network=host -v $PWD:/mnt --name triton-server nvcr.io/nvidia/tritonserver:26.07-py3
 
 # Start serving your models
 tritonserver --model-repository=/mnt/models
@@ -284,7 +284,7 @@ by setting the `-u` flag, such as `perf_analyzer -m densenet_onnx -u
 
 ```bash
 # Start the SDK container interactively
-docker run -ti --rm --gpus=all --network=host -v $PWD:/mnt --name triton-client nvcr.io/nvidia/tritonserver:26.06-py3-sdk
+docker run -ti --rm --gpus=all --network=host -v $PWD:/mnt --name triton-client nvcr.io/nvidia/tritonserver:26.07-py3-sdk
 
 # Benchmark model being served from step 3
 perf_analyzer -m densenet_onnx --concurrency-range 1:4

--- a/python/openai/README.md
+++ b/python/openai/README.md
@@ -46,7 +46,7 @@
 docker run -it --net=host --gpus all --rm \
   -v ${HOME}/.cache/huggingface:/root/.cache/huggingface \
   -e HF_TOKEN \
-  nvcr.io/nvidia/tritonserver:26.06-vllm-python-py3
+  nvcr.io/nvidia/tritonserver:26.07-vllm-python-py3
 ```
 
 2. Launch the OpenAI-compatible Triton Inference Server:
@@ -355,7 +355,7 @@ Currently, OpenAI-Compatible Frontend supports loading embedding models and embe
 docker run -it --net=host --gpus all --rm \
   -v ${HOME}/.cache/huggingface:/root/.cache/huggingface \
   -e HF_TOKEN \
-  nvcr.io/nvidia/tritonserver:26.06-vllm-python-py3
+  nvcr.io/nvidia/tritonserver:26.07-vllm-python-py3
 ```
 
 2. Launch the OpenAI-compatible Triton Inference Server:
@@ -451,7 +451,7 @@ docker run -it --net=host --gpus all --rm \
   -v ${HOME}/.cache/huggingface:/root/.cache/huggingface \
   -e HF_TOKEN \
   -e TRTLLM_ORCHESTRATOR=1 \
-  nvcr.io/nvidia/tritonserver:26.06-trtllm-python-py3
+  nvcr.io/nvidia/tritonserver:26.07-trtllm-python-py3
 ```
 
 2. Install dependencies inside the container:

--- a/qa/L2_build_presets/README.md
+++ b/qa/L2_build_presets/README.md
@@ -59,7 +59,7 @@ cd server/
 docker run --rm -v "$PWD":/workspace -w /workspace \
   -e TRITON_SERVER_BRANCH_NAME=<remote-branch> \
   -w /workspace/qa/L2_build_presets \
-  nvcr.io/nvidia/tritonserver:26.06-py3 python3 build_presets_test.py
+  nvcr.io/nvidia/tritonserver:26.07-py3 python3 build_presets_test.py
 ```
 
 ## Output

--- a/qa/common/gen_jetson_trt_models
+++ b/qa/common/gen_jetson_trt_models
@@ -34,7 +34,7 @@
 # Make all generated files accessible outside of container
 umask 0000
 # Set the version of the models
-TRITON_VERSION=${TRITON_VERSION:=26.06}
+TRITON_VERSION=${TRITON_VERSION:=26.07}
 # Set the CUDA device to use
 NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:=0}
 # Set TensorRT image

--- a/qa/common/gen_qa_model_repository
+++ b/qa/common/gen_qa_model_repository
@@ -66,7 +66,7 @@ log_message.status "Changing working directory to the script directory to: " "${
 cd ${TRITON_MDLS_BASE_SCRIPT_DIR}
 
 log_message.status "define: default values"
-TRITON_VERSION=${TRITON_VERSION:=26.06}
+TRITON_VERSION=${TRITON_VERSION:=26.07}
 ONNX_VERSION=1.20.1
 ONNX_OPSET=0
 OPENVINO_VERSION=2024.5.0


### PR DESCRIPTION
#### What does the PR do?

26.07 has released to NGC, so `main` moves onto the same upstream containers as the
just-released `r26.07` branch. Bumps `upstream_container_version`, NGC image tags, deploy
chart versions, docs, and QA model-repository defaults from `26.06`/`2.70.0` to
`26.07`/`2.71.0`, and carries forward the 26.07 compatibility-matrix rows.

The dev-train values are deliberately untouched: `TRITON_VERSION` stays `2.72.0dev`, and
`build.py`'s `release_version` / `triton_container_version` stay `2.72.0dev` / `26.08dev`
(set at code freeze). Also frozen, matching every prior cycle: `build_and_push.sh`
`MAJOR_VERSION=2.67`, gke `Chart.yaml` `appVersion "2.68"`, and the semver examples in
`src/python/build_wheel.py`.

The diff matches the previous cycle's `post: Update default branch post-26.05` (#8804)
file-for-file and line-for-line, with one addition: `qa/L2_build_presets/README.md`, which
did not exist then.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/client#913
- triton-inference-server/tutorials#165

#### Where should the reviewer start?

`build.py` — confirm only `upstream_container_version` moved inside
`DEFAULT_TRITON_VERSION_MAP` and the two dev-train fields are unchanged. Everything else is
a mechanical tag/semver replacement.

#### Test plan:

- `git grep "26\.06"` returns only the historical rows in `docs/introduction/compatibility.md`.
- The `[!WARNING]` main-branch notice at the top of `README.md` is intact, with only its
  version number and NGC tag updated.
- `git diff --stat` matches `258a8cbcf` per file and per line count.
- `pre-commit run --files <changed>` passes.

- CI Pipeline ID: 60058404

#### Caveats:

`tutorials/Build_Guide/RHEL_Manylinux/README.md` still targets 2.69.0 / NGC 26.05. It is
main-only (added after the r26.07 cut) so no cherry-pick reaches it, and its 26.05
references are coupled to a stated CUDA / TensorRT / PyTorch tuple — bumping the NGC number
alone would make that tuple wrong. Left for a separate doc refresh.

#### Background

Release step "[Before NGC Release] Advance master branch to next upstream release".
Follows `post: Update default branch post-26.05` (#8804) and
`post(TRI-1431): advance main with r26.06 upstream-tracking cherry-picks` (#8861).

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1601

<sup>
CI (internal): [#60058404](http://tritonserver.local/ci/pipelines/60058404)<br/>
</sup>
