### PR TITLE
fix: skip tritonclient.http import in dynamo L0_infer

### DIFF
--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -37,8 +37,14 @@ import infer_util as iu  # noqa: E402
 import numpy as np  # noqa: E402
 import test_util as tu  # noqa: E402
 import tritonclient.grpc as grpcclient  # noqa: E402
-import tritonclient.http as httpclient  # noqa: E402
 from tritonclient.utils import InferenceServerException  # noqa: E402
+
+# Dynamo images ship gRPC-only tritonclient (no gevent/http extra). Match
+# infer_util: skip the HTTP import so L0_infer can load in dynamo mode.
+if os.environ.get("SERVER_LAUNCH_MODE") == "dynamo":
+    httpclient = None
+else:
+    import tritonclient.http as httpclient  # noqa: E402
 
 TEST_SYSTEM_SHARED_MEMORY = bool(int(os.environ.get("TEST_SYSTEM_SHARED_MEMORY", 0)))
 TEST_CUDA_SHARED_MEMORY = bool(int(os.environ.get("TEST_CUDA_SHARED_MEMORY", 0)))

--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -39,13 +39,6 @@ import test_util as tu  # noqa: E402
 import tritonclient.grpc as grpcclient  # noqa: E402
 from tritonclient.utils import InferenceServerException  # noqa: E402
 
-# Dynamo images ship gRPC-only tritonclient (no gevent/http extra). Match
-# infer_util: skip the HTTP import so L0_infer can load in dynamo mode.
-if os.environ.get("SERVER_LAUNCH_MODE") == "dynamo":
-    httpclient = None
-else:
-    import tritonclient.http as httpclient  # noqa: E402
-
 TEST_SYSTEM_SHARED_MEMORY = bool(int(os.environ.get("TEST_SYSTEM_SHARED_MEMORY", 0)))
 TEST_CUDA_SHARED_MEMORY = bool(int(os.environ.get("TEST_CUDA_SHARED_MEMORY", 0)))
 CPU_ONLY = os.environ.get("TRITON_SERVER_CPU_ONLY") is not None
@@ -1201,6 +1194,8 @@ class InferTest(tu.TestResultCollector):
         expected = input0 + input1
 
         def _is_ready_http():
+            import tritonclient.http as httpclient
+
             with httpclient.InferenceServerClient(
                 f"{TRITONSERVER_IPADDR}:8000"
             ) as client:
@@ -1221,6 +1216,8 @@ class InferTest(tu.TestResultCollector):
             self.skipTest(f"{model_name} not loaded in this L0_infer phase")
 
         if USE_HTTP:
+            import tritonclient.http as httpclient
+
             with httpclient.InferenceServerClient(
                 f"{TRITONSERVER_IPADDR}:8000"
             ) as client:


### PR DESCRIPTION
#### What does the PR do?
Stop importing `tritonclient.http` at L0_infer module load. Import it only inside `USE_HTTP` paths in the AOTI smoke. gRPC-only images (Dynamo: `tritonclient[grpc]`, no gevent) can collect tests; native Triton still runs HTTP when `USE_HTTP` is on.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [x] fix

#### Related PRs:
Follow-up to https://github.com/triton-inference-server/server/pull/8948

#### Where should the reviewer start?
`qa/L0_infer/infer_test.py` — no module-level HTTP import; lazy import in `_is_ready_http` and the HTTP infer block.

#### Test plan:
- Native Triton L0_infer still uses HTTP when `USE_HTTP` is set.
- With `SERVER_LAUNCH_MODE=dynamo` (`USE_HTTP=False`), `infer_test.py` imports without gevent.
- Re-run Dynamo Post-Merge CI `triton-runtime / QA Test` after merge.

#### Caveats:
Does not add HTTP extras to the Dynamo image. Dynamo still uses gRPC only.

#### Background
#8948 imported HTTP at module load. Dynamo QA failed with `ModuleNotFoundError: No module named 'gevent'` before any test ran.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to #8948