### PR TITLE
docs: add 26.08 rows to the release compatibility matrix

### DIFF
--- a/docs/introduction/compatibility.md
+++ b/docs/introduction/compatibility.md
@@ -71,6 +71,7 @@
 
 | Triton release version	 | NGC Tag	 | Python version	 | vLLM version | CUDA version | CUDA Driver version | Size |
 | --- | --- | --- | --- | --- | --- | --- |
+| 26.08 | nvcr.io/nvidia/tritonserver:26.08-vllm-python-py3 | Python 3.12.3  | 0.27.1+b1082979.nv26.8.62699174 | 13.4.1.012 | 615.61 | 10.65 GB |
 | 26.07 | nvcr.io/nvidia/tritonserver:26.07-vllm-python-py3 | Python 3.12.3  | 0.24.0+092c4842.nv26.7.57386851| 13.3.0.035 | 610.43.02 | 10.28 GB |
 | 26.06 | nvcr.io/nvidia/tritonserver:26.06-vllm-python-py3 | Python 3.12.3  | 0.22.1+7b9cb5b7.nv26.6.55098374 | 13.3.0.035 | 610.43.02 | 10.21 GB |
 | 26.05 | nvcr.io/nvidia/tritonserver:26.05-vllm-python-py3 | Python 3.12.3  | 0.19.0+6bc3197f.nv26.04.48761268 | 13.2.1.009 | 595.58.03 | 9.3G |
@@ -104,6 +105,7 @@
 
 | Triton release version	 | ONNX Runtime	 |
 | --- | --- |
+| 26.08 | 1.28.0 |
 | 26.07 | 1.27.0 |
 | 26.06 | 1.24.4 |
 | 26.05 | 1.24.4 |


### PR DESCRIPTION
#### What does the PR do?
Adds the 26.08 rows to `docs/introduction/compatibility.md`.

| Table | Row added |
|---|---|
| `vllm-python-py3` | `26.08` \| Python 3.12.3 \| vLLM `0.27.1+b1082979.nv26.8.62699174` \| CUDA `13.4.1.012` \| driver `615.61` \| 10.65 GB |
| ONNX Runtime | `26.08` \| `1.28.0` |

**No `trtllm-python-py3` row** — that container is not built for 26.08.

Independent of #8932 — this touches only `compatibility.md`, which the version bump
does not modify, so the two can merge in either order.

Replaces #8933, which was opened against #8932's branch and could not have its base
changed while GitHub tracked it as part of a stack. Same branch, same commit content.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added succinct git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [x] docs

#### Related PRs:
Companion 26.08 bumps: #8932, triton-inference-server/model_analyzer#1035,
triton-inference-server/tutorials#167.

#### Where should the reviewer start?
The two added rows.

#### Test plan:
Provenance per cell:

| Field | Source |
|---|---|
| ONNX Runtime `1.28.0` | `build.py` `ort_version` on r26.08 |
| Python `3.12.3` | dpkg `python3.12` in the 26.08 image |
| CUDA `13.4.1.012` | `CUDA_VERSION` env in the 26.08 image config |
| Driver `615.61` | `CUDA_DRIVER_VERSION` env in the 26.08 image config |
| vLLM `0.27.1+b1082979.nv26.8.62699174` | supplied by the release owner |
| Size `10.65 GB` | supplied by the release owner (10.646617238409817, rounded to the 2-decimal column convention) |

The env-var method was checked against the already-shipped 26.07 row first: the 26.07
image reports `CUDA_DRIVER_VERSION 610.43.02`, exactly the shipped value.

#### Caveats:
- The vLLM build ID and Size come from the release build. The stage images currently
  in the registry are a later rebuild reporting
  `0.27.1+b1082979.nv26.8.62746760` — do not "correct" the row against a fresh scan
  without checking which build is shipping.
- Stage tags get rebuilt generally: the 26.07 image today reports
  `CUDA_VERSION 13.3.1.008` while the shipped 26.07 row says `13.3.0.035`. If 26.08
  is rebuilt before release, CUDA version should be re-confirmed too.
- Driver is recorded as `615.61`, two components, exactly as the image reports it —
  earlier rows carry three (`610.43.02`).

#### Background
Code-freeze step for the 26.08 release. For r26.07 this landed as its own commit (#8902)
after the version bump; keeping the same split here.

#### Related Issues:
- Relates to TRI-1679
