### PR TITLE
test: add torch_aoti smoke coverage to L0_infer

### DIFF
--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -36,6 +36,8 @@ import unittest
 import infer_util as iu
 import numpy as np
 import test_util as tu
+import tritonclient.grpc as grpcclient
+import tritonclient.http as httpclient
 from tritonclient.utils import *
 
 TEST_SYSTEM_SHARED_MEMORY = bool(int(os.environ.get("TEST_SYSTEM_SHARED_MEMORY", 0)))
@@ -1181,6 +1183,66 @@ class InferTest(tu.TestResultCollector):
                                 use_system_shared_memory=TEST_SYSTEM_SHARED_MEMORY,
                                 use_cuda_shared_memory=TEST_CUDA_SHARED_MEMORY,
                             )
+
+    def test_torch_aoti_float32(self):
+        # Light AOTI coverage: one existing add model (ARGS[0]/ARGS[1] -> RESULT).
+        # Not libtorch-shaped; infer_exact cannot be reused.
+        model_name = "torch_aoti_float32_float32"
+        input0 = np.ones((1, 16), dtype=np.float32)
+        input1 = np.full((1, 16), 2.0, dtype=np.float32)
+        expected = input0 + input1
+
+        def _is_ready_http():
+            with httpclient.InferenceServerClient("localhost:8000") as client:
+                return client.is_model_ready(model_name)
+
+        def _is_ready_grpc():
+            with grpcclient.InferenceServerClient("localhost:8001") as client:
+                return client.is_model_ready(model_name)
+
+        ready = False
+        if USE_HTTP:
+            ready = _is_ready_http()
+        elif USE_GRPC:
+            ready = _is_ready_grpc()
+        if not ready:
+            self.skipTest(f"{model_name} not loaded in this L0_infer phase")
+
+        if USE_HTTP:
+            with httpclient.InferenceServerClient("localhost:8000") as client:
+                inputs = [
+                    httpclient.InferInput("ARGS[0]", input0.shape, "FP32"),
+                    httpclient.InferInput("ARGS[1]", input1.shape, "FP32"),
+                ]
+                inputs[0].set_data_from_numpy(input0)
+                inputs[1].set_data_from_numpy(input1)
+                result = client.infer(
+                    model_name,
+                    inputs,
+                    outputs=[httpclient.InferRequestedOutput("RESULT")],
+                )
+                self.assertTrue(
+                    np.allclose(result.as_numpy("RESULT"), expected),
+                    "torch_aoti HTTP RESULT mismatch",
+                )
+
+        if USE_GRPC:
+            with grpcclient.InferenceServerClient("localhost:8001") as client:
+                inputs = [
+                    grpcclient.InferInput("ARGS[0]", input0.shape, "FP32"),
+                    grpcclient.InferInput("ARGS[1]", input1.shape, "FP32"),
+                ]
+                inputs[0].set_data_from_numpy(input0)
+                inputs[1].set_data_from_numpy(input1)
+                result = client.infer(
+                    model_name,
+                    inputs,
+                    outputs=[grpcclient.InferRequestedOutput("RESULT")],
+                )
+                self.assertTrue(
+                    np.allclose(result.as_numpy("RESULT"), expected),
+                    "torch_aoti gRPC RESULT mismatch",
+                )
 
 
 if __name__ == "__main__":

--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -30,15 +30,15 @@ import sys
 
 sys.path.append("../common")
 
-import os
-import unittest
+import os  # noqa: E402
+import unittest  # noqa: E402
 
-import infer_util as iu
-import numpy as np
-import test_util as tu
-import tritonclient.grpc as grpcclient
-import tritonclient.http as httpclient
-from tritonclient.utils import *
+import infer_util as iu  # noqa: E402
+import numpy as np  # noqa: E402
+import test_util as tu  # noqa: E402
+import tritonclient.grpc as grpcclient  # noqa: E402
+import tritonclient.http as httpclient  # noqa: E402
+from tritonclient.utils import InferenceServerException  # noqa: E402
 
 TEST_SYSTEM_SHARED_MEMORY = bool(int(os.environ.get("TEST_SYSTEM_SHARED_MEMORY", 0)))
 TEST_CUDA_SHARED_MEMORY = bool(int(os.environ.get("TEST_CUDA_SHARED_MEMORY", 0)))

--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -79,6 +79,8 @@ np_dtype_string = np.dtype(object)
 
 # 60 sec is the default value
 NETWORK_TIMEOUT = 300.0 if TEST_VALGRIND else 60.0
+# Same override infer_util uses (DoD / non-localhost server).
+TRITONSERVER_IPADDR = os.environ.get("TRITONSERVER_IPADDR", "localhost")
 
 
 class InferTest(tu.TestResultCollector):
@@ -1193,11 +1195,15 @@ class InferTest(tu.TestResultCollector):
         expected = input0 + input1
 
         def _is_ready_http():
-            with httpclient.InferenceServerClient("localhost:8000") as client:
+            with httpclient.InferenceServerClient(
+                f"{TRITONSERVER_IPADDR}:8000"
+            ) as client:
                 return client.is_model_ready(model_name)
 
         def _is_ready_grpc():
-            with grpcclient.InferenceServerClient("localhost:8001") as client:
+            with grpcclient.InferenceServerClient(
+                f"{TRITONSERVER_IPADDR}:8001"
+            ) as client:
                 return client.is_model_ready(model_name)
 
         ready = False
@@ -1209,7 +1215,9 @@ class InferTest(tu.TestResultCollector):
             self.skipTest(f"{model_name} not loaded in this L0_infer phase")
 
         if USE_HTTP:
-            with httpclient.InferenceServerClient("localhost:8000") as client:
+            with httpclient.InferenceServerClient(
+                f"{TRITONSERVER_IPADDR}:8000"
+            ) as client:
                 inputs = [
                     httpclient.InferInput("ARGS[0]", input0.shape, "FP32"),
                     httpclient.InferInput("ARGS[1]", input1.shape, "FP32"),
@@ -1227,7 +1235,9 @@ class InferTest(tu.TestResultCollector):
                 )
 
         if USE_GRPC:
-            with grpcclient.InferenceServerClient("localhost:8001") as client:
+            with grpcclient.InferenceServerClient(
+                f"{TRITONSERVER_IPADDR}:8001"
+            ) as client:
                 inputs = [
                     grpcclient.InferInput("ARGS[0]", input0.shape, "FP32"),
                     grpcclient.InferInput("ARGS[1]", input1.shape, "FP32"),

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -73,9 +73,9 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
 fi
 
 if [ "$TEST_SYSTEM_SHARED_MEMORY" -eq 1 ] || [ "$TEST_CUDA_SHARED_MEMORY" -eq 1 ]; then
-    EXPECTED_NUM_TESTS=${EXPECTED_NUM_TESTS:="33"}
+    EXPECTED_NUM_TESTS=${EXPECTED_NUM_TESTS:="34"}
 else
-    EXPECTED_NUM_TESTS=${EXPECTED_NUM_TESTS:="46"}
+    EXPECTED_NUM_TESTS=${EXPECTED_NUM_TESTS:="47"}
 fi
 
 TEST_JETSON=${TEST_JETSON:=0}
@@ -320,6 +320,12 @@ for TARGET in cpu gpu; do
 
     generate_model_repository
 
+    # Light torch_aoti coverage for Dynamo/L0_infer: one existing add model.
+    # GPU-only — the packaged .pt2 is CUDA. Skip CPU target so the server still starts.
+    if [ "$TARGET" == "gpu" ] && [ -d "${DATADIR}/qa_model_repository/torch_aoti_float32_float32" ]; then
+        cp -r ${DATADIR}/qa_model_repository/torch_aoti_float32_float32 models/.
+    fi
+
     # Check if running a memory leak check
     if [ "$TEST_VALGRIND" -eq 1 ]; then
         LEAKCHECK_LOG=$LEAKCHECK_LOG_BASE.${TARGET}.log
@@ -372,7 +378,7 @@ done
 # separately to reduce the loading time.
 if [ "$TEST_VALGRIND" -eq 1 ]; then
   TESTING_BACKENDS="python python_dlpack onnx"
-  EXPECTED_NUM_TESTS=36
+  EXPECTED_NUM_TESTS=37
   if [[ "aarch64" != $(uname -m) ]] ; then
       pip3 install torch==2.3.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
   else
@@ -391,6 +397,10 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
         # These two models are required by test_ensemble_mix_batch_nobatch test case.
         cp -fr ./models/onnx_float32_float32_float32 ./nobatch_models/.
         cp -fr ./models/custom_zero_1_float32 ./nobatch_models/.
+      fi
+      if [ "$TARGET" == "gpu" ] && [ -d "${DATADIR}/qa_model_repository/torch_aoti_float32_float32" ]; then
+        cp -r ${DATADIR}/qa_model_repository/torch_aoti_float32_float32 models/.
+        cp -r ${DATADIR}/qa_model_repository/torch_aoti_float32_float32 nobatch_models/.
       fi
 
       for BATCHING_MODE in batch nobatch; do

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -376,7 +376,9 @@ done
 # separately to reduce the loading time.
 if [ "$TEST_VALGRIND" -eq 1 ]; then
   TESTING_BACKENDS="python python_dlpack onnx"
-  EXPECTED_NUM_TESTS=37
+  # VALGRIND_TESTS=1 omits version/ensemble methods, so this phase cannot
+  # share EXPECTED_NUM_TESTS with the first loop (47, or the GitLab pin).
+  EXPECTED_NUM_VALGRIND_BACKEND_TESTS=${EXPECTED_NUM_VALGRIND_BACKEND_TESTS:="37"}
   if [[ "aarch64" != $(uname -m) ]] ; then
       pip3 install torch==2.3.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
   else
@@ -444,7 +446,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
             cat $CLIENT_LOG
             RET=1
         else
-            check_test_results $TEST_RESULT_FILE $EXPECTED_NUM_TESTS
+            check_test_results $TEST_RESULT_FILE $EXPECTED_NUM_VALGRIND_BACKEND_TESTS
             if [ $? -ne 0 ]; then
                 cat $CLIENT_LOG
                 cat $TEST_RESULT_FILE

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -320,7 +320,7 @@ for TARGET in cpu gpu; do
 
     generate_model_repository
 
-    if [ "$TARGET" == "gpu" ] && [ -d "${DATADIR}/qa_model_repository/torch_aoti_float32_float32" ]; then
+    if [ "$TARGET" == "gpu" ]; then
         cp -r ${DATADIR}/qa_model_repository/torch_aoti_float32_float32 models/.
     fi
 

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -320,8 +320,6 @@ for TARGET in cpu gpu; do
 
     generate_model_repository
 
-    # Light torch_aoti coverage for Dynamo/L0_infer: one existing add model.
-    # GPU-only — the packaged .pt2 is CUDA. Skip CPU target so the server still starts.
     if [ "$TARGET" == "gpu" ] && [ -d "${DATADIR}/qa_model_repository/torch_aoti_float32_float32" ]; then
         cp -r ${DATADIR}/qa_model_repository/torch_aoti_float32_float32 models/.
     fi

--- a/qa/L0_infer/test.sh
+++ b/qa/L0_infer/test.sh
@@ -396,7 +396,7 @@ if [ "$TEST_VALGRIND" -eq 1 ]; then
         cp -fr ./models/onnx_float32_float32_float32 ./nobatch_models/.
         cp -fr ./models/custom_zero_1_float32 ./nobatch_models/.
       fi
-      if [ "$TARGET" == "gpu" ] && [ -d "${DATADIR}/qa_model_repository/torch_aoti_float32_float32" ]; then
+      if [ "$TARGET" == "gpu" ]; then
         cp -r ${DATADIR}/qa_model_repository/torch_aoti_float32_float32 models/.
         cp -r ${DATADIR}/qa_model_repository/torch_aoti_float32_float32 nobatch_models/.
       fi


### PR DESCRIPTION
#### What does the PR do?
Adds a light torch AOTI pass to L0_infer: copy the existing `torch_aoti_float32_float32` add model in the GPU phase and infer `ARGS[0]`/`ARGS[1]` → `RESULT` over HTTP and gRPC. AOTI I/O names are not libtorch-shaped, so this does not reuse `infer_exact`. Nested/sequence/negative AOTI cases stay in `L0_torch_aoti`.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [ ] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
N/A

#### Where should the reviewer start?
`qa/L0_infer/test.sh` (GPU-only copy + expected test counts), then `qa/L0_infer/infer_test.py` (`test_torch_aoti_float32`).

#### Test plan:
- Local: generated `torch_aoti_float32_float32`, started tritonserver, ran `python3 -m unittest infer_test.InferTest.test_torch_aoti_float32` — **ok** (HTTP and gRPC).
- Full `L0_infer/test.sh` against QA DATADIR: GitLab CI after this PR.

- CI Pipeline ID:[#65592447]
GPU-only (packaged `.pt2` is CUDA). The new test skips if that model is not loaded. Expected test counts bump by one; CPU-only and missing-DATADIR phases still skip.

#### Background
L0_infer is the shared backend matrix (including Dynamo `SERVER_LAUNCH_MODE=dynamo`). It never loaded a torch AOTI model. This is one existing add model, not a rewrite of `L0_torch_aoti`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- N/A