### PR TITLE
docs: flag developer_tools C-API wrapper as deprecated

### DIFF
--- a/docs/customization_guide/inference_protocols.md
+++ b/docs/customization_guide/inference_protocols.md
@@ -32,7 +32,9 @@ Clients can communicate with Triton using either an [HTTP/REST
 protocol](#httprest-and-grpc-protocols), a [GRPC
 protocol](#httprest-and-grpc-protocols), or by an [in-process C
 API](inprocess_c_api.md) or its
-[C++ wrapper](https://github.com/triton-inference-server/developer_tools/tree/main/server).
+[C++ wrapper](https://github.com/triton-inference-server/developer_tools/tree/main/server)
+(**deprecated** — no longer built or tested; use the [in-process C
+API](inprocess_c_api.md) directly).
 
 ## HTTP/REST and GRPC Protocols
 

--- a/docs/customization_guide/inprocess_java_api.md
+++ b/docs/customization_guide/inprocess_java_api.md
@@ -111,7 +111,7 @@ Java program with the Java bindings with the following steps:
       $ docker cp ${id}:/workspace/install/java-api-bindings/tritonserver-java-bindings.jar <Uber Jar directory>/tritonserver-java-bindings.jar
       $ docker stop ${id}
       ```
-      **Note:** `tritonserver-java-bindings.jar` only includes the `In-Process Java Bindings`. To use the `C-API Wrapper Java Bindings`, please use the build script.
+      **Note:** `tritonserver-java-bindings.jar` only includes the `In-Process Java Bindings`. The `C-API Wrapper Java Bindings` are deprecated and unsupported; use the `In-Process Java Bindings` instead.
 2. Use the built "Uber Jar" that contains the Java bindings
    ```bash
    $ java -cp <Uber Jar directory>/tritonserver-java-bindings.jar <your Java program>
@@ -128,7 +128,7 @@ You can do this using the following steps:
 
 1. Create the JNI binaries in your local repository (`/root/.m2/repository`)
    with [`javacpp-presets/tritonserver`](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver).
-   **The C-API Wrapper Java bindings (Triton with C++ bindings) are deprecated and unsupported** —
+   **The `C-API Wrapper` Java bindings (Triton with C++ bindings) are deprecated and unsupported** —
    `developer_tools/server` is no longer built or tested; skip the cmake/rapidjson build-dependency
    steps in the [java installation script](https://github.com/triton-inference-server/client/blob/main/src/java-api-bindings/scripts/install_dependencies_and_build.sh)
    that are specific to it.

--- a/docs/customization_guide/inprocess_java_api.md
+++ b/docs/customization_guide/inprocess_java_api.md
@@ -96,9 +96,11 @@ Java program with the Java bindings with the following steps:
       # Run build script
       ## For In-Process C-API Java Bindings
       $ source clientrepo/src/java-api-bindings/scripts/install_dependencies_and_build.sh
-      ## For C-API Wrapper (Triton with C++ bindings) Java Bindings [DEPRECATED]
-      $ source clientrepo/src/java-api-bindings/scripts/install_dependencies_and_build.sh --enable-developer-tools-server
       ```
+      **The `C-API Wrapper` bindings (`--enable-developer-tools-server`) are deprecated and unsupported** —
+      `developer_tools/server` is no longer built or tested, so this flag is kept only for reference and
+      should not be used. Use the `In-Process C-API Java Bindings` command above instead.
+
       This will install the Java bindings to `/workspace/install/java-api-bindings/tritonserver-java-bindings.jar`
 
    *or*
@@ -126,10 +128,10 @@ You can do this using the following steps:
 
 1. Create the JNI binaries in your local repository (`/root/.m2/repository`)
    with [`javacpp-presets/tritonserver`](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver).
-   For C-API Wrapper Java bindings (Triton with C++ bindings), you need to
-   install some build specific dependencies including cmake and rapidjson.
-   Refer to [java installation script](https://github.com/triton-inference-server/client/blob/main/src/java-api-bindings/scripts/install_dependencies_and_build.sh)
-   for dependencies you need to install and modifications you need to make for your container.
+   **The C-API Wrapper Java bindings (Triton with C++ bindings) are deprecated and unsupported** —
+   `developer_tools/server` is no longer built or tested; skip the cmake/rapidjson build-dependency
+   steps in the [java installation script](https://github.com/triton-inference-server/client/blob/main/src/java-api-bindings/scripts/install_dependencies_and_build.sh)
+   that are specific to it.
 After installing dependencies, you can build the tritonserver project on javacpp-presets:
 ```bash
  $ git clone https://github.com/bytedeco/javacpp-presets.git

--- a/docs/customization_guide/inprocess_java_api.md
+++ b/docs/customization_guide/inprocess_java_api.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright 2018-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2018-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,6 +37,8 @@ Alternatively, the user can refer to the web version [API docs](http://bytedeco.
 generated from `tritonserver.java`.
 **Note:** Currently, `tritonserver.java` contains bindings for both the `In-process C-API`
 and the bindings for `C-API Wrapper`. More information about the [developer_tools/server C-API wrapper](https://github.com/triton-inference-server/developer_tools/blob/main/server/README.md) can be found in the [developer_tools repository](https://github.com/triton-inference-server/developer_tools/).
+**The `C-API Wrapper` bindings are deprecated** — `developer_tools/server` is
+no longer built or tested; use the `In-process C-API` bindings instead.
 
 A simple example using the Java API can be found in
 [Samples folder](https://github.com/bytedeco/javacpp-presets/tree/master/tritonserver/samples)
@@ -94,7 +96,7 @@ Java program with the Java bindings with the following steps:
       # Run build script
       ## For In-Process C-API Java Bindings
       $ source clientrepo/src/java-api-bindings/scripts/install_dependencies_and_build.sh
-      ## For C-API Wrapper (Triton with C++ bindings) Java Bindings
+      ## For C-API Wrapper (Triton with C++ bindings) Java Bindings [DEPRECATED]
       $ source clientrepo/src/java-api-bindings/scripts/install_dependencies_and_build.sh --enable-developer-tools-server
       ```
       This will install the Java bindings to `/workspace/install/java-api-bindings/tritonserver-java-bindings.jar`


### PR DESCRIPTION
#### What does the PR do?
- The `developer_tools/server` C++ wrapper and its Java bindings (`--enable-developer-tools-server`) are no longer built or tested, now that tritonserver's CI no longer exercises `developer_tools`.
- Flags both in the affected docs and removes the now-actionable `--enable-developer-tools-server` command, pointing readers to the in-process C API instead.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [x] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->
N/A

#### Where should the reviewer start?
- `docs/customization_guide/inprocess_java_api.md`
- `docs/customization_guide/inference_protocols.md`

#### Test plan:
- [x] `pre-commit run --files docs/customization_guide/inference_protocols.md docs/customization_guide/inprocess_java_api.md` passes clean
- [x] Doc-only change, no code/build impact

- CI Pipeline ID:
<!-- Only Pipeline ID and no direct link here -->
N/A (docs-only, no internal CI pipeline for this repo/branch)

#### Caveats:
None.

#### Background
The companion `tritonserver` MR removes `developer_tools`'s CI test execution and security-scan registration, leaving the C++ wrapper (`developer_tools/server`) with no test coverage or scanning. This PR flags the wrapper's docs as deprecated so readers aren't pointed at an untested, unsupported path.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1816
