### PR TITLE
build: Update C++ standard from c++17 to c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ project(tritonserver LANGUAGES C CXX)
 
 include(CMakeDependentOption)
 
-# Use C++17 standard as Triton's minimum required.
-set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
+# Use C++20 standard as Triton's minimum required.
+set(TRITON_MIN_CXX_STANDARD 20 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
 
 set(TRITON_VERSION "0.0.0" CACHE STRING "The version of the Triton shared library" )
 

--- a/qa/L0_sdk/test.sh
+++ b/qa/L0_sdk/test.sh
@@ -56,7 +56,7 @@ client_lib=$(pwd)/triton_client/lib
 client_inc=$(pwd)/triton_client/include
 
 # Test linking against the shared library
-g++ grpc_test.cc -o grpc_test -I$client_inc -L$client_lib -lgrpcclient
+g++ -std=gnu++20 grpc_test.cc -o grpc_test -I$client_inc -L$client_lib -lgrpcclient
 
 if [ $? -eq 0 ]; then
     if [[ ! -x "./grpc_test" ]]; then
@@ -82,7 +82,7 @@ fi
 
 grpc_static_libs="-Wl,--start-group $client_lib/*.a -Wl,--end-group"
 
-g++ grpc_test.cc $grpc_static_libs -o grpc_test_static -I$client_inc -lz -lssl -lcrypto -lpthread
+g++ -std=gnu++20 grpc_test.cc $grpc_static_libs -o grpc_test_static -I$client_inc -lz -lssl -lcrypto -lpthread
 
 if [ $? -eq 0 ]; then
     if [[ ! -x "./grpc_test_static" ]]; then
@@ -107,7 +107,7 @@ fi
 #
 
 # Test linking against the shared library
-g++ http_test.cc -o http_test -I$client_inc -L$client_lib -lhttpclient
+g++ -std=gnu++20 http_test.cc -o http_test -I$client_inc -L$client_lib -lhttpclient
 
 if [ $? -eq 0 ]; then
     if [[ ! -x "./http_test" ]]; then
@@ -127,7 +127,7 @@ else
     RET=1
 fi
 
-g++ http_test.cc $client_lib/libhttpclient_static.a $client_lib/libcurl.a -o http_test_static \
+g++ -std=gnu++20 http_test.cc $client_lib/libhttpclient_static.a $client_lib/libcurl.a -o http_test_static \
   -I$client_inc -lz -lssl -lcrypto -lpthread
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
#### What does the PR do?
- Upstream PyTorch raised ATen's minimum required C++ standard from 17 to 20 (pytorch/pytorch#178150), breaking the pytorch_backend build.
- Bumps this repo's C++ standard default from 17 to 20 for consistency across the Triton stack.
- This branch is stacked on `mchornyi/TRI-1855/build-against-upstream` (unrelated upstream-container work, tracked separately) — PR base is set to that branch so this diff shows only the C++20 change.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/pytorch_backend#210
- triton-inference-server/backend#129
- triton-inference-server/checksum_repository_agent#16
- triton-inference-server/identity_backend#38
- triton-inference-server/local_cache#18
- triton-inference-server/openvino_backend#123
- triton-inference-server/redis_cache#26
- triton-inference-server/repeat_backend#21
- triton-inference-server/square_backend#24
- triton-inference-server/tensorrt_backend#128
- triton-inference-server/third_party#82
- triton-inference-server/common#166
- triton-inference-server/core#525
- triton-inference-server/client#922
- triton-inference-server/onnxruntime_backend#359
- triton-inference-server/python_backend#455
- triton-inference-server/fil_backend#461
- triton-inference-server/dali_backend#311

#### Where should the reviewer start?
- `CMakeLists.txt` 

#### Test plan:
- CI Pipeline ID: 67062220

#### Caveats:
This repo has no direct dependency on ATen/libtorch; the bump is for cross-repo C++ standard consistency, not a confirmed build break here.

#### Background
Part of a coordinated C++17->C++20 bump across ~18 Triton component repos (TRI-1877), triggered by upstream PyTorch's ATen.h now requiring C++20.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1877
