### PR TITLE
fix: support text batches in OpenAI embeddings

### DIFF
--- a/python/openai/README.md
+++ b/python/openai/README.md
@@ -435,6 +435,25 @@ curl -s http://localhost:9000/v1/embeddings \
 
 </details>
 
+4. To embed multiple texts, pass an array of non-empty strings:
+
+```bash
+curl -s http://localhost:9000/v1/embeddings \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "all-MiniLM-L6-v2",
+    "input": ["The food was delicious.", "The service was excellent."],
+    "encoding_format": "float"
+  }'
+```
+
+The response contains one embedding per text, with `index` matching its input
+position and token usage summed across the inputs. Texts within one request are
+processed sequentially; this provides API compatibility, not native inference
+batching. A failure returns an error rather than a partial result. A flat array
+of integer token IDs still represents one input; arrays of token arrays are not
+supported.
+
 ## TensorRT-LLM
 
 0. Prepare your model repository for a TensorRT-LLM model, build the engine, etc. You can try any of the following options:

--- a/python/openai/openai_frontend/engine/triton_engine.py
+++ b/python/openai/openai_frontend/engine/triton_engine.py
@@ -91,6 +91,7 @@ from schemas.openai import (
     CreateEmbeddingRequest,
     CreateEmbeddingResponse,
     EmbeddingObject,
+    EmbeddingUsage,
     FinishReason,
     Function1,
     Function2,
@@ -438,18 +439,62 @@ class TritonLLMEngine(LLMEngine):
         metadata = self.model_metadata.get(model_name)
         self._validate_embedding_request(request, metadata)
 
-        # Convert to Triton request format and perform inference
-        responses = metadata.model.async_infer(
-            metadata.embedding_request_converter(
-                metadata.model,
-                request,
+        # An integer list is one tokenized input; a string list is a text batch.
+        inputs = (
+            request.input
+            if isinstance(request.input, list) and isinstance(request.input[0], str)
+            else [request.input]
+        )
+        data = []
+        usage = EmbeddingUsage(prompt_tokens=0, total_tokens=0)
+        for index, value in enumerate(inputs):
+            embedding_list, input_usage = await self._infer_embedding(
+                request.model_copy(update={"input": value}), metadata
             )
+            data.append(
+                EmbeddingObject(
+                    embedding=self._get_embedding(
+                        embedding_list, request.encoding_format
+                    ),
+                    index=index,
+                    object="embedding",
+                )
+            )
+            if usage is not None and input_usage is not None:
+                usage.prompt_tokens += input_usage.prompt_tokens
+                usage.total_tokens += input_usage.total_tokens
+            else:
+                usage = None
+
+        return CreateEmbeddingResponse(
+            object="list", data=data, model=request.model, usage=usage
         )
 
-        # Response validation with decoupled models in mind
-        responses = [response async for response in responses]
-        _validate_triton_responses_non_streaming(responses)
-        response = responses[0]
+    async def _infer_embedding(
+        self, request: CreateEmbeddingRequest, metadata: TritonModelMetadata
+    ) -> Tuple[List[float], Optional[EmbeddingUsage]]:
+        """Infer one input and cancel native work if response collection is interrupted."""
+        inference_request = metadata.embedding_request_converter(
+            metadata.model, request
+        )
+        inference_request.request_id = str(uuid.uuid4())
+        responses = metadata.model.async_infer(inference_request)
+
+        completed = False
+        try:
+            collected = [response async for response in responses]
+            completed = True
+        finally:
+            if not completed:
+                self._cancel_inference(
+                    responses,
+                    inference_request.request_id,
+                    "embedding response interrupted",
+                )
+
+        # Validate each input's envelope separately, including decoupled final markers.
+        _validate_triton_responses_non_streaming(collected)
+        response = collected[0]
 
         # Extract embedding from response (currently stored as JSON string in text_output)
         embedding_json = _get_output(response)
@@ -459,17 +504,7 @@ class TritonLLMEngine(LLMEngine):
             response, metadata.backend, RequestKind.EMBEDDING
         )
 
-        embedding = self._get_embedding(embedding_list, request.encoding_format)
-        embedding_obj = EmbeddingObject(
-            embedding=embedding, index=0, object="embedding"
-        )
-
-        return CreateEmbeddingResponse(
-            object="list",
-            data=[embedding_obj],
-            model=request.model,
-            usage=usage,
-        )
+        return embedding_list, usage
 
     @staticmethod
     def _get_embedding(

--- a/python/openai/openai_frontend/schemas/openai.py
+++ b/python/openai/openai_frontend/schemas/openai.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field, RootModel, confloat, conint
 
@@ -969,9 +969,9 @@ class CreateEmbeddingRequest(BaseModel):
     # Explicitly return errors for unknown fields.
     model_config: ConfigDict = ConfigDict(extra="forbid")
 
-    input: Union[str, List[int]] = Field(
+    input: Union[str, List[int], List[Annotated[str, Field(min_length=1)]]] = Field(
         ...,
-        description="Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays.",
+        description="Input text to embed, encoded as a string or array of tokens. To embed multiple texts in a single request, pass an array of non-empty strings. Arrays of token arrays are not supported.",
         min_length=1,
         examples=["The food was delicious and the waiter..."],
     )

--- a/python/openai/tests/test_embedding_engine.py
+++ b/python/openai/tests/test_embedding_engine.py
@@ -1,0 +1,297 @@
+# Copyright 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import asyncio
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import tritonserver
+from engine.triton_engine import TritonLLMEngine, TritonModelMetadata
+from engine.utils.triton import (
+    _create_vllm_embedding_request,
+    _create_vllm_generate_request,
+)
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from frontend.fastapi.routers import embeddings
+from schemas.openai import CreateEmbeddingRequest
+from utils.utils import ServerError
+
+
+def _response(vector=None, tokens=1, final=True):
+    outputs = {}
+    if vector is not None:
+        outputs["text_output"] = tritonserver.Tensor.from_string_array(
+            [json.dumps(vector)]
+        )
+    if tokens is not None:
+        outputs["num_input_tokens"] = tritonserver.Tensor.from_dlpack(
+            np.array([tokens], dtype=np.int32)
+        )
+        outputs["num_output_tokens"] = tritonserver.Tensor.from_dlpack(
+            np.array([0], dtype=np.int32)
+        )
+    return SimpleNamespace(outputs=outputs, final=final)
+
+
+class _Responses:
+    """Native response-handle stand-in with observable cancellation."""
+
+    def __init__(self, items, gate=None):
+        self.items = iter(items)
+        self.gate = gate
+        self.started = asyncio.Event()
+        self.cancel = Mock()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.started.set()
+        if self.gate is not None:
+            await self.gate.wait()
+        item = next(self.items, None)
+        if item is None:
+            raise StopAsyncIteration
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+@pytest.fixture
+def engine_and_model(monkeypatch):
+    model = SimpleNamespace(
+        create_request=Mock(
+            side_effect=lambda **kwargs: SimpleNamespace(request_id=None, **kwargs)
+        ),
+        async_infer=Mock(
+            side_effect=lambda request: _Responses([_response([1.0, 2.0])])
+        ),
+    )
+    metadata = TritonModelMetadata(
+        name="test-model",
+        backend="vllm",
+        model=model,
+        tokenizer=None,
+        lora_configs=None,
+        echo_tensor_name=None,
+        create_time=0,
+        inference_request_converter=_create_vllm_generate_request,
+        embedding_request_converter=_create_vllm_embedding_request,
+    )
+    monkeypatch.setattr(
+        TritonLLMEngine, "_get_model_metadata", lambda self: {metadata.name: metadata}
+    )
+    engine = TritonLLMEngine(server=None, tokenizer="", default_max_tokens=16)
+    return engine, model
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value, expected_inputs",
+    [
+        ("hello", ["hello"]),
+        ([101, 102], [[101, 102]]),
+        ([101, "102"], [[101, 102]]),
+        ([True], [[1]]),
+        ([101.0], [[101]]),
+        (["hello"], ["hello"]),
+        (["101", "102"], ["101", "102"]),
+    ],
+)
+async def test_embedding_input_forms(engine_and_model, value, expected_inputs):
+    engine, model = engine_and_model
+    response = await engine.embedding(
+        CreateEmbeddingRequest(model="test-model", input=value)
+    )
+
+    submitted = [
+        json.loads(call.args[0].inputs["embedding_request"][0])["input"]
+        for call in model.async_infer.call_args_list
+    ]
+    assert submitted == expected_inputs
+    assert [item.index for item in response.data] == list(range(len(expected_inputs)))
+
+
+@pytest.mark.parametrize(
+    "value", [["valid", ""], ["valid", 101], ["valid", None], [[101], [102]]]
+)
+def test_invalid_batch_submits_nothing(engine_and_model, value):
+    engine, model = engine_and_model
+    app = FastAPI()
+    app.include_router(embeddings.router)
+    app.engine = engine
+    with TestClient(app) as client:
+        response = client.post(
+            "/v1/embeddings", json={"model": "test-model", "input": value}
+        )
+
+    assert response.status_code == 422
+    model.create_request.assert_not_called()
+    model.async_infer.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("encoding", ["float", "base64"])
+async def test_batch_outputs_options_and_usage(engine_and_model, encoding):
+    engine, model = engine_and_model
+    vectors = {"a": [1.0, 2.0], "b": [3.0, 4.0]}
+    tokens = {"a": 2, "b": 3}
+
+    def infer(request):
+        payload = json.loads(request.inputs["embedding_request"][0])
+        assert payload["pooling_params"] == {"dimensions": [2]}
+        assert request.inputs["return_num_input_tokens"].tolist() == [True]
+        assert request.inputs["return_num_output_tokens"].tolist() == [True]
+        return _Responses(
+            [_response(vectors[payload["input"]], tokens[payload["input"]])]
+        )
+
+    model.async_infer.side_effect = infer
+    request = CreateEmbeddingRequest(
+        model="test-model",
+        input=["a", "b", "a"],
+        dimensions=2,
+        encoding_format=encoding,
+        user="test-user",
+    )
+    original = request.model_dump()
+    response = await engine.embedding(request)
+
+    assert request.model_dump() == original
+    assert response.model == "test-model" and response.object == "list"
+    assert len(response.data) == 3
+    for index, item in enumerate(response.data):
+        vector = item.embedding
+        if encoding == "base64":
+            vector = np.frombuffer(base64.b64decode(vector), dtype=np.float32)
+        np.testing.assert_array_equal(vector, vectors[request.input[index]])
+        assert item.index == index and item.object == "embedding"
+    assert response.usage.prompt_tokens == 7
+    assert response.usage.total_tokens == 7
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token_counts", [(None, 3), (2, None), (None, None), (0, 0)])
+async def test_batch_unknown_and_zero_usage(engine_and_model, token_counts):
+    engine, model = engine_and_model
+    model.async_infer.side_effect = [
+        _Responses([_response([1.0], tokens)]) for tokens in token_counts
+    ]
+    response = await engine.embedding(
+        CreateEmbeddingRequest(model="test-model", input=["a", "b"])
+    )
+    if None in token_counts:
+        assert response.usage is None
+    else:
+        assert response.usage.prompt_tokens == response.usage.total_tokens == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "envelope", ["single", "separate-final", "empty", "non-final", "extra"]
+)
+async def test_each_child_response_envelope(engine_and_model, envelope):
+    engine, model = engine_and_model
+    valid = _response([1.0])
+    cases = {
+        "single": [valid],
+        "separate-final": [_response([2.0], final=False), _response(tokens=None)],
+        "empty": [],
+        "non-final": [_response([2.0], final=False)],
+        "extra": [valid, valid, valid],
+    }
+    handles = [
+        _Responses([valid]),
+        _Responses(cases[envelope]),
+    ]
+    model.async_infer.side_effect = handles
+    request = CreateEmbeddingRequest(model="test-model", input=["a", "b"])
+    if envelope in ("single", "separate-final"):
+        response = await engine.embedding(request)
+        assert len(response.data) == 2
+        assert response.data[1].embedding == ([1.0] if envelope == "single" else [2.0])
+        for handle in handles:
+            handle.cancel.assert_not_called()
+    else:
+        with pytest.raises(ServerError):
+            await engine.embedding(request)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["conversion", "submission", "iteration"])
+async def test_batch_failure_stops_submission(engine_and_model, failure_point):
+    engine, model = engine_and_model
+    failure = RuntimeError("injected backend failure")
+    completed = _Responses([_response([1.0])])
+    responses = _Responses([failure])
+    if failure_point == "conversion":
+        model.create_request.side_effect = [SimpleNamespace(id="first"), failure]
+        model.async_infer.side_effect = [completed]
+    elif failure_point == "submission":
+        model.async_infer.side_effect = [completed, failure]
+    else:
+        model.async_infer.side_effect = [completed, responses]
+
+    with pytest.raises(RuntimeError, match="injected backend failure"):
+        await engine.embedding(
+            CreateEmbeddingRequest(model="test-model", input=["a", "b", "c"])
+        )
+    assert [
+        json.loads(call.kwargs["inputs"]["embedding_request"][0])["input"]
+        for call in model.create_request.call_args_list
+    ] == ["a", "b"]
+    assert model.async_infer.call_count == (1 if failure_point == "conversion" else 2)
+    completed.cancel.assert_not_called()
+    if failure_point == "iteration":
+        responses.cancel.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["a", ["a", "b", "c"]])
+async def test_cancellation_reaches_native_request(engine_and_model, value):
+    engine, model = engine_and_model
+    completed = _Responses([_response([1.0])])
+    responses = _Responses([_response([1.0])], gate=asyncio.Event())
+    model.async_infer.side_effect = (
+        [responses] if isinstance(value, str) else [completed, responses]
+    )
+    task = asyncio.create_task(
+        engine.embedding(CreateEmbeddingRequest(model="test-model", input=value))
+    )
+    try:
+        await asyncio.wait_for(responses.started.wait(), timeout=5)
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    responses.cancel.assert_called_once()
+    completed.cancel.assert_not_called()
+    assert model.async_infer.call_count == (1 if isinstance(value, str) else 2)

--- a/python/openai/tests/test_embeddings.py
+++ b/python/openai/tests/test_embeddings.py
@@ -533,6 +533,68 @@ class TestEmbeddings:
 
         self._check_embedding_response(response, model, encoding_format=encoding_format)
 
+    @pytest.mark.parametrize("encoding_format", ["float", "base64"])
+    @pytest.mark.parametrize(
+        "inputs",
+        [
+            ["The food was delicious and the waiter..."],
+            [
+                "The food was delicious and the waiter...",
+                "The deployment controller started a replacement replica and waited "
+                "for the model to become ready before routing inference requests.",
+                "101",
+                "102",
+                "The food was delicious and the waiter...",
+            ],
+        ],
+    )
+    def test_embeddings_text_batch(self, client, model, inputs, encoding_format):
+        expected = []
+        for text in inputs:
+            response = client.post(
+                "/v1/embeddings",
+                json={
+                    "model": model,
+                    "input": text,
+                    "encoding_format": encoding_format,
+                },
+            )
+            assert response.status_code == 200, response.json()
+            expected.append(response.json())
+
+        response = client.post(
+            "/v1/embeddings",
+            json={
+                "model": model,
+                "input": inputs,
+                "encoding_format": encoding_format,
+            },
+        )
+        assert response.status_code == 200, response.json()
+        batch = response.json()
+        assert batch["object"] == "list"
+        assert batch["model"] == model
+        assert len(batch["data"]) == len(inputs)
+        for index, (item, single) in enumerate(zip(batch["data"], expected)):
+            assert item["index"] == index
+            assert item["object"] == "embedding"
+            actual_vector = item["embedding"]
+            expected_vector = single["data"][0]["embedding"]
+            if encoding_format == "base64":
+                actual_vector = np.frombuffer(
+                    base64.b64decode(actual_vector), dtype=np.float32
+                )
+                expected_vector = np.frombuffer(
+                    base64.b64decode(expected_vector), dtype=np.float32
+                )
+            np.testing.assert_allclose(
+                actual_vector, expected_vector, rtol=0, atol=1e-3
+            )
+        for field in ("prompt_tokens", "total_tokens"):
+            assert batch["usage"][field] == sum(
+                single["usage"][field] for single in expected
+            )
+
     def test_embeddings_empty_request(self, client):
         response = client.post("/v1/embeddings", json={})
         assert response.status_code == 422


### PR DESCRIPTION
#### What does the PR do?

Accept non-empty text arrays in `/v1/embeddings`. Process each input through the existing single-input path, preserve its response index, and aggregate token usage when available. Scalar text and flat token-ID lists remain supported.

This draft proposes sequential frontend handling, without changing the backend protocol or adding concurrent dispatch.

#### Checklist
- [ ] I have read the [Contribution guidelines](https://github.com/triton-inference-server/server/blob/main/CONTRIBUTING.md) and signed the [Contributor License Agreement](https://github.com/NVIDIA/triton-inference-server/blob/master/Triton-CCLA-v1.pdf). CLA completion is not yet confirmed.
- [x] PR title reflects the change and follows `<commit_type>: <Title>`.
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated GitHub labels field.
- [x] Added test plan and verified the scoped tests pass.
- [ ] Verified that the PR passes existing CI.
- [ ] Ran repository-wide pre-commit (`pre-commit run --all-files`). Targeted pre-commit passed on all five changed files.
- [x] Verified copyright on changed files.
- [ ] Added succinct git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type
- [x] fix

#### Related PRs
None.

#### Where should the reviewer start?
`python/openai/openai_frontend/schemas/openai.py`, then `embedding()` and `_infer_embedding()` in `python/openai/openai_frontend/engine/triton_engine.py`.

#### Test plan
- Base `c29bbe17`: 18 new regression cases fail; 9 controls pass. Patched regression and neighboring tests: 63 pass.
- With current frontend requirements installed: 47 regression/request-size tests pass. This overlaps the 63-test run.
- MiniLM on RTX 4070 Ti SUPER, using the same eager-mode configuration on base and patch: all four new batch cases fail on base with HTTP 422; the patched embeddings suite passes all 23 tests. Batch vectors match individual requests (`rtol=0`, `atol=1e-3`), including float/base64 output, order, duplicates, and usage totals.
- Tests also cover invalid inputs, response envelopes, unknown/zero usage, failure handling, and cancellation.
- Targeted pre-commit and `git diff --check` pass.

#### Caveats
- Sequential compatibility only; no speedup claim. Nested token-array batches remain unsupported.
- GPU tests used a pinned Triton 2.71/vLLM 26.07 runtime. Default model startup failed on unchanged base; eager mode reached inference. Both base and patch logged runtime teardown errors, although patched pytest exited successfully. Runtime dependency conflicts are also present; this is not a clean full-stack validation.
- Full L0/multi-backend CI has not been run locally.

#### Background
The current endpoint accepts a single text but rejects text arrays during request validation.

#### Related Issues
Relates to #8655.
