### PR TITLE
ci: add copyright header to build preset requirements (TRI-1654)

### DIFF
--- a/qa/L2_build_presets/requirements.txt
+++ b/qa/L2_build_presets/requirements.txt
@@ -1,3 +1,29 @@
+# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 distro
 pytest
 requests


### PR DESCRIPTION
### Summary
`qa/L2_build_presets/requirements.txt` was merged without the required NVIDIA
copyright header, which fails the nightly L0_copyrights job. This adds it.

### Root cause
`qa/common/check_copyright.py` runs nightly across the whole repo and requires
every file to start with the NVIDIA copyright header. This file started with
`distro`, so the checker failed:

    incorrect prefix for copyright line, allowed prefixes '# ' or '// ',
    for qa/L2_build_presets/requirements.txt: distro

### Fix
Prepend the standard `#`-prefixed BSD copyright header (2026) to the file.

### Testing
    python3 qa/common/check_copyright.py --year=2026 *
→ exit 0, no violations.




