### PR TITLE
improve(Build): Add build script capabilities

### DIFF
--- a/build.py
+++ b/build.py
@@ -1761,6 +1761,11 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
             if os.environ.get(var):
                 runargs += ["-e", f"{var}={os.environ[var]}"]
 
+        # Forward the CUDA arch list into the buildbase container so nested
+        # backend builds honor --cuda-arch-list.
+        if FLAGS.cuda_arch_list is not None:
+            runargs += ["-e", f'"CUDA_ARCH_LIST={FLAGS.cuda_arch_list}"']
+
         runargs += ["tritonserver_buildbase"]
 
         runargs += ["./cmake_build"]

--- a/build.py
+++ b/build.py
@@ -1724,7 +1724,7 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         if not FLAGS.no_container_interactive:
             runargs += ["-it"]
 
-        runargs += ["-v", "/var/run/docker.sock:/var/run/docker.sock"]
+        runargs += docker_runargs()
         if FLAGS.use_user_docker_config:
             if os.path.exists(FLAGS.use_user_docker_config):
                 runargs += [
@@ -2243,6 +2243,29 @@ def min_cuda_arch(arch_list_str):
             val = val / 10.0
         mins.append(val)
     return f"{min(mins):.1f}" if mins else None
+
+
+def docker_runargs():
+    # Docker run args for the host-mounted build container: how to reach the
+    # daemon socket, and whether the host network is needed.
+    #
+    # DOCKER_HOST unset → system docker; mount the default socket. The default
+    # bridge has DNS, so no `--network host`.
+    #
+    # DOCKER_HOST set → rootless or remote daemon. Forward the env var so the
+    # in-container `docker build` reaches the same daemon. Rootless's default
+    # bridge has no DNS, so add `--network host` to let FetchContent resolve
+    # github.com. (We don't probe `docker info --format .Rootless` because if
+    # DOCKER_HOST is set we're already in the rootless/remote-daemon case.)
+    docker_host = os.getenv("DOCKER_HOST")
+    if docker_host is None:
+        return ["-v", "/var/run/docker.sock:/var/run/docker.sock"]
+
+    runargs = ["--network", "host", "-e", f"DOCKER_HOST={docker_host}"]
+    if docker_host.startswith("unix://"):
+        socket_path = docker_host[len("unix://") :]
+        runargs += ["-v", f"{socket_path}:{socket_path}"]
+    return runargs
 
 
 def enable_all():

--- a/build.py
+++ b/build.py
@@ -1730,9 +1730,12 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         # (TRITON_REPO_ORGANIZATION), so pointing it at a local mirror is the
         # only way to resolve deeply-nested clones (e.g. core -> common)
         # offline; FETCHCONTENT_SOURCE_DIR overrides do not reach those builds.
+        # FLAGS.github_organization is already normalized as an absolute path
         if FLAGS.github_organization and os.path.isdir(FLAGS.github_organization):
-            org_abs = os.path.abspath(FLAGS.github_organization)
-            runargs += ["-v", f"{org_abs}:{org_abs}"]
+            runargs += [
+                "-v",
+                f"{FLAGS.github_organization}:{FLAGS.github_organization}",
+            ]
         if FLAGS.use_user_docker_config:
             if os.path.exists(FLAGS.use_user_docker_config):
                 runargs += [
@@ -2755,6 +2758,12 @@ if __name__ == "__main__":
         FLAGS.extra_backend_cmake_arg = []
     if FLAGS.build_secret is None:
         FLAGS.build_secret = []
+
+    # When --github-organization is a local directory, resolve it to an absolute
+    # path, so nested clones and CMake's TRITON_REPO_ORGANIZATION properly reference it.
+    # Absolute values and remote URLs are left unchanged.
+    if FLAGS.github_organization and os.path.isdir(FLAGS.github_organization):
+        FLAGS.github_organization = os.path.abspath(FLAGS.github_organization)
 
     FLAGS.boost_url = os.getenv(
         "TRITON_BOOST_URL",

--- a/build.py
+++ b/build.py
@@ -668,12 +668,6 @@ def onnxruntime_cmake_args(images, library_paths):
             else FLAGS.ort_version,
         )
     ]
-    if FLAGS.build_parallel_was_explicit:
-        cargs.append(
-            cmake_backend_arg(
-                "onnxruntime", "TRITON_BUILD_PARALLEL", None, FLAGS.build_parallel
-            )
-        )
     # TRITON_ENABLE_GPU is already set for all backends in backend_cmake_args()
     if FLAGS.enable_gpu:
         # TODO: TPRD-712 TensorRT is not currently supported by our RHEL build for SBSA.
@@ -2954,6 +2948,11 @@ if __name__ == "__main__":
         )
         log('CMake core override "-D{}={}"'.format(parts[0], parts[1]))
         OVERRIDE_CORE_CMAKE_FLAGS[parts[0]] = parts[1]
+
+    if FLAGS.build_parallel_was_explicit and "onnxruntime" in backends:
+        FLAGS.extra_backend_cmake_arg.append(
+            f"onnxruntime:TRITON_BUILD_PARALLEL={FLAGS.build_parallel}"
+        )
 
     for cf in FLAGS.extra_backend_cmake_arg:
         parts = cf.split(":", 1)

--- a/build.py
+++ b/build.py
@@ -1725,6 +1725,14 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
             runargs += ["-it"]
 
         runargs += docker_runargs()
+        # If --github-organization is a local directory (a repo mirror), mount
+        # it too. The org propagates into every nested component configure
+        # (TRITON_REPO_ORGANIZATION), so pointing it at a local mirror is the
+        # only way to resolve deeply-nested clones (e.g. core -> common)
+        # offline; FETCHCONTENT_SOURCE_DIR overrides do not reach those builds.
+        if FLAGS.github_organization and os.path.isdir(FLAGS.github_organization):
+            org_abs = os.path.abspath(FLAGS.github_organization)
+            runargs += ["-v", f"{org_abs}:{org_abs}"]
         if FLAGS.use_user_docker_config:
             if os.path.exists(FLAGS.use_user_docker_config):
                 runargs += [

--- a/build.py
+++ b/build.py
@@ -82,6 +82,11 @@ DEFAULT_TRITON_VERSION_MAP = {
     "rhel_py_version": "3.12.3",
 }
 
+# Minimum CUDA compute capability Triton will load models for. Used as the
+# default for --min-compute-capability when neither that flag nor
+# --cuda-arch-list is given.
+DEFAULT_MIN_COMPUTE_CAPABILITY = "6.0"
+
 CORE_BACKENDS = ["ensemble"]
 
 FLAGS = None
@@ -669,7 +674,6 @@ def onnxruntime_cmake_args(images, library_paths):
                 "onnxruntime", "TRITON_BUILD_PARALLEL", None, FLAGS.build_parallel
             )
         )
-
     # TRITON_ENABLE_GPU is already set for all backends in backend_cmake_args()
     if FLAGS.enable_gpu:
         # TODO: TPRD-712 TensorRT is not currently supported by our RHEL build for SBSA.
@@ -2214,6 +2218,33 @@ def finalize_build(cmake_script, install_dir, ci_dir):
     cmake_script.cmd(f"chmod -R u+rwX,go+rX,go-w {ci_dir}")
 
 
+def min_cuda_arch(arch_list_str):
+    # Lowest compute capability in a CUDA_ARCH_LIST-style string, as a decimal
+    # string ("8.6"). Accepts the space/semicolon-separated forms used across
+    # the Triton build: "8.6", "86", "75-real", "100f", "PTX". Tokens that don't
+    # parse are skipped. Returns None if no token parses.
+    if not arch_list_str:
+        return None
+    arch_list_str = arch_list_str.replace("PTX", "")
+    mins = []
+    for tok in re.split(r"[;\s]+", arch_list_str):
+        tok = tok.strip()
+        if not tok:
+            continue
+        tok = tok.rstrip("f").removesuffix("-real").removesuffix("-ptx")
+        try:
+            val = float(tok)
+        except ValueError:
+            continue
+        # "86" means 8.6; "8.6" stays; "100" means 10.0
+        if val >= 100:
+            val = val / 10.0
+        elif val >= 20 and val.is_integer():
+            val = val / 10.0
+        mins.append(val)
+    return f"{min(mins):.1f}" if mins else None
+
+
 def enable_all():
     all_backends = [
         "ensemble",
@@ -2486,8 +2517,22 @@ if __name__ == "__main__":
         "--min-compute-capability",
         type=str,
         required=False,
-        default="6.0",
-        help="Minimum CUDA compute capability supported by server.",
+        default=None,
+        help=(
+            f"Minimum CUDA compute capability supported by server (runtime gate). "
+            f"Defaults to {DEFAULT_MIN_COMPUTE_CAPABILITY}, or to the lowest arch in "
+            f"--cuda-arch-list when that is given."
+        ),
+    )
+    parser.add_argument(
+        "--cuda-arch-list",
+        type=str,
+        required=False,
+        default=None,
+        help=(
+            "CUDA architectures to pass to nested backend builds (ONNX Runtime, "
+            "triton-backend kernel_library)."
+        ),
     )
 
     parser.add_argument(
@@ -2732,6 +2777,26 @@ if __name__ == "__main__":
     FLAGS.build_parallel_was_explicit = FLAGS.build_parallel is not None
     if FLAGS.build_parallel is None:
         FLAGS.build_parallel = default_build_parallel()
+
+    # CUDA arch list: export into the environment so every nested build that
+    # reads $CUDA_ARCH_LIST directly picks up the requested restriction --
+    # triton-backend's define.cuda_architectures.cmake and the ONNX Runtime
+    # backend's gen_ort_dockerfile.py.
+    if FLAGS.cuda_arch_list is not None:
+        os.environ["CUDA_ARCH_LIST"] = FLAGS.cuda_arch_list
+
+    # Min compute capability defaults to the baseline, but when a CUDA arch
+    # list is given the runtime gate should match the lowest compiled arch so
+    # models built for those arches aren't rejected at load time. An explicit
+    # --min-compute-capability always wins.
+    if FLAGS.min_compute_capability is None:
+        if FLAGS.cuda_arch_list is not None:
+            derived = min_cuda_arch(FLAGS.cuda_arch_list)
+            FLAGS.min_compute_capability = (
+                derived if derived is not None else DEFAULT_MIN_COMPUTE_CAPABILITY
+            )
+        else:
+            FLAGS.min_compute_capability = DEFAULT_MIN_COMPUTE_CAPABILITY
 
     log("Building Triton Inference Server")
     log("platform {}".format(target_platform()))

--- a/build.py
+++ b/build.py
@@ -663,6 +663,12 @@ def onnxruntime_cmake_args(images, library_paths):
             else FLAGS.ort_version,
         )
     ]
+    if FLAGS.build_parallel_was_explicit:
+        cargs.append(
+            cmake_backend_arg(
+                "onnxruntime", "TRITON_BUILD_PARALLEL", None, FLAGS.build_parallel
+            )
+        )
 
     # TRITON_ENABLE_GPU is already set for all backends in backend_cmake_args()
     if FLAGS.enable_gpu:
@@ -2723,6 +2729,7 @@ if __name__ == "__main__":
     elif re.match(r"^\d+\.\d+\.\d+$", FLAGS.version):
         os.environ.setdefault("TRITON_RELEASE_VERSION", FLAGS.version)
 
+    FLAGS.build_parallel_was_explicit = FLAGS.build_parallel is not None
     if FLAGS.build_parallel is None:
         FLAGS.build_parallel = default_build_parallel()
 

--- a/build.py
+++ b/build.py
@@ -85,7 +85,7 @@ DEFAULT_TRITON_VERSION_MAP = {
 # Minimum CUDA compute capability Triton will load models for. Used as the
 # default for --min-compute-capability when neither that flag nor
 # --cuda-arch-list is given.
-DEFAULT_MIN_COMPUTE_CAPABILITY = "6.0"
+DEFAULT_MIN_COMPUTE_CAPABILITY = "7.5"
 
 CORE_BACKENDS = ["ensemble"]
 


### PR DESCRIPTION
#### What does the PR do?
This PR adds several parameters to the main build script (and/or forwards them to ORT bakend build) to add configurability:
- forward the main build parallelism to ORT nested build (this is partly addressed by https://github.com/triton-inference-server/server/pull/8873, but having the parameter forwarded makes it unified on nested build, and it allows to fix issues when the 2GB / concurrent compiler does not hold)
- Define a CUDA arch list to support by the built image (and forward to ORT build). This allows to speed up the build and produce lighter artifacts when one doesn't need to support the full set of compute capabilities.
- Allow to use a local directory as `--github-organization`. This enables having a local clone of needed triton repos and build against them instead of fetching remote repositories, even in nested builds. 

#### Checklist
- [x] I have read the [Contribution guidelines](#../../CONTRIBUTING.md) and signed the [Contributor License
Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf)
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] I ran pre-commit locally (`pre-commit install, pre-commit run --all`) 
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
https://github.com/triton-inference-server/onnxruntime_backend/pull/354

#### Where should the reviewer start?
Only 1 file changed in the PR

#### Test plan:
Run the build with related options 
Tested on internal CI

#### Caveats:
Only tested forwarding to onnx runtime, other backends could need adaption for these options to be active

#### Background
We needed this for adaption to our build system's constraints, and to iterate faster by removing unneeded CPs in nested buids, ORT in particular

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
None
