### PR TITLE
docs(openai): note OpenAI client base_url for multi-model gateways

### DIFF
--- a/python/openai/README.md
+++ b/python/openai/README.md
@@ -225,6 +225,8 @@ completion = client.chat.completions.create(
 print(completion.choices[0].message.content)
 ```
 
+The same `base_url` pattern works with any OpenAI-compatible multi-model gateway when you are not self-hosting (for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`).
+
 7. Run tests (NOTE: The server should not be running, the tests will handle starting/stopping the server as necessary):
 ```bash
 cd /opt/tritonserver/python/openai/


### PR DESCRIPTION
## Summary

The OpenAI frontend README already shows the OpenAI Python client via `base_url`.

This PR adds a short tip that the same client pattern works with OpenAI-compatible multi-model gateways when not running the Triton OpenAI frontend locally, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] README tip renders
- [ ] Local Triton client example unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>