### PR TITLE
[Docs] Update Docs Index for QwenVL guide

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -38,7 +38,7 @@
 
    getting_started/quick_deployment
    LLM With TensorRT-LLM <getting_started/trtllm_user_guide.md>
-   Multimodal model <../tutorials/Popular_Models_Guide/Llava1.5/llava_trtllm_guide.md>
+   Multimodal model <../tutorials/Popular_Models_Guide/Qwen2.5-VL/qwen2_5_vl_trtllm_guide.md>
    Stable diffusion <../tutorials/Popular_Models_Guide/StableDiffusion/README.md>
    HSTU (Generative Recommenders) <../tutorials/Popular_Models_Guide/HSTU/README.md>
 


### PR DESCRIPTION
TensorRT-LLM is retiring the prebuilt-TensorRT-engine multimodal path that the
Llava1.5 guide is built on — it is end-of-life as of TensorRT-LLM v1.2, in favor
of the PyTorch backend via the LLM API.

This points the "Multimodal model" entry in `docs/contents.rst` at the new
Qwen2.5-VL guide, which documents the replacement path.

**Draft:** blocked on triton-inference-server/tutorials#169, which adds the guide
this entry links to. Merging before that lands would break the docs build.

Related: #8945 (the outdated-guide issue), NVIDIA/TensorRT-LLM#18381 (the backend
change that enables the new path).
