### PR TITLE
docs: add Nebius Serverless HTTP deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ images.
 - Examples for deploying Triton Inference Server with Kubernetes and Helm on [GCP](deploy/gcp/README.md),
   [AWS](deploy/aws/README.md), and [NVIDIA FleetCommand](deploy/fleetcommand/README.md)
 - [Secure Deployment Considerations](docs/customization_guide/deploy.md)
+- [Deploy an HTTP Endpoint on Nebius Serverless](deploy/nebius/README.md)
 
 ### Using Triton
 

--- a/deploy/nebius/.dockerignore
+++ b/deploy/nebius/.dockerignore
@@ -1,0 +1,5 @@
+*
+!Dockerfile
+!entrypoint.sh
+!build/
+!build/**

--- a/deploy/nebius/.gitignore
+++ b/deploy/nebius/.gitignore
@@ -1,0 +1,5 @@
+/build/
+/receipts/
+/reference.json
+/.env*
+__pycache__/

--- a/deploy/nebius/Dockerfile
+++ b/deploy/nebius/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# The pinned manifest and GPU deployment target are Linux amd64.
+ARG TRITON_PLATFORM=linux/amd64
+FROM --platform=${TRITON_PLATFORM} nvcr.io/nvidia/tritonserver:26.08-py3@sha256:71a23d2f27001af58c242380fe05c9d46d5dbc79913d62c60de72543964267df
+
+COPY build/ /opt/nebius-example/
+COPY entrypoint.sh /opt/nebius-entrypoint.sh
+RUN cd /opt/nebius-example && sha256sum --check SHA256SUMS \
+    && chmod -R a+rX,a-w /opt/nebius-example \
+    && chmod 0555 /opt/nebius-entrypoint.sh
+
+USER 1000:1000
+EXPOSE 8000
+ENTRYPOINT ["/opt/nebius-entrypoint.sh"]

--- a/deploy/nebius/README.md
+++ b/deploy/nebius/README.md
@@ -32,11 +32,11 @@ This example packages DenseNet-121 with Triton and serves it through a
 It uses one GPU, one HTTP port and managed HTTPS bearer-token authentication.
 No Kubernetes cluster or changes to Triton are required.
 
-> **Validation status:** model preparation and the local CPU/HTTP-contract tests
-> have been exercised. The GPU container and Nebius deployment have not yet been
-> validated. Complete the [validation checklist](#validation-checklist) before
-> relying on this example. In particular, confirm the selected image's driver
-> compatibility with the GPU platform.
+> **Validation status:** the image and authenticated GPU inference were exercised
+> on Nebius with one L40S, including a successful stop/start and repeat smoke
+> test. The [validation checklist](#validation-checklist) records the scope and
+> remaining limits. The current API requires a short unique image tag instead
+> of a digest reference; see [image preparation](#prepare-the-model-and-image).
 
 An Endpoint runs until stopped or deleted. This recipe does not configure
 autoscaling, scale-to-zero, high availability or preemptible recovery. It uses
@@ -59,15 +59,17 @@ they are not needed for this example.
 configuration/labels, and their source revisions and SHA-256 hashes. This is the
 full ONNX-capable server image, not an SDK, minimal or LLM-specific image.
 
+The pinned image was exercised on a single L40S in `eu-north1` with NVIDIA
+driver **580.173.02**. The image's runtime API reports **CUDA 13.4**; its ONNX
+Runtime library is **1.28.0**, and the serving API reports **Triton 2.72.0**.
+GPU inference passed the numerical reference check with TF32 disabled.
+
 The [26.08 release notes](https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/rel-26-08.html)
-list ONNX Runtime 1.28.0 and GPUs with compute capability 7.5 or later. At the time
-this example was prepared, that page had conflicting CUDA versions and an
-incomplete minimum-driver field. Treat this pin as a candidate until GPU
-initialization and inference pass on your selected platform. An L40S is a
-reasonable single-GPU candidate, but no region's capacity or preset is assumed.
-If another release is required, update the pin and Dockerfile together and
-repeat the tests; do not use `latest` or assume a TensorRT-LLM image's driver
-matrix applies to the full server image.
+had conflicting CUDA details and an incomplete minimum-driver field when this
+example was prepared. The observed combination above is evidence for that
+specific setup, not a general driver-compatibility matrix or a region-capacity
+guarantee. Revalidate other platforms, drivers or image releases; update the pin
+and Dockerfile together if changing the base, and do not use `latest`.
 
 ## Prepare the model and image
 
@@ -80,7 +82,9 @@ python3 prepare_models.py
 
 Preparation downloads approximately 32 MB plus configuration and notices,
 verifies each pinned size/hash, and adds a single GPU instance and a policy
-selecting only model version 1. It publishes `build/` only after success and
+selecting only model version 1. It also disables ONNX Runtime CUDA TF32 so the
+FP32 zero-input result can be compared with the CPU reference at the stated
+tolerance. It publishes `build/` only after success and
 refuses to replace an existing directory. It downloads actual model bytes,
 not the Git LFS pointer. To repeat preparation, move the existing build aside
 or choose `--output` with a new directory. The Dockerfile expects `build/`.
@@ -106,17 +110,32 @@ This example does not publish an image on your behalf.
 Build and push to your registry, then resolve the resulting image digest:
 
 ```bash
-export IMAGE_REPOSITORY='YOUR_REGISTRY/YOUR_NAMESPACE/triton-densenet'
-export IMAGE_TAG="${IMAGE_REPOSITORY}:nebius-example-1"
+export IMAGE_REPOSITORY='YOUR_REGISTRY/YOUR_NAMESPACE/t'
+export IMAGE_TAG="${IMAGE_REPOSITORY}:UNIQUE_SHORT_TAG"
+# The complete ASCII image reference must fit the current 64-character limit.
+(( ${#IMAGE_TAG} <= 64 )) || { echo 'Shorten the image reference' >&2; exit 1; }
 docker buildx build --platform linux/amd64 --tag "$IMAGE_TAG" --push .
 docker buildx imagetools inspect "$IMAGE_TAG"
 ```
 
-Set `IMAGE` to the returned digest reference, for example
-`YOUR_REGISTRY/YOUR_NAMESPACE/triton-densenet@sha256:...`. Use the **derived**
-image digest, not the base image digest from `pins.json`: the base does not
-contain the prepared model. Keep the image available while an Endpoint may
-restart. A private registry also requires the credential secret described below.
+Record the returned **derived** image digest; the base digest in `pins.json`
+does not include the prepared model. Set `IMAGE` to the short, unique tag:
+
+```bash
+export IMAGE="$IMAGE_TAG"
+```
+
+**Observed API limitation (2026-09-12):** a digest reference was rejected because
+the service copied the 135-character image reference into a compute label with
+a 64-character limit. A 57-character tag referencing the same manifest passed
+validation. Until this is fixed, digest-addressed deployment is unavailable in
+this workflow. Never move or reuse the unique tag, and verify its manifest digest
+against the recorded digest before creating or restarting an Endpoint. This is
+an operational convention, not an atomic digest pin enforced by the Endpoint.
+The base image and model artifacts remain checksum-pinned.
+
+Keep the tag and image available while an Endpoint may restart. A private registry
+also requires the credential secret described below.
 
 ## Create an authenticated Endpoint
 
@@ -139,7 +158,7 @@ export SUBNET_ID='YOUR_SUBNET_ID'
 export GPU_PLATFORM='YOUR_SINGLE_GPU_PLATFORM'
 export GPU_PRESET='YOUR_COMPATIBLE_SINGLE_GPU_PRESET'
 export AUTH_TOKEN_SECRET='YOUR_SECRET_ID@YOUR_VERSION_ID'
-export IMAGE='YOUR_REGISTRY/YOUR_NAMESPACE/triton-densenet@sha256:YOUR_DIGEST'
+export IMAGE='YOUR_REGISTRY/YOUR_NAMESPACE/t:UNIQUE_SHORT_TAG'
 
 umask 077
 RUN_DIR="receipts/$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 4)"
@@ -156,7 +175,7 @@ nebius --profile "$NEBIUS_PROFILE" ai endpoint create \
   --container-port 8000/http \
   --auth token --token-secret "$AUTH_TOKEN_SECRET" \
   --disk-size 250Gi --shm-size 1Gi \
-  --async --retries 1 --format json > "$RUN_DIR/create-operation.json"
+  --async --retries 1 > "$RUN_DIR/create-output.txt"
 ```
 
 Stop here if creation returns an error or the response is missing. A lost
@@ -165,21 +184,37 @@ name, image and creation time in the console or `ai endpoint list`; names are
 not necessarily unique. Do not automatically run create again. Keep the receipt
 directory private: raw service responses may contain sensitive information.
 
-On a successful asynchronous response, save the operation and resource IDs:
+CLI 0.12.265 returns `Endpoint ID: aiendpoint-...` from asynchronous creation,
+even when `--format json` is requested. Save and validate that ID, then discover
+the creation operation for that exact resource. Do not parse the create output
+as operation JSON:
 
 ```bash
-OPERATION_ID=$(jq -er '.id | select(type == "string" and length > 0)' \
-  "$RUN_DIR/create-operation.json")
-ENDPOINT_ID=$(jq -er '.resource_id | select(type == "string" and length > 0)' \
-  "$RUN_DIR/create-operation.json")
-printf '%s\n' "${ENDPOINT_ID:?Missing Endpoint ID}" > "$RUN_DIR/endpoint-id"
+ENDPOINT_ID=$(sed -nE 's/^Endpoint ID: (aiendpoint-[a-z0-9]+)$/\1/p' \
+  "$RUN_DIR/create-output.txt")
+[[ "$ENDPOINT_ID" =~ ^aiendpoint-[a-z0-9]+$ ]] || \
+  { echo 'Reconcile the saved create response before continuing' >&2; exit 1; }
+printf '%s\n' "$ENDPOINT_ID" > "$RUN_DIR/endpoint-id"
+nebius --profile "$NEBIUS_PROFILE" ai endpoint operation list \
+  --resource-id "$ENDPOINT_ID" --all --format json > "$RUN_DIR/create-operations.json"
+OPERATION_ID=$(jq -er --arg id "$ENDPOINT_ID" \
+  '[.operations[] | select(.resource_id == $id and .description == "Create endpoint")] |
+   if length == 1 then .[0].id else error("Reconcile creation operations") end' \
+  "$RUN_DIR/create-operations.json")
 nebius --profile "$NEBIUS_PROFILE" ai endpoint operation wait \
   "${OPERATION_ID:?Missing operation ID}" --timeout 35m --format json \
-  > "$RUN_DIR/create-result.json"
+  > "$RUN_DIR/create-result.txt"
+nebius --profile "$NEBIUS_PROFILE" ai endpoint operation get "$OPERATION_ID" \
+  --format json > "$RUN_DIR/create-operation-final.json"
+jq -e '.finished_at != null and ((.status.code // 0) == 0)' \
+  "$RUN_DIR/create-operation-final.json" || exit 1
 ```
 
-Confirm successful operation completion. If waiting times out, inspect the
-**same operation** with `ai endpoint operation get "$OPERATION_ID"` and the
+Confirm successful operation completion explicitly: CLI 0.12.265's
+`operation wait` returned an Endpoint resource and exited zero even for a failed
+startup whose operation had status code 9. `operation get` returns the authoritative
+`finished_at` and `status.code` (omitted/zero for success), not a `done` boolean. If
+waiting times out, inspect the **same operation** with `ai endpoint operation get "$OPERATION_ID"` and the
 Endpoint's state/details; do not create another resource. Choose your own
 bounded waiting/spending limit. The service documents a 30-minute capacity
 provisioning timeout; image pull and model readiness are separate stages.
@@ -224,7 +259,10 @@ unset ENDPOINT_AUTH_TOKEN
 
 The smoke test waits for **both** `/v2/health/ready` and
 `/v2/models/densenet_onnx/versions/1/ready`, then verifies that missing and wrong
-tokens return 401/403 at health and inference routes. It sends a zero-filled
+tokens return 401/403 at health and inference routes. The unauthorized inference
+probe uses a small `{"inputs": []}` body: the gateway can reject authorization
+and close the connection before a full tensor finishes uploading. Authenticated
+inference still sends the complete zero-filled
 FP32 tensor to `/v2/models/densenet_onnx/versions/1/infer` with
 `Authorization: Bearer ...` and checks model/version, output metadata and 1,000
 finite values. Credentials and response bodies are not printed; redirects are
@@ -236,7 +274,8 @@ execution and the HTTP contract, not image-classification accuracy. These
 outputs are logits, not probabilities. The script limits response size to 1 MiB
 and does not retry inference. It is an example client, not a load generator.
 
-`RUNNING` or `/v2/health/live` alone does not prove model readiness. No custom
+`operation wait` success, `RUNNING`, or `/v2/health/live` alone does not prove
+model readiness. No custom
 platform readiness-probe field is configured; do not assume Docker health
 checks gate Nebius ingress. Strict Triton readiness and client polling provide
 the checks here, while early callers may still receive startup errors.
@@ -252,24 +291,39 @@ An external repository needs its own credentials, immutable revisions,
 checksums and live validation; this recipe does not poll a mutable bucket.
 
 Stop/start preserves the Endpoint definition, not warm GPU memory or a specific
-VM. Stop synchronously and wait for the operation to finish before starting:
+VM. Stop and verify the operation has finished successfully before starting:
 
 ```bash
-nebius --profile "$NEBIUS_PROFILE" ai endpoint stop "${ENDPOINT_ID:?}" --timeout 10m
+nebius --profile "$NEBIUS_PROFILE" ai endpoint stop "${ENDPOINT_ID:?}" \
+  --async --retries 1 > "$RUN_DIR/stop-operation-id"
+OPERATION_ID=$(cat "$RUN_DIR/stop-operation-id")
+[[ "$OPERATION_ID" =~ ^opvmapp-[a-z0-9]+$ ]] || exit 1
+nebius --profile "$NEBIUS_PROFILE" ai endpoint operation wait "$OPERATION_ID" --timeout 10m
+nebius --profile "$NEBIUS_PROFILE" ai endpoint operation get "$OPERATION_ID" \
+  --format json > "$RUN_DIR/stop-operation-final.json"
+jq -e '.finished_at != null and ((.status.code // 0) == 0)' \
+  "$RUN_DIR/stop-operation-final.json" || exit 1
 nebius --profile "$NEBIUS_PROFILE" ai endpoint get "$ENDPOINT_ID" \
   --format jsonpath='{.status.state}'
 ```
 
 Confirm `STOPPED`. If stop times out, inspect `ai endpoint operation list
 --resource-id "$ENDPOINT_ID" --all` and wait for the relevant operation before
-starting again; state alone is not confirmation of operation completion.
+starting again; state alone is not confirmation of operation completion. Verify that the unique
+image tag still resolves to the recorded derived digest before starting.
 
 ```bash
 nebius --profile "$NEBIUS_PROFILE" ai endpoint start "$ENDPOINT_ID" \
-  --async --retries 1 --format json > "$RUN_DIR/start-operation.json"
-OPERATION_ID=$(jq -er '.id' "$RUN_DIR/start-operation.json")
+  --async --retries 1 > "$RUN_DIR/start-operation-id"
+OPERATION_ID=$(cat "$RUN_DIR/start-operation-id")
+[[ "$OPERATION_ID" =~ ^opvmapp-[a-z0-9]+$ ]] || \
+  { echo 'Reconcile the saved start response' >&2; exit 1; }
 nebius --profile "$NEBIUS_PROFILE" ai endpoint operation wait \
   "${OPERATION_ID:?}" --timeout 35m
+nebius --profile "$NEBIUS_PROFILE" ai endpoint operation get "$OPERATION_ID" \
+  --format json > "$RUN_DIR/start-operation-final.json"
+jq -e '.finished_at != null and ((.status.code // 0) == 0)' \
+  "$RUN_DIR/start-operation-final.json" || exit 1
 ```
 
 Retrieve the current URL and repeat readiness/auth/inference checks after a
@@ -282,12 +336,29 @@ returns **NotFound**, not a connection/authentication error:
 
 ```bash
 nebius --profile "$NEBIUS_PROFILE" ai endpoint delete "${ENDPOINT_ID:?}" \
-  --async --retries 1 --format json > "$RUN_DIR/delete-operation.json"
-OPERATION_ID=$(jq -er '.id' "$RUN_DIR/delete-operation.json")
-nebius --profile "$NEBIUS_PROFILE" ai endpoint operation wait \
-  "${OPERATION_ID:?}" --timeout 10m
+  --async --retries 1 > "$RUN_DIR/delete-operation-id"
+OPERATION_ID=$(cat "$RUN_DIR/delete-operation-id")
+[[ "$OPERATION_ID" =~ ^opvmapp-[a-z0-9]+$ ]] || \
+  { echo 'Reconcile the saved delete response' >&2; exit 1; }
+DELETE_DEADLINE=$((SECONDS + 600))
+while (( SECONDS < DELETE_DEADLINE )); do
+  nebius --profile "$NEBIUS_PROFILE" ai endpoint operation get "$OPERATION_ID" \
+    --format json > "$RUN_DIR/delete-operation.json" || exit 1
+  if jq -e '.finished_at != null' "$RUN_DIR/delete-operation.json" >/dev/null; then
+    break
+  fi
+  sleep 5
+done
+jq -e '.finished_at != null and ((.status.code // 0) == 0)' \
+  "$RUN_DIR/delete-operation.json" || \
+  { echo 'Deletion incomplete or failed; reconcile before cleanup' >&2; exit 1; }
 nebius --profile "$NEBIUS_PROFILE" ai endpoint get "$ENDPOINT_ID"
 ```
+
+CLI 0.12.265's `operation wait` can return `NotFound` after a successful delete
+because it tries to retrieve the removed Endpoint. The loop above verifies the
+operation directly; the final Endpoint get must separately return `NotFound`.
+Do not treat an arbitrary wait failure as proof of successful deletion.
 
 If deletion is incomplete, retain the receipt and reconcile it through
 Serverless. Do not directly modify the managed VM. Closing a terminal or
@@ -336,8 +407,30 @@ Before marking this example cloud-validated, record:
 - No public VM IP; working registry pull and secret delivery; observed ingress
   size/time limits, not assumptions about raw Triton ports.
 
-The local HTTP fixtures exercise the example's client, not Nebius's gateway.
-Neither those tests nor CPU ONNX inference establish GPU compatibility.
+The local HTTP fixtures exercise the example's client. On 2026-09-12, live
+checks on `gpu-l40s-a` / `1gpu-8vcpu-32gb` in `eu-north1` also verified:
+
+- Private-registry pull and separate SecretStash credentials, managed HTTPS,
+  correct-token inference and HTTP 401 for missing/wrong-token probes.
+- Two starts of the corrected image, numerical CPU-reference agreement
+  (`max_abs_error = 6.4e-6`), and finite concurrency 1/2/4.
+- Version/model rejection (404), disabled model load (503), and continued
+  readiness after rejected requests. An empty `{}` request returned 500; this
+  is an observed server-error response, not a claim that malformed input is
+  correctly classified as a client error.
+- A corrupted model failed the startup checksum gate: the Endpoint reached
+  `ERROR / StartFailed` and readiness returned 404. Its creation wait command
+  still exited zero despite operation status code 9, so both operation status
+  and application readiness require explicit checks.
+- All three test Endpoint definitions were deleted: each deletion operation
+  completed successfully and each Endpoint ID subsequently returned `NotFound`.
+- Four bounded requests issued alongside stop all returned 200. Triton logged
+  its graceful shutdown path; this does not establish the platform's maximum
+  termination grace or behavior for long-running inferences.
+
+The create request omitted `--public`; managed HTTPS worked without requesting
+a public VM IP. The ~753 KB JSON inference body passed. Maximum ingress size,
+request-duration limits and other GPU/driver combinations remain unmeasured.
 Use [Serverless lifecycle/status details](https://docs.nebius.com/serverless/lifecycle)
 and logs to distinguish capacity, image-pull, model-load and authentication failures.
 GPU OOM requires an explicit concurrency/preset decision. Keep model-control

--- a/deploy/nebius/README.md
+++ b/deploy/nebius/README.md
@@ -328,8 +328,10 @@ jq -e '.finished_at != null and ((.status.code // 0) == 0)' \
 
 Retrieve the current URL and repeat readiness/auth/inference checks after a
 successful start. Replacements can require another image pull and model load.
-The entrypoint uses `exec` and Triton's 30-second exit allowance, but platform
-termination grace and in-flight request draining still require validation.
+The entrypoint uses `exec` and Triton's 30-second exit allowance. Finish client
+requests before stopping the Endpoint: a live test returned HTTP 502 to
+confirmed in-flight requests while Triton was still waiting for them to finish.
+The server's exit allowance does not guarantee delivery through the gateway.
 
 When finished, delete by the recorded ID and confirm that a subsequent get
 returns **NotFound**, not a connection/authentication error:
@@ -428,9 +430,31 @@ checks on `gpu-l40s-a` / `1gpu-8vcpu-32gb` in `eu-north1` also verified:
   its graceful shutdown path; this does not establish the platform's maximum
   termination grace or behavior for long-running inferences.
 
-The create request omitted `--public`; managed HTTPS worked without requesting
-a public VM IP. The ~753 KB JSON inference body passed. Maximum ingress size,
-request-duration limits and other GPU/driver combinations remain unmeasured.
+On 2026-09-13, the unchanged image also passed the smoke client, numerical
+CPU-reference comparison and concurrency 1/2/4 on `gpu-h100-sxm` /
+`1gpu-16vcpu-200gb` in `eu-north1`. Both GPU platforms used driver 580.173.02.
+Other driver branches remain untested.
+
+A separate L40S test fixture added a Python backend model to measure request
+sizes and delayed responses, retaining the example's HTTP/authentication and
+30-second exit settings. Observations through managed HTTPS were:
+
+- A request body of exactly 1,048,576 bytes (1 MiB), including JSON metadata,
+  passed. A body of 1,048,577 bytes returned HTTP 413. Early rejection could
+  first appear as an SSL/upload error before reading the HTTP response.
+- A 59-second delayed response passed. Delays of 61, 65 and 125 seconds returned
+  HTTP 504 after approximately 60 seconds without a response. The test backend
+  subsequently completed its work. This does not measure streaming timeouts.
+- Two requests, with 15- and 45-second computations, were confirmed executing
+  before stop. Both clients received HTTP 502 approximately 6.3 seconds after
+  stop was requested. Triton logged its shutdown wait and later completed the
+  15-second computation; its result did not reach the client.
+
+These are observations from this configuration, not provider guarantees or a
+production SLA. The request fixture is not included in the deployment image.
+The create requests omitted `--public`; managed HTTPS worked without requesting
+a public VM IP. The example's ~753 KB JSON inference body stayed below the
+observed size limit. Header, response-size and streaming limits remain untested.
 Use [Serverless lifecycle/status details](https://docs.nebius.com/serverless/lifecycle)
 and logs to distinguish capacity, image-pull, model-load and authentication failures.
 GPU OOM requires an explicit concurrency/preset decision. Keep model-control

--- a/deploy/nebius/README.md
+++ b/deploy/nebius/README.md
@@ -1,0 +1,349 @@
+<!--
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+# Triton on a Nebius Serverless HTTP Endpoint
+
+This example packages DenseNet-121 with Triton and serves it through a
+[Nebius Serverless Endpoint](https://docs.nebius.com/serverless/overview).
+It uses one GPU, one HTTP port and managed HTTPS bearer-token authentication.
+No Kubernetes cluster or changes to Triton are required.
+
+> **Validation status:** model preparation and the local CPU/HTTP-contract tests
+> have been exercised. The GPU container and Nebius deployment have not yet been
+> validated. Complete the [validation checklist](#validation-checklist) before
+> relying on this example. In particular, confirm the selected image's driver
+> compatibility with the GPU platform.
+
+An Endpoint runs until stopped or deleted. This recipe does not configure
+autoscaling, scale-to-zero, high availability or preemptible recovery. It uses
+the Triton V2 inference protocol, not the Nebius Token Factory/AI Studio model
+APIs. Serverless Jobs are finite background workloads without an inference URL;
+they are not needed for this example.
+
+## Prerequisites and version selection
+
+- Python 3.10 or later, Docker with Buildx, `jq`, and a Bash-compatible shell.
+- A registry you can push to and from which Nebius can pull images.
+- [Nebius CLI](https://docs.nebius.com/cli/install) configured for your project;
+  the commands below were checked against **0.12.265** help.
+- Project permissions and quotas for Serverless Endpoints, GPU resources, disks
+  and networking; a subnet and an available single-GPU platform/preset pair.
+- A Linux amd64 GPU environment to validate the image before cloud deployment.
+
+[pins.json](pins.json) fixes the Linux amd64 manifest of
+`nvcr.io/nvidia/tritonserver:26.08-py3`, the DenseNet ONNX file, Triton's model
+configuration/labels, and their source revisions and SHA-256 hashes. This is the
+full ONNX-capable server image, not an SDK, minimal or LLM-specific image.
+
+The [26.08 release notes](https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/rel-26-08.html)
+list ONNX Runtime 1.28.0 and GPUs with compute capability 7.5 or later. At the time
+this example was prepared, that page had conflicting CUDA versions and an
+incomplete minimum-driver field. Treat this pin as a candidate until GPU
+initialization and inference pass on your selected platform. An L40S is a
+reasonable single-GPU candidate, but no region's capacity or preset is assumed.
+If another release is required, update the pin and Dockerfile together and
+repeat the tests; do not use `latest` or assume a TensorRT-LLM image's driver
+matrix applies to the full server image.
+
+## Prepare the model and image
+
+From the root of the Triton checkout:
+
+```bash
+cd deploy/nebius
+python3 prepare_models.py
+```
+
+Preparation downloads approximately 32 MB plus configuration and notices,
+verifies each pinned size/hash, and adds a single GPU instance and a policy
+selecting only model version 1. It publishes `build/` only after success and
+refuses to replace an existing directory. It downloads actual model bytes,
+not the Git LFS pointer. To repeat preparation, move the existing build aside
+or choose `--output` with a new directory. The Dockerfile expects `build/`.
+
+```text
+build/
+  SHA256SUMS
+  model_repository/densenet_onnx/
+    config.pbtxt
+    densenet_labels.txt
+    1/model.onnx
+  notices/
+```
+
+The generated checksum manifest covers the final configuration as well as
+weights and labels. The image checks it during build and startup, and makes
+the files non-writable for UID/GID 1000. The source DenseNet README declares
+MIT, while the ONNX model repository's root license is Apache-2.0; preparation
+preserves both source notices, together with Triton's license. Keep these
+notices and review model/container terms before redistributing an image.
+This example does not publish an image on your behalf.
+
+Build and push to your registry, then resolve the resulting image digest:
+
+```bash
+export IMAGE_REPOSITORY='YOUR_REGISTRY/YOUR_NAMESPACE/triton-densenet'
+export IMAGE_TAG="${IMAGE_REPOSITORY}:nebius-example-1"
+docker buildx build --platform linux/amd64 --tag "$IMAGE_TAG" --push .
+docker buildx imagetools inspect "$IMAGE_TAG"
+```
+
+Set `IMAGE` to the returned digest reference, for example
+`YOUR_REGISTRY/YOUR_NAMESPACE/triton-densenet@sha256:...`. Use the **derived**
+image digest, not the base image digest from `pins.json`: the base does not
+contain the prepared model. Keep the image available while an Endpoint may
+restart. A private registry also requires the credential secret described below.
+
+## Create an authenticated Endpoint
+
+Choose your own project and resources. The CLI profile supplies control-plane
+IAM credentials; these are separate from the Endpoint's inference token.
+Create a [SecretStash secret version](https://docs.nebius.com/mysterybox/overview)
+with an `AUTH_TOKEN` payload containing a random token (for example generated
+with `openssl rand -hex 32`). Retain the token securely for the client. Set
+`AUTH_TOKEN_SECRET` to its `SECRET_ID@VERSION_ID` selector. Do not embed tokens
+in this checkout, image or command-line arguments.
+
+For a private registry, create a separate secret version with
+`REGISTRY_USERNAME` and `REGISTRY_PASSWORD` payload keys and add
+`--registry-secret "$REGISTRY_SECRET"` to the create command.
+
+```bash
+export NEBIUS_PROFILE='YOUR_CONFIGURED_PROFILE'
+export PROJECT_ID='YOUR_PROJECT_ID'
+export SUBNET_ID='YOUR_SUBNET_ID'
+export GPU_PLATFORM='YOUR_SINGLE_GPU_PLATFORM'
+export GPU_PRESET='YOUR_COMPATIBLE_SINGLE_GPU_PRESET'
+export AUTH_TOKEN_SECRET='YOUR_SECRET_ID@YOUR_VERSION_ID'
+export IMAGE='YOUR_REGISTRY/YOUR_NAMESPACE/triton-densenet@sha256:YOUR_DIGEST'
+
+umask 077
+RUN_DIR="receipts/$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 4)"
+mkdir -p "$RUN_DIR"
+export ENDPOINT_NAME="triton-$(basename "$RUN_DIR")"
+printf '%s\n' "$PROJECT_ID" > "$RUN_DIR/project-id"
+printf '%s\n' "$IMAGE" > "$RUN_DIR/image"
+cp pins.json "$RUN_DIR/pins.json"
+
+nebius --profile "$NEBIUS_PROFILE" ai endpoint create \
+  --parent-id "$PROJECT_ID" --subnet-id "$SUBNET_ID" \
+  --name "$ENDPOINT_NAME" --image "$IMAGE" \
+  --platform "$GPU_PLATFORM" --preset "$GPU_PRESET" \
+  --container-port 8000/http \
+  --auth token --token-secret "$AUTH_TOKEN_SECRET" \
+  --disk-size 250Gi --shm-size 1Gi \
+  --async --retries 1 --format json > "$RUN_DIR/create-operation.json"
+```
+
+Stop here if creation returns an error or the response is missing. A lost
+response does not prove that no Endpoint exists. Reconcile using your project,
+name, image and creation time in the console or `ai endpoint list`; names are
+not necessarily unique. Do not automatically run create again. Keep the receipt
+directory private: raw service responses may contain sensitive information.
+
+On a successful asynchronous response, save the operation and resource IDs:
+
+```bash
+OPERATION_ID=$(jq -er '.id | select(type == "string" and length > 0)' \
+  "$RUN_DIR/create-operation.json")
+ENDPOINT_ID=$(jq -er '.resource_id | select(type == "string" and length > 0)' \
+  "$RUN_DIR/create-operation.json")
+printf '%s\n' "${ENDPOINT_ID:?Missing Endpoint ID}" > "$RUN_DIR/endpoint-id"
+nebius --profile "$NEBIUS_PROFILE" ai endpoint operation wait \
+  "${OPERATION_ID:?Missing operation ID}" --timeout 35m --format json \
+  > "$RUN_DIR/create-result.json"
+```
+
+Confirm successful operation completion. If waiting times out, inspect the
+**same operation** with `ai endpoint operation get "$OPERATION_ID"` and the
+Endpoint's state/details; do not create another resource. Choose your own
+bounded waiting/spending limit. The service documents a 30-minute capacity
+provisioning timeout; image pull and model readiness are separate stages.
+
+No public VM IP is requested: the managed HTTPS URL works without `--public`.
+Ensure the subnet can reach the registry. Only port 8000 is registered; the
+entrypoint disables Triton's gRPC and native metrics listeners. Although Nebius
+CLI help describes gRPC over managed HTTPS, this recipe does not validate Triton
+gRPC clients or expose raw ports 8001/8002.
+
+## Wait for the model and send inference
+
+Get the Endpoint, confirm its state is `RUNNING`, and extract the single HTTPS
+URL returned for this example:
+
+```bash
+nebius --profile "$NEBIUS_PROFILE" ai endpoint get "${ENDPOINT_ID:?}" \
+  --format json > "$RUN_DIR/endpoint.json"
+jq -e '.status.state == "RUNNING"' "$RUN_DIR/endpoint.json"
+export ENDPOINT_URL=$(jq -er \
+  '[.status.public_endpoints[] | select(startswith("https://"))] |
+   if length == 1 then .[0] else error("Expected one HTTPS URL") end' \
+  "$RUN_DIR/endpoint.json")
+```
+
+If not yet running, inspect `status.state_details` and logs before checking again:
+
+```bash
+nebius --profile "$NEBIUS_PROFILE" ai endpoint logs "$ENDPOINT_ID"
+```
+
+Supply the same `AUTH_TOKEN` to the client through the environment, preferably
+from your secret manager. For a local interactive test in Bash:
+
+```bash
+read -r -s -p 'Endpoint token: ' ENDPOINT_AUTH_TOKEN
+printf '\n'
+export ENDPOINT_AUTH_TOKEN
+python3 smoke_test.py --wait-seconds 600 --request-timeout 15
+unset ENDPOINT_AUTH_TOKEN
+```
+
+The smoke test waits for **both** `/v2/health/ready` and
+`/v2/models/densenet_onnx/versions/1/ready`, then verifies that missing and wrong
+tokens return 401/403 at health and inference routes. It sends a zero-filled
+FP32 tensor to `/v2/models/densenet_onnx/versions/1/infer` with
+`Authorization: Bearer ...` and checks model/version, output metadata and 1,000
+finite values. Credentials and response bodies are not printed; redirects are
+not followed with the token.
+
+The JSON input shape is `[3,224,224]`: the model configuration reshapes it to
+ONNX's `[1,3,224,224]`. Likewise the output is exposed as `[1000]`. This checks
+execution and the HTTP contract, not image-classification accuracy. These
+outputs are logits, not probabilities. The script limits response size to 1 MiB
+and does not retry inference. It is an example client, not a load generator.
+
+`RUNNING` or `/v2/health/live` alone does not prove model readiness. No custom
+platform readiness-probe field is configured; do not assume Docker health
+checks gate Nebius ingress. Strict Triton readiness and client polling provide
+the checks here, while early callers may still receive startup errors.
+
+## Persistence, stop/start and cleanup
+
+The image is the durable model source. Local caches/container disk are
+disposable, and inference results are returned to the client. No bucket or
+shared filesystem is required. For larger models, see
+[Triton model repositories](../../docs/user_guide/model_repository.md) and
+[Nebius volume configuration](https://docs.nebius.com/serverless/endpoints/manage).
+An external repository needs its own credentials, immutable revisions,
+checksums and live validation; this recipe does not poll a mutable bucket.
+
+Stop/start preserves the Endpoint definition, not warm GPU memory or a specific
+VM. Stop synchronously and wait for the operation to finish before starting:
+
+```bash
+nebius --profile "$NEBIUS_PROFILE" ai endpoint stop "${ENDPOINT_ID:?}" --timeout 10m
+nebius --profile "$NEBIUS_PROFILE" ai endpoint get "$ENDPOINT_ID" \
+  --format jsonpath='{.status.state}'
+```
+
+Confirm `STOPPED`. If stop times out, inspect `ai endpoint operation list
+--resource-id "$ENDPOINT_ID" --all` and wait for the relevant operation before
+starting again; state alone is not confirmation of operation completion.
+
+```bash
+nebius --profile "$NEBIUS_PROFILE" ai endpoint start "$ENDPOINT_ID" \
+  --async --retries 1 --format json > "$RUN_DIR/start-operation.json"
+OPERATION_ID=$(jq -er '.id' "$RUN_DIR/start-operation.json")
+nebius --profile "$NEBIUS_PROFILE" ai endpoint operation wait \
+  "${OPERATION_ID:?}" --timeout 35m
+```
+
+Retrieve the current URL and repeat readiness/auth/inference checks after a
+successful start. Replacements can require another image pull and model load.
+The entrypoint uses `exec` and Triton's 30-second exit allowance, but platform
+termination grace and in-flight request draining still require validation.
+
+When finished, delete by the recorded ID and confirm that a subsequent get
+returns **NotFound**, not a connection/authentication error:
+
+```bash
+nebius --profile "$NEBIUS_PROFILE" ai endpoint delete "${ENDPOINT_ID:?}" \
+  --async --retries 1 --format json > "$RUN_DIR/delete-operation.json"
+OPERATION_ID=$(jq -er '.id' "$RUN_DIR/delete-operation.json")
+nebius --profile "$NEBIUS_PROFILE" ai endpoint operation wait \
+  "${OPERATION_ID:?}" --timeout 10m
+nebius --profile "$NEBIUS_PROFILE" ai endpoint get "$ENDPOINT_ID"
+```
+
+If deletion is incomplete, retain the receipt and reconcile it through
+Serverless. Do not directly modify the managed VM. Closing a terminal or
+interrupting a request does not stop the Endpoint. Separately mounted storage
+has its own lifecycle/billing; remove only dedicated test objects, images and
+secrets after confirming no remaining Endpoint uses them. There is no cleanup
+watchdog in this example.
+
+## Validation checklist
+
+Run the offline tests without cloud access or a GPU:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+On a Linux GPU host, build locally with `--load` instead of `--push`, run the
+container with `--gpus 1 --shm-size 1g -p 127.0.0.1:8000:8000`, and verify GPU
+initialization and inference. A bare local Triton container has no Nebius
+gateway; the full smoke test must reject its unauthenticated surface. To check
+only the local model during this stage:
+
+```python
+from smoke_test import Client
+
+client = Client("http://127.0.0.1:8000", "local-test", allow_local_http=True)
+client.wait_ready(60, 15)
+values = client.infer(15)
+assert len(values) == 1000
+```
+
+For numerical validation, generate a 1,000-value JSON reference array by running
+`build/model_repository/densenet_onnx/1/model.onnx` with ONNX Runtime's CPU
+provider and a zero FP32 input of shape `[1,3,224,224]`. Pass it to
+`smoke_test.py --reference reference.json` against the authenticated Endpoint.
+The comparison uses `rtol=1e-3, atol=1e-4`; investigate differences rather than
+loosening tolerances merely to pass.
+
+Before marking this example cloud-validated, record:
+
+- Exact derived digest, model/config hashes, CLI, GPU, driver and backend versions.
+- Two cold starts, correct-token success, missing/wrong-token rejection, numerical
+  reference agreement, and malformed input/unknown version rejection.
+- Failed startup with a missing/corrupt model, finite concurrency 1/2/4,
+  stop/start, an in-flight request during stop, and complete deletion reconciliation.
+- No public VM IP; working registry pull and secret delivery; observed ingress
+  size/time limits, not assumptions about raw Triton ports.
+
+The local HTTP fixtures exercise the example's client, not Nebius's gateway.
+Neither those tests nor CPU ONNX inference establish GPU compatibility.
+Use [Serverless lifecycle/status details](https://docs.nebius.com/serverless/lifecycle)
+and logs to distinguish capacity, image-pull, model-load and authentication failures.
+GPU OOM requires an explicit concurrency/preset decision. Keep model-control
+mode `none`; authenticated callers are not given model-load/unload access.
+
+For contribution checks, run the repository's pre-commit hooks and documentation
+checks and follow [CONTRIBUTING.md](../../CONTRIBUTING.md), including the CLA and
+required upstream CI/test evidence. This example makes no gRPC, binary-tensor,
+streaming-model, multi-GPU, autoscaling or production SLA claim.

--- a/deploy/nebius/entrypoint.sh
+++ b/deploy/nebius/entrypoint.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+set -eu
+cd /opt/nebius-example
+sha256sum --check --status SHA256SUMS
+exec tritonserver \
+  --model-repository=/opt/nebius-example/model_repository \
+  --model-control-mode=none --strict-readiness=true --exit-on-error=true \
+  --allow-http=true --http-address=0.0.0.0 --http-port=8000 \
+  --allow-grpc=false --allow-metrics=false --exit-timeout-secs=30

--- a/deploy/nebius/pins.json
+++ b/deploy/nebius/pins.json
@@ -1,0 +1,49 @@
+{
+  "runtime": {
+    "tag": "nvcr.io/nvidia/tritonserver:26.08-py3",
+    "platform": "linux/amd64",
+    "digest": "sha256:71a23d2f27001af58c242380fe05c9d46d5dbc79913d62c60de72543964267df"
+  },
+  "sources": {
+    "triton_server": "34fafaaf274dcb7dce3a98ec938c6ec4d3e511ef",
+    "onnx_models": "4f43949841cb55a0b98dc8fcd045431ccafd9f96"
+  },
+  "artifacts": [
+    {
+      "path": "model_repository/densenet_onnx/1/model.onnx",
+      "url": "https://media.githubusercontent.com/media/onnx/models/4f43949841cb55a0b98dc8fcd045431ccafd9f96/validated/vision/classification/densenet-121/model/densenet-7.onnx",
+      "size_bytes": 32719461,
+      "sha256": "79c3bc0974696a2ea9efd2f7bca19fdd630834bd0086f1b4a1c3db3dce3b2a51"
+    },
+    {
+      "path": "model_repository/densenet_onnx/config.pbtxt",
+      "url": "https://raw.githubusercontent.com/triton-inference-server/server/34fafaaf274dcb7dce3a98ec938c6ec4d3e511ef/docs/examples/model_repository/densenet_onnx/config.pbtxt",
+      "size_bytes": 387,
+      "sha256": "fd425185cc2ff71f8eee474a4f8ab30b93eb9ae2703e9438c7f5743ba116559f"
+    },
+    {
+      "path": "model_repository/densenet_onnx/densenet_labels.txt",
+      "url": "https://raw.githubusercontent.com/triton-inference-server/server/34fafaaf274dcb7dce3a98ec938c6ec4d3e511ef/docs/examples/model_repository/densenet_onnx/densenet_labels.txt",
+      "size_bytes": 10311,
+      "sha256": "9c89e59490666e2976a0dded535a755b9878a71e14400804df8d356131d2fc04"
+    },
+    {
+      "path": "notices/onnx-models-LICENSE",
+      "url": "https://raw.githubusercontent.com/onnx/models/4f43949841cb55a0b98dc8fcd045431ccafd9f96/LICENSE",
+      "size_bytes": 11358,
+      "sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30"
+    },
+    {
+      "path": "notices/densenet-README.md",
+      "url": "https://raw.githubusercontent.com/onnx/models/4f43949841cb55a0b98dc8fcd045431ccafd9f96/validated/vision/classification/densenet-121/README.md",
+      "size_bytes": 3143,
+      "sha256": "75839fbaa1760841d486c7e6a365b0cbbfa9265e4f6b7c60514c2a74df28a537"
+    },
+    {
+      "path": "notices/triton-LICENSE",
+      "url": "https://raw.githubusercontent.com/triton-inference-server/server/34fafaaf274dcb7dce3a98ec938c6ec4d3e511ef/LICENSE",
+      "size_bytes": 1490,
+      "sha256": "179f37347fde9030609578b02539af12bc66b39c291de1c30d8525c6cd390036"
+    }
+  ]
+}

--- a/deploy/nebius/prepare_models.py
+++ b/deploy/nebius/prepare_models.py
@@ -42,6 +42,10 @@ GPU_CONFIG = (
     "\n# This example serves only version 1 on one GPU.\n"
     "instance_group [{ kind: KIND_GPU count: 1 gpus: [0] }]\n"
     "version_policy: { specific: { versions: [1] } }\n"
+    "# Disable reduced-precision TF32 for the FP32 numerical reference check.\n"
+    "optimization { execution_accelerators { gpu_execution_accelerator [ {\n"
+    '  name: "cuda" parameters { key: "use_tf32" value: "0" }\n'
+    "} ] } }\n"
 )
 CONFIG_PATH = "model_repository/densenet_onnx/config.pbtxt"
 

--- a/deploy/nebius/prepare_models.py
+++ b/deploy/nebius/prepare_models.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""Prepare the fixed DenseNet repository; no dependencies beyond Python 3.10+."""
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePosixPath
+
+HERE = Path(__file__).resolve().parent
+GPU_CONFIG = (
+    "\n# This example serves only version 1 on one GPU.\n"
+    "instance_group [{ kind: KIND_GPU count: 1 gpus: [0] }]\n"
+    "version_policy: { specific: { versions: [1] } }\n"
+)
+CONFIG_PATH = "model_repository/densenet_onnx/config.pbtxt"
+
+
+def destination(root, relative):
+    path = PurePosixPath(relative)
+    if (
+        not path.parts
+        or path.is_absolute()
+        or ".." in path.parts
+        or "\\" in relative
+        or path.parts[0] not in {"model_repository", "notices"}
+    ):
+        raise ValueError("Unsafe artifact path in pins.json")
+    return root.joinpath(*path.parts)
+
+
+def fetch(artifact, target):
+    """Enforce the byte count as well as the digest, including on partial reads."""
+    expected_size = artifact["size_bytes"]
+    digest = hashlib.sha256()
+    received = 0
+    deadline = time.monotonic() + 180
+    request = urllib.request.Request(artifact["url"], headers={"User-Agent": "Triton"})
+    with urllib.request.urlopen(request, timeout=30) as response, target.open(
+        "xb"
+    ) as f:
+        if not response.geturl().startswith("https://"):
+            raise ValueError("Artifact download did not use HTTPS")
+        while True:
+            if time.monotonic() >= deadline:
+                raise ValueError("Artifact download exceeded its deadline")
+            chunk = response.read(min(65536, expected_size - received + 1))
+            if not chunk:
+                break
+            received += len(chunk)
+            if received > expected_size:
+                raise ValueError("Artifact exceeds the pinned size")
+            digest.update(chunk)
+            f.write(chunk)
+    if received != expected_size or digest.hexdigest() != artifact["sha256"]:
+        raise ValueError("Artifact size or SHA-256 mismatch; refusing the download")
+
+
+def prepare(output, pins, download=fetch):
+    """Publish a complete build context only after all artifacts are verified."""
+    output = Path(output).absolute()
+    if output.exists() or output.is_symlink():
+        raise ValueError("Output already exists; choose a new directory")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".nebius-models-", dir=output.parent))
+    try:
+        for artifact in pins["artifacts"]:
+            target = destination(staging, artifact["path"])
+            target.parent.mkdir(parents=True, exist_ok=True)
+            download(artifact, target)
+        config = staging / CONFIG_PATH
+        config.write_text(
+            config.read_text(encoding="utf-8") + GPU_CONFIG, encoding="utf-8"
+        )
+        manifest = []
+        for file in sorted(staging.rglob("*")):
+            if file.is_file():
+                digest = hashlib.sha256(file.read_bytes()).hexdigest()
+                manifest.append(f"{digest}  {file.relative_to(staging).as_posix()}\n")
+        (staging / "SHA256SUMS").write_text("".join(manifest), encoding="utf-8")
+        if output.exists() or output.is_symlink():
+            raise ValueError(
+                "Output was created during preparation; refusing to replace it"
+            )
+        staging.rename(output)
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging)
+    return output
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=HERE / "build")
+    args = parser.parse_args()
+    try:
+        pins = json.loads((HERE / "pins.json").read_text(encoding="utf-8"))
+        output = prepare(args.output, pins)
+    except (OSError, ValueError, urllib.error.URLError):
+        print(
+            "Preparation failed; check network, output path and pinned artifacts.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Prepared {output}; checksums are in SHA256SUMS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/nebius/smoke_test.py
+++ b/deploy/nebius/smoke_test.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""Check an existing authenticated Triton HTTP endpoint; creates no resources."""
+
+import argparse
+import http.client
+import json
+import math
+import os
+import secrets
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+MODEL = "densenet_onnx"
+MODEL_READY = f"/v2/models/{MODEL}/versions/1/ready"
+INFER = f"/v2/models/{MODEL}/versions/1/infer"
+TRANSIENT = {404, 429, 500, 502, 503, 504}
+MAX_RESPONSE_BYTES = 1024 * 1024
+
+
+class CheckError(Exception):
+    """Safe-to-display error that never contains tokens or response bodies."""
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def positive_seconds(value):
+    number = float(value)
+    if not math.isfinite(number) or number <= 0:
+        raise argparse.ArgumentTypeError("must be a positive finite number")
+    return number
+
+
+def inference_payload():
+    return {
+        "inputs": [
+            {
+                "name": "data_0",
+                "shape": [3, 224, 224],
+                "datatype": "FP32",
+                "data": [0.0] * (3 * 224 * 224),
+            }
+        ],
+        "outputs": [{"name": "fc6_1"}],
+    }
+
+
+class Client:
+    def __init__(self, url, token, allow_local_http=False):
+        parsed = urllib.parse.urlsplit(url)
+        local_http = (
+            allow_local_http
+            and parsed.scheme == "http"
+            and parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+        )
+        if (
+            (parsed.scheme != "https" and not local_http)
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+            or any(c.isspace() for c in url)
+        ):
+            raise CheckError(
+                "Use the returned HTTPS URL without credentials or query parameters"
+            )
+        if not token or any(c.isspace() for c in token):
+            raise CheckError("Set a nonempty ENDPOINT_AUTH_TOKEN without whitespace")
+        self.url = url.rstrip("/")
+        self.token = token
+        self.opener = urllib.request.build_opener(NoRedirect())
+
+    def request(self, path, timeout, payload=None, token=None):
+        headers = {}
+        if token is not None:
+            headers["Authorization"] = "Bearer " + token
+        body = None
+        if payload is not None:
+            body = json.dumps(payload, allow_nan=False).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(self.url + path, data=body, headers=headers)
+        try:
+            with self.opener.open(request, timeout=timeout) as response:
+                data = response.read(MAX_RESPONSE_BYTES + 1)
+                if len(data) > MAX_RESPONSE_BYTES:
+                    raise CheckError("Response exceeds the smoke test's 1 MiB limit")
+                return response.status, data
+        except urllib.error.HTTPError as exc:
+            code = exc.code
+            exc.close()
+            return code, b""
+        except (
+            urllib.error.URLError,
+            OSError,
+            ValueError,
+            http.client.HTTPException,
+        ) as exc:
+            # Keep response bodies, supplied URLs and authorization out of errors.
+            raise CheckError(
+                "HTTP transport failed; check URL, TLS and connectivity"
+            ) from exc
+
+    def wait_ready(self, wait_seconds, request_timeout):
+        deadline = time.monotonic() + wait_seconds
+        while time.monotonic() < deadline:
+            ready = True
+            for path in ("/v2/health/ready", MODEL_READY):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                status, _ = self.request(
+                    path, min(request_timeout, remaining), token=self.token
+                )
+                if status in {401, 403}:
+                    raise CheckError("Readiness authentication failed (401/403)")
+                if status != 200:
+                    ready = False
+                    if status not in TRANSIENT:
+                        raise CheckError(f"Unexpected readiness HTTP status: {status}")
+                    break
+            else:
+                if ready:
+                    return
+            time.sleep(max(0, min(2, deadline - time.monotonic())))
+        raise CheckError(
+            "Model readiness deadline exceeded; inspect Endpoint status and logs"
+        )
+
+    def check_auth(self, request_timeout):
+        wrong_token = secrets.token_hex(32)
+        while wrong_token == self.token:
+            wrong_token = secrets.token_hex(32)
+        for path, payload in (("/v2/health/ready", None), (INFER, inference_payload())):
+            for token in (None, wrong_token):
+                status, _ = self.request(path, request_timeout, payload, token)
+                if status not in {401, 403}:
+                    raise CheckError(
+                        "Missing/wrong token was not rejected with 401 or 403"
+                    )
+
+    def infer(self, request_timeout):
+        status, data = self.request(
+            INFER, request_timeout, inference_payload(), self.token
+        )
+        if status != 200:
+            raise CheckError(f"Inference failed with HTTP status {status}")
+        try:
+            response = json.loads(data)
+            return validate_output(response)
+        except (ValueError, TypeError, KeyError, AttributeError, OverflowError) as exc:
+            raise CheckError("Inference returned an invalid model response") from exc
+
+
+def validate_values(values):
+    if not isinstance(values, list) or len(values) != 1000:
+        raise ValueError("Expected 1000 values")
+    if any(type(v) not in (float, int) or not math.isfinite(v) for v in values):
+        raise ValueError("Expected finite numbers")
+    return values
+
+
+def validate_output(response):
+    if response["model_name"] != MODEL or response["model_version"] != "1":
+        raise ValueError("Unexpected model or version")
+    outputs = response["outputs"]
+    if not isinstance(outputs, list) or len(outputs) != 1:
+        raise ValueError("Expected one output")
+    output = outputs[0]
+    if (
+        output["name"] != "fc6_1"
+        or output["datatype"] != "FP32"
+        or output["shape"] != [1000]
+    ):
+        raise ValueError("Unexpected tensor metadata")
+    return validate_values(output["data"])
+
+
+def compare_reference(values, reference):
+    validate_values(reference)
+    if any(abs(a - b) > 1e-4 + 1e-3 * abs(b) for a, b in zip(values, reference)):
+        raise CheckError(
+            "Inference differs from the CPU reference (rtol=1e-3, atol=1e-4)"
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=os.environ.get("ENDPOINT_URL", ""))
+    parser.add_argument("--wait-seconds", type=positive_seconds, default=600)
+    parser.add_argument("--request-timeout", type=positive_seconds, default=15)
+    parser.add_argument(
+        "--reference", type=Path, help="Optional 1000-value zero-input JSON array"
+    )
+    parser.add_argument(
+        "--allow-local-http", action="store_true", help="Allow loopback HTTP testing"
+    )
+    args = parser.parse_args()
+    try:
+        reference = None
+        if args.reference:
+            reference = validate_values(
+                json.loads(args.reference.read_text(encoding="utf-8"))
+            )
+        client = Client(
+            args.url, os.environ.get("ENDPOINT_AUTH_TOKEN", ""), args.allow_local_http
+        )
+        client.wait_ready(args.wait_seconds, args.request_timeout)
+        client.check_auth(args.request_timeout)
+        values = client.infer(args.request_timeout)
+        if reference is not None:
+            compare_reference(values, reference)
+    except CheckError as exc:
+        print(f"Check failed: {exc}", file=sys.stderr)
+        return 1
+    except (OSError, ValueError):
+        print("Check failed: invalid URL or reference file", file=sys.stderr)
+        return 1
+    print("PASS: model ready; missing/wrong tokens rejected; 1000 finite FP32 outputs")
+    if reference is not None:
+        print("PASS: numerical CPU reference comparison")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/nebius/smoke_test.py
+++ b/deploy/nebius/smoke_test.py
@@ -162,7 +162,9 @@ class Client:
         wrong_token = secrets.token_hex(32)
         while wrong_token == self.token:
             wrong_token = secrets.token_hex(32)
-        for path, payload in (("/v2/health/ready", None), (INFER, inference_payload())):
+        # Gateways can reject authorization before reading the request body.
+        # Keep this probe small so an early 401 does not interrupt a large upload.
+        for path, payload in (("/v2/health/ready", None), (INFER, {"inputs": []})):
             for token in (None, wrong_token):
                 status, _ = self.request(path, request_timeout, payload, token)
                 if status not in {401, 403}:

--- a/deploy/nebius/tests/test_example.py
+++ b/deploy/nebius/tests/test_example.py
@@ -1,0 +1,303 @@
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""Offline preparation and HTTP-contract tests; no cloud credentials or GPU."""
+
+import contextlib
+import hashlib
+import io
+import json
+import math
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import prepare_models  # noqa: E402
+import smoke_test  # noqa: E402
+
+
+class FakeDownload(io.BytesIO):
+    def geturl(self):
+        return "https://example.invalid/model"
+
+
+class PreparationTests(unittest.TestCase):
+    def artifact(self, content):
+        return {
+            "path": prepare_models.CONFIG_PATH,
+            "url": "https://example.invalid/config",
+            "size_bytes": len(content),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+
+    def test_download_verifies_content_and_size(self):
+        correct = b"fixed model bytes"
+        bad = [b"x" * len(correct), correct[:-1], correct + b"x"]
+        with tempfile.TemporaryDirectory() as temp:
+            for i, body in enumerate([correct] + bad):
+                target = Path(temp) / str(i)
+                with patch("urllib.request.urlopen", return_value=FakeDownload(body)):
+                    if i == 0:
+                        prepare_models.fetch(self.artifact(correct), target)
+                        self.assertEqual(target.read_bytes(), correct)
+                    else:
+                        with self.assertRaises(ValueError):
+                            prepare_models.fetch(self.artifact(correct), target)
+
+    def test_lfs_pointer_is_not_a_model(self):
+        pointer = b"version https://git-lfs.github.com/spec/v1\noid sha256:fake\n"
+        with tempfile.TemporaryDirectory() as temp:
+            with patch("urllib.request.urlopen", return_value=FakeDownload(pointer)):
+                with self.assertRaises(ValueError):
+                    prepare_models.fetch(
+                        self.artifact(b"a real model"), Path(temp) / "model"
+                    )
+
+    def test_failed_prepare_publishes_nothing(self):
+        with tempfile.TemporaryDirectory() as temp:
+            out = Path(temp) / "build"
+            with patch("urllib.request.urlopen", return_value=FakeDownload(b"bad")):
+                with self.assertRaises(ValueError):
+                    prepare_models.prepare(
+                        out, {"artifacts": [self.artifact(b"correct")]}
+                    )
+            self.assertFalse(out.exists())
+            self.assertEqual(list(Path(temp).iterdir()), [])
+
+    def test_prepare_does_not_replace_existing_directory(self):
+        with tempfile.TemporaryDirectory() as temp:
+            sentinel = Path(temp) / "keep"
+            sentinel.write_text("existing data")
+            with self.assertRaises(ValueError):
+                prepare_models.prepare(Path(temp), {"artifacts": []})
+            self.assertEqual(sentinel.read_text(), "existing data")
+
+    def test_path_traversal_is_rejected(self):
+        for relative in [
+            "../secret",
+            "/tmp/secret",
+            "model_repository/../../secret",
+            "notices\\secret",
+            "",
+        ]:
+            with self.subTest(relative=relative), self.assertRaises(ValueError):
+                prepare_models.destination(Path("/tmp/build"), relative)
+
+    def test_complete_repository_has_verifiable_final_config(self):
+        source = b'name: "densenet_onnx"\n'
+        with tempfile.TemporaryDirectory() as temp:
+            out = Path(temp) / "build"
+            with patch("urllib.request.urlopen", return_value=FakeDownload(source)):
+                prepare_models.prepare(out, {"artifacts": [self.artifact(source)]})
+            config = (out / prepare_models.CONFIG_PATH).read_bytes()
+            self.assertIn(b"KIND_GPU", config)
+            self.assertIn(b"versions: [1]", config)
+            checksum, path = (out / "SHA256SUMS").read_text().strip().split("  ")
+            self.assertEqual(
+                hashlib.sha256((out / path).read_bytes()).hexdigest(), checksum
+            )
+
+    def test_runtime_pin_matches_dockerfile(self):
+        root = Path(__file__).resolve().parents[1]
+        runtime = json.loads((root / "pins.json").read_text())["runtime"]
+        self.assertIn(
+            runtime["tag"] + "@" + runtime["digest"], (root / "Dockerfile").read_text()
+        )
+
+
+def valid_response():
+    return {
+        "model_name": "densenet_onnx",
+        "model_version": "1",
+        "outputs": [
+            {
+                "name": "fc6_1",
+                "datatype": "FP32",
+                "shape": [1000],
+                "data": [0.25] * 1000,
+            }
+        ],
+    }
+
+
+class OutputTests(unittest.TestCase):
+    def test_rejects_wrong_metadata_and_nonfinite_or_boolean_values(self):
+        changes = [
+            lambda r: r.update(model_version="2"),
+            lambda r: r.update(model_name="other"),
+            lambda r: r["outputs"][0].update(shape=[1, 1000]),
+            lambda r: r["outputs"][0].update(datatype="INT32"),
+            lambda r: r["outputs"][0].update(name="wrong"),
+            lambda r: r["outputs"][0].update(data=[0.0] * 999),
+            lambda r: r["outputs"][0]["data"].__setitem__(0, math.nan),
+            lambda r: r["outputs"][0]["data"].__setitem__(0, True),
+        ]
+        for change in changes:
+            response = valid_response()
+            change(response)
+            with self.assertRaises(ValueError):
+                smoke_test.validate_output(response)
+
+    def test_reference_comparison_detects_wrong_numerical_result(self):
+        smoke_test.compare_reference([0.1] * 1000, [0.10001] * 1000)
+        with self.assertRaises(smoke_test.CheckError):
+            smoke_test.compare_reference([0.1] * 1000, [0.2] * 1000)
+
+    def test_url_and_token_validation(self):
+        for url in [
+            "http://example.com",
+            "https://user:password@example.com",
+            "https://example.com/?token=x",
+            "https://example.com/#x",
+            "https://example.com/\n",
+        ]:
+            with self.subTest(url=url), self.assertRaises(smoke_test.CheckError):
+                smoke_test.Client(url, "test-token", allow_local_http=True)
+        with self.assertRaises(smoke_test.CheckError):
+            smoke_test.Client("https://example.com", "secret\r\nInjected: x")
+
+
+class HTTPTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def respond(self, code, body=b""):
+                self.send_response(code)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def handle_request(self, payload=None):
+                state = self.server.state
+                state["requests"].append(
+                    (self.path, self.headers.get("Authorization"), payload)
+                )
+                if state.get("redirect"):
+                    self.send_response(302)
+                    self.send_header("Location", state["redirect"])
+                    self.end_headers()
+                    return
+                if (
+                    not state.get("auth_disabled")
+                    and self.headers.get("Authorization") != "Bearer test-token"
+                ):
+                    self.respond(401)
+                elif self.path == "/v2/health/ready":
+                    self.respond(200)
+                elif self.path == smoke_test.MODEL_READY:
+                    self.respond(state.get("model_ready", 200))
+                elif self.path == smoke_test.INFER:
+                    self.respond(
+                        200, state.get("body", json.dumps(valid_response()).encode())
+                    )
+                else:
+                    self.respond(404)
+
+            def do_GET(self):
+                self.handle_request()
+
+            def do_POST(self):
+                payload = json.loads(
+                    self.rfile.read(int(self.headers["Content-Length"]))
+                )
+                self.handle_request(payload)
+
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.url = f"http://127.0.0.1:{cls.server.server_port}"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.thread.join()
+
+    def setUp(self):
+        self.server.state = {"requests": []}
+        self.client = smoke_test.Client(self.url, "test-token", allow_local_http=True)
+
+    def test_ready_auth_and_real_http_inference(self):
+        self.client.wait_ready(1, 1)
+        self.client.check_auth(1)
+        self.assertEqual(len(self.client.infer(1)), 1000)
+        calls = self.server.state["requests"]
+        self.assertEqual(len(calls), 7)
+        payload = calls[-1][2]
+        self.assertEqual(payload["inputs"][0]["shape"], [3, 224, 224])
+        self.assertEqual(len(payload["inputs"][0]["data"]), 150528)
+        self.assertEqual(calls[-1][0], smoke_test.INFER)
+
+    def test_server_ready_without_model_is_not_success(self):
+        self.server.state["model_ready"] = 503
+        with self.assertRaisesRegex(smoke_test.CheckError, "deadline"):
+            self.client.wait_ready(0.05, 1)
+
+    def test_bad_readiness_token_fails_immediately(self):
+        self.client.token = "wrong"
+        with self.assertRaisesRegex(smoke_test.CheckError, "authentication"):
+            self.client.wait_ready(1, 1)
+        self.assertEqual(len(self.server.state["requests"]), 1)
+
+    def test_public_endpoint_fails_auth_check(self):
+        self.server.state["auth_disabled"] = True
+        with self.assertRaisesRegex(smoke_test.CheckError, "not rejected"):
+            self.client.check_auth(1)
+
+    def test_redirect_is_not_followed_with_a_token(self):
+        self.server.state["redirect"] = self.url + "/capture"
+        with self.assertRaisesRegex(smoke_test.CheckError, "302"):
+            self.client.wait_ready(1, 1)
+        self.assertEqual(len(self.server.state["requests"]), 1)
+
+    def test_malformed_and_oversized_responses(self):
+        for body in [b"not json", b"x" * (smoke_test.MAX_RESPONSE_BYTES + 1)]:
+            self.server.state["body"] = body
+            with self.assertRaises(smoke_test.CheckError):
+                self.client.infer(1)
+
+    def test_main_does_not_log_response_secrets(self):
+        self.server.state["body"] = b"test-token secret body"
+        stderr = io.StringIO()
+        with patch.dict("os.environ", {"ENDPOINT_AUTH_TOKEN": "test-token"}):
+            with patch.object(
+                sys, "argv", ["smoke_test.py", "--url", self.url, "--allow-local-http"]
+            ):
+                with contextlib.redirect_stderr(stderr):
+                    self.assertEqual(smoke_test.main(), 1)
+        self.assertNotIn("test-token", stderr.getvalue())
+        self.assertNotIn("secret body", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/customization_guide/deploy.md
+++ b/docs/customization_guide/deploy.md
@@ -86,6 +86,9 @@ as an "Application" or "Service" within the trusted internal network.
 * [https://konghq.com/blog/enterprise/envoy-service-mesh]
 * [https://www.solo.io/topics/envoy-proxy/]
 
+For an example using a managed HTTPS gateway with bearer-token authentication,
+see [Triton on Nebius Serverless](https://github.com/triton-inference-server/server/tree/main/deploy/nebius).
+
 ## Securing Model and Backend Code
 
 > [!WARNING]


### PR DESCRIPTION
#### What does the PR do?

Adds `deploy/nebius`, an example that packages a fixed DenseNet ONNX repository into a Triton GPU image with checksum-pinned base/model inputs and serves it through one authenticated Nebius Serverless HTTP Endpoint.

The example verifies model files before building, fixes the model version and GPU instance, disables gRPC/metrics listeners and dynamic model control, and includes a bounded HTTP readiness/authentication/inference client. The guide covers image preparation, asynchronous creation and receipt recovery, secret references, stop/start, persistence and deletion reconciliation. Root and deployment-guide links make it discoverable. No Triton runtime/backend code or other cloud charts change.

Live validation passed on L40S and H100 in eu-north1. The original L40S lifecycle tests covered: authenticated inference, numerical CPU-reference comparison, concurrency 1/2/4, a second cold start, corrupted-model startup failure and Endpoint deletion. The current CLI/API rejects long digest references through a 64-character compute-label limit, so the guide requires a short unique tag verified against the derived digest. This limitation is explicit; the Endpoint does not enforce an atomic digest pin.

#### Checklist

- [ ] I have read the contribution guidelines and signed the CLA. Guidelines reviewed; CLA status not established.
- [x] PR title describes the change using a conventional commit type.
- [x] Changes and limitations are described here.
- [x] Related work was checked; no Nebius issue/PR was found at preparation time.
- [ ] GitHub labels are populated. Maintainer action needed: `PR: docs`, `Documentation`, `External`; the author has read-only upstream access.
- [x] Added a test plan with results: example tests, live GPU checks and L0_config_json pass; unsuccessful and unrun checks are explicitly recorded.
- [ ] All required validation passes: hosted CI, the remaining `qa/L0_*` suites and a warning-free documentation build remain pending.
- [x] Ran changed-file and full-repository pre-commit checks. Changed-file checks pass. The full run exits 1 on existing Flake8 and copyright issues outside the PR paths; see the test plan.
- [x] Applied the upstream copyright hook and reviewed changed files.
- [x] Prepared a succinct squash message below for the maintainer to apply at merge.
- [x] All applicable template sections are filled out.

#### Commit Type

- [x] docs

#### Related PRs

Related work reviewed during preparation: PR #8847 documents generic S3-compatible model repositories. This example bundles the model in the image and does not duplicate that change. PRs #5112 (AWS temporary credentials) and #8324 (on-prem chart configuration) do not implement Nebius Serverless.

#### Where should the reviewer start?

1. `deploy/nebius/README.md`: workflow, validation status and boundaries.
2. `deploy/nebius/pins.json`, `prepare_models.py`, `Dockerfile`, `entrypoint.sh`: immutable model/image inputs and fixed runtime behavior.
3. `deploy/nebius/smoke_test.py` and `tests/test_example.py`: HTTP/auth checks and negative cases.

#### Test plan

Completed locally:

- `python -m unittest discover -s deploy/nebius/tests -v`: **17 passed** on Python 3.10 after the live-test fixes; earlier preflight runs also passed all 17 tests on Python 3.12.8 and 3.14.3. HTTP fixtures are loopback-only and emulate authentication; no cloud credentials are used.
- Executed `prepare_models.py` against all six pinned public sources. Recomputed all generated checksums. Corrupt, short/oversized and LFS-pointer downloads, path traversal and existing-output handling are covered by the tests.
- ONNX structural checker and CPU ONNX Runtime inference against the actual prepared model: 1,000 finite logits; generated the optional numerical reference. Local versions: ONNX 1.19.0, ONNX Runtime 1.23.2, NumPy 2.2.6.
- `docker buildx build --check --platform linux/amd64 deploy/nebius`: passed with no warnings. The subsequent full Linux amd64 image build also passed, including in-image model checksum verification. The corrected image subsequently passed actual L40S inference.
- Changed-file upstream pre-commit hooks passed, including secret scan, format/lint, JSON and whitespace checks. The copyright hook reports that JSON and ignore files have no handler but exits successfully.
- Python compilation, shell syntax for the entrypoint and all Bash guide fences, local Markdown file-link validation, and targeted Markdown-to-HTML rendering passed.
- Actual Triton 2.72.0 HTTP execution in the built image under amd64 emulation with a temporary CPU model configuration: 1,000 finite output values matched the independent reference, concurrent requests at 1/2/4 succeeded, and readiness remained healthy after rejected requests. Unknown model/version returned 404; empty inference returned 500 (recorded anomaly); disabled dynamic load returned 503. Both temporary containers were removed. This bypassed the GPU entrypoint and does not validate Nebius ingress/authentication.
- Live Triton 2.72.0 / ONNX Runtime 1.28.0 / CUDA 13.4 on L40S driver 580.173.02: two starts passed the final smoke client and concurrency 1/2/4. With use_tf32=0, all 1,000 outputs met the original tolerance; maximum absolute error was 6.4e-6. Missing/wrong token probes returned 401. Four requests issued alongside stop returned 200.
- Corrupt-model startup reached ERROR / StartFailed, operation status code 9, and readiness 404. All three test Endpoint definitions were deleted with successful delete operations and NotFound verification; temporary image artifacts and IAM access were removed, and secrets soft-deleted.
- Full Sphinx HTML generation with Sphinx 7.4.7, Triton client 2.72.0 HTTP/gRPC extras and all 14 repositories from `docs/repositories.txt`: strict `-W --keep-going` builds exited 1 on both PR and base, with exactly the same 404 diagnostic lines and no additions/removals. CUDA Python extras are unavailable on the macOS host.
- Unmodified upstream `qa/L0_config_json/test.sh 26.08` passed against the cached Linux amd64 Triton image under ARM emulation. ONNX fixtures came from upstream `qa/common/gen_qa_models.py --onnx --onnx_opset 21`. This is one L0 suite, not a claim that all suites passed.
- The unchanged image passed the existing smoke client, CPU-reference comparison and concurrency 1/2/4 on H100 (`gpu-h100-sxm`, `1gpu-16vcpu-200gb`) with driver 580.173.02.
- A separate L40S fixture using the same HTTP/authentication and exit settings accepted an HTTP body of exactly 1,048,576 bytes and rejected 1,048,577 bytes with HTTP 413. A 59-second response passed; 61/65/125-second delayed responses returned HTTP 504 at approximately 60 seconds. The backend later completed those computations. These tests do not establish streaming limits.
- The fixture confirmed 15- and 45-second requests executing before stop. Both clients received HTTP 502 approximately 6.3 seconds after stop was requested, while Triton was still waiting for requests. The 15-second computation completed afterward without reaching the client. The guide now requires finishing client requests before stopping an Endpoint.
- Both follow-up Endpoints and their observed VMs return NotFound. Their temporary image artifact, two secrets (soft deletion) and four IAM resources were also removed and verified.
- The reviewed accelerator declaration now uses an explicit colon. The old and new complete configurations parse to identical protobuf messages; the regenerated configuration loaded in actual Triton CPU execution and passed numerical-reference comparison and concurrency 1/2/4. All 17 example tests and changed-file pre-commit checks passed after this change. The previous GPU runs cover the semantically equivalent configuration.
- Full-repository `pre-commit run --all-files` ran in an isolated checkout: secret scanning and the other hooks passed, but Flake8 reported 1,055 diagnostics in 149 existing files and the copyright hook changed 972 existing files. None overlap the 11 PR paths. Those automatic edits were not included in the PR.
- Patch whitespace checks passed; the exported patch and Git bundle are updated with the review follow-up.

Remaining validation and submission checks:

- A warning-free documentation build and the remaining `qa/L0_*` suites. The strict Sphinx build generated HTML but reported the same 404 diagnostics on the PR and base with identical dependencies and documentation-repository snapshots. Linux/CUDA client autodoc remains outside this macOS environment.
- Hosted CodeQL and pre-commit workflows currently report `action_required` with no jobs run; upstream maintainer approval is needed. Maintainer review, CLA and ownership agreement remain pending.
- Other driver branches, header/response-size limits and streaming behavior remain untested. The measurements below are configuration-specific observations, not provider guarantees or a performance/SLA claim.

#### Caveats

The 26.08 release page had inconsistent CUDA details; the tested image directly reports CUDA runtime 13.4 and was validated on the specific L40S/driver combination above. Other environments require validation. The deployment tag must remain unique and unchanged because the current CLI/API cannot accept the long digest reference.

Live testing also corrected the CLI receipt handling: asynchronous create prints an Endpoint ID and lifecycle actions print operation IDs despite JSON formatting. `operation wait` returned zero for the failed startup, and returned NotFound after a successful delete. The guide now verifies operation status and resource existence separately. Authentication probes use a small body to avoid broken pipes when the gateway rejects a large unauthorized upload. TF32 is disabled instead of loosening numerical tolerances.

Empty `{}` inference requests returned HTTP 500; this is recorded as an anomaly, not a correctly classified client error. The observed gateway limits are 1 MiB per request body and approximately 60 seconds without a response. Triton's exit allowance did not preserve in-flight responses through Endpoint stop. These findings come from a test-only Python backend fixture injected at launch; it is not distributed in the example image.

The example makes no raw gRPC, streaming-model, multi-GPU, autoscaling, HA or production SLA claim. No automatic cleanup watchdog is included in the example.

The model-specific source README declares MIT, while the ONNX repository root license is Apache-2.0; both are retained with the prepared artifacts. Container redistribution terms are separate. No container image is distributed with the PR. Temporary private images used for testing were deleted.

Maintainer agreement on placement/ongoing ownership and the contributor CLA remain unresolved. The contribution guide requires a signed CLA sent to the Triton team; no confirmation of that submission is available. Existing provider-specific `deploy` directories do not guarantee acceptance.

#### Background

Triton already has upstream AWS/GCP/OCI Kubernetes deployment examples. This adds a container-level HTTP Endpoint example for Nebius Serverless, with explicit differences from Kubernetes probes and multi-port load balancers. Nebius Compute VM orchestration and Token Factory/AI Studio model APIs are outside its scope.

#### Related Issues

None.

#### Suggested squash message

```text
docs: add Nebius Serverless HTTP deployment example

Add pinned DenseNet model preparation, a Triton HTTP container and an
authenticated smoke client. Document Endpoint lifecycle operations,
L40S/H100 validation, and observed gateway and shutdown limitations.
```
