### PR TITLE
test: Enable L0_infer classification tests in dynamo mode

### DIFF
--- a/qa/L0_infer/infer_test.py
+++ b/qa/L0_infer/infer_test.py
@@ -26,6 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# flake8: noqa: E402,F403,F405
 import sys
 
 sys.path.append("../common")
@@ -54,9 +55,6 @@ DYNAMO = os.environ.get("SERVER_LAUNCH_MODE") == "dynamo"
 # Reasons the corresponding tests are skipped under Dynamo.
 DYNAMO_SKIP_FP16 = (
     "FP16/BF16 tensors: Dynamo tensor DataType has no half-precision variant"
-)
-DYNAMO_SKIP_CLASS = (
-    "classification output: Dynamo frontend drops the KServe classification parameter"
 )
 DYNAMO_SKIP_VERSION = "model version selection: Dynamo routes by model name only, serving the default version"
 
@@ -537,7 +535,6 @@ class InferTest(tu.TestResultCollector):
     # shared memory does not support class output
     if not (TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY):
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_bbb(self):
             self._full_exact(
                 np.int8,
@@ -548,7 +545,6 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_sss(self):
             self._full_exact(
                 np.int16,
@@ -559,7 +555,6 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_iii(self):
             self._full_exact(
                 np.int32,
@@ -570,7 +565,6 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_lll(self):
             self._full_exact(
                 np.int64,
@@ -581,7 +575,6 @@ class InferTest(tu.TestResultCollector):
                 swap=False,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_fff(self):
             self._full_exact(
                 np.float32,
@@ -592,7 +585,6 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_class_iff(self):
             self._full_exact(
                 np.int32,
@@ -603,7 +595,6 @@ class InferTest(tu.TestResultCollector):
                 swap=False,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_bbb(self):
             self._full_exact(
                 np.int8,
@@ -614,7 +605,6 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_sss(self):
             self._full_exact(
                 np.int16,
@@ -625,7 +615,6 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_iii(self):
             self._full_exact(
                 np.int32,
@@ -636,7 +625,6 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_lll(self):
             self._full_exact(
                 np.int64,
@@ -647,7 +635,6 @@ class InferTest(tu.TestResultCollector):
                 swap=False,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_fff(self):
             self._full_exact(
                 np.float32,
@@ -658,7 +645,6 @@ class InferTest(tu.TestResultCollector):
                 swap=True,
             )
 
-        @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
         def test_mix_iff(self):
             self._full_exact(
                 np.int32,
@@ -1104,7 +1090,6 @@ class InferTest(tu.TestResultCollector):
 
             if not (TEST_SYSTEM_SHARED_MEMORY or TEST_CUDA_SHARED_MEMORY):
 
-                @unittest.skipIf(DYNAMO, DYNAMO_SKIP_CLASS)
                 def test_ensemble_label_lookup(self):
                     if all(x in BACKENDS for x in ["onnx", "libtorch"]):
                         # Ensemble needs to look up label from the actual model

--- a/src/grpc/grpc_utils.cc
+++ b/src/grpc/grpc_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/grpc/grpc_utils.cc
+++ b/src/grpc/grpc_utils.cc
@@ -133,7 +133,7 @@ ParseClassificationParams(
     if (cnt <= 0) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
-          "invalid value for 'classification' parameter, expected >= 0");
+          "invalid value for 'classification' parameter, expected >= 1");
     }
 
     *classification_count = cnt;


### PR DESCRIPTION
#### What does the PR do?
Run the L0_infer classification and mixed class/raw cases when Triton is launched through Dynamo, now that the tensor path can honor KServe `classification`. Also correct the gRPC `classification` parameter error to `expected >= 1`, matching the `cnt <= 0` check.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [x] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [x] test

#### Related PRs:
- https://github.com/ai-dynamo/dynamo/pull/14618
- https://github.com/ai-dynamo/dynamo/pull/14619

#### Where should the reviewer start?
`qa/L0_infer/infer_test.py` (removed Dynamo skips on class/mix/ensemble label tests), then the one-line message fix in `src/grpc/grpc_utils.cc`.

#### Test plan:
- L0_infer with `SERVER_LAUNCH_MODE=dynamo`: classification and mix tests (`test_class_*`, `test_mix_*`, `test_ensemble_label_lookup`) are no longer skipped.
- gRPC `classification` of `0` returns `expected >= 1`.

- CI Pipeline ID:

#### Caveats:
Dynamo-mode classification coverage depends on the related Dynamo PRs landing the requested-outputs plumbing and worker top-K handling.

#### Background
These L0_infer cases were skipped because Dynamo dropped KServe requested-output `classification`. That path now exists, so the skips can come off. The gRPC error string said `>= 0` while the code rejects `cnt <= 0`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to https://github.com/ai-dynamo/dynamo/pull/14618
- Relates to https://github.com/ai-dynamo/dynamo/pull/14619