### PR TITLE
build: bump fastapi and starlette pins in openai frontend

### DIFF
--- a/python/openai/requirements.txt
+++ b/python/openai/requirements.txt
@@ -25,7 +25,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # FastAPI Application
-fastapi==0.121.2
+# Keep within [0.133.0, 0.137.0): older releases cap starlette below 1.0,
+# and vllm requires fastapi[standard]<0.137.0,>=0.133.0.
+fastapi==0.136.3
 # Fix httpx version to avoid bug in openai library:
 # https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/3
 httpx==0.27.2
@@ -34,7 +36,5 @@ partial-json-parser # used for parsing partial JSON outputs
 
 # FIXME [TRI-641]: The latest stable version of scipy is 1.17.0 which caused segfault during tests. See TRI-620.
 scipy==1.16.3
-# Minimum starlette version needed to address CVE(s):
-# https://github.com/advisories/GHSA-f96h-pmfr-66vw
-# https://github.com/advisories/GHSA-7f5h-v6xp-fcq8
-starlette>=0.49.1
+# 1.3.1 is the minimum version with all known security fixes applied.
+starlette>=1.3.1,<2


### PR DESCRIPTION
#### What does the PR do?
Backports the fastapi and starlette pin bump to `r26.08`, so the release branch
picks up the starlette CVE fix.

`starlette` moves to `>=1.3.1,<2`. That floor cannot be met by the pinned
fastapi, because releases before 0.133.0 cap starlette below 1.0, so `fastapi`
moves to `0.136.3`. The upper bound stays below 0.137.0 because vllm requires
`fastapi[standard]<0.137.0,>=0.133.0`. The two pins are coupled, which is why
they move together.

Cherry-picked from the change already merged to `main`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/server#8940

#### Where should the reviewer start?
`python/openai/requirements.txt` — confirm the backported pins match what landed
on `main` and that the vllm constraint still holds for the 26.08 train.

#### Test plan:
Diff against `r26.08` is a single file, `+5/-5`, identical to the change merged
to `main`.

- CI Pipeline ID:

#### Caveats:
The fastapi bound is dictated by vllm's own requirement range, so a future vllm
bump on this branch may need this revisited.

#### Background
Part of the post-code-freeze security scan pass for 26.08. The CVE fix landed on
`main` first and is backported here so the release branch is not left on the
vulnerable starlette range.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: TRI-1683
