### PR TITLE
ci: replace SPDX header with LICENSE header on L0_torch_aoti_hstu (TRI-1654)

### DIFF
--- a/qa/L0_torch_aoti_hstu/test.sh
+++ b/qa/L0_torch_aoti_hstu/test.sh
@@ -1,6 +1,29 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # HSTU (Generative Recommenders) Torch AOTI serving test, mirroring the serving
 # half of Devtech-Compute/distributed-recommender: ci/tritonserver_test.sh.


### PR DESCRIPTION
#### What does the PR do?
Converts the two-line SPDX header on `qa/L0_torch_aoti_hstu/test.sh` to the long-form BSD LICENSE header that `qa/common/check_copyright.py` requires. This was the last remaining copyright violation failing the nightly `L0_copyrights` job.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] ci

#### Related PRs:
Part of TRI-1654. Companion changes already merged:
- server `#8928` — copyright header on `qa/L2_build_presets/requirements.txt`
- server_ci (internal) `!1855` — copyright headers on the RHEL tutorial tests

#### Where should the reviewer start?
`qa/L0_torch_aoti_hstu/test.sh` — the header swap is the entire diff (+25/-2).

#### Test plan:
- `python3 qa/common/check_copyright.py --year=2026 *` → exit 0 (was exit 1 on this file). Last remaining violation, so the nightly `L0_copyrights` goes green.
- CI Pipeline ID: 64723722

#### Caveats:
None — header-only change, no functional or behavioral impact.

#### Background
The file was added (#8907) with a two-line SPDX header. `check_copyright.py` only accepts the long-form BSD header, and the `add-license` pre-commit hook doesn't convert SPDX (it sees the SPDX copyright line as already present), so it slipped through and broke the nightly. Same class of fix as `82cf9596`.

#### Related Issues:
- Relates to TRI-1654 (internal Linear). No GitHub issue.


