### PR TITLE
ci(models): warn and skip when TensorRT has no kernels for the GPU

### DIFF
--- a/qa/common/check_tensorrt_target.py
+++ b/qa/common/check_tensorrt_target.py
@@ -1,0 +1,132 @@
+# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Does the TensorRT in this container have kernels for the GPU we are on?
+
+A GPU newer than the TensorRT that ships beside it is the case this exists
+for: every generator that calls `build_serialized_network` then gets a null
+plan back, and the ones that write it unchecked die on a TypeError that says
+nothing about the real cause.
+
+Two users, both reading the same answer from TensorRT itself:
+
+  * `UNSUPPORTED_TARGET_MARKER` is what gen_qa_model_repository.py's per-step
+    wrapper greps a failed generator's output for, to tell "this GPU is out
+    of TensorRT's reach" from "this generator is broken".
+  * `unsupported_target_reason()` asks the question up front, which
+    gen_qa_torchtrt_models.py does to skip before downloading model weights
+    it would only throw away.
+"""
+
+import subprocess
+import sys
+
+# The escapes gen_qa_model_repository.py uses, so a warning raised here reads
+# the same in a CI log as one raised by the driver around it.
+COLOR_WARNING = "\033[33m"
+COLOR_RESET = "\033[0m"
+
+# How TensorRT names a target it has no kernels for, e.g. "Target GPU SM 107
+# is not supported by this TensorRT release."
+UNSUPPORTED_TARGET_MARKER = "is not supported by this TensorRT release"
+
+
+def warn(message):
+    print(
+        "{}[WARNING] {}{}".format(COLOR_WARNING, message, COLOR_RESET),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def compute_capability():
+    """The running GPU's compute capability, in TensorRT's dotted spelling.
+
+    Read from nvidia-smi rather than torch: this runs in the TensorRT stage's
+    container too, which has no torch in it.
+    """
+    try:
+        completed = subprocess.run(
+            ["nvidia-smi", "--query-gpu=compute_cap", "--format=csv,noheader"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    return lines[0] if lines else None
+
+
+def _probe_unsupported_target():
+    """TensorRT's own words for why it cannot build here, or None if it can.
+
+    TensorRT publishes no list of the SMs it was compiled for, so the question
+    goes to the builder instead of to a table this script would have to keep
+    in step with each release: serialize a one-layer engine for the current
+    device and read what the builder logs. The SM guard lives in
+    IBuilder::buildSerializedNetwork -- which is what the error names -- so a
+    trivial network trips it exactly as a real model does, in a fraction of
+    the time.
+    """
+    import tensorrt as trt
+
+    class _Recorder(trt.ILogger):
+        def __init__(self):
+            trt.ILogger.__init__(self)
+            self.messages = []
+
+        def log(self, severity, message):
+            self.messages.append(message)
+
+    recorder = _Recorder()
+    builder = trt.Builder(recorder)
+    network = builder.create_network()
+    identity = network.add_identity(
+        network.add_input("input", trt.float32, (1, 1, 1, 1))
+    )
+    network.mark_output(identity.get_output(0))
+    if builder.build_serialized_network(network, builder.create_builder_config()):
+        return None
+    for message in recorder.messages:
+        if UNSUPPORTED_TARGET_MARKER in message:
+            return message.strip()
+    # The probe failed for some other reason. Report nothing and let the real
+    # generators fail loudly, rather than turn an unrelated regression into a
+    # silent skip of every TensorRT model.
+    return None
+
+
+def unsupported_target_reason():
+    """_probe_unsupported_target, with the probe itself never fatal."""
+    try:
+        return _probe_unsupported_target()
+    except Exception as error:
+        # A gate that cannot run is not a gate. If tensorrt is absent, or its
+        # builder API moved between releases, fall through to generation and
+        # let that report the truth.
+        warn("Could not ask TensorRT whether it supports this GPU: {}".format(error))
+        return None

--- a/qa/common/gen_qa_model_repository.py
+++ b/qa/common/gen_qa_model_repository.py
@@ -708,10 +708,11 @@ def build_stages(ctx):
                 "    rm -rf build && mkdir build && cd build && cmake .. &&"
                 " make -j && \\\n"
                 "    cp libcustomHardmaxPlugin.so " + plugin_root + "/.\n"
-                # `run_step env VAR=...` rather than a `VAR=... run_step`
-                # prefix: bash keeps an assignment made in front of a *shell
-                # function* in effect after the call, which would leak
-                # LD_PRELOAD into everything after this step.
+                # `run_step env VAR=...` keeps the assignment attached to
+                # the command run_step exec's, which is what needs it. A
+                # `VAR=... run_step` prefix would set it for the function call
+                # itself and rely on that reaching the exec'd child -- true in
+                # bash, but a level of indirection to reason about for nothing.
                 "  run_step env"
                 " LD_PRELOAD=" + plugin_root + "/libcustomHardmaxPlugin.so \\\n"
                 "    python3 " + ctx.source_dir + "/gen_qa_trt_plugin_models.py \\\n"
@@ -742,10 +743,16 @@ def build_stages(ctx):
 # --------------------------------------------------------------------------
 
 
-STEP_LOG = "/tmp/triton-model-gen-step.log"
+# Named inside the build directory, not in /tmp. The enroot runtime bind-mounts
+# the host's /tmp into the container, so a fixed /tmp path is shared by every
+# concurrent job on the node -- two of them would tee into one file and each
+# could read the other's output when classifying a failure. build_dir is
+# already per-job on both runtimes (mount_root + job id), which is the same
+# reason the enroot image and container name carry the job id.
+STEP_LOG_NAME = ".gen-step.log"
 
 
-def render_step_wrapper():
+def render_step_wrapper(ctx):
     """The shell function every generator invocation is run through.
 
     TensorRT refusing the GPU it is running on is the one generator failure
@@ -768,7 +775,7 @@ def render_step_wrapper():
     """
     return [
         "",
-        "TRITON_STEP_LOG=" + STEP_LOG,
+        "TRITON_STEP_LOG={}/{}".format(ctx.build_dir, STEP_LOG_NAME),
         "run_step() {",
         "  local status",
         '  "$@" 2>&1 | tee "${TRITON_STEP_LOG}"',
@@ -818,7 +825,7 @@ def render_stage_script(stage, ctx, final=False):
     ]
     lines += list(stage.prelude)
     lines.append("set -e")
-    lines += render_step_wrapper()
+    lines += render_step_wrapper(ctx)
     lines += list(stage.setup)
     lines.append("")
     for step in stage.steps:

--- a/qa/common/gen_qa_model_repository.py
+++ b/qa/common/gen_qa_model_repository.py
@@ -76,6 +76,8 @@ import shutil
 import subprocess
 import sys
 
+from check_tensorrt_target import UNSUPPORTED_TARGET_MARKER
+
 SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
 
 COLOR_ERROR = "\033[31m"
@@ -231,7 +233,10 @@ class Generate:
 
     def render(self, ctx):
         target = "{}/{}/{}".format(ctx.build_dir, MODEL_TREE_DIRNAME, self.repository)
-        command = ["python3", "{}/{}".format(ctx.source_dir, self.script)]
+        # run_step, not bare python3: see render_step_wrapper. A generator the
+        # GPU's compute capability puts out of reach is skipped with a warning
+        # instead of ending the stage.
+        command = ["run_step", "python3", "{}/{}".format(ctx.source_dir, self.script)]
         command += self.flags
         command.append("--models_dir={}".format(target))
         lines = [" ".join(command)]
@@ -680,7 +685,9 @@ def build_stages(ctx):
                 + SH_COLOR_RESET
                 + " Skipping model generation for data dependent shape"
                 " (NonZero not supported on this GPU)" + SH_COLOR_RESET + "'"
-                " || python3 " + ctx.source_dir + "/gen_qa_trt_data_dependent_shape.py"
+                " || run_step python3 "
+                + ctx.source_dir
+                + "/gen_qa_trt_data_dependent_shape.py"
                 " --models_dir=" + data_dependent_root + "\n"
                 "chmod -R 777 " + data_dependent_root,
                 "data dependent shape models, skipped on sm 10.7 / 11.0",
@@ -701,7 +708,12 @@ def build_stages(ctx):
                 "    rm -rf build && mkdir build && cd build && cmake .. &&"
                 " make -j && \\\n"
                 "    cp libcustomHardmaxPlugin.so " + plugin_root + "/.\n"
-                "  LD_PRELOAD=" + plugin_root + "/libcustomHardmaxPlugin.so \\\n"
+                # `run_step env VAR=...` rather than a `VAR=... run_step`
+                # prefix: bash keeps an assignment made in front of a *shell
+                # function* in effect after the call, which would leak
+                # LD_PRELOAD into everything after this step.
+                "  run_step env"
+                " LD_PRELOAD=" + plugin_root + "/libcustomHardmaxPlugin.so \\\n"
                 "    python3 " + ctx.source_dir + "/gen_qa_trt_plugin_models.py \\\n"
                 "    --models_dir=" + plugin_root + "\n"
                 "  chmod -R 777 " + plugin_root + "\n"
@@ -730,6 +742,66 @@ def build_stages(ctx):
 # --------------------------------------------------------------------------
 
 
+STEP_LOG = "/tmp/triton-model-gen-step.log"
+
+
+def render_step_wrapper():
+    """The shell function every generator invocation is run through.
+
+    TensorRT refusing the GPU it is running on is the one generator failure
+    that is not a defect in this repository: the SM the container was built
+    for and the SM in the machine are a release apart, every generator that
+    reaches build_serialized_network gets a null plan back, and the ones that
+    write it unchecked die on a TypeError naming neither cause. Classified
+    per step rather than per stage, so one framework being out of reach costs
+    only its own models -- the rest of the stage still runs, and the trees it
+    did fill still ship.
+
+    The decision is made on the step's own output: TensorRT's wording for the
+    refusal is the only thing that turns a failure into a warning. Anything
+    else exits non-zero as before and `set -e` ends the stage, so a real
+    regression is still loud.
+
+    A shell function rather than a Python wrapper so `set -x` keeps printing
+    the generator's own command line, which is what makes a CI failure
+    reproducible by hand.
+    """
+    return [
+        "",
+        "TRITON_STEP_LOG=" + STEP_LOG,
+        "run_step() {",
+        "  local status",
+        '  "$@" 2>&1 | tee "${TRITON_STEP_LOG}"',
+        # tee is the last command in the pipeline, so the pipeline succeeds and
+        # `set -e` stays out of this; the generator's own status is PIPESTATUS.
+        "  status=${PIPESTATUS[0]}",
+        '  if [ "${status}" -eq 0 ]; then',
+        "    return 0",
+        "  fi",
+        '  if grep -qF "' + UNSUPPORTED_TARGET_MARKER + '" "${TRITON_STEP_LOG}"; then',
+        '    echo -e "'
+        + SH_COLOR_WARNING
+        + "[WARNING]"
+        + SH_COLOR_RESET
+        + " Skipping models from: $*"
+        + SH_COLOR_RESET
+        + '" >&2',
+        '    echo -e "'
+        + SH_COLOR_WARNING
+        + "[WARNING]"
+        + SH_COLOR_RESET
+        + " TensorRT has no kernels for this GPU; the rest of the stage"
+        + " continues."
+        + SH_COLOR_RESET
+        + '" >&2',
+        "    return 0",
+        "  fi",
+        '  return "${status}"',
+        "}",
+        "",
+    ]
+
+
 def render_stage_script(stage, ctx, final=False):
     """The bash script a stage runs inside its container."""
     lines = [
@@ -746,6 +818,7 @@ def render_stage_script(stage, ctx, final=False):
     ]
     lines += list(stage.prelude)
     lines.append("set -e")
+    lines += render_step_wrapper()
     lines += list(stage.setup)
     lines.append("")
     for step in stage.steps:

--- a/qa/common/gen_qa_model_repository.py
+++ b/qa/common/gen_qa_model_repository.py
@@ -746,9 +746,12 @@ def build_stages(ctx):
 # Named inside the build directory, not in /tmp. The enroot runtime bind-mounts
 # the host's /tmp into the container, so a fixed /tmp path is shared by every
 # concurrent job on the node -- two of them would tee into one file and each
-# could read the other's output when classifying a failure. build_dir is
-# already per-job on both runtimes (mount_root + job id), which is the same
-# reason the enroot image and container name carry the job id.
+# could read the other's output when classifying a failure. Left to itself
+# build_dir is mount_root plus the job id on either runtime, which is the same
+# reason the enroot image and the container name carry that id. A caller who
+# passes --build-dir supplies the whole path and owns that distinction: point
+# two concurrent jobs at one directory and they share this log again, along
+# with the model tree it sits beside.
 STEP_LOG_NAME = ".gen-step.log"
 
 

--- a/qa/common/gen_qa_model_repository.py
+++ b/qa/common/gen_qa_model_repository.py
@@ -804,6 +804,12 @@ def render_step_wrapper(ctx):
         + " continues."
         + SH_COLOR_RESET
         + '" >&2',
+        # The generator got as far as creating the model directory and opening
+        # model.plan before the null plan raised, so a config.pbtxt beside a
+        # zero-byte engine is sitting there. Left alone it would be archived
+        # and published as a real model. The step's own arguments carry the
+        # --models_dir to clean up under.
+        "    python3 " + ctx.source_dir + '/prune_partial_models.py "$@"',
         "    return 0",
         "  fi",
         '  return "${status}"',

--- a/qa/common/gen_qa_torchtrt_models.py
+++ b/qa/common/gen_qa_torchtrt_models.py
@@ -33,14 +33,14 @@ import sys
 import gen_manifest
 import torch
 import torchvision
+from check_tensorrt_target import compute_capability, unsupported_target_reason, warn
 
 try:
     import torch_tensorrt
 except ImportError:
-    print(
-        "WARNING: torch_tensorrt is not available in this environment. "
-        "Skipping Torch-TensorRT model generation.",
-        file=sys.stderr,
+    warn(
+        "torch_tensorrt is not available in this environment. "
+        "Skipping Torch-TensorRT model generation."
     )
     sys.exit(0)
 
@@ -120,6 +120,18 @@ if __name__ == "__main__":
         "--models_dir", type=str, required=True, help="Top-level model directory"
     )
     FLAGS, unparsed = parser.parse_known_args()
+
+    # Asked before the weights download and the trace: on a GPU this TensorRT
+    # has no kernels for, every one of those is wasted and the compile ends the
+    # whole PyTorch stage, which runs under `set -e`.
+    reason = unsupported_target_reason()
+    if reason:
+        capability = compute_capability()
+        warn(
+            "Skipping Torch-TensorRT model generation on compute capability"
+            " {}: {}".format(capability or "unknown", reason)
+        )
+        sys.exit(0)
 
     # Fingerprint the tree first, so emit_manifests() below stamps only the
     # models this script creates rather than relabelling every other stage's.

--- a/qa/common/prune_partial_models.py
+++ b/qa/common/prune_partial_models.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Delete the half-written models a refused TensorRT build leaves behind.
+
+Every plan generator writes its config.pbtxt first and its engine second, and
+serializes with
+
+    with open(model_version_dir + "/model.plan", "wb") as f:
+        f.write(engine_bytes)
+
+so when the builder hands back a null plan, the open() has already created the
+file before the write raises. What survives is a model directory that looks
+complete -- a config.pbtxt beside a zero-byte model.plan -- which is worse
+than one that is simply absent: nothing downstream opens the engine, so the
+manifest records it, the archive ships it, and Triton is the first thing to
+notice, at load time.
+
+Run from gen_qa_model_repository.py's step wrapper after a step is skipped
+because TensorRT has no kernels for this GPU. Takes the skipped step's own
+command line and reads --models_dir out of it.
+
+Deliberately narrow. A zero-byte model.plan is never a legitimate artifact, so
+that alone is the signal; a plan with any content at all is left untouched.
+Only version directories under the named --models_dir are considered, and the
+model directory goes only once its last version has, since a config.pbtxt with
+no version left to serve is equally unloadable.
+"""
+
+import os
+import shutil
+import sys
+
+COLOR_WARNING = "\033[33m"
+COLOR_RESET = "\033[0m"
+
+ENGINE_NAME = "model.plan"
+
+
+def warn(message):
+    print(
+        "{}[WARNING] {}{}".format(COLOR_WARNING, message, COLOR_RESET),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def models_dir_from(argv):
+    """The --models_dir the skipped step was given, or None."""
+    for index, arg in enumerate(argv):
+        if arg.startswith("--models_dir="):
+            return arg.split("=", 1)[1]
+        if arg == "--models_dir" and index + 1 < len(argv):
+            return argv[index + 1]
+    return None
+
+
+def _contained(path, root):
+    """Is path inside root? Guards the removals below against a stray path."""
+    path = os.path.realpath(path)
+    root = os.path.realpath(root)
+    return path == root or path.startswith(root + os.sep)
+
+
+def prune(models_dir):
+    """Remove every model whose engine was never actually written."""
+    removed = []
+    if not os.path.isdir(models_dir):
+        return removed
+
+    for model_name in sorted(os.listdir(models_dir)):
+        model_dir = os.path.join(models_dir, model_name)
+        if not os.path.isdir(model_dir):
+            continue
+
+        from_this_model = []
+        for version in sorted(os.listdir(model_dir)):
+            version_dir = os.path.join(model_dir, version)
+            engine = os.path.join(version_dir, ENGINE_NAME)
+            if not os.path.isfile(engine) or os.path.getsize(engine) != 0:
+                continue
+            if not _contained(version_dir, models_dir):
+                continue
+            shutil.rmtree(version_dir, ignore_errors=True)
+            from_this_model.append(version_dir)
+
+        removed.extend(from_this_model)
+        if not from_this_model:
+            continue
+
+        # A config.pbtxt whose every version has gone cannot be served, so the
+        # model goes with them -- but only when this model is the one that
+        # lost them. A directory that was already empty is left alone.
+        remaining = [
+            entry
+            for entry in os.listdir(model_dir)
+            if os.path.isdir(os.path.join(model_dir, entry))
+        ]
+        if not remaining and _contained(model_dir, models_dir):
+            shutil.rmtree(model_dir, ignore_errors=True)
+            removed.append(model_dir)
+
+    return removed
+
+
+def main(argv):
+    models_dir = models_dir_from(argv)
+    if models_dir is None:
+        return 0
+
+    removed = prune(models_dir)
+    if removed:
+        warn(
+            "Removed {} partially written model path(s) under {}:".format(
+                len(removed), models_dir
+            )
+        )
+        for path in removed:
+            warn("  {}".format(path))
+    return 0
+
+
+if __name__ == "__main__":
+    # Best-effort cleanup: never turn tidying up after a skip into the thing
+    # that fails the stage.
+    try:
+        sys.exit(main(sys.argv[1:]))
+    except Exception as error:  # noqa: BLE001
+        warn("Could not prune partial models: {}".format(error))
+        sys.exit(0)


### PR DESCRIPTION
#### What does the PR do?
- A generator that fails **only** because TensorRT has no kernels for the running GPU is now warned about and skipped; the rest of the stage still runs and the tree still ships.
- Every generator call goes through a `run_step` wrapper. Any other failure still exits non-zero, so `set -e` ends the stage on a real regression.
- No SM is hardcoded: the decision comes from TensorRT's own refusal text, so generation resumes by itself once a release ships kernels for the GPU.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [x] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
None — this change is contained to this repository.

#### Where should the reviewer start?
- `qa/common/gen_qa_model_repository.py` — `render_step_wrapper()` defines the `run_step` shell function; `Generate.render()` routes every generator through it. Two shell details matter: `tee` is last in the pipeline so `set -e` does not act on a failing generator (its status comes from `PIPESTATUS[0]`), and the status test is a full `if` rather than a `&&` list, which would itself trip `set -e`.
- `qa/common/check_tensorrt_target.py` — the probe and the marker string both callers share.

#### Test plan:
- CI Pipeline ID: 65497609

Full GenModels matrix, 22/22 jobs green, including the two jobs this fixes:
- `GenModels-build--x86-rubin-10.7` and `GenModels-build--sbsa-rubin-10.7` — previously failed, now pass; 18 generation steps warned and skipped per job, manifest summary written, artifacts uploaded.
- `GenModels-download--*-rubin-10.7` — pass, so the uploaded tree is consumable downstream.
- No regression on the other nine GPUs (8.0, 8.7, 9.0, 10.0, 10.3, 11.0, 12.0, 12.1).

Behaviour was also verified against a stubbed generator: success runs normally, a TensorRT refusal is warned and skipped with later steps still running, and any other failure aborts the stage.

#### Caveats:
- Steps now run and fail rather than being skipped up front, so a generator that writes `config.pbtxt` before its engine could leave a partially written model directory. Not observed in CI, and the download jobs only fetch the tree rather than loading models, so it is not yet ruled out. Auditing write ordering across the TensorRT generators is a follow-up.
- A step is classified by grepping its whole output for TensorRT's refusal text, not by anchoring to the failure itself. Only already-failing steps are classified, and if TensorRT refuses the target then every engine build in the stage fails for that same reason, so a co-occurring unrelated failure is unlikely — but a failure that merely mentions the phrase would be downgraded to a skip.
- The torchtrt generator keeps its own up-front check so it can skip before downloading model weights it would discard. `run_step` would catch that failure anyway; the pre-check only saves time.

#### Background
On a GPU a release ahead of the TensorRT beside it, every generator reaching `build_serialized_network` gets a null plan back. The ones that write it unchecked die on `TypeError: a bytes-like object is required, not 'NoneType'`, which names neither TensorRT nor the GPU. Under the stage's `set -e` the first of them ended the job, which then uploaded no artifacts at all — losing the trees earlier stages had already filled.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1767

<sup>
CI (internal): [#65497609](http://tritonserver.local/ci/pipelines/65497609)<br/>
</sup>

