### PR TITLE
build: Add build secrets and authenticate GitHub clones

### DIFF
--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -176,19 +176,10 @@ RUN mkdir -p qa/custom_models/custom_sequence_int32/1 && \
     cp tritonbuild/tritonserver/backends/dyna_sequence/libtriton_dyna_sequence.so \
         qa/custom_models/custom_dyna_sequence_int32/1/.
 
-# Authenticate the GitHub clones cmake performs for the component repos. The
-# helper stores no credential, only a reference to GITHUB_TOKEN, so it is safe
-# in a layer and in the pushed image. Each step that clones supplies the value
-# with --mount=type=secret,id=github_token. The helper prints nothing when the
-# token is absent, leaving git to clone anonymously as before.
-RUN git config --global credential."https://github.com".helper \
-      '!f() { test -n "${GITHUB_TOKEN}" || exit 0; \
-              echo username=x-access-token; \
-              echo "password=${GITHUB_TOKEN}"; }; f'
-
 # L0_lifecycle needs No-GPU build of identity backend.
 WORKDIR  /workspace/tritonbuild/identity
-RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+RUN --mount=type=secret,id=gitconfig,target=/run/secrets/gitconfig,required=false \
+    export GIT_CONFIG_GLOBAL=/run/secrets/gitconfig && \
     rm -rf install build && mkdir build && cd build && \
     cmake -DTRITON_ENABLE_GPU=OFF \
         -DCMAKE_INSTALL_PREFIX:PATH=/workspace/tritonbuild/identity/install \
@@ -202,7 +193,8 @@ RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
 # L0_backend_python test require triton_shm_monitor
 ARG TRITON_BOOST_URL="https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz"
 WORKDIR /workspace/tritonbuild/python
-RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+RUN --mount=type=secret,id=gitconfig,target=/run/secrets/gitconfig,required=false \
+    export GIT_CONFIG_GLOBAL=/run/secrets/gitconfig && \
     rm -rf install build && mkdir build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/workspace/tritonbuild/python/install \
         -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -52,7 +52,8 @@ ARG IGPU_BUILD
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+RUN --mount=type=secret,id=apt_sources,target=/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list,required=false \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
             build-essential \
             libarchive-dev \
@@ -328,7 +329,8 @@ ARG TARGETPLATFORM
 ENV DEBIAN_FRONTEND=noninteractive
 
 # install platform specific packages
-RUN if grep -qE '^VERSION_ID="(18\.04|20\.04|22\.04|24\.04)' /etc/os-release; then \
+RUN --mount=type=secret,id=apt_sources,target=/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list,required=false \
+    if grep -qE '^VERSION_ID="(18\.04|20\.04|22\.04|24\.04)' /etc/os-release; then \
         apt-get update && \
         apt-get install -y --no-install-recommends \
                 libpng-dev && \
@@ -341,7 +343,8 @@ RUN if grep -qE '^VERSION_ID="(18\.04|20\.04|22\.04|24\.04)' /etc/os-release; th
 
 # CI/QA for memcheck requires valgrind
 # libarchive-dev is required by Python backend
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=secret,id=apt_sources,target=/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list,required=false \
+    apt-get update && apt-get install -y --no-install-recommends \
                               curl \
                               gdb \
                               libarchive-dev \

--- a/Dockerfile.QA
+++ b/Dockerfile.QA
@@ -175,9 +175,20 @@ RUN mkdir -p qa/custom_models/custom_sequence_int32/1 && \
     cp tritonbuild/tritonserver/backends/dyna_sequence/libtriton_dyna_sequence.so \
         qa/custom_models/custom_dyna_sequence_int32/1/.
 
+# Authenticate the GitHub clones cmake performs for the component repos. The
+# helper stores no credential, only a reference to GITHUB_TOKEN, so it is safe
+# in a layer and in the pushed image. Each step that clones supplies the value
+# with --mount=type=secret,id=github_token. The helper prints nothing when the
+# token is absent, leaving git to clone anonymously as before.
+RUN git config --global credential."https://github.com".helper \
+      '!f() { test -n "${GITHUB_TOKEN}" || exit 0; \
+              echo username=x-access-token; \
+              echo "password=${GITHUB_TOKEN}"; }; f'
+
 # L0_lifecycle needs No-GPU build of identity backend.
 WORKDIR  /workspace/tritonbuild/identity
-RUN rm -rf install build && mkdir build && cd build && \
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+    rm -rf install build && mkdir build && cd build && \
     cmake -DTRITON_ENABLE_GPU=OFF \
         -DCMAKE_INSTALL_PREFIX:PATH=/workspace/tritonbuild/identity/install \
         -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
@@ -190,7 +201,8 @@ RUN rm -rf install build && mkdir build && cd build && \
 # L0_backend_python test require triton_shm_monitor
 ARG TRITON_BOOST_URL="https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.gz"
 WORKDIR /workspace/tritonbuild/python
-RUN rm -rf install build && mkdir build && cd build && \
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+    rm -rf install build && mkdir build && cd build && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/workspace/tritonbuild/python/install \
         -DTRITON_REPO_ORGANIZATION:STRING=${TRITON_REPO_ORGANIZATION} \
         -DTRITON_COMMON_REPO_TAG:STRING=${TRITON_COMMON_REPO_TAG} \

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -124,18 +124,9 @@ WORKDIR /workspace
 COPY TRITON_VERSION .
 COPY ${TRITON_CLIENT_REPO_SUBDIR} client
 
-# Authenticate the GitHub clones cmake performs for the component repos. The
-# helper stores no credential, only a reference to GITHUB_TOKEN, so it is safe
-# in a layer and in the pushed image. Each step that clones supplies the value
-# with --mount=type=secret,id=github_token. The helper prints nothing when the
-# token is absent, leaving git to clone anonymously as before.
-RUN git config --global credential."https://github.com".helper \
-      '!f() { test -n "${GITHUB_TOKEN}" || exit 0; \
-              echo username=x-access-token; \
-              echo "password=${GITHUB_TOKEN}"; }; f'
-
 WORKDIR /workspace/client_build
-RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+RUN --mount=type=secret,id=gitconfig,target=/run/secrets/gitconfig,required=false \
+    export GIT_CONFIG_GLOBAL=/run/secrets/gitconfig && \
     cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
           -DTRITON_VERSION=`cat /workspace/TRITON_VERSION` \
           -DTRITON_REPO_ORGANIZATION=${TRITON_REPO_ORGANIZATION} \
@@ -149,13 +140,15 @@ RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
           -DTRITON_ENABLE_EXAMPLES=ON -DTRITON_ENABLE_TESTS=ON \
           -DTRITON_ENABLE_GPU=${TRITON_ENABLE_GPU} /workspace/client
 RUN --mount=type=secret,id=maven_settings,target=/run/secrets/maven_settings,required=false \
-    --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+    --mount=type=secret,id=gitconfig,target=/run/secrets/gitconfig,required=false \
+    export GIT_CONFIG_GLOBAL=/run/secrets/gitconfig && \
     if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="--settings /run/secrets/maven_settings"; fi && \
     cmake --build . -v --parallel ${TRITON_CLIENT_BUILD_PARALLEL} --target cc-clients java-clients python-clients
 
 # Install Java API Bindings
 RUN --mount=type=secret,id=maven_settings,target=/run/secrets/maven_settings,required=false \
-    --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+    --mount=type=secret,id=gitconfig,target=/run/secrets/gitconfig,required=false \
+    export GIT_CONFIG_GLOBAL=/run/secrets/gitconfig && \
     if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="--settings /run/secrets/maven_settings"; fi && \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         source /workspace/client/src/java-api-bindings/scripts/install_dependencies_and_build.sh \
@@ -271,13 +264,8 @@ RUN rm -f /usr/bin/python && \
 # Install Model Analyzer
 ARG TRITON_MODEL_ANALYZER_REPO_TAG
 ARG TRITON_MODEL_ANALYZER_REPO="${TRITON_REPO_ORGANIZATION}/model_analyzer@${TRITON_MODEL_ANALYZER_REPO_TAG}"
-# Separate stage from the client build, so the credential helper is configured
-# again here. It stores no credential, only a reference to GITHUB_TOKEN.
-RUN git config --global credential."https://github.com".helper \
-      '!f() { test -n "${GITHUB_TOKEN}" || exit 0; \
-              echo username=x-access-token; \
-              echo "password=${GITHUB_TOKEN}"; }; f'
-RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+RUN --mount=type=secret,id=gitconfig,target=/run/secrets/gitconfig,required=false \
+    export GIT_CONFIG_GLOBAL=/run/secrets/gitconfig && \
     pip3 install "git+${TRITON_MODEL_ANALYZER_REPO}"
 
 # Entrypoint Banner

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -124,8 +124,19 @@ WORKDIR /workspace
 COPY TRITON_VERSION .
 COPY ${TRITON_CLIENT_REPO_SUBDIR} client
 
+# Authenticate the GitHub clones cmake performs for the component repos. The
+# helper stores no credential, only a reference to GITHUB_TOKEN, so it is safe
+# in a layer and in the pushed image. Each step that clones supplies the value
+# with --mount=type=secret,id=github_token. The helper prints nothing when the
+# token is absent, leaving git to clone anonymously as before.
+RUN git config --global credential."https://github.com".helper \
+      '!f() { test -n "${GITHUB_TOKEN}" || exit 0; \
+              echo username=x-access-token; \
+              echo "password=${GITHUB_TOKEN}"; }; f'
+
 WORKDIR /workspace/client_build
-RUN cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+    cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
           -DTRITON_VERSION=`cat /workspace/TRITON_VERSION` \
           -DTRITON_REPO_ORGANIZATION=${TRITON_REPO_ORGANIZATION} \
           -DTRITON_COMMON_REPO_TAG=${TRITON_COMMON_REPO_TAG} \
@@ -138,11 +149,13 @@ RUN cmake -DCMAKE_INSTALL_PREFIX=/workspace/install \
           -DTRITON_ENABLE_EXAMPLES=ON -DTRITON_ENABLE_TESTS=ON \
           -DTRITON_ENABLE_GPU=${TRITON_ENABLE_GPU} /workspace/client
 RUN --mount=type=secret,id=maven_settings,target=/run/secrets/maven_settings,required=false \
+    --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
     if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="--settings /run/secrets/maven_settings"; fi && \
     cmake --build . -v --parallel ${TRITON_CLIENT_BUILD_PARALLEL} --target cc-clients java-clients python-clients
 
 # Install Java API Bindings
 RUN --mount=type=secret,id=maven_settings,target=/run/secrets/maven_settings,required=false \
+    --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
     if [ -f /run/secrets/maven_settings ]; then export MAVEN_ARGS="--settings /run/secrets/maven_settings"; fi && \
     if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
         source /workspace/client/src/java-api-bindings/scripts/install_dependencies_and_build.sh \
@@ -257,7 +270,14 @@ RUN rm -f /usr/bin/python && \
 # Install Model Analyzer
 ARG TRITON_MODEL_ANALYZER_REPO_TAG
 ARG TRITON_MODEL_ANALYZER_REPO="${TRITON_REPO_ORGANIZATION}/model_analyzer@${TRITON_MODEL_ANALYZER_REPO_TAG}"
-RUN pip3 install "git+${TRITON_MODEL_ANALYZER_REPO}"
+# Separate stage from the client build, so the credential helper is configured
+# again here. It stores no credential, only a reference to GITHUB_TOKEN.
+RUN git config --global credential."https://github.com".helper \
+      '!f() { test -n "${GITHUB_TOKEN}" || exit 0; \
+              echo username=x-access-token; \
+              echo "password=${GITHUB_TOKEN}"; }; f'
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN,required=false \
+    pip3 install "git+${TRITON_MODEL_ANALYZER_REPO}"
 
 # Entrypoint Banner
 ENV NVIDIA_PRODUCT_NAME="Triton Server SDK"

--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -180,7 +180,8 @@ ARG TRITON_CORE_REPO_TAG
 ARG TARGETPLATFORM
 ARG TRITON_ENABLE_GPU
 
-RUN apt-get update && \
+RUN --mount=type=secret,id=apt_sources,target=/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list,required=false \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
             curl \
             default-jdk \

--- a/build.py
+++ b/build.py
@@ -1236,6 +1236,23 @@ RUN apt-get update \\
             os.getenv("CCACHE_REMOTE_STORAGE")
         )
 
+    # Authenticate GitHub clones. cmake_build clones the component and backend
+    # repositories while running inside this container, not while the image is
+    # being built, so a docker build secret cannot reach it. Configure a
+    # credential helper instead: it holds no credential itself, only a
+    # reference to GITHUB_TOKEN, so it is safe in a layer and in the pushed
+    # build base image. The value is supplied by 'docker run -e GITHUB_TOKEN'.
+    #
+    # The helper exits without printing anything when GITHUB_TOKEN is empty,
+    # which leaves git to fall back to unauthenticated access rather than
+    # offering an empty password and failing a clone that used to work.
+    df += """
+RUN git config --global credential."https://github.com".helper \\
+      '!f() { test -n "${GITHUB_TOKEN}" || exit 0; \\
+              echo username=x-access-token; \\
+              echo "password=${GITHUB_TOKEN}"; }; f'
+"""
+
     # Copy in the triton source. We remove existing contents first in
     # case the FROM container has something there already.
     df += """
@@ -1849,6 +1866,13 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         # or explicit --release-version). Dev / pre-release builds leave it
         # unset so build_wheel.py reads the in-tree TRITON_VERSION file and
         # takes the PEP 817 variant path.
+        # Forward the GitHub token to the clones cmake_build performs in this
+        # container. Passed by name rather than as NAME=value: 'docker run -e
+        # VAR' takes the value from the ambient environment, so the token stays
+        # out of this script, which CI publishes as a build artifact.
+        if os.environ.get("GITHUB_TOKEN"):
+            runargs += ["-e", "GITHUB_TOKEN"]
+
         if "TRITON_RELEASE_VERSION" in os.environ:
             runargs += [
                 "-e",

--- a/build.py
+++ b/build.py
@@ -878,17 +878,43 @@ RUN curl -o /tmp/cuda-keyring.deb \\
                 )
 
 
-def secret_spec_id(spec):
-    """Return the 'id' of a Docker --secret spec, or "" when it has none.
+# Keys that 'docker build --secret' accepts. A spec may also carry keys that
+# only the Dockerfile side understands ('target', 'required', 'mode', ...);
+# passing those to the build command is an error, so they are filtered out.
+DOCKER_BUILD_SECRET_KEYS = ("id", "src", "source", "env", "type")
 
-    Docker does not require 'id' to come first, so the fields are scanned
-    rather than indexed.
+# Id whose secret is mounted over the apt source list, and where it lands when
+# the spec does not say.
+APT_SOURCES_SECRET_ID = "apt_sources"
+APT_SOURCES_DEFAULT_TARGET = "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list"
+
+
+def parse_secret_spec(spec):
+    """Split a Docker secret spec into ordered (key, value) pairs.
+
+    Docker does not require any particular field order, so callers look up
+    keys by name rather than by position.
     """
+    fields = []
     for field in spec.split(","):
         key, _, value = field.partition("=")
-        if key.strip() == "id":
-            return value.strip()
+        key = key.strip()
+        if key:
+            fields.append((key, value.strip()))
+    return fields
+
+
+def secret_spec_value(spec, name):
+    """Return the value of one field of a secret spec, or "" when unset."""
+    for key, value in parse_secret_spec(spec):
+        if key == name:
+            return value
     return ""
+
+
+def secret_spec_id(spec):
+    """Return the 'id' of a Docker secret spec, or "" when it has none."""
+    return secret_spec_value(spec, "id")
 
 
 def declared_secret_specs():
@@ -904,28 +930,40 @@ def declared_secret_ids():
 def secret_build_args():
     """Return the '--secret' arguments to forward to 'docker build'.
 
-    Specs are passed through untouched, so anything 'docker build --secret'
-    accepts works here.
+    Only the keys the build command understands are forwarded. Keys that
+    belong to the Dockerfile mount are dropped here and applied where the
+    Dockerfile is generated instead.
     """
-    return ["--secret {}".format(spec) for spec in declared_secret_specs()]
+    args = []
+    for spec in declared_secret_specs():
+        fields = [
+            "{}={}".format(key, value)
+            for key, value in parse_secret_spec(spec)
+            if key in DOCKER_BUILD_SECRET_KEYS
+        ]
+        if fields:
+            args.append("--secret {}".format(",".join(fields)))
+    return args
 
 
 def apt_sources_secret_mount():
-    """Return the RUN mount flag that overlays the NVIDIA Artifactory apt
-    source list, or an empty string when the secret was not requested.
+    """Return the RUN mount flag that overlays the apt source list, or an
+    empty string when no such secret was requested.
 
-    The secret is supplied either as '--secret id=apt_sources,src=<path>' or
-    as '--build-secret apt_sources <path>'. When it is absent this returns ""
-    and the generated Dockerfiles are byte-identical to a build without this
-    feature, so the default path is unchanged.
+    The mount point comes from the spec's 'target' when it has one, so
+    '--docker-build-secret id=apt_sources,src=<path>,target=<path>' controls
+    where the list lands. Without a 'target' it defaults to the NVIDIA
+    Artifactory source list. When the secret is absent this returns "" and the
+    generated Dockerfiles are byte-identical to a build without this feature.
     """
-    if "apt_sources" not in declared_secret_ids():
-        return ""
-    return (
-        "--mount=type=secret,id=apt_sources,"
-        "target=/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list,"
-        "required=false "
-    )
+    for spec in declared_secret_specs():
+        if secret_spec_id(spec) != APT_SOURCES_SECRET_ID:
+            continue
+        target = secret_spec_value(spec, "target") or APT_SOURCES_DEFAULT_TARGET
+        return "--mount=type=secret,id={},target={},required=false ".format(
+            APT_SOURCES_SECRET_ID, target
+        )
+    return ""
 
 
 def mount_apt_sources_secret(df, skip=0):
@@ -2709,11 +2747,14 @@ if __name__ == "__main__":
         "  - 'id=<id>'             read the environment variable of the same name\n\n"
         "May be repeated. The secret is available to a Dockerfile step that mounts it with "
         "'RUN --mount=type=secret,id=<id>', and never becomes part of an image layer.\n\n"
-        "The id 'apt_sources' carries extra meaning: it is also mounted over "
-        "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list for the duration of each apt step in the "
-        "generated Dockerfile and Dockerfile.buildbase, so package installs resolve through the NVIDIA "
-        "Artifactory mirror. When it is omitted the generated Dockerfiles are unchanged and apt uses the "
-        "distribution repositories.",
+        "A spec may additionally carry 'target=<path>'. Docker rejects that key on the command line "
+        "because it belongs to the Dockerfile mount, so it is stripped from the build command and "
+        "applied where the Dockerfile is generated.\n\n"
+        "The id 'apt_sources' carries extra meaning: it is also mounted for the duration of each apt step "
+        "in the generated Dockerfile and Dockerfile.buildbase, so package installs resolve through a "
+        "package mirror. It lands on 'target' when the spec sets one, and on "
+        "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list otherwise. When the secret is omitted the "
+        "generated Dockerfiles are unchanged and apt uses the distribution repositories.",
     )
     parser.add_argument(
         "--triton-wheels-dependencies-group",

--- a/build.py
+++ b/build.py
@@ -878,16 +878,49 @@ RUN curl -o /tmp/cuda-keyring.deb \\
                 )
 
 
+def secret_spec_id(spec):
+    """Return the 'id' of a Docker --secret spec, or "" when it has none.
+
+    Docker does not require 'id' to come first, so the fields are scanned
+    rather than indexed.
+    """
+    for field in spec.split(","):
+        key, _, value = field.partition("=")
+        if key.strip() == "id":
+            return value.strip()
+    return ""
+
+
+def secret_build_args():
+    """Return the '--secret' arguments to forward to 'docker build'.
+
+    Specs given with --secret are passed through untouched. Pairs given with
+    the older --build-secret are rendered into the equivalent Docker spec.
+    """
+    args = ["--secret {}".format(spec) for spec in getattr(FLAGS, "secret", None) or []]
+    for key, value in getattr(FLAGS, "build_secret", None) or []:
+        if key == "apt_sources" and value:
+            args.append("--secret id={},src={}".format(key, value))
+    return args
+
+
+def declared_secret_ids():
+    """Ids of every secret supplied with --secret or --build-secret."""
+    ids = {secret_spec_id(spec) for spec in getattr(FLAGS, "secret", None) or []}
+    ids |= {key for key, value in getattr(FLAGS, "build_secret", None) or [] if value}
+    return {i for i in ids if i}
+
+
 def apt_sources_secret_mount():
     """Return the RUN mount flag that overlays the NVIDIA Artifactory apt
     source list, or an empty string when the secret was not requested.
 
-    The secret is supplied as '--build-secret apt_sources <path>'. When it is
-    absent this returns "" and the generated Dockerfiles are byte-identical to
-    a build without this feature, so the default path is unchanged.
+    The secret is supplied either as '--secret id=apt_sources,src=<path>' or
+    as '--build-secret apt_sources <path>'. When it is absent this returns ""
+    and the generated Dockerfiles are byte-identical to a build without this
+    feature, so the default path is unchanged.
     """
-    secrets = dict(getattr(FLAGS, "build_secret", None) or [])
-    if not secrets.get("apt_sources"):
+    if "apt_sources" not in declared_secret_ids():
         return ""
     return (
         "--mount=type=secret,id=apt_sources,"
@@ -1731,10 +1764,7 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
 
         baseargs += ["--cache-from={}".format(k) for k in cachefrommap]
 
-        if secrets.get("apt_sources"):
-            baseargs += [
-                "--secret id=apt_sources,src={}".format(secrets["apt_sources"]),
-            ]
+        baseargs += secret_build_args()
 
         baseargs += ["."]
 
@@ -1846,10 +1876,7 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
                 "--secret id=NVPL_SLIM_URL",
                 f"--build-arg BUILD_PUBLIC_VLLM={build_public_vllm}",
             ]
-        if secrets.get("apt_sources"):
-            finalargs += [
-                "--secret id=apt_sources,src={}".format(secrets["apt_sources"]),
-            ]
+        finalargs += secret_build_args()
         finalargs += [
             "-t",
             "tritonserver",
@@ -2680,6 +2707,24 @@ if __name__ == "__main__":
         help="This flag sets the Python version for RHEL platform of Triton Inference Server to be built. Default: the latest supported version.",
     )
     parser.add_argument(
+        "--secret",
+        action="append",
+        required=False,
+        metavar="spec",
+        help="Pass a build secret to 'docker build' using Docker's own syntax. The spec is forwarded "
+        "unchanged, so every form 'docker build --secret' accepts is supported:\n\n"
+        "  - 'id=<id>,src=<path>'  read the secret from a file (source= is an accepted alias)\n"
+        "  - 'id=<id>,env=<var>'   read the secret from an environment variable\n"
+        "  - 'id=<id>'             read the environment variable of the same name\n\n"
+        "May be repeated. The secret is available to a Dockerfile step that mounts it with "
+        "'RUN --mount=type=secret,id=<id>', and never becomes part of an image layer.\n\n"
+        "A secret with id 'apt_sources' is also mounted automatically over "
+        "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list for the duration of each apt step in the "
+        "generated Dockerfile and Dockerfile.buildbase, so package installs resolve through the NVIDIA "
+        "Artifactory mirror. When it is omitted the generated Dockerfiles are unchanged and apt uses the "
+        "distribution repositories.",
+    )
+    parser.add_argument(
         "--build-secret",
         action="append",
         required=False,
@@ -2729,6 +2774,8 @@ if __name__ == "__main__":
         FLAGS.extra_backend_cmake_arg = []
     if FLAGS.build_secret is None:
         FLAGS.build_secret = []
+    if FLAGS.secret is None:
+        FLAGS.secret = []
 
     FLAGS.boost_url = os.getenv(
         "TRITON_BOOST_URL",

--- a/build.py
+++ b/build.py
@@ -966,30 +966,25 @@ def apt_sources_secret_mount():
     return ""
 
 
-def mount_apt_sources_secret(df, skip=0):
-    """Prefix each 'RUN apt-get update' in df with the Artifactory source-list
-    secret mount, leaving the first 'skip' occurrences untouched.
+def mount_apt_sources_secret(df):
+    """Prefix every 'RUN apt-get update' in df with the apt source list mount.
 
-    A secret mount is scoped to a single RUN instruction, so every apt block
-    that should resolve through Artifactory needs its own mount. The build base
-    skips its first block: that block bootstraps ca-certificates from the
-    distribution repositories, and a base image without CA certificates
-    (ubuntu:24.04 ships none) cannot complete a TLS handshake with Artifactory
-    until it has finished.
+    A secret mount is scoped to a single RUN instruction, so every apt step
+    that should resolve through the mirror needs its own.
+
+    The first step of the build base is included even though it is the step
+    that installs ca-certificates. On a base image that already carries them
+    the step resolves through the mirror like any other. On one that does not,
+    apt reports the failed TLS handshake, still exits 0, and installs from the
+    distribution repositories, so the step behaves as it did before the mount
+    was added.
     """
     mount = apt_sources_secret_mount()
     if not mount:
         return df
 
     marker = "RUN apt-get update"
-    chunks = df.split(marker)
-    result = chunks[0]
-    for i, chunk in enumerate(chunks[1:]):
-        if i < skip:
-            result += marker + chunk
-        else:
-            result += "RUN " + mount + "apt-get update" + chunk
-    return result
+    return df.replace(marker, "RUN " + mount + "apt-get update")
 
 
 def create_dockerfile_buildbase_rhel(ddir, dockerfile_name, argmap):
@@ -1262,7 +1257,7 @@ COPY . .
 ENTRYPOINT []
 """
 
-    df = mount_apt_sources_secret(df, skip=1)
+    df = mount_apt_sources_secret(df)
 
     with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
         dfile.write(df)

--- a/build.py
+++ b/build.py
@@ -888,6 +888,12 @@ DOCKER_BUILD_SECRET_KEYS = ("id", "src", "source", "env", "type")
 APT_SOURCES_SECRET_ID = "apt_sources"
 APT_SOURCES_DEFAULT_TARGET = "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list"
 
+# Id whose secret is a git config authenticating GitHub, and where it is mounted.
+# git is pointed at it with GIT_CONFIG_GLOBAL rather than by installing it at the
+# default path, so nothing outside the step that mounts it picks it up.
+GIT_CONFIG_SECRET_ID = "gitconfig"
+GIT_CONFIG_TARGET = "/run/secrets/gitconfig"
+
 
 def parse_secret_spec(spec):
     """Split a Docker secret spec into ordered (key, value) pairs.
@@ -925,6 +931,18 @@ def declared_secret_specs():
 def declared_secret_ids():
     """Ids of every secret supplied with --docker-build-secret."""
     return {i for i in (secret_spec_id(s) for s in declared_secret_specs()) if i}
+
+
+def secret_source_path(secret_id):
+    """Return the host path a declared secret reads from, or "" when it has none.
+
+    Only a file-backed secret has a path. One sourced from the environment has
+    nothing to bind into a container, so callers that need a file skip it.
+    """
+    for spec in declared_secret_specs():
+        if secret_spec_id(spec) == secret_id:
+            return secret_spec_value(spec, "src") or secret_spec_value(spec, "source")
+    return ""
 
 
 def secret_build_args():
@@ -1230,23 +1248,6 @@ RUN apt-get update \\
 """.format(
             os.getenv("CCACHE_REMOTE_STORAGE")
         )
-
-    # Authenticate GitHub clones. cmake_build clones the component and backend
-    # repositories while running inside this container, not while the image is
-    # being built, so a docker build secret cannot reach it. Configure a
-    # credential helper instead: it holds no credential itself, only a
-    # reference to GITHUB_TOKEN, so it is safe in a layer and in the pushed
-    # build base image. The value is supplied by 'docker run -e GITHUB_TOKEN'.
-    #
-    # The helper exits without printing anything when GITHUB_TOKEN is empty,
-    # which leaves git to fall back to unauthenticated access rather than
-    # offering an empty password and failing a clone that used to work.
-    df += """
-RUN git config --global credential."https://github.com".helper \\
-      '!f() { test -n "${GITHUB_TOKEN}" || exit 0; \\
-              echo username=x-access-token; \\
-              echo "password=${GITHUB_TOKEN}"; }; f'
-"""
 
     # Copy in the triton source. We remove existing contents first in
     # case the FROM container has something there already.
@@ -1861,12 +1862,20 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         # or explicit --release-version). Dev / pre-release builds leave it
         # unset so build_wheel.py reads the in-tree TRITON_VERSION file and
         # takes the PEP 817 variant path.
-        # Forward the GitHub token to the clones cmake_build performs in this
-        # container. Passed by name rather than as NAME=value: 'docker run -e
-        # VAR' takes the value from the ambient environment, so the token stays
-        # out of this script, which CI publishes as a build artifact.
-        if os.environ.get("GITHUB_TOKEN"):
-            runargs += ["-e", "GITHUB_TOKEN"]
+        # Authenticate the GitHub clones cmake_build performs in this container.
+        # It runs the build rather than an image build, so a build secret cannot
+        # reach it: bind the same git config read only instead, and point git at
+        # it by environment rather than installing it at the default path. Only
+        # the host path reaches this script, which CI publishes as a build
+        # artifact, so the credential the config carries stays out of it.
+        git_config_src = secret_source_path(GIT_CONFIG_SECRET_ID)
+        if git_config_src:
+            runargs += [
+                "-v",
+                "{}:{}:ro".format(git_config_src, GIT_CONFIG_TARGET),
+                "-e",
+                "GIT_CONFIG_GLOBAL={}".format(GIT_CONFIG_TARGET),
+            ]
 
         if "TRITON_RELEASE_VERSION" in os.environ:
             runargs += [

--- a/build.py
+++ b/build.py
@@ -888,11 +888,10 @@ DOCKER_BUILD_SECRET_KEYS = ("id", "src", "source", "env", "type")
 APT_SOURCES_SECRET_ID = "apt_sources"
 APT_SOURCES_DEFAULT_TARGET = "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list"
 
-# Id whose secret is a git config authenticating GitHub, and where it is mounted.
-# git is pointed at it with GIT_CONFIG_GLOBAL rather than by installing it at the
-# default path, so nothing outside the step that mounts it picks it up.
-GIT_CONFIG_SECRET_ID = "gitconfig"
-GIT_CONFIG_TARGET = "/run/secrets/gitconfig"
+# Variables through which git reads configuration straight from the environment.
+# The build container is given these so its clones authenticate without a file,
+# which a bind mount could not deliver across the docker daemon boundary.
+GIT_CONFIG_ENV_VARS = ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0")
 
 
 def parse_secret_spec(spec):
@@ -931,18 +930,6 @@ def declared_secret_specs():
 def declared_secret_ids():
     """Ids of every secret supplied with --docker-build-secret."""
     return {i for i in (secret_spec_id(s) for s in declared_secret_specs()) if i}
-
-
-def secret_source_path(secret_id):
-    """Return the host path a declared secret reads from, or "" when it has none.
-
-    Only a file-backed secret has a path. One sourced from the environment has
-    nothing to bind into a container, so callers that need a file skip it.
-    """
-    for spec in declared_secret_specs():
-        if secret_spec_id(spec) == secret_id:
-            return secret_spec_value(spec, "src") or secret_spec_value(spec, "source")
-    return ""
 
 
 def secret_build_args():
@@ -1864,23 +1851,17 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         # takes the PEP 817 variant path.
         # Authenticate the GitHub clones cmake_build performs in this container.
         # It runs the build rather than an image build, so a build secret cannot
-        # reach it: bind the same git config read only instead, and point git at
-        # it by environment rather than installing it at the default path. Only
-        # the path reaches this script, which CI publishes as a build artifact,
-        # so the credential the config carries stays out of it.
+        # reach it, and a bind mount cannot either: docker resolves the source
+        # path on the daemon, which need not share the filesystem this script
+        # runs on, and silently creates a directory when it does not find it.
+        # git reads configuration straight from the environment instead.
         #
-        # docker resolves the source path on the daemon rather than here, so the
-        # config has to sit somewhere the daemon also sees. A path under /tmp is
-        # not such a place when the runner has a private one: docker finds no
-        # file and silently mounts a new directory in its place.
-        git_config_src = secret_source_path(GIT_CONFIG_SECRET_ID)
-        if git_config_src:
-            runargs += [
-                "-v",
-                "{}:{}:ro".format(git_config_src, GIT_CONFIG_TARGET),
-                "-e",
-                "GIT_CONFIG_GLOBAL={}".format(GIT_CONFIG_TARGET),
-            ]
+        # Passed by name rather than as NAME=value, so the values, one of which
+        # carries the credential, stay out of this script, which CI publishes as
+        # a build artifact.
+        for var in GIT_CONFIG_ENV_VARS:
+            if os.environ.get(var):
+                runargs += ["-e", var]
 
         if "TRITON_RELEASE_VERSION" in os.environ:
             runargs += [

--- a/build.py
+++ b/build.py
@@ -888,11 +888,10 @@ DOCKER_BUILD_SECRET_KEYS = ("id", "src", "source", "env", "type")
 APT_SOURCES_SECRET_ID = "apt_sources"
 APT_SOURCES_DEFAULT_TARGET = "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list"
 
-# Id whose secret is a git config authenticating GitHub, and where it is mounted.
-# git is pointed at it with GIT_CONFIG_GLOBAL rather than by installing it at the
-# default path, so nothing outside the step that mounts it picks it up.
-GIT_CONFIG_SECRET_ID = "gitconfig"
-GIT_CONFIG_TARGET = "/run/secrets/gitconfig"
+# Variables through which git reads configuration straight from the environment.
+# The build container is given these so its clones authenticate without a file,
+# which a bind mount could not deliver across the docker daemon boundary.
+GIT_CONFIG_ENV_VARS = ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0")
 
 
 def parse_secret_spec(spec):
@@ -931,18 +930,6 @@ def declared_secret_specs():
 def declared_secret_ids():
     """Ids of every secret supplied with --docker-build-secret."""
     return {i for i in (secret_spec_id(s) for s in declared_secret_specs()) if i}
-
-
-def secret_source_path(secret_id):
-    """Return the host path a declared secret reads from, or "" when it has none.
-
-    Only a file-backed secret has a path. One sourced from the environment has
-    nothing to bind into a container, so callers that need a file skip it.
-    """
-    for spec in declared_secret_specs():
-        if secret_spec_id(spec) == secret_id:
-            return secret_spec_value(spec, "src") or secret_spec_value(spec, "source")
-    return ""
 
 
 def secret_build_args():
@@ -1864,18 +1851,17 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         # takes the PEP 817 variant path.
         # Authenticate the GitHub clones cmake_build performs in this container.
         # It runs the build rather than an image build, so a build secret cannot
-        # reach it: bind the same git config read only instead, and point git at
-        # it by environment rather than installing it at the default path. Only
-        # the host path reaches this script, which CI publishes as a build
-        # artifact, so the credential the config carries stays out of it.
-        git_config_src = secret_source_path(GIT_CONFIG_SECRET_ID)
-        if git_config_src:
-            runargs += [
-                "-v",
-                "{}:{}:ro".format(git_config_src, GIT_CONFIG_TARGET),
-                "-e",
-                "GIT_CONFIG_GLOBAL={}".format(GIT_CONFIG_TARGET),
-            ]
+        # reach it, and a bind mount cannot either: docker resolves the source
+        # path on the daemon, which need not share the filesystem this script
+        # runs on, and silently creates a directory when it does not find it.
+        # git reads configuration straight from the environment instead.
+        #
+        # Passed by name rather than as NAME=value, so the values, one of which
+        # carries the credential, stay out of this script, which CI publishes as
+        # a build artifact.
+        for var in GIT_CONFIG_ENV_VARS:
+            if os.environ.get(var):
+                runargs += ["-e", var]
 
         if "TRITON_RELEASE_VERSION" in os.environ:
             runargs += [

--- a/build.py
+++ b/build.py
@@ -888,10 +888,12 @@ DOCKER_BUILD_SECRET_KEYS = ("id", "src", "source", "env", "type")
 APT_SOURCES_SECRET_ID = "apt_sources"
 APT_SOURCES_DEFAULT_TARGET = "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list"
 
-# Variables through which git reads configuration straight from the environment.
-# The build container is given these so its clones authenticate without a file,
-# which a bind mount could not deliver across the docker daemon boundary.
-GIT_CONFIG_ENV_VARS = ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0")
+# Variable holding a git config, and where the build container writes it out.
+# The container is handed the contents rather than the file because docker
+# resolves a bind mount source on the daemon, which need not share a filesystem
+# with this script, and silently mounts a directory when it finds nothing there.
+GIT_CONFIG_CONTENT_ENV = "TRITON_GITCONFIG"
+GIT_CONFIG_CONTAINER_PATH = "/tmp/gitconfig"
 
 
 def parse_secret_spec(spec):
@@ -1854,14 +1856,13 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         # reach it, and a bind mount cannot either: docker resolves the source
         # path on the daemon, which need not share the filesystem this script
         # runs on, and silently creates a directory when it does not find it.
-        # git reads configuration straight from the environment instead.
+        # Hand the container the contents instead and let it write the file.
         #
-        # Passed by name rather than as NAME=value, so the values, one of which
-        # carries the credential, stay out of this script, which CI publishes as
-        # a build artifact.
-        for var in GIT_CONFIG_ENV_VARS:
-            if os.environ.get(var):
-                runargs += ["-e", var]
+        # Passed by name rather than as NAME=value, so the contents, which carry
+        # a credential, stay out of this script, which CI publishes as a build
+        # artifact.
+        if os.environ.get(GIT_CONFIG_CONTENT_ENV):
+            runargs += ["-e", GIT_CONFIG_CONTENT_ENV]
 
         if "TRITON_RELEASE_VERSION" in os.environ:
             runargs += [
@@ -1879,7 +1880,23 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
 
         runargs += ["tritonserver_buildbase"]
 
-        runargs += ["./cmake_build"]
+        # Write the git config out inside the container, where the contents
+        # arrived as an environment variable, and point git at it for the build
+        # only. Single quoted so the outer shell leaves the expansion to the
+        # container, whose environment is the one holding the value.
+        if os.environ.get(GIT_CONFIG_CONTENT_ENV):
+            runargs += [
+                "bash",
+                "-c",
+                '\'printf "%s" "${}" > {} && export GIT_CONFIG_GLOBAL={} && '
+                "./cmake_build'".format(
+                    GIT_CONFIG_CONTENT_ENV,
+                    GIT_CONFIG_CONTAINER_PATH,
+                    GIT_CONFIG_CONTAINER_PATH,
+                ),
+            ]
+        else:
+            runargs += ["./cmake_build"]
 
         # Remove existing tritonserver_builder container...
         docker_script._file.write(

--- a/build.py
+++ b/build.py
@@ -891,24 +891,23 @@ def secret_spec_id(spec):
     return ""
 
 
-def secret_build_args():
-    """Return the '--secret' arguments to forward to 'docker build'.
-
-    Specs given with --secret are passed through untouched. Pairs given with
-    the older --build-secret are rendered into the equivalent Docker spec.
-    """
-    args = ["--secret {}".format(spec) for spec in getattr(FLAGS, "secret", None) or []]
-    for key, value in getattr(FLAGS, "build_secret", None) or []:
-        if key == "apt_sources" and value:
-            args.append("--secret id={},src={}".format(key, value))
-    return args
+def declared_secret_specs():
+    """Every --docker-build-secret spec, in the order it was given."""
+    return [spec for spec in getattr(FLAGS, "docker_build_secret", None) or [] if spec]
 
 
 def declared_secret_ids():
-    """Ids of every secret supplied with --secret or --build-secret."""
-    ids = {secret_spec_id(spec) for spec in getattr(FLAGS, "secret", None) or []}
-    ids |= {key for key, value in getattr(FLAGS, "build_secret", None) or [] if value}
-    return {i for i in ids if i}
+    """Ids of every secret supplied with --docker-build-secret."""
+    return {i for i in (secret_spec_id(s) for s in declared_secret_specs()) if i}
+
+
+def secret_build_args():
+    """Return the '--secret' arguments to forward to 'docker build'.
+
+    Specs are passed through untouched, so anything 'docker build --secret'
+    accepts works here.
+    """
+    return ["--secret {}".format(spec) for spec in declared_secret_specs()]
 
 
 def apt_sources_secret_mount():
@@ -1868,14 +1867,6 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
             "docker",
             "build",
         ]
-        if secrets.get("req"):
-            finalargs += [
-                f"--secret id=req,src={requirements}",
-                "--secret id=VLLM_INDEX_URL",
-                "--secret id=PYTORCH_TRITON_URL",
-                "--secret id=NVPL_SLIM_URL",
-                f"--build-arg BUILD_PUBLIC_VLLM={build_public_vllm}",
-            ]
         finalargs += secret_build_args()
         finalargs += [
             "-t",
@@ -2707,7 +2698,7 @@ if __name__ == "__main__":
         help="This flag sets the Python version for RHEL platform of Triton Inference Server to be built. Default: the latest supported version.",
     )
     parser.add_argument(
-        "--secret",
+        "--docker-build-secret",
         action="append",
         required=False,
         metavar="spec",
@@ -2718,26 +2709,11 @@ if __name__ == "__main__":
         "  - 'id=<id>'             read the environment variable of the same name\n\n"
         "May be repeated. The secret is available to a Dockerfile step that mounts it with "
         "'RUN --mount=type=secret,id=<id>', and never becomes part of an image layer.\n\n"
-        "A secret with id 'apt_sources' is also mounted automatically over "
+        "The id 'apt_sources' carries extra meaning: it is also mounted over "
         "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list for the duration of each apt step in the "
         "generated Dockerfile and Dockerfile.buildbase, so package installs resolve through the NVIDIA "
         "Artifactory mirror. When it is omitted the generated Dockerfiles are unchanged and apt uses the "
         "distribution repositories.",
-    )
-    parser.add_argument(
-        "--build-secret",
-        action="append",
-        required=False,
-        nargs=2,
-        metavar=("key", "value"),
-        help="Add build secrets in the form of <key> <value>. These secrets are used during the build process for vllm. The secrets are passed to the Docker build step as `--secret id=<key>`. The following keys are expected and their purposes are described below:\n\n"
-        "  - 'req': A file containing a list of dependencies for pip (e.g., requirements.txt).\n"
-        "  - 'build_public_vllm': A flag (default is 'true') indicating whether to build the public VLLM version.\n"
-        "  - 'apt_sources': A file mounted at /etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list for the\n"
-        "    duration of each apt step, so package installs resolve through the NVIDIA Artifactory mirror. It\n"
-        "    holds credentials, so it is passed as a secret and never written to an image layer. When omitted\n"
-        "    the generated Dockerfiles are unchanged and apt uses the distribution repositories.\n\n"
-        "Ensure that the required environment variables for these secrets are set before running the build.",
     )
     parser.add_argument(
         "--triton-wheels-dependencies-group",
@@ -2772,10 +2748,8 @@ if __name__ == "__main__":
         FLAGS.override_backend_cmake_arg = []
     if FLAGS.extra_backend_cmake_arg is None:
         FLAGS.extra_backend_cmake_arg = []
-    if FLAGS.build_secret is None:
-        FLAGS.build_secret = []
-    if FLAGS.secret is None:
-        FLAGS.secret = []
+    if FLAGS.docker_build_secret is None:
+        FLAGS.docker_build_secret = []
 
     FLAGS.boost_url = os.getenv(
         "TRITON_BOOST_URL",
@@ -2884,12 +2858,6 @@ if __name__ == "__main__":
                 )
             )
             backends["python"] = backends["vllm"]
-
-    secrets = dict(getattr(FLAGS, "build_secret", []))
-    if secrets:
-        requirements = secrets.get("req", "")
-        build_public_vllm = secrets.get("build_public_vllm", "true")
-        log('Build Arg for BUILD_PUBLIC_VLLM: "{}"'.format(build_public_vllm))
 
     # Initialize map of repo agents to build and repo-tag for each.
     repoagents = {}

--- a/build.py
+++ b/build.py
@@ -888,10 +888,11 @@ DOCKER_BUILD_SECRET_KEYS = ("id", "src", "source", "env", "type")
 APT_SOURCES_SECRET_ID = "apt_sources"
 APT_SOURCES_DEFAULT_TARGET = "/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list"
 
-# Variables through which git reads configuration straight from the environment.
-# The build container is given these so its clones authenticate without a file,
-# which a bind mount could not deliver across the docker daemon boundary.
-GIT_CONFIG_ENV_VARS = ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0")
+# Id whose secret is a git config authenticating GitHub, and where it is mounted.
+# git is pointed at it with GIT_CONFIG_GLOBAL rather than by installing it at the
+# default path, so nothing outside the step that mounts it picks it up.
+GIT_CONFIG_SECRET_ID = "gitconfig"
+GIT_CONFIG_TARGET = "/run/secrets/gitconfig"
 
 
 def parse_secret_spec(spec):
@@ -930,6 +931,18 @@ def declared_secret_specs():
 def declared_secret_ids():
     """Ids of every secret supplied with --docker-build-secret."""
     return {i for i in (secret_spec_id(s) for s in declared_secret_specs()) if i}
+
+
+def secret_source_path(secret_id):
+    """Return the host path a declared secret reads from, or "" when it has none.
+
+    Only a file-backed secret has a path. One sourced from the environment has
+    nothing to bind into a container, so callers that need a file skip it.
+    """
+    for spec in declared_secret_specs():
+        if secret_spec_id(spec) == secret_id:
+            return secret_spec_value(spec, "src") or secret_spec_value(spec, "source")
+    return ""
 
 
 def secret_build_args():
@@ -1851,17 +1864,23 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
         # takes the PEP 817 variant path.
         # Authenticate the GitHub clones cmake_build performs in this container.
         # It runs the build rather than an image build, so a build secret cannot
-        # reach it, and a bind mount cannot either: docker resolves the source
-        # path on the daemon, which need not share the filesystem this script
-        # runs on, and silently creates a directory when it does not find it.
-        # git reads configuration straight from the environment instead.
+        # reach it: bind the same git config read only instead, and point git at
+        # it by environment rather than installing it at the default path. Only
+        # the path reaches this script, which CI publishes as a build artifact,
+        # so the credential the config carries stays out of it.
         #
-        # Passed by name rather than as NAME=value, so the values, one of which
-        # carries the credential, stay out of this script, which CI publishes as
-        # a build artifact.
-        for var in GIT_CONFIG_ENV_VARS:
-            if os.environ.get(var):
-                runargs += ["-e", var]
+        # docker resolves the source path on the daemon rather than here, so the
+        # config has to sit somewhere the daemon also sees. A path under /tmp is
+        # not such a place when the runner has a private one: docker finds no
+        # file and silently mounts a new directory in its place.
+        git_config_src = secret_source_path(GIT_CONFIG_SECRET_ID)
+        if git_config_src:
+            runargs += [
+                "-v",
+                "{}:{}:ro".format(git_config_src, GIT_CONFIG_TARGET),
+                "-e",
+                "GIT_CONFIG_GLOBAL={}".format(GIT_CONFIG_TARGET),
+            ]
 
         if "TRITON_RELEASE_VERSION" in os.environ:
             runargs += [

--- a/build.py
+++ b/build.py
@@ -878,6 +878,50 @@ RUN curl -o /tmp/cuda-keyring.deb \\
                 )
 
 
+def apt_sources_secret_mount():
+    """Return the RUN mount flag that overlays the NVIDIA Artifactory apt
+    source list, or an empty string when the secret was not requested.
+
+    The secret is supplied as '--build-secret apt_sources <path>'. When it is
+    absent this returns "" and the generated Dockerfiles are byte-identical to
+    a build without this feature, so the default path is unchanged.
+    """
+    secrets = dict(getattr(FLAGS, "build_secret", None) or [])
+    if not secrets.get("apt_sources"):
+        return ""
+    return (
+        "--mount=type=secret,id=apt_sources,"
+        "target=/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list,"
+        "required=false "
+    )
+
+
+def mount_apt_sources_secret(df, skip=0):
+    """Prefix each 'RUN apt-get update' in df with the Artifactory source-list
+    secret mount, leaving the first 'skip' occurrences untouched.
+
+    A secret mount is scoped to a single RUN instruction, so every apt block
+    that should resolve through Artifactory needs its own mount. The build base
+    skips its first block: that block bootstraps ca-certificates from the
+    distribution repositories, and a base image without CA certificates
+    (ubuntu:24.04 ships none) cannot complete a TLS handshake with Artifactory
+    until it has finished.
+    """
+    mount = apt_sources_secret_mount()
+    if not mount:
+        return df
+
+    marker = "RUN apt-get update"
+    chunks = df.split(marker)
+    result = chunks[0]
+    for i, chunk in enumerate(chunks[1:]):
+        if i < skip:
+            result += marker + chunk
+        else:
+            result += "RUN " + mount + "apt-get update" + chunk
+    return result
+
+
 def create_dockerfile_buildbase_rhel(ddir, dockerfile_name, argmap):
     df = """
 ARG TRITON_VERSION={}
@@ -1131,6 +1175,8 @@ COPY . .
 ENTRYPOINT []
 """
 
+    df = mount_apt_sources_secret(df, skip=1)
+
     with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
         dfile.write(df)
 
@@ -1259,6 +1305,8 @@ RUN ldconfig && \\
     ldconfig
 
 """
+    df = mount_apt_sources_secret(df)
+
     with open(os.path.join(ddir, dockerfile_name), "w") as dfile:
         dfile.write(df)
 
@@ -1683,6 +1731,11 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
 
         baseargs += ["--cache-from={}".format(k) for k in cachefrommap]
 
+        if secrets.get("apt_sources"):
+            baseargs += [
+                "--secret id=apt_sources,src={}".format(secrets["apt_sources"]),
+            ]
+
         baseargs += ["."]
 
         docker_script.cwd(THIS_SCRIPT_DIR)
@@ -1785,13 +1838,17 @@ def create_docker_build_script(script_name, container_install_dir, container_ci_
             "docker",
             "build",
         ]
-        if secrets:
+        if secrets.get("req"):
             finalargs += [
                 f"--secret id=req,src={requirements}",
                 "--secret id=VLLM_INDEX_URL",
                 "--secret id=PYTORCH_TRITON_URL",
                 "--secret id=NVPL_SLIM_URL",
                 f"--build-arg BUILD_PUBLIC_VLLM={build_public_vllm}",
+            ]
+        if secrets.get("apt_sources"):
+            finalargs += [
+                "--secret id=apt_sources,src={}".format(secrets["apt_sources"]),
             ]
         finalargs += [
             "-t",
@@ -2630,7 +2687,11 @@ if __name__ == "__main__":
         metavar=("key", "value"),
         help="Add build secrets in the form of <key> <value>. These secrets are used during the build process for vllm. The secrets are passed to the Docker build step as `--secret id=<key>`. The following keys are expected and their purposes are described below:\n\n"
         "  - 'req': A file containing a list of dependencies for pip (e.g., requirements.txt).\n"
-        "  - 'build_public_vllm': A flag (default is 'true') indicating whether to build the public VLLM version.\n\n"
+        "  - 'build_public_vllm': A flag (default is 'true') indicating whether to build the public VLLM version.\n"
+        "  - 'apt_sources': A file mounted at /etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list for the\n"
+        "    duration of each apt step, so package installs resolve through the NVIDIA Artifactory mirror. It\n"
+        "    holds credentials, so it is passed as a secret and never written to an image layer. When omitted\n"
+        "    the generated Dockerfiles are unchanged and apt uses the distribution repositories.\n\n"
         "Ensure that the required environment variables for these secrets are set before running the build.",
     )
     parser.add_argument(

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -235,27 +235,28 @@ The token has to appear in the file. git does not expand environment variables
 inside `url.<base>.insteadOf`, so a config that refers to one is stored
 literally and silently fails to authenticate.
 
-build.py mounts the config on each step that clones and points git at it with
-GIT_CONFIG_GLOBAL rather than installing it at the default path, so nothing
-outside those steps picks it up. The config is never part of an image layer,
-and only its path reaches the generated build scripts.
+That covers the steps that clone while an image is being built. build.py mounts
+the config on each of them and points git at it with GIT_CONFIG_GLOBAL rather
+than installing it at the default path, so nothing outside those steps picks it
+up. The config is never part of an image layer, and only its path reaches the
+generated build scripts.
 
 cmake_build clones while the build runs inside the container rather than while
-an image is built, so no build secret reaches it, and neither does a bind mount:
-docker resolves the source path on the daemon, which need not share the
-filesystem build.py runs on, and silently creates a directory when it does not
-find it. Set the configuration in the environment for that case instead, and
-build.py forwards the variables to the build container by name, keeping the
-value that carries the token out of the generated build scripts.
+an image is built, so no build secret reaches it. Neither does a bind mount:
+docker resolves the source path on the daemon, which need not share a filesystem
+with build.py, and silently mounts a directory when it finds nothing there. Put
+the same text in TRITON_GITCONFIG for that case. build.py forwards the variable
+to the container by name and has it write the file there, so the contents stay
+out of the generated build scripts.
 
 ```bash
-$ export GIT_CONFIG_COUNT=1
-$ export GIT_CONFIG_KEY_0="url.https://x-access-token:<token>@github.com/.insteadOf"
-$ export GIT_CONFIG_VALUE_0="https://github.com/"
+$ export TRITON_GITCONFIG="$(cat /tmp/gitconfig)"
 $ ./build.py ...
 ```
 
-When the secret is omitted the clones stay unauthenticated.
+Set both when a build needs authenticated clones throughout: the secret for the
+image builds, the variable for the build itself. Omit either and the steps it
+covers clone unauthenticated.
 
 #### Experimental: Build Presets
 

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -237,12 +237,23 @@ literally and silently fails to authenticate.
 
 build.py mounts the config on each step that clones and points git at it with
 GIT_CONFIG_GLOBAL rather than installing it at the default path, so nothing
-outside those steps picks it up. Steps that run while an image is being built
-receive it as a build secret. cmake_build clones while the build runs inside
-the container rather than while an image is built, where a build secret cannot
-reach it, so there the same file is bind mounted read only instead. Either way
-the config is never part of an image layer, and only its path reaches the
-generated build scripts.
+outside those steps picks it up. The config is never part of an image layer,
+and only its path reaches the generated build scripts.
+
+cmake_build clones while the build runs inside the container rather than while
+an image is built, so no build secret reaches it, and neither does a bind mount:
+docker resolves the source path on the daemon, which need not share the
+filesystem build.py runs on, and silently creates a directory when it does not
+find it. Set the configuration in the environment for that case instead, and
+build.py forwards the variables to the build container by name, keeping the
+value that carries the token out of the generated build scripts.
+
+```bash
+$ export GIT_CONFIG_COUNT=1
+$ export GIT_CONFIG_KEY_0="url.https://x-access-token:<token>@github.com/.insteadOf"
+$ export GIT_CONFIG_VALUE_0="https://github.com/"
+$ ./build.py ...
+```
 
 When the secret is omitted the clones stay unauthenticated.
 

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -218,22 +218,33 @@ added.
 
 Source from several other repos is fetched during the build, as described
 above. Those clones are unauthenticated by default, which is subject to
-GitHub's rate limits and cannot reach a private repo. Set GITHUB_TOKEN in the
-environment to authenticate them.
+GitHub's rate limits and cannot reach a private repo. Supply a git config that
+rewrites the GitHub URL to an authenticated one, as the `gitconfig` build
+secret.
 
 ```bash
-$ export GITHUB_TOKEN=<token>
-$ ./build.py ...
+$ cat > /tmp/gitconfig <<EOF
+[url "https://x-access-token:<token>@github.com/"]
+	insteadOf = https://github.com/
+EOF
+$ chmod 600 /tmp/gitconfig
+$ ./build.py ... --docker-build-secret id=gitconfig,src=/tmp/gitconfig
 ```
 
-This is not a build secret. The component and backend repos are cloned while
-the build runs inside the container, not while an image is being built, so a
-build secret cannot reach them. build.py instead configures a git credential
-helper in the build base image and forwards the token to the build container
-when the variable is set. The helper holds no credential of its own, only a
-reference to GITHUB_TOKEN, so it is safe in an image layer, and it keeps the
-token out of .git/config, which an authenticated clone URL would not. When
-GITHUB_TOKEN is unset the clones stay unauthenticated.
+The token has to appear in the file. git does not expand environment variables
+inside `url.<base>.insteadOf`, so a config that refers to one is stored
+literally and silently fails to authenticate.
+
+build.py mounts the config on each step that clones and points git at it with
+GIT_CONFIG_GLOBAL rather than installing it at the default path, so nothing
+outside those steps picks it up. Steps that run while an image is being built
+receive it as a build secret. cmake_build clones while the build runs inside
+the container rather than while an image is built, where a build secret cannot
+reach it, so there the same file is bind mounted read only instead. Either way
+the config is never part of an image layer, and only its path reaches the
+generated build scripts.
+
+When the secret is omitted the clones stay unauthenticated.
 
 #### Experimental: Build Presets
 

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -200,15 +200,19 @@ Dockerfile rather than the build command, so build.py removes it before
 invoking docker and applies it when generating the Dockerfile.
 
 The id `apt_sources` has an additional meaning. Its secret is mounted for the
-duration of each apt step in the generated Dockerfile and Dockerfile.buildbase,
+duration of every apt step in the generated Dockerfile and Dockerfile.buildbase,
 so package installs resolve through the mirror the list names. It lands on
 target when the spec sets one, and on
-/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list otherwise. The first apt
-step of Dockerfile.buildbase is deliberately excluded, because it installs
-ca-certificates and a base image without them cannot complete a TLS handshake
-with the mirror until that install finishes. When the secret is omitted the
-generated Dockerfiles are unchanged and apt uses the distribution
-repositories.
+/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list otherwise. When the
+secret is omitted the generated Dockerfiles are unchanged and apt uses the
+distribution repositories.
+
+This includes the first step of Dockerfile.buildbase, which is also the step
+that installs ca-certificates. On a base image that already carries them the
+step resolves through the mirror like any other. On one that does not, apt
+reports the failed TLS handshake, still exits 0, and installs from the
+distribution repositories, so the step behaves as it did before the mount was
+added.
 
 #### Authenticating Clones From GitHub
 

--- a/docs/customization_guide/build.md
+++ b/docs/customization_guide/build.md
@@ -180,6 +180,57 @@ you have a branch called "mybranch" in the
 repo that you want to use in the build, you would specify
 --backend=onnxruntime:mybranch.
 
+#### Build Secrets
+
+Some builds need a credential, for example an apt source list naming an
+authenticated package mirror. Pass these with --docker-build-secret, which
+takes a Docker build secret spec and forwards it to `docker build --secret`
+unchanged. Every form Docker accepts works and the flag may be repeated.
+
+```bash
+$ ./build.py ... --docker-build-secret id=<id>,src=<path> --docker-build-secret id=<id>,env=<variable>
+```
+
+A secret is mounted only for the duration of the build step that uses it and
+never becomes part of an image layer.
+
+A spec may also carry target=`<path>`, which selects where the secret is
+mounted. Docker rejects that key on the command line because it belongs to the
+Dockerfile rather than the build command, so build.py removes it before
+invoking docker and applies it when generating the Dockerfile.
+
+The id `apt_sources` has an additional meaning. Its secret is mounted for the
+duration of each apt step in the generated Dockerfile and Dockerfile.buildbase,
+so package installs resolve through the mirror the list names. It lands on
+target when the spec sets one, and on
+/etc/apt/sources.list.d/nvidia-artifactory-ubuntu.list otherwise. The first apt
+step of Dockerfile.buildbase is deliberately excluded, because it installs
+ca-certificates and a base image without them cannot complete a TLS handshake
+with the mirror until that install finishes. When the secret is omitted the
+generated Dockerfiles are unchanged and apt uses the distribution
+repositories.
+
+#### Authenticating Clones From GitHub
+
+Source from several other repos is fetched during the build, as described
+above. Those clones are unauthenticated by default, which is subject to
+GitHub's rate limits and cannot reach a private repo. Set GITHUB_TOKEN in the
+environment to authenticate them.
+
+```bash
+$ export GITHUB_TOKEN=<token>
+$ ./build.py ...
+```
+
+This is not a build secret. The component and backend repos are cloned while
+the build runs inside the container, not while an image is being built, so a
+build secret cannot reach them. build.py instead configures a git credential
+helper in the build base image and forwards the token to the build container
+when the variable is set. The helper holds no credential of its own, only a
+reference to GITHUB_TOKEN, so it is safe in an image layer, and it keeps the
+token out of .git/config, which an authenticated clone URL would not. When
+GITHUB_TOKEN is unset the clones stay unauthenticated.
+
 #### Experimental: Build Presets
 
 > **Experimental.** This feature is gated behind the


### PR DESCRIPTION
#### What does the PR do?
Adds a build secret mechanism to `build.py` and uses it to authenticate the
GitHub clones the build performs and to route package installs through a
package mirror.

`--docker-build-secret` takes a Docker build secret spec and forwards it to
`docker build --secret` unchanged, so every form Docker accepts works:
`id=<id>`, `id=<id>,src=<path>` and `id=<id>,env=<var>`. A spec may also carry
`target=<path>`; Docker rejects that key on the command line because it belongs
to the Dockerfile, so `build.py` strips it from the build command and applies it
when generating the Dockerfile.

Two ids carry meaning. `apt_sources` is mounted over the apt source list for the
duration of every apt step in the generated `Dockerfile` and
`Dockerfile.buildbase`, and on the corresponding steps of `Dockerfile.sdk` and
`Dockerfile.QA`. `GITHUB_TOKEN` is an environment variable rather than a build
secret: the component and backend repos are cloned by `cmake_build` while the
build runs inside the container, not while an image is built, so a build secret
cannot reach them. `build.py` configures a git credential helper in the build
base and forwards the token to the build container instead. The helper holds no
credential of its own, only a reference, so it is safe in a layer and in the
pushed build base image, and it keeps the token out of `.git/config`.

Every mount is `required=false` and the helper prints nothing when the token is
absent, so a build without either secret behaves exactly as it does today: the
generated Dockerfiles are byte-identical and clones stay unauthenticated.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- The CI-side counterpart lives in the internal GitLab tritonserver project and
     is not linked here, per the rule against GitLab links in GitHub PRs. -->
A follow-up PR stacked on this branch bumps the fastapi and starlette pins in
the openai frontend; it is listed here once opened.

#### Where should the reviewer start?
`build.py` — `secret_spec_id`, `parse_secret_spec`, `secret_build_args`,
`apt_sources_secret_mount` and `mount_apt_sources_secret`, then the two
`docker build` argument lists and the `docker run` invocation that forwards
`GITHUB_TOKEN`.

#### Test plan:
Verified with `--dryrun`, by inspecting the generated build scripts, and with
real BuildKit builds.

- `./build.py --enable-all --dryrun` with no secret: generated Dockerfiles are
  byte-identical to a build without this feature, and no `--secret` reaches
  `docker build`.
- `./build.py --enable-all --dryrun --docker-build-secret id=apt_sources,src=<file>`:
  both `docker build` invocations carry `--secret`, and every apt step of
  `Dockerfile` and `Dockerfile.buildbase` carries the matching mount.
- `target=` is absent from the build command and present on the Dockerfile mount.
- Real BuildKit build with an apt source list mounted: packages resolve through
  the mirror, and the secret is absent from the image, from `docker history`,
  from `docker inspect` and from the exported filesystem.
- Real BuildKit build with `GITHUB_TOKEN`: an authenticated clone succeeds, the
  token does not appear in `.git/config`, and an unauthenticated build still
  clones a public repo successfully.

- CI Pipeline ID:

#### Caveats:
The apt source list carries credentials, which is why it is passed as a secret
and mounted per step rather than copied in. On a base image without CA
certificates the first apt step of `Dockerfile.buildbase` reports a failed TLS
handshake, still exits 0, and installs from the distribution repositories, so
that step behaves as it did before the mount was added.

#### Background
The build clones several repositories from GitHub and installs a large number of
packages. Both were unauthenticated, which is subject to rate limiting and
cannot reach a private repository or an authenticated mirror.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1736
