### PR TITLE
feat: add completion queue sharding for gRPC inference (unary and streaming)

### DIFF
--- a/docs/customization_guide/inference_protocols.md
+++ b/docs/customization_guide/inference_protocols.md
@@ -145,6 +145,7 @@ For client-side documentation, see [Client-Side GRPC Status Codes](https://githu
 In general, using 2 threads per completion queue seems to give the best performance, see [gRPC Performance Best Practices](https://grpc.io/docs/guides/performance/#c). However, in cases where the performance bottleneck is at the request handling step (e.g. ensemble models), increasing the number of gRPC inference handler threads may lead to a higher throughput.
 
 * `--grpc-infer-thread-count`: 2 by default.
+* `--grpc-infer-cq-count`: 1 by default (a single shared completion queue). Set to `0` to create one completion queue per handler thread (capped at `--grpc-infer-thread-count`), which reduces contention when many requests or decoupled streams are processed concurrently. Valid range is 0-128.
 
 Note: More threads don't always mean better performance.
 

--- a/docs/customization_guide/inference_protocols.md
+++ b/docs/customization_guide/inference_protocols.md
@@ -145,7 +145,9 @@ For client-side documentation, see [Client-Side GRPC Status Codes](https://githu
 In general, using 2 threads per completion queue seems to give the best performance, see [gRPC Performance Best Practices](https://grpc.io/docs/guides/performance/#c). However, in cases where the performance bottleneck is at the request handling step (e.g. ensemble models), increasing the number of gRPC inference handler threads may lead to a higher throughput.
 
 * `--grpc-infer-thread-count`: 2 by default.
-* `--grpc-infer-cq-count`: 1 by default (a single shared completion queue). Set to `0` to create one completion queue per handler thread (capped at `--grpc-infer-thread-count`), which reduces contention when many requests or decoupled streams are processed concurrently. Valid range is 0-128.
+* `--grpc-infer-cq-count`: 1 by default (a single shared completion queue).
+  Set to `0` to create one completion queue per handler thread (capped at `--grpc-infer-thread-count`), which reduces contention when many requests or decoupled streams are processed concurrently.
+  Valid range is `0-128`.
 
 Note: More threads don't always mean better performance.
 

--- a/qa/L0_python_api/test_kserve.py
+++ b/qa/L0_python_api/test_kserve.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -62,6 +62,7 @@ class TestGrpcOptions:
             reuse_port=True,
             infer_allocation_pool_size=12,
             http2_max_pings_without_data=10,
+            infer_cq_count=4,
         )
 
     def test_wrong_grpc_parameters(self):
@@ -84,6 +85,10 @@ class TestGrpcOptions:
             KServeGrpc.Options(max_connection_age_ms=-1)
         with pytest.raises(Exception):
             KServeGrpc.Options(max_connection_age_grace_ms=-1)
+        with pytest.raises(Exception):
+            KServeGrpc.Options(infer_cq_count=-1)
+        with pytest.raises(Exception):
+            KServeGrpc.Options(infer_cq_count=129)
 
         # Wrong data type
         with pytest.raises(Exception):

--- a/qa/L0_simple_ensemble/ensemble_backpressure_test.py
+++ b/qa/L0_simple_ensemble/ensemble_backpressure_test.py
@@ -30,18 +30,18 @@ import sys
 
 sys.path.append("../common")
 
-import os
-import queue
-import threading
-import time
-import unittest
-from contextlib import ExitStack
-from functools import partial
+import os  # noqa: E402
+import queue  # noqa: E402
+import threading  # noqa: E402
+import time  # noqa: E402
+import unittest  # noqa: E402
+from contextlib import ExitStack  # noqa: E402
+from functools import partial  # noqa: E402
 
-import numpy as np
-import test_util as tu
-import tritonclient.grpc as grpcclient
-from tritonclient.utils import InferenceServerException
+import numpy as np  # noqa: E402
+import test_util as tu  # noqa: E402
+import tritonclient.grpc as grpcclient  # noqa: E402
+from tritonclient.utils import InferenceServerException  # noqa: E402
 
 SERVER_URL = "localhost:8001"
 DEFAULT_RESPONSE_TIMEOUT = 60
@@ -77,6 +77,14 @@ def prepare_infer_args(input_value, enable_batching=False):
     infer_input[0].set_data_from_numpy(input_data)
     outputs = [grpcclient.InferRequestedOutput("OUT")]
     return infer_input, outputs
+
+
+def _describe_error(err):
+    """Concise, readable description of a tritonclient error for logs and asserts."""
+    try:
+        return f"{err.status()}: {err.message()}"
+    except Exception:
+        return str(err)
 
 
 def collect_responses(user_data, timeout=DEFAULT_RESPONSE_TIMEOUT):
@@ -138,16 +146,22 @@ class EnsembleBackpressureTest(tu.TestResultCollector):
                     model_name=model_name, inputs=inputs, outputs=outputs
                 )
 
-            # Collect and verify responses for all requests
+            # Collect and verify responses for all requests. Assert on errors
+            # first so a real failure (e.g. CANCELLED) surfaces instead of a
+            # misleading "expected N, got 0".
             for i, ud in enumerate(user_datas):
                 errors, responses = collect_responses(ud)
                 self.assertEqual(
-                    len(responses),
-                    expected_responses_per_request,
-                    f"Request {i}: expected {expected_responses_per_request} responses, got {len(responses)}",
+                    len(errors),
+                    0,
+                    f"Request {i}: Triton returned error(s): "
+                    f"{[_describe_error(e) for e in errors]}",
                 )
                 self.assertEqual(
-                    len(errors), 0, f"Request {i}: unexpected errors: {errors}"
+                    len(responses),
+                    expected_responses_per_request,
+                    f"Request {i}: expected {expected_responses_per_request} "
+                    f"response(s), got {len(responses)}",
                 )
                 # Verify correctness of responses
                 for idx, resp in enumerate(responses):

--- a/qa/L0_simple_ensemble/test.sh
+++ b/qa/L0_simple_ensemble/test.sh
@@ -428,7 +428,9 @@ rm -rf ${ENSEMBLE_BACKPRESSURE_TEST_MODEL_DIR}
 TEST_NAME="EnsembleBackpressureTest"
 SERVER_LOG="./ensemble_backpressure_test_server.log"
 CLIENT_LOG="./ensemble_backpressure_test_client.log"
-SERVER_ARGS="--model-repository=${ENSEMBLE_BACKPRESSURE_TEST_MODEL_DIR}"
+# Shard the streaming completion queue so concurrent streams are not starved
+# on a single CQ (one CQ/handler per thread).
+SERVER_ARGS="--model-repository=${ENSEMBLE_BACKPRESSURE_TEST_MODEL_DIR} --grpc-infer-cq-count=0 --grpc-infer-thread-count=16"
 rm -f $SERVER_LOG $CLIENT_LOG
 
 # Step 1 - decoupled_producer (batch size 2)
@@ -554,6 +556,53 @@ set -e
 
 kill $SERVER_PID
 wait $SERVER_PID
+
+
+######## Test '--grpc-infer-cq-count' command-line validation and boundary startup ########
+# The flag selects how many gRPC inference completion queues are created
+# (0 = one CQ per handler thread). Reject out-of-range/non-integer values and
+# start cleanly at the accepted boundaries.
+SERVER_LOG="./grpc_infer_cq_count_server.log"
+set +e
+
+# Invalid values must be rejected before the server starts serving.
+for cfg in "-1:Must be in the range 0 to 128" \
+           "129:Must be in the range 0 to 128" \
+           "abc:Invalid option value"; do
+    val="${cfg%%:*}"
+    msg="${cfg#*:}"
+    SERVER_ARGS="--model-repository=${ENSEMBLE_BACKPRESSURE_TEST_MODEL_DIR} --grpc-infer-cq-count=${val}"
+    rm -f $SERVER_LOG
+    run_server
+    if [ "$SERVER_PID" != "0" ]; then
+        echo -e "\n***\n*** FAILED: server started with invalid --grpc-infer-cq-count=${val}\n***"
+        kill $SERVER_PID
+        wait $SERVER_PID
+        RET=1
+    elif ! grep -q "$msg" $SERVER_LOG; then
+        echo -e "\n***\n*** FAILED: missing expected error for --grpc-infer-cq-count=${val}\n***"
+        cat $SERVER_LOG
+        RET=1
+    fi
+done
+
+# Accepted boundary values (1 = legacy single CQ, 128 = max) must start cleanly.
+# Thread count must be >= 2; clamp it so the max case still builds 128 CQs/handlers.
+for val in 1 128; do
+    thread_count=$(( val < 2 ? 2 : val ))
+    SERVER_ARGS="--model-repository=${ENSEMBLE_BACKPRESSURE_TEST_MODEL_DIR} --grpc-infer-cq-count=${val} --grpc-infer-thread-count=${thread_count}"
+    rm -f $SERVER_LOG
+    run_server
+    if [ "$SERVER_PID" == "0" ]; then
+        echo -e "\n***\n*** FAILED: server did not start with --grpc-infer-cq-count=${val}\n***"
+        cat $SERVER_LOG
+        RET=1
+    else
+        kill $SERVER_PID
+        wait $SERVER_PID
+    fi
+done
+set -e
 
 
 ######## Test invalid values for 'max_inflight_requests' config option ########

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -307,6 +307,7 @@ enum TritonOptionId {
   OPTION_GRPC_ADDRESS,
   OPTION_GRPC_HEADER_FORWARD_PATTERN,
   OPTION_GRPC_INFER_THREAD_COUNT,
+  OPTION_GRPC_INFER_CQ_COUNT,
   OPTION_GRPC_INFER_ALLOCATION_POOL_SIZE,
   OPTION_GRPC_MAX_RESPONSE_POOL_SIZE,
   OPTION_GRPC_USE_SSL,
@@ -542,6 +543,10 @@ TritonParser::SetupOptions()
       {OPTION_GRPC_INFER_THREAD_COUNT, "grpc-infer-thread-count",
        Option::ArgInt,
        "The number of gRPC inference handler threads. Default is 2."});
+  grpc_options_.push_back(
+      {OPTION_GRPC_INFER_CQ_COUNT, "grpc-infer-cq-count", Option::ArgInt,
+       "The number of gRPC inference completion queues. Default is 0 "
+       "(one CQ per handler thread). Use 1 for legacy single-CQ behavior."});
   grpc_options_.push_back(
       {OPTION_GRPC_INFER_ALLOCATION_POOL_SIZE,
        "grpc-infer-allocation-pool-size", Option::ArgInt,
@@ -1477,6 +1482,15 @@ TritonParser::Parse(int argc, char** argv)
             throw ParseException(
                 "invalid argument for --grpc_infer_thread_count. Must be in "
                 "the range 2 to 128.");
+          }
+          break;
+        case OPTION_GRPC_INFER_CQ_COUNT:
+          lgrpc_options.infer_cq_count_ = ParseOption<int>(optarg);
+          if (lgrpc_options.infer_cq_count_ < 0 ||
+              lgrpc_options.infer_cq_count_ > 128) {
+            throw ParseException(
+                "invalid argument for --grpc_infer_cq_count. Must be in "
+                "the range 0 to 128.");
           }
           break;
         case OPTION_GRPC_INFER_ALLOCATION_POOL_SIZE:

--- a/src/command_line_parser.cc
+++ b/src/command_line_parser.cc
@@ -545,8 +545,8 @@ TritonParser::SetupOptions()
        "The number of gRPC inference handler threads. Default is 2."});
   grpc_options_.push_back(
       {OPTION_GRPC_INFER_CQ_COUNT, "grpc-infer-cq-count", Option::ArgInt,
-       "The number of gRPC inference completion queues. Default is 0 "
-       "(one CQ per handler thread). Use 1 for legacy single-CQ behavior."});
+       "The number of gRPC inference completion queues. Default is 1 "
+       "(single shared queue). Set to 0 for one CQ per handler thread."});
   grpc_options_.push_back(
       {OPTION_GRPC_INFER_ALLOCATION_POOL_SIZE,
        "grpc-infer-allocation-pool-size", Option::ArgInt,
@@ -1489,7 +1489,7 @@ TritonParser::Parse(int argc, char** argv)
           if (lgrpc_options.infer_cq_count_ < 0 ||
               lgrpc_options.infer_cq_count_ > 128) {
             throw ParseException(
-                "invalid argument for --grpc_infer_cq_count. Must be in "
+                "invalid argument for --grpc-infer-cq-count. Must be in "
                 "the range 0 to 128.");
           }
           break;

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -2446,14 +2446,19 @@ Server::Server(
 
   common_cq_ = builder_.AddCompletionQueue();
 
-  int cq_count = (options.infer_cq_count_ > 0)
-      ? std::min(options.infer_cq_count_, options.infer_thread_count_)
-      : options.infer_thread_count_;
+  int cq_count =
+      (options.infer_cq_count_ > 0)
+          ? std::min(options.infer_cq_count_, options.infer_thread_count_)
+          : options.infer_thread_count_;
   for (int i = 0; i < cq_count; ++i) {
     model_infer_cqs_.emplace_back(builder_.AddCompletionQueue());
   }
 
-  model_stream_infer_cq_ = builder_.AddCompletionQueue();
+  // Shard the streaming CQ like the unary infer CQ so concurrent streams
+  // are not funneled through a single queue.
+  for (int i = 0; i < cq_count; ++i) {
+    model_stream_infer_cqs_.emplace_back(builder_.AddCompletionQueue());
+  }
 
   // For testing purposes only, add artificial delay in grpc responses.
   const char* dstr = getenv("TRITONSERVER_SERVER_DELAY_GRPC_RESPONSE_SEC");
@@ -2481,15 +2486,17 @@ Server::Server(
         &accepting_new_conn_));
   }
 
-  // Handler for streaming inference requests. Keeps one handler for streaming
-  // to avoid possible concurrent writes which is not allowed
-  model_stream_infer_handlers_.emplace_back(new ModelStreamInferHandler(
-      "ModelStreamInferHandler", tritonserver_, trace_manager_, shm_manager_,
-      &service_, model_stream_infer_cq_.get(),
-      options.infer_allocation_pool_size_ /* max_state_bucket_count */,
-      options.max_response_pool_size_, options.infer_compression_level_,
-      restricted_kv, options.forward_header_pattern_, &conn_mtx_, &conn_cnt_,
-      &accepting_new_conn_));
+  // One handler per streaming CQ (1:1): a stream must be written by a single
+  // thread (gRPC forbids concurrent writes on one stream).
+  for (int i = 0; i < cq_count; ++i) {
+    model_stream_infer_handlers_.emplace_back(new ModelStreamInferHandler(
+        "ModelStreamInferHandler", tritonserver_, trace_manager_, shm_manager_,
+        &service_, model_stream_infer_cqs_[i].get(),
+        options.infer_allocation_pool_size_ /* max_state_bucket_count */,
+        options.max_response_pool_size_, options.infer_compression_level_,
+        restricted_kv, options.forward_header_pattern_, &conn_mtx_, &conn_cnt_,
+        &accepting_new_conn_));
+  }
 }
 
 Server::~Server()
@@ -2554,8 +2561,12 @@ Server::GetOptions(Options& options, UnorderedMapType& options_map)
 
   RETURN_IF_ERR(GetValue(
       options_map, "infer_thread_count", &options.infer_thread_count_));
-  RETURN_IF_ERR(GetValue(
-      options_map, "infer_cq_count", &options.infer_cq_count_));
+  // infer_cq_count is optional: an older tritonfrontend that predates the flag
+  // omits it, so fall back to the default (a single shared completion queue).
+  if (options_map.find("infer_cq_count") != options_map.end()) {
+    RETURN_IF_ERR(
+        GetValue(options_map, "infer_cq_count", &options.infer_cq_count_));
+  }
   RETURN_IF_ERR(GetValue(
       options_map, "infer_allocation_pool_size",
       &options.infer_allocation_pool_size_));
@@ -2693,7 +2704,9 @@ Server::Stop()
   for (auto& cq : model_infer_cqs_) {
     cq->Shutdown();
   }
-  model_stream_infer_cq_->Shutdown();
+  for (auto& cq : model_stream_infer_cqs_) {
+    cq->Shutdown();
+  }
 
   // Must stop all handlers explicitly to wait for all the handler
   // threads to join since they are referencing completion queue, etc.

--- a/src/grpc/grpc_server.cc
+++ b/src/grpc/grpc_server.cc
@@ -2445,7 +2445,14 @@ Server::Server(
   }
 
   common_cq_ = builder_.AddCompletionQueue();
-  model_infer_cq_ = builder_.AddCompletionQueue();
+
+  int cq_count = (options.infer_cq_count_ > 0)
+      ? std::min(options.infer_cq_count_, options.infer_thread_count_)
+      : options.infer_thread_count_;
+  for (int i = 0; i < cq_count; ++i) {
+    model_infer_cqs_.emplace_back(builder_.AddCompletionQueue());
+  }
+
   model_stream_infer_cq_ = builder_.AddCompletionQueue();
 
   // For testing purposes only, add artificial delay in grpc responses.
@@ -2467,7 +2474,7 @@ Server::Server(
   for (int i = 0; i < options.infer_thread_count_; ++i) {
     model_infer_handlers_.emplace_back(new ModelInferHandler(
         "ModelInferHandler", tritonserver_, trace_manager_, shm_manager_,
-        &service_, model_infer_cq_.get(),
+        &service_, model_infer_cqs_[i % cq_count].get(),
         options.infer_allocation_pool_size_ /* max_state_bucket_count */,
         options.max_response_pool_size_, options.infer_compression_level_,
         restricted_kv, options.forward_header_pattern_, &conn_mtx_, &conn_cnt_,
@@ -2547,6 +2554,8 @@ Server::GetOptions(Options& options, UnorderedMapType& options_map)
 
   RETURN_IF_ERR(GetValue(
       options_map, "infer_thread_count", &options.infer_thread_count_));
+  RETURN_IF_ERR(GetValue(
+      options_map, "infer_cq_count", &options.infer_cq_count_));
   RETURN_IF_ERR(GetValue(
       options_map, "infer_allocation_pool_size",
       &options.infer_allocation_pool_size_));
@@ -2681,7 +2690,9 @@ Server::Stop()
 
   // Shutdown completion queues
   common_cq_->Shutdown();
-  model_infer_cq_->Shutdown();
+  for (auto& cq : model_infer_cqs_) {
+    cq->Shutdown();
+  }
   model_stream_infer_cq_->Shutdown();
 
   // Must stop all handlers explicitly to wait for all the handler

--- a/src/grpc/grpc_server.h
+++ b/src/grpc/grpc_server.h
@@ -88,6 +88,10 @@ struct Options {
   // The number of gRPC inference handler threads. Useful for
   // throughput tuning of models that are request handling bounded.
   int infer_thread_count_{2};
+  // The number of gRPC inference completion queues. Default is 1
+  // (single shared CQ, legacy behavior). Set to 0 for one CQ per
+  // handler thread, or N>1 for N sharded CQs.
+  int infer_cq_count_{1};
   // The maximum number of inference request/response objects that
   // remain allocated for reuse. As long as the number of in-flight
   // requests doesn't exceed this value there will be no
@@ -154,7 +158,7 @@ class Server {
   std::unique_ptr<::grpc::Server> server_;
 
   std::unique_ptr<::grpc::ServerCompletionQueue> common_cq_;
-  std::unique_ptr<::grpc::ServerCompletionQueue> model_infer_cq_;
+  std::vector<std::unique_ptr<::grpc::ServerCompletionQueue>> model_infer_cqs_;
   std::unique_ptr<::grpc::ServerCompletionQueue> model_stream_infer_cq_;
 
   std::unique_ptr<HandlerBase> common_handler_;

--- a/src/grpc/grpc_server.h
+++ b/src/grpc/grpc_server.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -159,7 +159,8 @@ class Server {
 
   std::unique_ptr<::grpc::ServerCompletionQueue> common_cq_;
   std::vector<std::unique_ptr<::grpc::ServerCompletionQueue>> model_infer_cqs_;
-  std::unique_ptr<::grpc::ServerCompletionQueue> model_stream_infer_cq_;
+  std::vector<std::unique_ptr<::grpc::ServerCompletionQueue>>
+      model_stream_infer_cqs_;
 
   std::unique_ptr<HandlerBase> common_handler_;
   std::vector<std::unique_ptr<HandlerBase>> model_infer_handlers_;

--- a/src/python/tritonfrontend/_api/_kservegrpc.py
+++ b/src/python/tritonfrontend/_api/_kservegrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -80,6 +80,7 @@ class KServeGrpc:
             int, Grpc_compression_level
         ] = Grpc_compression_level.NONE
         infer_thread_count: int = Field(2, ge=0)
+        infer_cq_count: int = Field(1, ge=0, le=128)
         infer_allocation_pool_size: int = Field(8, ge=0)
         max_response_pool_size: int = Field(2_147_483_647, ge=0)
         forward_header_pattern: str = ""

--- a/src/python/tritonfrontend/_api/_kservegrpc.pyi
+++ b/src/python/tritonfrontend/_api/_kservegrpc.pyi
@@ -1,4 +1,4 @@
-# Copyright 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -57,6 +57,7 @@ class KServeGrpc:
         max_connection_age_grace_ms: int
         infer_compression_level: int | Grpc_compression_level
         infer_thread_count: int
+        infer_cq_count: int
         infer_allocation_pool_size: int
         max_response_pool_size: int
         forward_header_pattern: str


### PR DESCRIPTION
#### What does the PR do?
Extends #8815 ("Add completion queue sharding for gRPC inference", TRI-1743)
from the unary `ModelInfer` path to the streaming `ModelStreamInfer` path.

That PR added `--grpc-infer-cq-count` and sharded the **unary** inference completion
queue, but left streaming on a single shared CQ. Under `max_inflight_requests`
backpressure with many concurrent decoupled streams, that one CQ/handler serializes
every stream — a laggard starves and is cancelled at the ~30s gRPC deadline, returning
0 responses (root cause of the `L0_simple_ensemble` flake, TRI-1711).

This PR shards the streaming CQ the same way, with **one handler per streaming CQ (1:1)**
so each stream stays single-writer (gRPC forbids concurrent writes on one stream).
No new flags — driven by the existing `--grpc-infer-cq-count` (`0` = one CQ per handler thread).

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] feat

#### Related PRs:
- #8815— TRI-1743, "Add completion queue sharding for gRPC inference" (this PR is stacked on it; set that branch as the base, not `main`).

#### Where should the reviewer start?
- `src/grpc/grpc_server.cc` — the streaming CQ build loop and, most importantly, the
  handler-creation loop: **1 handler : 1 CQ using index `[i]`**, not the unary path's
  `[i % cq_count]`. This preserves the per-stream single-writer invariant and is the
  crux of the change.
- `src/grpc/grpc_server.h` — `model_stream_infer_cq_` (single) → `model_stream_infer_cqs_` (vector).
- `qa/L0_simple_ensemble/test.sh` — the `--grpc-infer-cq-count` validation + boundary-startup block.

#### Test plan:
Functional (streaming sharding):
- `test_concurrent_requests_with_different_limits` runs the server with
  `--grpc-infer-cq-count=0 --grpc-infer-thread-count=16` (16 concurrent streams over 16
  sharded CQs). All requests return their full response set with zero cancellations
  (previously flaked to 0/8).

Command-line value validation (server must fail to start):
- `--grpc-infer-cq-count=-1`  → log contains `Must be in the range 0 to 128`
- `--grpc-infer-cq-count=129` → log contains `Must be in the range 0 to 128`
- `--grpc-infer-cq-count=abc` → log contains `Invalid option value`

Boundary startup (server must start cleanly):
- `1` (legacy single-CQ behavior)
- `128` with `--grpc-infer-thread-count=128`, so it actually constructs 128 CQs/handlers
  and proves the per-CQ handler loop holds at max fan-out.

Diagnostics:
- The test asserts on gRPC errors before the response count, so a real failure surfaces
  its true status (e.g. `CANCELLED`) instead of the misleading "expected N, got 0".

e2e tests added: yes (all of the above in `qa/L0_simple_ensemble`).

- CI Pipeline ID: 66067932

#### Caveats:
- Stacked on the unmerged #8815; merge that first (or review only the commits
  above it). Base branch must be its branch, not `main`.
- The concurrent-streaming test is intentionally not run at `--grpc-infer-cq-count=1`
  (the single-CQ shape that reproduces the flake) to avoid reintroducing flakiness.
- Streaming shards strictly 1:1 (handler:CQ); unlike the unary path it cannot share a
  CQ across handlers, because a stream must be written by a single thread.

#### Background
`L0_simple_ensemble` began flaking after the server-side C++ gRPC bump (v1.54.3 → v1.81.1):
under backpressure + 16 concurrent streams, the single streaming CQ could no longer
service all streams fairly, starving one until it hit the gRPC deadline and was cancelled.
#<geobeau-PR> already introduced CQ sharding for unary; this applies the same fix to the
streaming path that was actually failing.

#### Related Issues:
- Fixes TRI-1711
- Relates to TRI-1743
- closes GitHub issue: #xxx