### PR TITLE
refactor: extract macro for gRPC shared-memory error reporting

### DIFF
--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -62,6 +62,15 @@
 #include "../tracer.h"
 #endif  // TRITON_ENABLE_TRACING
 
+// Reports a gRPC error to STATUS, releases it, and returns from the handler.
+#define RESPOND_WITH_ERR_AND_RETURN(STATUS, ERR) \
+  do {                                           \
+    TRITONSERVER_Error* err__ = (ERR);           \
+    GrpcStatusUtil::Create((STATUS), err__);     \
+    TRITONSERVER_ErrorDelete(err__);             \
+    return;                                      \
+  } while (false)
+
 namespace triton { namespace server { namespace grpc {
 
 namespace {
@@ -1665,12 +1674,10 @@ CommonHandler::RegisterSystemSharedMemoryStatus()
           ::grpc::Status* status) {
         // No shared memory manager (e.g. in-process Python frontend).
         if (shm_manager_ == nullptr) {
-          TRITONSERVER_Error* err = TRITONSERVER_ErrorNew(
-              TRITONSERVER_ERROR_UNAVAILABLE,
-              kSharedMemoryManagerUnavailableErrorStr);
-          GrpcStatusUtil::Create(status, err);
-          TRITONSERVER_ErrorDelete(err);
-          return;
+          RESPOND_WITH_ERR_AND_RETURN(
+              status, TRITONSERVER_ErrorNew(
+                          TRITONSERVER_ERROR_UNAVAILABLE,
+                          kSharedMemoryManagerUnavailableErrorStr));
         }
         triton::common::TritonJson::Value shm_status_json(
             triton::common::TritonJson::ValueType::ARRAY);
@@ -1749,12 +1756,10 @@ CommonHandler::RegisterSystemSharedMemoryRegister()
           ::grpc::Status* status) {
         // No shared memory manager (e.g. in-process Python frontend).
         if (shm_manager_ == nullptr) {
-          TRITONSERVER_Error* err = TRITONSERVER_ErrorNew(
-              TRITONSERVER_ERROR_UNAVAILABLE,
-              kSharedMemoryManagerUnavailableErrorStr);
-          GrpcStatusUtil::Create(status, err);
-          TRITONSERVER_ErrorDelete(err);
-          return;
+          RESPOND_WITH_ERR_AND_RETURN(
+              status, TRITONSERVER_ErrorNew(
+                          TRITONSERVER_ERROR_UNAVAILABLE,
+                          kSharedMemoryManagerUnavailableErrorStr));
         }
         TRITONSERVER_Error* err = nullptr;
         if (!shm_manager_->AllowClientSharedMemory()) {
@@ -1803,12 +1808,10 @@ CommonHandler::RegisterSystemSharedMemoryUnregister()
           ::grpc::Status* status) {
         // No shared memory manager (e.g. in-process Python frontend).
         if (shm_manager_ == nullptr) {
-          TRITONSERVER_Error* err = TRITONSERVER_ErrorNew(
-              TRITONSERVER_ERROR_UNAVAILABLE,
-              kSharedMemoryManagerUnavailableErrorStr);
-          GrpcStatusUtil::Create(status, err);
-          TRITONSERVER_ErrorDelete(err);
-          return;
+          RESPOND_WITH_ERR_AND_RETURN(
+              status, TRITONSERVER_ErrorNew(
+                          TRITONSERVER_ERROR_UNAVAILABLE,
+                          kSharedMemoryManagerUnavailableErrorStr));
         }
         TRITONSERVER_Error* err = nullptr;
         if (!shm_manager_->AllowClientSharedMemory()) {
@@ -1857,12 +1860,10 @@ CommonHandler::RegisterCudaSharedMemoryStatus()
           ::grpc::Status* status) {
         // No shared memory manager (e.g. in-process Python frontend).
         if (shm_manager_ == nullptr) {
-          TRITONSERVER_Error* err = TRITONSERVER_ErrorNew(
-              TRITONSERVER_ERROR_UNAVAILABLE,
-              kSharedMemoryManagerUnavailableErrorStr);
-          GrpcStatusUtil::Create(status, err);
-          TRITONSERVER_ErrorDelete(err);
-          return;
+          RESPOND_WITH_ERR_AND_RETURN(
+              status, TRITONSERVER_ErrorNew(
+                          TRITONSERVER_ERROR_UNAVAILABLE,
+                          kSharedMemoryManagerUnavailableErrorStr));
         }
         triton::common::TritonJson::Value shm_status_json(
             triton::common::TritonJson::ValueType::ARRAY);
@@ -1934,12 +1935,10 @@ CommonHandler::RegisterCudaSharedMemoryRegister()
           ::grpc::Status* status) {
         // No shared memory manager (e.g. in-process Python frontend).
         if (shm_manager_ == nullptr) {
-          TRITONSERVER_Error* err = TRITONSERVER_ErrorNew(
-              TRITONSERVER_ERROR_UNAVAILABLE,
-              kSharedMemoryManagerUnavailableErrorStr);
-          GrpcStatusUtil::Create(status, err);
-          TRITONSERVER_ErrorDelete(err);
-          return;
+          RESPOND_WITH_ERR_AND_RETURN(
+              status, TRITONSERVER_ErrorNew(
+                          TRITONSERVER_ERROR_UNAVAILABLE,
+                          kSharedMemoryManagerUnavailableErrorStr));
         }
         TRITONSERVER_Error* err = nullptr;
 #ifdef TRITON_ENABLE_GPU
@@ -1999,12 +1998,10 @@ CommonHandler::RegisterCudaSharedMemoryUnregister()
           ::grpc::Status* status) {
         // No shared memory manager (e.g. in-process Python frontend).
         if (shm_manager_ == nullptr) {
-          TRITONSERVER_Error* err = TRITONSERVER_ErrorNew(
-              TRITONSERVER_ERROR_UNAVAILABLE,
-              kSharedMemoryManagerUnavailableErrorStr);
-          GrpcStatusUtil::Create(status, err);
-          TRITONSERVER_ErrorDelete(err);
-          return;
+          RESPOND_WITH_ERR_AND_RETURN(
+              status, TRITONSERVER_ErrorNew(
+                          TRITONSERVER_ERROR_UNAVAILABLE,
+                          kSharedMemoryManagerUnavailableErrorStr));
         }
         TRITONSERVER_Error* err = nullptr;
         if (!shm_manager_->AllowClientSharedMemory()) {


### PR DESCRIPTION
#### What does the PR do?
Applies the review suggestion from PR #8936: the six gRPC shared-memory control
handlers in `src/grpc/grpc_server.cc` each repeated the same block —
create a `TRITONSERVER_Error`, report it via `GrpcStatusUtil::Create`, delete it,
and `return`. This extracts that into a single macro, `RESPOND_WITH_ERR_AND_RETURN`,
following the `do{…}while(false)` idiom of the existing `common.h` error macros.

- New `RESPOND_WITH_ERR_AND_RETURN(STATUS, ERR)` macro (1 definition).
- The 6 shared-memory-manager null guards collapse from a 6-line block to one call.
- Pure refactor — no behavior change; the macro expands to the identical code.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added succinct git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] refactor

#### Related PRs:
#8936 (introduced the shared-memory null guards; this addresses its review feedback).

#### Where should the reviewer start?
- `src/grpc/grpc_server.cc` — the `RESPOND_WITH_ERR_AND_RETURN` macro definition (just below the includes) and the 6 call sites in the `CommonHandler::Register{System,Cuda}SharedMemory{Status,Register,Unregister}` handlers.

#### Test plan:
- Mechanical, behavior-preserving refactor: the macro expands to the exact code it replaces, so existing coverage applies (`L0_python_api` shared-memory-frontend test + the gRPC shared-memory control tests exercise these handlers).
- No new tests needed; CI build confirms it compiles.
- Pipeline ID: 66045430

#### Caveats:
Scope is limited to the exact pattern flagged in review — the 6 shared-memory handlers that create a fresh error and return early. The ~18 other `GrpcStatusUtil::Create + TRITONSERVER_ErrorDelete` sites in this file have no early `return` (they fall through at end-of-handler), so they'd need a separate no-return variant; intentionally left out to keep this change focused.

#### Background
Follow-up to review comment on PR #8936: "create a macro for this error reporting pattern."

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
Relates to TRI-1815.
